### PR TITLE
Reorder inheritance of RemoveBadChannelsRecording and the arguments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,16 @@ examples/*/*/*/*/*.npy
 examples/*/*/sorter_outputs
 examples/*/*/*_to_phy
 
-
-
 .vscode/*
+
+# MauroToro: My absolute mess of envs
+bin/
+DATA/
+etc/
+include/
+share/
+dist_metrics.pxd
+pyvenv.cfg
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -162,4 +169,3 @@ examples/modules/comparison/tmp_*
 examples/modules/comparison/a_study_folder/*
 examples/modules/toolkit/phy/*
 examples/modules/toolkit/tmp_*
-

--- a/spikeinterface/toolkit/preprocessing/remove_bad_channels.py
+++ b/spikeinterface/toolkit/preprocessing/remove_bad_channels.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-from spikeinterface.core.channelslicerecording import (ChannelSliceRecording, 
+from spikeinterface.core.channelslicerecording import (ChannelSliceRecording,
     ChannelSliceRecordingSegment)
 from .basepreprocessor import BasePreprocessor,BasePreprocessorSegment
 
@@ -9,7 +9,7 @@ from ..utils import get_random_data_chunks
 
 class RemoveBadChannelsRecording(BasePreprocessor, ChannelSliceRecording):
     """
-    Remove bad channels from the recording extractor given a thershold 
+    Remove bad channels from the recording extractor given a thershold
     on standard deviation.
 
     Parameters
@@ -19,7 +19,7 @@ class RemoveBadChannelsRecording(BasePreprocessor, ChannelSliceRecording):
     bad_threshold: float
         If automatic is used, the threshold for the standard deviation over which channels are removed
     **random_chunk_kwargs
-    
+
     Returns
     -------
     remove_bad_channels_recording: RemoveBadChannelsRecording
@@ -28,20 +28,20 @@ class RemoveBadChannelsRecording(BasePreprocessor, ChannelSliceRecording):
     name = 'remove_bad_channels'
 
     def __init__(self, recording, bad_threshold=5, **random_chunk_kwargs):
-            
+
 
         random_data = get_random_data_chunks(recording, **random_chunk_kwargs)
-        
+
         stds = np.std(random_data, axis=0)
         thresh = bad_threshold * np.median(stds)
         keep_inds, = np.nonzero(stds < thresh)
-        
+
         parents_chan_ids = recording.get_channel_ids()
         channel_ids = parents_chan_ids[keep_inds]
         self._parent_channel_indices = recording.ids_to_indices(channel_ids)
-        
+
+        BasePreprocessor.__init__(self, recording)
         ChannelSliceRecording.__init__(self, recording, channel_ids=channel_ids)
-        BasePreprocessor.__init__(self, self)
 
         self._kwargs = dict(recording=recording.to_dict(), bad_threshold=bad_threshold)
         self._kwargs.update(random_chunk_kwargs)
@@ -51,4 +51,3 @@ class RemoveBadChannelsRecording(BasePreprocessor, ChannelSliceRecording):
 def remove_bad_channels(*args, **kwargs):
     return RemoveBadChannelsRecording(*args, **kwargs)
 remove_bad_channels.__doc__ = RemoveBadChannelsRecording.__doc__
-

--- a/spikeinterface/toolkit/preprocessing/tests/test_remove_bad_channels.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_remove_bad_channels.py
@@ -33,14 +33,16 @@ def test_remove_bad_channels():
     probe.set_device_channel_indices(np.arange(num_channels))
     rec.set_probe(probe, in_place=True)
 
-
     rec2 = remove_bad_channels(rec, bad_threshold=5.)
+
     # Check that the noisy channel is taken out
-    assert np.array_equal(rec2.get_channel_ids(), [0,2,3])
+    assert np.array_equal(rec2.get_channel_ids(), [0,2,3]), "wrong channel detected."
     # Check that the number of segments is maintained after preprocessor
-    assert np.array_equal(rec2.get_num_segments(), rec.get_num_segments())
+    assert np.array_equal(rec2.get_num_segments(), rec.get_num_segments()), "wrong numbber of segments."
     # Check that the size of the segments os maintained after preprocessor
-    assert np.array_equal(*([r.get_num_frames(x) for x in range(rec.get_num_segments())] for r  in [rec, rec2]))
+    assert np.array_equal(*([r.get_num_frames(x) for x in range(rec.get_num_segments())] for r  in [rec, rec2])), "wrong lenght of resulting segments."
+    # Check that locations are mantained
+    assert np.array_equal(rec.get_channel_locations()[[0,2,3]], rec2.get_channel_locations()), "wrong channels locations."
 
 
 if __name__ == '__main__':

--- a/spikeinterface/toolkit/preprocessing/tests/test_remove_bad_channels.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_remove_bad_channels.py
@@ -16,7 +16,7 @@ def test_remove_bad_channels():
     sampling_frequency = 30000.
     durations = [10.325, 3.5]
 
-    num_segments = len(durations)j
+    num_segments = len(durations)
     num_timepoints = [int(sampling_frequency * d) for d in durations]
 
     traces_list = []

--- a/spikeinterface/toolkit/preprocessing/tests/test_remove_bad_channels.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_remove_bad_channels.py
@@ -15,10 +15,10 @@ def test_remove_bad_channels():
     num_channels = 4
     sampling_frequency = 30000.
     durations = [10.325, 3.5]
-    
-    num_segments = len(durations)
+
+    num_segments = len(durations)j
     num_timepoints = [int(sampling_frequency * d) for d in durations]
-    
+
     traces_list = []
     for i in range(num_segments):
         traces = np.random.randn(num_timepoints[i], num_channels).astype('float32')
@@ -28,14 +28,19 @@ def test_remove_bad_channels():
         traces += np.sin(2*np.pi*50*times)[:, None]
         traces_list.append(traces)
     rec = NumpyRecording(traces_list, sampling_frequency)
-    
+
     probe = generate_linear_probe(num_elec=num_channels)
     probe.set_device_channel_indices(np.arange(num_channels))
     rec.set_probe(probe, in_place=True)
 
-    
+
     rec2 = remove_bad_channels(rec, bad_threshold=5.)
+    # Check that the noisy channel is taken out
     assert np.array_equal(rec2.get_channel_ids(), [0,2,3])
+    # Check that the number of segments is maintained after preprocessor
+    assert np.array_equal(rec2.get_num_segments(), rec.get_num_segments())
+    # Check that the size of the segments os maintained after preprocessor
+    assert np.array_equal(*([r.get_num_frames(x) for x in range(rec.get_num_segments())] for r  in [rec, rec2]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If a recording was passed to the remove_bad_channel preprocessor, the resulting object got the recording and probe properties destroyed. Reordering the inheritance and changing some arguments seems to correct this issue.