### PR TITLE
[Work in progress] Add isolation metric

### DIFF
--- a/spikeinterface/toolkit/qualitymetrics/quality_metric_calculator.py
+++ b/spikeinterface/toolkit/qualitymetrics/quality_metric_calculator.py
@@ -61,7 +61,7 @@ class QualityMetricCalculator:
         if 'seed' in kwargs:
             seed = kwargs['seed']
         else:
-            seed = 0
+            seed = None
 
         if metric_names is None:
             # metric_names = list(_metric_name_to_func.keys()) + _possible_pc_metric_names

--- a/spikeinterface/toolkit/qualitymetrics/quality_metric_calculator.py
+++ b/spikeinterface/toolkit/qualitymetrics/quality_metric_calculator.py
@@ -38,11 +38,31 @@ class QualityMetricCalculator:
         metric_names: list or None
             List of quality metrics to compute. If None, all metrics are computed
         **kwargs: keyword arguments for quality metrics (TODO)
+            max_spikes_for_nn: int
+                maximum number of spikes to use per cluster in PCA metrics
+            n_neighbors: int
+                number of nearest neighbors to check membership of in PCA metrics
+            seed: int
+                seed for pseudorandom number generator used in PCA metrics (e.g. nn_isolation)
 
         Returns
         -------
+        metrics: pd.DataFrame
 
         """
+        if 'max_spikes_for_nn' in kwargs:
+            max_spikes_for_nn = kwargs['max_spikes_for_nn']
+        else:
+            max_spikes_for_nn = 2000
+        if 'n_neighbors' in kwargs:
+            n_neighbors = kwargs['n_neighbors']
+        else:
+            n_neighbors = 6
+        if 'seed' in kwargs:
+            seed = kwargs['seed']
+        else:
+            seed = 0
+
         if metric_names is None:
             # metric_names = list(_metric_name_to_func.keys()) + _possible_pc_metric_names
             
@@ -73,7 +93,8 @@ class QualityMetricCalculator:
         if len(pc_metric_names):
             if self.waveform_principal_component is None:
                 raise ValueError('waveform_principal_component must be provied')
-            pc_metrics = calculate_pc_metrics(self.waveform_principal_component, metric_names=pc_metric_names)
+            pc_metrics = calculate_pc_metrics(self.waveform_principal_component, metric_names=pc_metric_names, 
+                                              max_spikes_for_nn=max_spikes_for_nn, n_neighbors=n_neighbors, seed=seed)
             for col, values in pc_metrics.items():
                 metrics[col] = pd.Series(values)
 


### PR DESCRIPTION
This PR adds a new metric called isolation metric to `toolkit.qualitymetrics`. It is described in [Chung 2017](https://doi.org/10.1016/j.neuron.2017.08.030). 
* There is already an implementation of this metric in the form of `nn_hit_rate` in `nearest_neighbors_metrics` function in `misc_metrics.py`. However, this implementation has a couple of issues:
  * It fails to handle the case in which `n_neighbors`=1 (returns nan).
  * It is also _not the same_ as the isolation metric from Chung 2017, even though the docstring claims that it is. This difference is known and is discussed [here](https://github.com/SpikeInterface/spikemetrics#a-note-on-calculations).
* While it is true that the metric can be unreliable when comparing two clusters with a large difference in firing rate, Chung 2017 actually addresses this point and suggests randomly subsampling the two clusters such that the number of spikes in each cluster is equal before computing isolation. 
* The `nearest_neighbors_isolation` function in this PR implements the random subsampling as described in Chung 2017 with a seed parameter to set a pseudorandom number generator. 
* Right now the new function is not referenced by others (e.g. `calculate_pc_metrics`). @alejoe91 Once you approve adding this metric I will work on these. 