### PR TITLE
Auto-generated author list from commits (not done)

### DIFF
--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -1,21 +1,27 @@
 Contact Us
 ==========
 
-The following people have contributed code and/or ideas to the current version
-of SpikeInterface. The institutional affiliations are those at the time of the contribution,
-and may not be the current affiliation of a contributor.
+The following people have contributed code and/or ideas to the current version of SpikeInterface. The institutional affiliations are those at the time of the contribution, and may not be the current affiliation of a contributor.
 
-* `Alessio Paolo Buccino <https://www.mn.uio.no/ifi/english/people/aca/alessiob/>`_ [1]
-* `Cole Hurwitz <https://www.inf.ed.ac.uk/people/students/Cole_Hurwitz.html>`_ [2]
-* `Jeremy Magland <https://www.simonsfoundation.org/team/jeremy-magland>`_ [3]
-* `Matthias Hennig <http://homepages.inf.ed.ac.uk/mhennig/>`_ [2]
-* `Samuel Garcia <https://github.com/samuelgarcia>`_ [4]
-* `Josh Siegle <https://alleninstitute.org/what-we-do/brain-science/about/team/staff-profiles/josh-siegle/>`_ [5]
+**Core developers**
+- <img src="https://avatars3.githubusercontent.com/u/31068646?v=4" width="16"/> [Cole Hurwitz](https://github.com/colehurwitz), University of Edinburgh
+- <img src="https://avatars2.githubusercontent.com/u/3679296?v=4" width="16"/> [Jeremy Magland](https://github.com/magland), None
+- <img src="https://avatars0.githubusercontent.com/u/5928956?v=4" width="16"/> [Matthias H. Hennig](https://github.com/mhhennig), University of Edinburgh
+- <img src="https://avatars0.githubusercontent.com/u/17097257?v=4" width="16"/> [Alessio Buccino](https://github.com/alejoe91), University of Oslo
+- <img src="https://avatars1.githubusercontent.com/u/815627?v=4" width="16"/> [Garcia Samuel](https://github.com/samuelgarcia), CNRS
+- <img src="https://avatars0.githubusercontent.com/u/10051773?v=4" width="16"/> [Roger Hurwitz](https://github.com/rogerhurwitz), None
+
+**External contributors**
+- <img src="https://avatars2.githubusercontent.com/u/3418096?v=4" width="16"/> [Mikkel Elle Lepperød](https://github.com/lepmik), None 
+- <img src="https://avatars3.githubusercontent.com/u/6409964?v=4" width="16"/> [Jose Guzman](https://github.com/JoseGuzman), Institute of Molecular Biotechnology (IMBA) Austria 
+- <img src="https://avatars2.githubusercontent.com/u/13655521?v=4" width="16"/> [Alexander Morley](https://github.com/alexmorley), MRC BNDU (University of Oxford) 
+- <img src="https://avatars3.githubusercontent.com/u/24541631?v=4" width="16"/> [Luiz Tauffer](https://github.com/luiztauffer), @kth 
+- <img src="https://avatars0.githubusercontent.com/u/844306?v=4" width="16"/> [Ben Dichter](https://github.com/bendichter), None 
+- <img src="https://avatars2.githubusercontent.com/u/38734201?v=4" width="16"/> [NMI Microsystems & Nanotechnology](https://github.com/NMI-MSNT), None 
+- <img src="https://avatars0.githubusercontent.com/u/2369197?v=4" width="16"/> [Achilleas Koutsou](https://github.com/achilleas-k), @G-Node  
+- <img src="https://avatars2.githubusercontent.com/u/15884111?v=4" width="16"/> [Shawn Guo](https://github.com/Shawn-Guo-CN), None 
+- <img src="https://avatars3.githubusercontent.com/u/8941752?v=4" width="16"/> [James Jun](https://github.com/jamesjun), Rocket Ephys, LLC 
+- <img src="https://avatars2.githubusercontent.com/u/11293950?v=4" width="16"/> [Martino Sorbaro](https://github.com/martinosorb), University of Edinburgh 
+- <img src="https://avatars1.githubusercontent.com/u/1672447?v=4" width="16"/> [Pierre Yger](https://github.com/yger), Institut de la Vision 
 
 For any inquiries, please contact Alessio Buccino (alessiop.buccino@gmail.com), Cole Hurwitz (cole.hurwitz@ed.ac.uk), or just write an issue!
-
-1. Center for Inegrative Neurolasticity (CINPLA), Department of Biosciences, Physics, and Informatics, University of Oslo, Oslo, Norway.
-2. The Institute for Adaptive and Neural Computation (ANC), University of Edinburgh, Edinburgh, Scotland.
-3. Center for Computational Biology (CCB), Flatiron Institute, New York, United States.
-4. Centre de Recherche en Neuroscience de Lyon (CRNL), Lyon, France.
-5. Allen Institute for Brain Science, Washington, United States.


### PR DESCRIPTION
Some authors should add their affiliation to their github profile, this is automatically pulled using the github API.