### PR TITLE
Path for run_sorters with docker images

### DIFF
--- a/spikeinterface/core/job_tools.py
+++ b/spikeinterface/core/job_tools.py
@@ -209,6 +209,10 @@ class ChunkRecordingExecutor:
         else:
             returns = None
 
+        import sys
+        if self.n_jobs != 1 and not (sys.version_info >= (3, 8)):
+            self.n_jobs = 1
+
         if self.n_jobs == 1:
             if self.progress_bar:
                 all_chunks = tqdm(all_chunks, ascii=True, desc=self.job_name)

--- a/spikeinterface/extractors/phykilosortextractors.py
+++ b/spikeinterface/extractors/phykilosortextractors.py
@@ -48,7 +48,12 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
         # try to load cluster info
         cluster_info_files = [p for p in phy_folder.iterdir() if p.suffix in ['.csv', '.tsv']
                               and "cluster_info" in p.name]
-        if len(cluster_info_files) == 1:
+
+        if len(cluster_info_files) == 0:
+            cluster_info = pd.DataFrame({'id' : unit_ids})
+            cluster_info['group'] = ['unsorted']*len(unit_ids)
+
+        elif len(cluster_info_files) == 1:
             cluster_info_file = cluster_info_files[0]
             if cluster_info_file.suffix == ".tsv":
                 delimeter = "\t"
@@ -72,6 +77,7 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
                     cluster_info = pd.merge(cluster_info, new_property, on='cluster_id')
 
             cluster_info["id"] = cluster_info["cluster_id"]
+
             del cluster_info["cluster_id"]
 
         if exclude_cluster_groups is not None:
@@ -84,8 +90,8 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
 
         if keep_good_only and "KSLabel" in cluster_info.columns:
             cluster_info = cluster_info.query(f"KSLabel != 'good'")
-
         unit_ids = cluster_info["id"].values
+
         BaseSorting.__init__(self, sampling_frequency, unit_ids)
 
         for prop_name in cluster_info.columns:

--- a/spikeinterface/sorters/launcher.py
+++ b/spikeinterface/sorters/launcher.py
@@ -12,6 +12,7 @@ import json
 from spikeinterface.core import load_extractor
 
 from .sorterlist import sorter_dict
+from .runsorters import run_sorter_local, run_sorter_docker
 
 
 def _run_one(arg_list):

--- a/spikeinterface/sorters/launcher.py
+++ b/spikeinterface/sorters/launcher.py
@@ -12,7 +12,7 @@ import json
 from spikeinterface.core import load_extractor
 
 from .sorterlist import sorter_dict
-from .runsorters import run_sorter_local, run_sorter_docker
+from .runsorter import run_sorter_local, run_sorter_docker
 
 
 def _run_one(arg_list):
@@ -40,7 +40,7 @@ def _run_one(arg_list):
 
         run_sorter_docker(sorter_name, recording, docker_image, output_folder=output_folder,
                       remove_existing_folder=remove_existing_folder, delete_output_folder=delete_output_folder,
-                      verbose=verbose, raise_error=raise_error, **sorter_params):
+                      verbose=verbose, raise_error=raise_error, **sorter_params)
 
 
 _implemented_engine = ('loop', 'joblib', 'dask')

--- a/spikeinterface/sorters/launcher.py
+++ b/spikeinterface/sorters/launcher.py
@@ -110,6 +110,10 @@ def run_sorters(sorter_list,
     with_output: bool
         return the output.
 
+    docker_images: dict
+        A dictionary {sorter_name : docker_image} to specify is some sorters
+        should use docker images
+
     run_sorter_kwargs: dict
         This contains kwargs specific to run_sorter function:\
             * 'raise_error' :  bool
@@ -167,11 +171,7 @@ def run_sorters(sorter_list,
                         shutil.rmtree(str(output_folder))
 
             params = sorter_params.get(sorter_name, {})
-            use_docker = sorter_name in docker_images
-            if use_docker:
-                docker_image = docker_images[sorter_name]
-            else:
-                docker_image = None
+            docker_image = docker_images.get(sorter_name, None)
 
             if need_dump:
                 if not recording.is_dumpable:

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -242,9 +242,9 @@ run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
         print(f"Running sorter in {docker_image}")
         # flush whatever is in the stdout
         sys.stdout.flush()
+
     try:
-        res = client.containers.run(docker_image, command=command, volumes=volumes, stdout=verbose,
-                                    **extra_kwargs)
+        res = client.containers.run(docker_image, command=command, volumes=volumes, **extra_kwargs)
         # clean useless files
         os.remove(parent_folder / 'in_docker_recording.json')
         os.remove(parent_folder / 'in_docker_params.json')

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -254,7 +254,10 @@ run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
         os.remove(parent_folder / 'in_docker_recording.json')
         os.remove(parent_folder / 'in_docker_params.json')
         os.remove(parent_folder / 'in_docker_sorter_script.py')
-        raise SpikeSortingError(f"Spike sorting in docker failed with the following error:\n{e}")
+        if raise_error:
+            raise SpikeSortingError(f"Spike sorting in docker failed with the following error:\n{e}")
+        else:
+            return
 
     sorting = SorterClass.get_result_from_folder(output_folder)
 


### PR DESCRIPTION
We would like to be able to use run_sorters with docker images for some of the sorters. This should deal with that. The run_sorters command also accept docker_images = {sorter_name : docker_image}. If provided, adequate docker image are used instead of local sorters