### PR TITLE
Shebang for linux command had an extra uneeded space.

### DIFF
--- a/spikeinterface/sorters/combinato/combinato.py
+++ b/spikeinterface/sorters/combinato/combinato.py
@@ -169,7 +169,7 @@ class CombinatoSorter(BaseSorter):
             extra_cmd = str(tmpdir)[:2]
             shell_cmd = shell_cmd.replace('/', '\\')
         else:
-            extra_cmd = '# !/bin/bash'
+            extra_cmd = '#!/bin/bash'
 
         shell_cmd = shell_cmd.format(
             extra_cmd=extra_cmd,


### PR DESCRIPTION
Led to an Exec format error when trying to run the combinato sorter 

'# !/bin/bash'  -->  '#!bin/bash'