### PR TITLE
Load maxwell electrode as property

### DIFF
--- a/spikeinterface/extractors/neoextractors/maxwell.py
+++ b/spikeinterface/extractors/neoextractors/maxwell.py
@@ -35,6 +35,7 @@ class MaxwellRecordingExtractor(NeoBaseRecordingExtractor):
         rec_name = self.neo_reader.rec_name
         probe = pi.read_maxwell(file_path, well_name=well_name, rec_name=rec_name)
         self.set_probe(probe, in_place=True)
+        self.set_property("electrode", self.get_property("contact_vector")["electrode"])
         self._kwargs = dict(file_path=str(file_path), stream_id=stream_id, rec_name=rec_name)
 
 


### PR DESCRIPTION
depends on `probeinterface==0.2.5` (https://github.com/SpikeInterface/probeinterface/pull/68)