### PR TITLE
remove flat API

### DIFF
--- a/spikeinterface/__init__.py
+++ b/spikeinterface/__init__.py
@@ -1,1 +1,8 @@
 from .version import version as __version__
+
+# from .extractors import *
+# from .toolkit import *
+# from .toolkit import *
+# from .sorters import *
+# from .widgets import *
+# from .comparison import *

--- a/spikeinterface/__init__.py
+++ b/spikeinterface/__init__.py
@@ -1,9 +1,1 @@
 from .version import version as __version__
-
-from .extractors import *
-from .toolkit import *
-from .toolkit import *
-from .sorters import *
-from .widgets import *
-from .comparison import *
-

--- a/spikeinterface/extractors.py
+++ b/spikeinterface/extractors.py
@@ -1,2 +1,1 @@
 from spikeextractors import *
- 


### PR DESCRIPTION
I don't know why but keeping both the flat and the modules API does not allow to access the extractors.

e.g. 
```
import spikeinterface.extractors as se
se.MEArecRecordingExtractor
```
 gives an attribute error. If the flat API is removed it works...