### PR TITLE
Fix reading of legacy OpenEphys recording format

### DIFF
--- a/spikeinterface/extractors/neoextractors/openephys.py
+++ b/spikeinterface/extractors/neoextractors/openephys.py
@@ -103,7 +103,7 @@ def read_openephys(folder_path, **kwargs):
     """
     # auto guess format
     files = [str(f) for f in Path(folder_path).iterdir()]
-    if np.any([f.startswith('Continuous') for f in files]):
+    if np.any([f.endswith('continuous') for f in files]):
         #  format = 'legacy'
         recording = OpenEphysLegacyRecordingExtractor(folder_path, **kwargs)
     else:


### PR DESCRIPTION
Previously in the version 0.90, only new binary openephys format could be loaded. The legacy format were detected as new one. The problem came from this if condition.