### PR TITLE
with_output should be False in run_sorters

### DIFF
--- a/spikeinterface/comparison/groundtruthstudy.py
+++ b/spikeinterface/comparison/groundtruthstudy.py
@@ -107,7 +107,6 @@ class GroundTruthStudy:
             fname = rec_name + '[#]' + sorter_name
             npz_filename = sorting_folders / (fname + '.npz')
 
-            sorting = SorterClass.get_result_from_folder(output_folder)
             try:
                 sorting = SorterClass.get_result_from_folder(output_folder)
                 NpzSortingExtractor.write_sorting(sorting, npz_filename)

--- a/spikeinterface/sorters/__init__.py
+++ b/spikeinterface/sorters/__init__.py
@@ -2,5 +2,6 @@ from .basesorter import BaseSorter
 from .sorterlist import *
 from .runsorter import *
 
+
 from .launcher import (run_sorters,
                        collect_sorting_outputs, iter_output_folders, iter_sorting_output)

--- a/spikeinterface/sorters/launcher.py
+++ b/spikeinterface/sorters/launcher.py
@@ -16,7 +16,8 @@ from .sorterlist import sorter_dict
 
 def _run_one(arg_list):
     # the multiprocessing python module force to have one unique tuple argument
-    sorter_name, recording, output_folder, verbose, sorter_params = arg_list
+    sorter_name, recording, output_folder, verbose, sorter_params, docker_image, with_output = arg_list
+
     if isinstance(recording, dict):
         recording = load_extractor(recording)
     else:
@@ -31,11 +32,16 @@ def _run_one(arg_list):
     # because we won't want the loop/worker to break
     raise_error = False
 
-    # only classmethod call not instance (stateless at instance level but state is in folder)
-    output_folder = SorterClass.initialize_folder(recording, output_folder, verbose, remove_existing_folder)
-    SorterClass.set_params_to_folder(recording, output_folder, sorter_params, verbose)
-    SorterClass.setup_recording(recording, output_folder, verbose=verbose)
-    SorterClass.run_from_folder(output_folder, raise_error, verbose)
+    if docker_image is None:
+
+        run_sorter_local(sorter_name, recording, output_folder, remove_existing_folder,
+            delete_output_folder, verbose, raise_error, with_output)
+
+    else:
+
+        run_sorter_docker(sorter_name, recording, docker_image, output_folder=output_folder,
+                      remove_existing_folder=remove_existing_folder, delete_output_folder=delete_output_folder,
+                      verbose=verbose, raise_error=raise_error, with_output=with_output, **sorter_params)
 
 
 _implemented_engine = ('loop', 'joblib', 'dask')
@@ -167,7 +173,9 @@ def run_sorters(sorter_list,
                 recording_arg = recording.to_dict()
             else:
                 recording_arg = recording
-            task_args = (sorter_name, recording_arg, output_folder, verbose, params)
+
+            task_args = (sorter_name, recording_arg, output_folder, verbose, params, docker_image, with_output)
+
             task_args_list.append(task_args)
 
     if engine == 'loop':

--- a/spikeinterface/sorters/launcher.py
+++ b/spikeinterface/sorters/launcher.py
@@ -12,6 +12,7 @@ import json
 from spikeinterface.core import load_extractor
 
 from .sorterlist import sorter_dict
+from .runsorter import run_sorter_local, run_sorter_docker
 
 
 def _run_one(arg_list):

--- a/spikeinterface/sorters/launcher.py
+++ b/spikeinterface/sorters/launcher.py
@@ -56,6 +56,7 @@ def run_sorters(sorter_list,
                 engine_kwargs={},
                 verbose=False,
                 with_output=True,
+                docker_images={}
                 ):
     """
     This run several sorter on several recording.
@@ -109,6 +110,10 @@ def run_sorters(sorter_list,
 
     with_output: bool
         return the output.
+
+    docker_images: dict
+        A dictionary {sorter_name : docker_image} to specify is some sorters
+        should use docker images
 
     run_sorter_kwargs: dict
         This contains kwargs specific to run_sorter function:\
@@ -167,6 +172,8 @@ def run_sorters(sorter_list,
                         shutil.rmtree(str(output_folder))
 
             params = sorter_params.get(sorter_name, {})
+            docker_image = docker_images.get(sorter_name, None)
+            
             if need_dump:
                 if not recording.is_dumpable:
                     raise Exception('recording not dumpable call recording.save() before')

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -45,7 +45,7 @@ _common_param_doc = """
 def run_sorter(sorter_name, recording, output_folder=None,
                remove_existing_folder=True, delete_output_folder=False,
                verbose=False, raise_error=True, docker_image=None,
-               **sorter_params):
+               with_output=True, **sorter_params):
     """
     Generic function to run a sorter via function approach.
 
@@ -56,18 +56,19 @@ def run_sorter(sorter_name, recording, output_folder=None,
         sorting = run_sorter_local(sorter_name, recording, output_folder=output_folder,
                                    remove_existing_folder=remove_existing_folder,
                                    delete_output_folder=delete_output_folder,
-                                   verbose=verbose, raise_error=raise_error, **sorter_params)
+                                   verbose=verbose, raise_error=raise_error, with_output=with_output, **sorter_params)
     else:
         sorting = run_sorter_docker(sorter_name, recording, docker_image, output_folder=output_folder,
                                     remove_existing_folder=remove_existing_folder,
                                     delete_output_folder=delete_output_folder,
-                                    verbose=verbose, raise_error=raise_error, **sorter_params)
+                                    verbose=verbose, raise_error=raise_error, 
+                                    with_output=with_output, **sorter_params)
     return sorting
 
 
 def run_sorter_local(sorter_name, recording, output_folder=None,
                      remove_existing_folder=True, delete_output_folder=False,
-                     verbose=False, raise_error=True, **sorter_params):
+                     verbose=False, raise_error=True, with_output=True, **sorter_params):
     if isinstance(recording, list):
         raise Exception('You you want to run several sorters/recordings use run_sorters(...)')
 
@@ -78,7 +79,10 @@ def run_sorter_local(sorter_name, recording, output_folder=None,
     SorterClass.set_params_to_folder(recording, output_folder, sorter_params, verbose)
     SorterClass.setup_recording(recording, output_folder, verbose=verbose)
     SorterClass.run_from_folder(output_folder, raise_error, verbose)
-    sorting = SorterClass.get_result_from_folder(output_folder)
+    if with_output:
+        sorting = SorterClass.get_result_from_folder(output_folder)
+    else:
+        return
 
     if delete_output_folder:
         shutil.rmtree(output_folder)
@@ -137,7 +141,7 @@ def modify_input_folder(d, input_folder):
 
 def run_sorter_docker(sorter_name, recording, docker_image, output_folder=None,
                       remove_existing_folder=True, delete_output_folder=False,
-                      verbose=False, raise_error=True, **sorter_params):
+                      verbose=False, raise_error=True, with_output=True, **sorter_params):
     import docker
 
     if output_folder is None:
@@ -256,10 +260,14 @@ run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
         os.remove(parent_folder / 'in_docker_sorter_script.py')
         raise SpikeSortingError(f"Spike sorting in docker failed with the following error:\n{e}")
 
-    sorting = SorterClass.get_result_from_folder(output_folder)
+    if with_output:
+        sorting = SorterClass.get_result_from_folder(output_folder)
 
-    if delete_output_folder:
-        shutil.rmtree(output_folder)
+        if delete_output_folder:
+            shutil.rmtree(output_folder)
+
+    else:
+        return
 
     return sorting
 

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -247,7 +247,7 @@ run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
         # flush whatever is in the stdout
         sys.stdout.flush()
     try:
-        res = client.containers.run(docker_image, command=command, volumes=volumes, stdout=verbose,
+        res = client.containers.run(docker_image, command=command, volumes=volumes, 
                                     **extra_kwargs)
         # clean useless files
         os.remove(parent_folder / 'in_docker_recording.json')

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -258,7 +258,10 @@ run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
         os.remove(parent_folder / 'in_docker_recording.json')
         os.remove(parent_folder / 'in_docker_params.json')
         os.remove(parent_folder / 'in_docker_sorter_script.py')
-        raise SpikeSortingError(f"Spike sorting in docker failed with the following error:\n{e}")
+        if raise_error:
+            raise SpikeSortingError(f"Spike sorting in docker failed with the following error:\n{e}")
+        else:
+            return
 
     if with_output:
         sorting = SorterClass.get_result_from_folder(output_folder)


### PR DESCRIPTION
When launching run_sorters in a study, one should not collect outputs, such that if there is a crash of any sorters, the loop keeps working. Plus, this is redondant with copy_sorters()