### PR TITLE
Add return_scaled params to WaveforExtractor

### DIFF
--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -102,15 +102,22 @@ class BaseRecording(BaseExtractor):
             assert order in ["C", "F"]
             traces = np.asanyarray(traces, order=order)
         if return_scaled:
-            gains = self.get_property('gain_to_uV')
-            offsets = self.get_property('offset_to_uV')
-            if gains is None or offsets is None:
+            if not self.has_scaled_traces():
                 raise ValueError('This recording do not support return_scaled=True (need gain_to_uV and offset_'
                                  'to_uV properties)')
-            gains = gains[channel_indices].astype('float32')
-            offsets = offsets[channel_indices].astype('float32')
-            traces = traces.astype('float32') * gains + offsets
+            else:
+                gains = self.get_property('gain_to_uV')
+                offsets = self.get_property('offset_to_uV')
+                gains = gains[channel_indices].astype('float32')
+                offsets = offsets[channel_indices].astype('float32')
+                traces = traces.astype('float32') * gains + offsets
         return traces
+
+    def has_scaled_traces(self):
+        if self.get_property('gain_to_uV') is None or self.get_property('offset_to_uV') is None:
+            return False
+        else:
+            return True
 
     def is_filtered(self):
         # the is_filtered is handle with annotation

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -85,16 +85,22 @@ def test_extract_waveforms():
     folder1 = Path('test_extract_waveforms_1job')
     if folder1.is_dir():
         shutil.rmtree(folder1)
-    we1 = extract_waveforms(recording, sorting, folder1, max_spikes_per_unit=None)
+    we1 = extract_waveforms(recording, sorting, folder1, max_spikes_per_unit=None, return_scaled=False)
 
     folder2 = Path('test_extract_waveforms_2job')
     if folder2.is_dir():
         shutil.rmtree(folder2)
-    we2 = extract_waveforms(recording, sorting, folder2, n_jobs=2, total_memory="10M", max_spikes_per_unit=None)
+    we2 = extract_waveforms(recording, sorting, folder2, n_jobs=2, total_memory="10M", max_spikes_per_unit=None,
+                            return_scaled=False)
 
     folder3 = Path('test_extract_waveforms_returnscaled')
     if folder3.is_dir():
         shutil.rmtree(folder3)
+
+    # set scaling values to recording
+    gain = 0.1
+    recording.set_channel_gains(gain)
+    recording.set_channel_offsets(0)
     we3 = extract_waveforms(recording, sorting, folder3, n_jobs=2, total_memory="10M", max_spikes_per_unit=None,
                             return_scaled=True)
 
@@ -103,7 +109,7 @@ def test_extract_waveforms():
     assert np.array_equal(wf1, wf2)
 
     wf3 = we3.get_waveforms(0)
-    assert np.array_equal(wf1.shape, wf3.shape)
+    assert np.array_equal((wf1).astype("float32") * gain, wf3)
 
 
 if __name__ == '__main__':

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -92,9 +92,18 @@ def test_extract_waveforms():
         shutil.rmtree(folder2)
     we2 = extract_waveforms(recording, sorting, folder2, n_jobs=2, total_memory="10M", max_spikes_per_unit=None)
 
+    folder3 = Path('test_extract_waveforms_returnscaled')
+    if folder3.is_dir():
+        shutil.rmtree(folder3)
+    we3 = extract_waveforms(recording, sorting, folder3, n_jobs=2, total_memory="10M", max_spikes_per_unit=None,
+                            return_scaled=True)
+
     wf1 = we1.get_waveforms(0)
     wf2 = we2.get_waveforms(0)
     assert np.array_equal(wf1, wf2)
+
+    wf3 = we3.get_waveforms(0)
+    assert np.array_equal(wf1.shape, wf3.shape)
 
 
 if __name__ == '__main__':

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -141,6 +141,13 @@ class WaveformExtractor:
         if dtype is None:
             dtype = self.recording.get_dtype()
 
+        if return_scaled:
+            # check if has scaled values:
+            if "gain_to_uV" not in self.recording.get_property_keys() \
+                    and "offset_to_uV" not in self.recording.get_property_keys():
+                print("Setting 'return_scaled' to False")
+                return_scaled = False
+
         if np.issubdtype(dtype, np.integer) and return_scaled:
             dtype = "float32"
 

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -140,6 +140,10 @@ class WaveformExtractor:
 
         if dtype is None:
             dtype = self.recording.get_dtype()
+
+        if np.issubdtype(dtype, np.integer) and return_scaled:
+            dtype = "float32"
+
         if max_spikes_per_unit is not None:
             max_spikes_per_unit = int(max_spikes_per_unit)
 

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -431,6 +431,7 @@ def _waveform_extractor_chunk(segment_index, start_frame, end_frame, worker_ctx)
     selected_spike_times = worker_ctx['selected_spike_times']
     nbefore = worker_ctx['nbefore']
     nafter = worker_ctx['nafter']
+    return_scaled = worker_ctx['return_scaled']
     unit_cum_sum = worker_ctx['unit_cum_sum']
 
     to_extract = {}
@@ -448,7 +449,8 @@ def _waveform_extractor_chunk(segment_index, start_frame, end_frame, worker_ctx)
         end = int(end)
 
         # load trace in memory
-        traces = recording.get_traces(start_frame=start, end_frame=end, segment_index=segment_index)
+        traces = recording.get_traces(start_frame=start, end_frame=end, segment_index=segment_index,
+                                      return_scaled=return_scaled)
 
         for unit_id, (i0, i1, local_spike_times) in to_extract.items():
             wfs = np.load(wfs_memmap_files[unit_id], mmap_mode="r+")

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -143,8 +143,7 @@ class WaveformExtractor:
 
         if return_scaled:
             # check if has scaled values:
-            if "gain_to_uV" not in self.recording.get_property_keys() \
-                    and "offset_to_uV" not in self.recording.get_property_keys():
+            if not self.recording.has_scaled_traces():
                 print("Setting 'return_scaled' to False")
                 return_scaled = False
 

--- a/spikeinterface/toolkit/qualitymetrics/misc_metrics.py
+++ b/spikeinterface/toolkit/qualitymetrics/misc_metrics.py
@@ -110,7 +110,8 @@ def compute_snrs(waveform_extractor, peak_sign='neg', **kwargs):
 
     extremum_channels_ids = get_template_extremum_channel(waveform_extractor, peak_sign=peak_sign)
     unit_amplitudes = get_template_extremum_amplitude(waveform_extractor, peak_sign=peak_sign)
-    noise_levels = get_noise_levels(recording, **kwargs)
+    return_scaled = waveform_extractor.return_scaled
+    noise_levels = get_noise_levels(recording, return_scaled=return_scaled, **kwargs)
 
     # make a dict to acces by chan_id
     noise_levels = dict(zip(channel_ids, noise_levels))

--- a/spikeinterface/toolkit/tests/test_utils.py
+++ b/spikeinterface/toolkit/tests/test_utils.py
@@ -25,7 +25,12 @@ def test_get_closest_channels():
 def test_get_noise_levels():
     rec = generate_recording(num_channels=2, sampling_frequency=1000., durations=[60.])
 
-    noise_levels = get_noise_levels(rec)
+    noise_levels = get_noise_levels(rec, return_scaled=False)
+    print(noise_levels)
+
+    rec.set_channel_gains(0.1)
+    rec.set_channel_offsets(0)
+    noise_levels = get_noise_levels(rec, return_scaled=True)
     print(noise_levels)
 
 

--- a/spikeinterface/toolkit/utils.py
+++ b/spikeinterface/toolkit/utils.py
@@ -2,12 +2,29 @@ import numpy as np
 import scipy.spatial
 
 
-def get_random_data_chunks(recording, num_chunks_per_segment=20, chunk_size=10000, seed=0):
+def get_random_data_chunks(recording, return_scaled=False, num_chunks_per_segment=20, chunk_size=10000, seed=0):
     """
-    Take chunks across segments randomly
-    
+    Exctract random chunks across segments
+
     This is used for instance in get_noise_levels() to estimate noise on traces.
-    
+
+    Parameters
+    ----------
+    recording: BaseRecording
+        The recording to get random chunks from
+    return_scaled: bool
+        If True, returned chunks are scaled ti uV
+    num_chunks_per_segment: int
+        Number of chunks per segment
+    chunk_size: int
+        Size of a chink in number of frames
+    seed: int
+        Random seed
+
+    Returns
+    -------
+    chunk_list: np.array
+        Array of concatenate chunks per segment
     """
     # TODO: if segment have differents length make another sampling that dependant on the lneght of the segment
     # Should be done by chnaging kwargs with total_num_chunks=XXX and total_duration=YYYY
@@ -21,7 +38,8 @@ def get_random_data_chunks(recording, num_chunks_per_segment=20, chunk_size=1000
         for start_frame in random_starts:
             chunk = recording.get_traces(start_frame=start_frame,
                                          end_frame=start_frame + chunk_size,
-                                         segment_index=segment_index)
+                                         segment_index=segment_index,
+                                         return_scaled=return_scaled)
             chunk_list.append(chunk)
     return np.concatenate(chunk_list, axis=0)
 
@@ -69,7 +87,7 @@ def get_closest_channels(recording, channel_ids=None, num_channels=None):
     return np.array(closest_channels_inds), np.array(dist)
 
 
-def get_noise_levels(recording, **random_chunk_kwargs):
+def get_noise_levels(recording, return_scaled=True, **random_chunk_kwargs):
     """
     Estimate noise for each channel using MAD methods.
     
@@ -77,7 +95,7 @@ def get_noise_levels(recording, **random_chunk_kwargs):
     And then, it use MAD estimator (more robust than STD)
     
     """
-    random_chunks = get_random_data_chunks(recording, **random_chunk_kwargs)
+    random_chunks = get_random_data_chunks(recording, return_scaled=return_scaled, **random_chunk_kwargs)
     med = np.median(random_chunks, axis=0, keepdims=True)
     noise_levels = np.median(np.abs(random_chunks - med), axis=0) / 0.6745
     return noise_levels


### PR DESCRIPTION
Add option to `extract_waveforms` to return scaled waveforms. This is Tru by default, as waveforms and templates are usually retrieved in uV