### PR TITLE
[DOC] - Typo fixes on documentation & examples

### DIFF
--- a/doc/implement_spike_sorter.rst
+++ b/doc/implement_spike_sorter.rst
@@ -1,5 +1,5 @@
 Implement a spike sorter
---------------------------
+------------------------
 
 Implementing a new spike sorter for a specific file format is as simple as creating a new
 subclass based on the predefined base class :code:`BaseSorter`.
@@ -87,7 +87,7 @@ Now you can start filling out the required methods:
     @classmethod
     def _check_params(cls, recording, output_folder, params):
         # optional
-        # can be implemented in subclass for custum checks
+        # can be implemented in subclass for custom checks
         return params
 
 
@@ -96,14 +96,14 @@ Now you can start filling out the required methods:
         return False
 
         #  optional
-        # can be implemented in subclass to check if the filter will be apllied
+        # can be implemented in subclass to check if the filter will be applied
 
 
     @classmethod
     def _run_from_folder(cls, output_folder, params, verbose):
 
         # Fill code to run your spike sorter based on the files created in the _setup_recording()
-        # You can run CLI commands (e.g. klusta, spykingcircus, tridescous), pure Python code (e.g. Mountainsort4,
+        # You can run CLI commands (e.g. klusta, spykingcircus, tridesclous), pure Python code (e.g. Mountainsort4,
         # Herding Spikes), or even MATLAB code (e.g. Kilosort, Kilosort2, Ironclust)
 
     @classmethod
@@ -121,8 +121,8 @@ Moreover, you have to add a launcher function like `run_XXXX()`.
 
 .. code-block:: python
 
-    def run_myspikesorter(*args, **kargs):
-        return run_sorter('myspikesorter', *args, **kargs)
+    def run_myspikesorter(*args, **kwargs):
+        return run_sorter('myspikesorter', *args, **kwargs)
 
 
 When you are done you need to write a test in **tests/test_myspikesorter.py**. In order to be tested, you can

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,7 +6,7 @@ Welcome to SpikeInterface's documentation!
 .. warning::
 
     This is the documentation for SpikeInterface (0.90.0), which breaks compatibility with version 0.13.0.
-    
+
     See the documentation for the version 0.13.0 (old API) `here <https://spikeinterface.readthedocs.io/en/0.13.0/>`_.
 
 .. image:: images/logo.png
@@ -34,7 +34,7 @@ With SpikeInterface, users can:
 
 - New SpikeInterface major release! Version 0.90.0 is out!
 
-  * breaks backward compatility with 0.10/0.11/0.12/0.13 series
+  * breaks backward compatibility with 0.10/0.11/0.12/0.13 series
   * has been released on 31st July 2021
   * is not a metapackage anymore
   * doesn't depend on spikeextractors/spiketoolkit/spikesorters/spikecomparison/spikewidgets sub-packages
@@ -45,7 +45,7 @@ With SpikeInterface, users can:
 .. toctree::
     :maxdepth: 2
     :caption: Contents:
-   
+
     overview
     installation
     getting_started/plot_getting_started.rst
@@ -64,12 +64,12 @@ For more information, please have a look at:
 - The `eLife paper <https://elifesciences.org/articles/61834>`_
 
 - 1-hour `video tutorial <https://www.youtube.com/watch?v=fvKG_-xQ4D8&t=3364s&ab_channel=NeurodataWithoutBorders>`_, recorded for the NWB User Days (Sep 2020)
-   
+
 - A collection of analysis notebook `SpikeInterface Reports <https://spikeinterface.github.io/>`_
 
 .. Indices and tables
 .. ==================
-.. 
+..
 .. * :ref:`genindex`
 .. * :ref:`modindex`
 .. * :ref:`search`

--- a/doc/install_sorters.rst
+++ b/doc/install_sorters.rst
@@ -1,10 +1,10 @@
-Installing Spike Sorters 
+Installing Spike Sorters
 ========================
 
 An important aspect of spikeinterface is the `spikeinterface.sorters` module.
 This module wraps many popular spike sorting tools.
 This means that you can run multiple sorters on the same dataset with only a few lines of code
-and through Python. 
+and through Python.
 
 These spike sorting algorithms **must be installed externally**.
 Some of theses sorters are written in Matlab, so you will also to install Matlab if you want
@@ -13,13 +13,13 @@ Some of then will also need some computing library like CUDA (Kilosort, Kilosort
 opencl (Tridesclous) to use hardware acceleration (GPU).
 
 Here is a list of the implemented wrappers and some instructions to install them on your local machine.
-Installation instructions are given for an **Unbuntu** platform. Please check the documentation of the different spike 
+Installation instructions are given for an **Unbuntu** platform. Please check the documentation of the different spike
 sorters to retrieve installation instructions for other operating systems.
 We use **pip** to install packages, but **conda** should also work in many cases.
 
-If you experience installation problems please directly contact the authors of theses tools or write on the 
+If you experience installation problems please directly contact the authors of theses tools or write on the
 related mailing list, google group, etc.
- 
+
 Please feel free to enhance this document with more installation tips.
 
 Herdingspikes2
@@ -69,7 +69,7 @@ Kilosort
       # or using KilosortSorter.set_kilosort_path()
 
 * See also for Matlab/cuda: https://www.mathworks.com/help/parallel-computing/gpu-support-by-release.html
-    
+
 Kilosort2
 ---------
 
@@ -122,7 +122,7 @@ pykilosort
 * Authors: Marius Pachitariu, Shashwat Sridhar, Alexander Morley, Cyril Rossant
 
 * Installation needs Matlab and cudatoolkit::
-    
+
     pip install cupy  (or pip install cupy-cudaXXX)  >>> can be quite hard
     pip install phylib, pypandic
     git clone https://github.com/MouseLand/pykilosort
@@ -164,7 +164,7 @@ SpykingCircus
 * Url: https://spyking-circus.readthedocs.io
 * Authors: Pierre Yger, Olivier Marre
 * Installation::
-      
+
         sudo apt install libmpich-dev
         pip install mpi4py
         pip install spyking-circus --no-binary=mpi4py
@@ -177,11 +177,11 @@ Tridesclous
 * Url: https://tridesclous.readthedocs.io
 * Authors: Samuel Garcia, Christophe Pouzat
 * Installation::
-        
+
         pip install tridesclous
 
 * Optional installation of opencl ICD and pyopencl for hardware acceleration::
-        
+
         sudo apt-get install beignet (optional if intel GPU)
         sudo apt-get install nvidia-opencl-XXX (optional if nvidia GPU)
         sudo apt-get install pocl-opencl-icd (optional for multi core CPU)
@@ -222,5 +222,5 @@ Yass
 * Url: https://github.com/paninski-lab/yass
 * Authors: Liam Paninski
 * Installation::
-      
+
       https://github.com/paninski-lab/yass/wiki/Installation-Local

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -34,7 +34,7 @@ from source. You also need :code:`neo` and :code:`probeinterface`:
 Requirements
 ------------
 
-spiekinterface.core itself has only a few dependencies:
+spikeinterface.core itself has only a few dependencies:
 
   * numpy
   * neo>=0.9.0

--- a/doc/module_comparison.rst
+++ b/doc/module_comparison.rst
@@ -7,7 +7,7 @@ SpikeInterface has a :comparison:`comparison` module that can be used for three 
   1. compare a spike sorting output with a ground-truth dataset
   2. compare the output of two spike sorters (symmetric comparison)
   3. compare the output of multiple spike sorters
-  
+
 
 Even if the three comparison cases share the same underlying idea (they compare spike trains!) the internal
 implementations are slightly different.
@@ -24,11 +24,11 @@ a patch or juxtacellular electrode (either **in vitro** or **in vivo**), or it c
 The comparison to ground-truth datasets is useful to benchmark spike sorting algorithms.
 
 As an example, the SpikeForest platform benchmarks the performance of several spike sorters on a variety of
-available gorund-truth datasets on a daily basis. For more detailse see
+available ground-truth datasets on a daily basis. For more details see
 `spikeforest notes <https://spikeforest.flatironinstitute.org/metrics>`_.
 
 
-This is the main workflow used to compute perfomance metrics:
+This is the main workflow used to compute performance metrics:
 
 Given:
   * **i = 1, ..., n_gt** the list ground-truth (GT) units
@@ -37,55 +37,55 @@ Given:
   * **event_counts_ST[k]** the number of spikes for each units of tested unit
 
   1. **Matching firing events**
-   
+
     For all pairs of GT unit and tested unit we first count how many
-    events are matched within a *delta_time* tolerence (0.4 ms by defualt).
-      
+    events are matched within a *delta_time* tolerance (0.4 ms by default).
+
     This gives a matrix called **match_event_count** of size *(n_gt X n_tested)*. This is an example of such matrices:
-      
+
     .. image:: images/spikecomparison_match_count.png
         :scale: 100 %
-    
+
     Note that this matrix represents the number of **true positive** (TP) spikes
     of each pair. We can also compute the number of **false negatives** (FN) and **false positive** (FP) spikes.
-    
+
       *  **num_tp** [i, k] = match_event_count[i, k]
       *  **num_fn** [i, k] = event_counts_GT[i] - match_event_count[i, k]
       *  **num_fp** [i, k] = event_counts_ST[k] - match_event_count[i, k]
 
   2. **Compute agreement score**
-   
+
     Given the **match_event_count** we can then compute the **agreement_score**, which is normalized in the range [0, 1].
 
     This is done as follows:
-    
+
       * agreement_score[i, k] = match_event_count[i, k] / (event_counts_GT[i] + event_counts_ST[k] - match_event_count[i, k])
-    
+
     which is equivalent to:
-    
+
       * agreement_score[i, k] = num_tp[i, k] / (num_tp[i, k] + num_fp[i, k] + num_fn[i,k])
-    
+
     or more practically:
-    
+
       * agreement_score[i, k] = intersection(I, K) / union(I, K)
-    
+
     which is also equivalent to the **accuracy** metric.
 
-    
+
     Here is an example of the agreement matrix, in which only scores > 0.5 are displayed:
-    
+
     .. image:: images/spikecomparison_agreement_unordered.png
         :scale: 100 %
-    
+
     This matrix can be ordered for a better visualization:
-    
+
     .. image:: images/spikecomparison_agreement.png
         :scale: 100 %
 
-    
+
 
    3. **Match units**
-   
+
       During this step, given the **agreement_score** matrix each GT units can be matched to a tested units.
       For matching, a minimum **match_score** is used (0.5 by default). If the agreement is below this threshold,
       the possible match is discarded.
@@ -96,17 +96,17 @@ Given:
       The `hungarian method <https://en.wikipedia.org/wiki/Hungarian_algorithm>`_
       finds the best association between GT and tested units. With this method, both GT and tested units can be matched
       only to another unit, or not matched at all.
-      
+
       For the **best** method, each GT unit is associated to a tested unit that has
       the **best** agreement_score, independently of all others units. Using this method
       several tested units can be associated to the same GT unit. Note that for the "best match" the minimum
       score is not the match_Score, but the **chance_score** (0.1 by default).
-      
+
       Here is an example of matching with the **hungarian** method. The first column represents the GT unit id
       and the second column the tested unit id. -1 means that the tested unit is not matched:
-      
+
       .. parsed-literal::
-      
+
           GT    TESTED
           0     49
           1     -1
@@ -118,59 +118,59 @@ Given:
           7     -1
           8     42
           ...
-      
+
       Note that the SpikeForest project uses the **best** match method.
-       
-   
+
+
    4. **Compute performances**
-   
+
       With the list of matched units we can compute performance metrics.
       Given : **tp** the number of true positive events, **fp** number of false
-      positive event, **fn** the number of false negative event, **num_gt** the number 
+      positive event, **fn** the number of false negative event, **num_gt** the number
       of event of the matched tested units, the following metrics are computed for each GT unit:
-      
+
         * accuracy = tp / (tp + fn + fp)
         * recall = tp / (tp + fn)
         * precision = tp / (tp + fp)
         * false_discovery_rate = fp / (tp + fp)
         * miss_rate = fn / num_gt
-      
+
       The overall performances can be visualised with the **confusion matrix**, where
       the last columns counts **FN** and the last row counts **FP**.
-      
+
     .. image:: images/spikecomparison_confusion.png
         :scale: 100 %
 
-    
-    
+
+
 More information about **hungarian** or **best** match methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    
-    
+
+
     * **Hungarian**:
-      
+
       Finds the best paring. If the matrix is square, then all units are associated.
       If the matrix is rectangular, then each row is matched.
       A GT unit (row) can be match one time only.
-      
+
       * Pros
-      
+
         * Each spike is counted only once
         * Hit score near chance levels are set to zero
         * Good FP estimation
-      
-      
+
+
       * Cons
-      
+
         * Does not catch units that are split in several sub-units. Only the best math will be listed
         * More complicated implementation
-    
+
     * **Best**
-    
+
         Each GT units is associated to the tested unit that has the best **agreement score**.
 
       * Pros:
-      
+
         * Each GT unit is matched totally independently from others units
         * The accuracy score of a GT unit is totally independent from other units
         * It can identify over-merged units, as they would match multiple GT units
@@ -201,7 +201,7 @@ A **redundant** unit has a relatively high agreement (>= 0.2 by default), but it
 it could either be an oversplit unit or a duplicate unit.
 
 An **over-merged** unit has a relatively high agreement (>= 0.2 by default) for more than one GT unit.
-  
+
 2. Compare the output of two spike sorters (symmetric comparison)
 ------------------------------------------------------------------
 
@@ -228,7 +228,7 @@ Comparison of multiple sorters uses the following procedure:
   3. Extract units in agreement between two or more spike sorters
   4. Build agreement spike trains, which only contain the spikes in agreement for the comparison with the highest agreement score
 
-  
-  
+
+
 
 

--- a/doc/module_sorters.rst
+++ b/doc/module_sorters.rst
@@ -76,7 +76,7 @@ In this code example, 3 sorters are run on 2 recordings using 6 jobs:
     # recording1 and recording2 are RecordingExtractor objects
     recording_dict = {"rec1": recording1, "rec2": recording2}
 
-    sorting_outputs = ss.run_sorters(sorter_list=["tridescouls", "herdingspikes", "ironclust"],
+    sorting_outputs = ss.run_sorters(sorter_list=["tridesclous", "herdingspikes", "ironclust"],
                                      recording_dict_or_list=recording_dict,
                                      working_folder="all_sorters",
                                      verbose=False,

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -1,18 +1,18 @@
 Overview
 ========
 
-Extracellular recordings are an essential source of data in experimental and clinical neuroscience. 
-Of particular interest in these recordings is the activity of single neurons which must be inferred 
-using a blind source separation procedure called spike sorting. 
+Extracellular recordings are an essential source of data in experimental and clinical neuroscience.
+Of particular interest in these recordings is the activity of single neurons which must be inferred
+using a blind source separation procedure called spike sorting.
 
-Given the importance of spike sorting, much attention has been directed towards the development of tools 
-and algorithms that can increase its performance and automation. These developments, however, introduce new challenges 
+Given the importance of spike sorting, much attention has been directed towards the development of tools
+and algorithms that can increase its performance and automation. These developments, however, introduce new challenges
 in software and file format incompatibility which reduce interoperability, hinder benchmarking, and preclude reproducible analysis.
 
-To address these limitations, we developed **SpikeInterface**, a Python framework designed to unify preexisting spike sorting technologies 
-into a single code base and to standardize extracellular data file handling. With a few lines of code, users can run, compare, and benchmark 
-most modern spike sorting algorithms; pre-process, post-process, and visualize extracellular datasets; validate, curate, and export sorted results; 
-and more, regardless of the underlying data format. 
+To address these limitations, we developed **SpikeInterface**, a Python framework designed to unify preexisting spike sorting technologies
+into a single code base and to standardize extracellular data file handling. With a few lines of code, users can run, compare, and benchmark
+most modern spike sorting algorithms; pre-process, post-process, and visualize extracellular datasets; validate, curate, and export sorted results;
+and more, regardless of the underlying data format.
 
 In the following documentation, we provide an overview of SpikeInterface.
 
@@ -22,7 +22,7 @@ Organization
 
 SpikeInterface consists of 5 main sub-packages which encapsulate all steps in a typical spike sorting pipeline:
 
-- spikeinterface.extrtactors
+- spikeinterface.extractors
 - spikeinterface.toolkit
 - spikeinterface.sorters
 - spikeinterface.comparisons
@@ -30,7 +30,7 @@ SpikeInterface consists of 5 main sub-packages which encapsulate all steps in a 
 
 
 Contrary to the previous version (<0.90.0), :code:`spikeinterface` is now one unique package.
-Before that, :code:`spikeinterface` was a metapacage that depended on 5 independent package.
+Before that, :code:`spikeinterface` was a metapackage that depended on 5 independent packages.
 
 .. image:: images/overview.png
 
@@ -41,8 +41,8 @@ Related projects
 - `probeinterface <https://github.com/SpikeInterface/probeinterface>`_ is a python package to define and handle neural
    probes and the wiring to recording devices.
 - `spikeforest <https://spikeforest.flatironinstitute.org>`_ is a reproducible, continuously updating platform which
-  benchmarks the performance of some spike sorting software (kilosort, herdingspike, ironcliust, jrclust, klusta,
-  moutainsort4, spykingcircus, tridesclous, waveclus) using many ground-truth datasets. The processing engine is based
+  benchmarks the performance of some spike sorting software (kilosort, herdingspike, ironclust, jrclust, klusta,
+  mountainsort4, spykingcircus, tridesclous, waveclus) using many ground-truth datasets. The processing engine is based
   on SpikeInterface.
 - `spikely <https://github.com/SpikeInterface/spikely>`_ is a graphical user interface (GUI) that allows users to build
   and run SpikeInterface spike sorting pipelines on extracellular datasets.

--- a/doc/supported_formats_and_sorters.rst
+++ b/doc/supported_formats_and_sorters.rst
@@ -31,7 +31,7 @@ For raw data formats, we currently support:
 * **Neuroscope** - NeuroscopeRecordingExtractor
 * **NIX** - NIXIORecordingExtractor
 * **Neuralynx** - NeuralynxRecordingExtractor
-* **Open Ephys Leagacy** - OpenEphysLegacyRecordingExtractor
+* **Open Ephys Legacy** - OpenEphysLegacyRecordingExtractor
 * **Open Ephys Binary** - OpenEphysBinaryRecordingExtractor
 * **Phy/Kilosort** - PhyRecordingExtractor/KilosortRecordingExtractor
 * **Plexon** - PlexonRecordingExtractor
@@ -80,7 +80,7 @@ Then you can check the installed RecordingExtractor list,
 .. code:: python
 
   se.installed_recording_extractor_list
-  
+
 which outputs,
 
 .. parsed-literal::
@@ -88,7 +88,7 @@ which outputs,
    spikeinterface.extractorsBiocamRecordingExtractor,
    spikeinterface.core..BinaryRecordingExtractor,
    ...
-   
+
 and the installed SortingExtractors list,
 
 .. code:: python
@@ -101,7 +101,7 @@ which outputs,
   [spikeinterface.extractors.SpykingCircusSortingExtractor,
    spikeinterface.extractors.HerdingspikesSortingExtractor,
    ...
- 
+
 When trying to use an extractor that has not been installed in your environment, an installation message will appear indicating which python packages must be installed as a prerequisite to using the extractor,
 
 .. code:: python
@@ -118,7 +118,7 @@ throws the error,
 
   pip install MEARec
 
-  
+
 Dealing with Non-Supported File Formats
 =======================================
 
@@ -131,7 +131,7 @@ Once instantiated, the NumpyRecordingExtractor can be used like any other Record
 The NumpySortingExtractor does not need any data during instantiation. However, after instantiation, it can be filled with data using its built-in functions (load_from_extractor, set_times_labels, and add_unit).
 After sorted data is added to the NumpySortingExtractor, it can be used like any other SortingExtractor.
 
-With these two objects, we hope that any user can access SpikeInterface regardless of the nature of their underlying file format. If you feel like a non-supported file format should be included in SpikeInterface as 
+With these two objects, we hope that any user can access SpikeInterface regardless of the nature of their underlying file format. If you feel like a non-supported file format should be included in SpikeInterface as
 an actual extractor, please leave an issue in the spikeextractors repository.
 
 Supported Spike Sorters
@@ -173,7 +173,7 @@ Then you can check the installed Sorter list,
 .. code:: python
 
   ss.installed_sorters()
-  
+
 which outputs,
 
 .. parsed-literal::
@@ -194,7 +194,7 @@ throws the error,
 
 .. parsed-literal::
   AssertionError: This sorter ironclust is not installed.
-        Please install it with:  
+        Please install it with:
 
   To use IronClust run:
 

--- a/examples/getting_started/plot_getting_started.py
+++ b/examples/getting_started/plot_getting_started.py
@@ -12,12 +12,12 @@ import matplotlib.pyplot as plt
 
 ##############################################################################
 # The spikeinterface module by itself import only the spikeinterface.core submodule
-# which is not usefull for end user
+# which is not useful for end user
 
 import spikeinterface
 
 ##############################################################################
-# We need to import one by one different submodules separately (preferred). 
+# We need to import one by one different submodules separately (preferred).
 # There are 5 modules:
 #
 # - :code:`extractors` : file IO
@@ -37,7 +37,7 @@ import spikeinterface.widgets as sw
 #  We can also import all submodules at once with this
 #   this internally import core+extractors+toolkit+sorters+comparison+widgets+exporters
 #
-# This is usefull for notbooks but this is a more heavy import because internally many more dependency
+# This is useful for notebooks but this is a more heavy import because internally many more dependency
 # are imported (scipy/sklearn/networkx/matplotlib/h5py...)
 
 import spikeinterface.full as si
@@ -106,8 +106,8 @@ plot_probe(probe)
 
 ##############################################################################
 # Using the :code:`toolkit`, you can perform preprocessing on the recordings.
-# Each pre-processing function also returns a :code:`RecordingExtractor`, 
-# which makes it easy to build pipelines. Here, we filter the recording and 
+# Each pre-processing function also returns a :code:`RecordingExtractor`,
+# which makes it easy to build pipelines. Here, we filter the recording and
 # apply common median reference (CMR).
 # All theses preprocessing steps are "lazy". The computation is done on demand when we call
 # `recording.get_traces(...)` or when we save the object to disk.
@@ -217,7 +217,7 @@ print(isi_violations_rate)
 print(isi_violations_count)
 
 ##############################################################################
-# All theses quality mertics can be computed in one shot and returned as
+# All theses quality metrics can be computed in one shot and returned as
 # a :code:`pandas.Dataframe`
 
 metrics = st.compute_quality_metrics(we_TDC, metric_names=['snr', 'isi_violation', 'amplitude_cutoff'])
@@ -225,7 +225,7 @@ print(metrics)
 
 ##############################################################################
 # Quality metrics can be also used to automatically curate the spike sorting
-# output. For example, you can select sorted units with a SNR above a 
+# output. For example, you can select sorted units with a SNR above a
 # certain threshold:
 
 keep_mask = (metrics['snr'] > 7.5) & (metrics['isi_violations_rate'] < 0.01)
@@ -239,7 +239,7 @@ print(curated_sorting)
 
 ##############################################################################
 # The final part of this tutorial deals with comparing spike sorting outputs.
-# We can either (1) compare the spike sorting results with the ground-truth 
+# We can either (1) compare the spike sorting results with the ground-truth
 # sorting :code:`sorting_true`, (2) compare the output of two (HerdingSpikes
 # and Tridesclous), or (3) compare the output of multiple sorters:
 

--- a/examples/modules/comparison/generate_erroneous_sorting.py
+++ b/examples/modules/comparison/generate_erroneous_sorting.py
@@ -13,18 +13,18 @@ import spikeinterface.widgets as sw
 
 def generate_erroneous_sorting():
     rec, sorting_true = se.toy_example(num_channels=4, num_units=10, duration=10, seed=10, num_segments=1)
-    
-    # artificilaly remap to one based
+
+    # artificially remap to one based
     sorting_true = sorting_true.select_units(unit_ids=None,
                 renamed_unit_ids=np.arange(10, dtype='int64')+1)
-    
+
     sampling_frequency = sorting_true.get_sampling_frequency()
-    
+
     units_err = {}
-    
+
     # sorting_true have 10 units
     np.random.seed(0)
-    
+
     # unit 1 2 are perfect
     for u in [1, 2]:
         st = sorting_true.get_unit_spike_train(u)
@@ -35,14 +35,14 @@ def generate_erroneous_sorting():
         st = sorting_true.get_unit_spike_train(u)
         st = np.sort(np.random.choice(st, size=int(st.size*score), replace=False))
         units_err[u] = st
-    
+
     # unit 5 6 are over merge
     st5 = sorting_true.get_unit_spike_train(5)
     st6 = sorting_true.get_unit_spike_train(6)
     st = np.unique(np.concatenate([st5, st6]))
     st = np.sort(np.random.choice(st, size=int(st.size*0.7), replace=False))
     units_err[56] = st
-    
+
     # unit 7 is over split in 2 part
     st7 = sorting_true.get_unit_spike_train(7)
     st70 = st7[::2]
@@ -50,7 +50,7 @@ def generate_erroneous_sorting():
     st71 = st7[1::2]
     st71 = np.sort(np.random.choice(st71, size=int(st71.size*0.9), replace=False))
     units_err[71] = st71
-    
+
     # unit 8 is redundant 3 times
     st8 = sorting_true.get_unit_spike_train(8)
     st80 = np.sort(np.random.choice(st8, size=int(st8.size*0.65), replace=False))
@@ -59,22 +59,22 @@ def generate_erroneous_sorting():
     units_err[80] = st80
     units_err[81] = st81
     units_err[81] = st82
-    
+
     # unit 9 is missing
-    
+
     # there are some units that do not exist 15 16 and 17
     nframes = rec.get_num_frames(segment_index=0)
     for u in [15,16,17]:
         st = np.sort(np.random.randint(0, high=nframes, size=35))
         units_err[u] = st
     sorting_err = se.NumpySorting.from_dict(units_err, sampling_frequency)
-    
-    
+
+
     return sorting_true, sorting_err
-    
 
 
-    
+
+
 if __name__ == '__main__':
     # just for check
     sorting_true, sorting_err = generate_erroneous_sorting()

--- a/examples/modules/comparison/plot_1_compare_two_sorters.py
+++ b/examples/modules/comparison/plot_1_compare_two_sorters.py
@@ -31,7 +31,7 @@ print(sorting)
 
 
 #############################################################################
-# Then run two spike sorters and compare their ouput.
+# Then run two spike sorters and compare their output.
 
 sorting_HS = ss.run_herdingspikes(recording)
 sorting_TDC = ss.run_tridesclous(recording)
@@ -45,7 +45,7 @@ sorting_TDC = ss.run_tridesclous(recording)
 # 
 # Let’s see how to inspect and access this matching.
 
-cmp_HS_TDC = sc.compare_two_sorters(sorting1=sorting_HS, sorting2=sorting_TDC, 
+cmp_HS_TDC = sc.compare_two_sorters(sorting1=sorting_HS, sorting2=sorting_TDC,
                                                sorting1_name='HS', sorting2_name='TDC')
 
 #############################################################################

--- a/examples/modules/comparison/plot_2_compare_multiple_sorters.py
+++ b/examples/modules/comparison/plot_2_compare_multiple_sorters.py
@@ -130,7 +130,7 @@ ax.plot(st2, 2 * np.ones(st2.size), '|')
 ax.plot(st3, 3 * np.ones(st3.size), '|')
 
 print('mountainsort4 spike train length', st0.size)
-print('herdingsspieks spike train length', st1.size)
+print('herdingspikes spike train length', st1.size)
 print('Tridesclous spike train length', st2.size)
 print('Agreement spike train length', st3.size)
 

--- a/examples/modules/comparison/plot_3_compare_sorter_with_ground_truth.py
+++ b/examples/modules/comparison/plot_3_compare_sorter_with_ground_truth.py
@@ -60,26 +60,26 @@ sw.plot_agreement_matrix(cmp_gt_HS, ordered=True)
 ##############################################################################
 # This function first matches the ground-truth and spike sorted units, and
 # then it computes several performance metrics.
-# 
-# Once the spike trains are matched, each spike is labelled as: 
-# 
+#
+# Once the spike trains are matched, each spike is labeled as:
+#
 # - true positive (tp): spike found both in :code:`gt_sorting` and :code:`tested_sorting`
-# - false negative (fn): spike found in :code:`gt_sorting`, but not in :code:`tested_sorting` 
-# - false positive (fp): spike found in :code:`tested_sorting`, but not in :code:`gt_sorting` 
-# 
+# - false negative (fn): spike found in :code:`gt_sorting`, but not in :code:`tested_sorting`
+# - false positive (fp): spike found in :code:`tested_sorting`, but not in :code:`gt_sorting`
+#
 # From the counts of these labels the following performance measures are
 # computed:
-# 
+#
 # -  accuracy: #tp / (#tp+ #fn + #fp)
 # -  recall: #tp / (#tp + #fn)
 # -  precision: #tp / (#tp + #fn)
 # -  miss rate: #fn / (#tp + #fn1)
 # -  false discovery rate: #fp / (#tp + #fp)
-# 
+#
 # The :code:`get_performance` method a pandas dataframe (or a dictionary if
 # :code:`output='dict'`) with the comparison metrics. By default, these are
 # calculated for each spike train of :code:`sorting1:code:`, the results can be
-# pooles by average (average of the metrics) and by sum (all counts are
+# pooled by average (average of the metrics) and by sum (all counts are
 # summed and the metrics are computed then).
 
 perf = cmp_gt_HS.get_performance()

--- a/examples/modules/comparison/plot_4_ground_truth_study.py
+++ b/examples/modules/comparison/plot_4_ground_truth_study.py
@@ -10,7 +10,7 @@ The submodule study and the class  propose high level tools functions
 to run many groundtruth comparison with many sorter on many recordings
 and then collect and aggregate results in an easy way.
 
-The all mechanism is based on an intrinsinct organisation
+The all mechanism is based on an intrinsic organization
 into a "study_folder" with several subfolder:
 
 * raw_files : contain a copy in binary format of recordings
@@ -19,8 +19,8 @@ into a "study_folder" with several subfolder:
 * sortings: contains light copy of all sorting in npz format
 * tables: some table in cvs format
 
-In order to run and re run the computation all gt_sorting anf
-recordings are copied to a fast and universal format : 
+In order to run and re run the computation all gt_sorting and
+recordings are copied to a fast and universal format :
 binary (for recordings) and npz (for sortings).
 """
 
@@ -37,7 +37,7 @@ from spikeinterface.comparison import GroundTruthStudy
 ##############################################################################
 # Setup study folder and run all sorters
 # --------------------------------------
-# 
+#
 # We first generate the folder.
 # this can take some time because recordings are copied inside the folder.
 
@@ -60,7 +60,7 @@ study.run_sorters(sorter_list, mode_if_folder_exists="keep")
 
 ##############################################################################
 # You can re run **run_study_sorters** as many time as you want.
-# By default **mode='keep'** so only uncomputed sorter are rerun.
+# By default **mode='keep'** so only uncomputed sorters are rerun.
 # For instance, so just remove the "sorter_folders/rec1/herdingspikes" to re-run
 # only one sorter on one recording.
 #
@@ -75,9 +75,9 @@ study.copy_sortings()
 #  
 # You can collect in one shot all results and run the
 # GroundTruthComparison on it.
-# So you can acces finely to all individual results.
+# So you can access finely to all individual results.
 #  
-# Note that exhaustive_gt=True when you excatly how many
+# Note that exhaustive_gt=True when you exactly how many
 # units in ground truth (for synthetic datasets)
 
 study.run_comparisons(exhaustive_gt=True)
@@ -96,7 +96,7 @@ for (rec_name, sorter_name), comp in study.comparisons.items():
 ##############################################################################
 # Collect synthetic dataframes and display
 # ----------------------------------------
-# 
+#
 # As shown previously, the performance is returned as a pandas dataframe.
 # The :code:`aggregate_performances_table` function, gathers all the outputs in
 # the study folder and merges them in a single dataframe.

--- a/examples/modules/comparison/plot_5_comparison_sorter_weaknesses.py
+++ b/examples/modules/comparison/plot_5_comparison_sorter_weaknesses.py
@@ -2,7 +2,7 @@
 Explore sorters weaknesses with with ground-truth comparison
 =============================================================
 
-Here a syntetic dataset will demonstrate some weaknesses.
+Here a synthetic dataset will demonstrate some weaknesses.
 
 Standard weaknesses :
 
@@ -13,11 +13,11 @@ Standard weaknesses :
 Other weaknesses:
 
   * detect too many units (false positive units)
-  * detect units twice (or more) (reduntant units = oversplit units)
+  * detect units twice (or more) (redundant units = oversplit units)
   * several units are merged into one units (overmerged units)
 
 
-To demonstarte this the script `generate_erroneous_sorting.py` generate a ground truth sorting with 10 units.
+To demonstrate this the script `generate_erroneous_sorting.py` generate a ground truth sorting with 10 units.
 We duplicate the results and modify it a bit to inject some "errors":
 
   * unit 1 2 are perfect
@@ -49,7 +49,7 @@ from generate_erroneous_sorting import generate_erroneous_sorting
 
 
 ##############################################################################
-# Here the agreement matrix 
+# Here the agreement matrix
 
 sorting_true, sorting_err = generate_erroneous_sorting()
 comp = sc.compare_sorter_to_ground_truth(sorting_true, sorting_err, exhaustive_gt=True)
@@ -90,7 +90,7 @@ print('bad', comp.get_bad_units())
 
 
 ##############################################################################
-# There is a convinient function to summary everything.
+# There is a convenient function to summary everything.
 
 comp.print_summary(well_detected_score=0.75, redundant_score=0.2, overmerged_score=0.2)
 

--- a/examples/modules/core/plot_1_recording_extractor.py
+++ b/examples/modules/core/plot_1_recording_extractor.py
@@ -69,7 +69,7 @@ recording = recording.set_probe(probe)
 plot_probe(probe)
 
 ##############################################################################
-# Some extractors also implement a :code:`write` function. 
+# Some extractors also implement a :code:`write` function.
 
 file_paths = ['traces0.raw', 'traces1.raw']
 se.BinaryRecordingExtractor.write_recording(recording, file_paths)
@@ -77,7 +77,7 @@ se.BinaryRecordingExtractor.write_recording(recording, file_paths)
 ##############################################################################
 # We can read the written recording back with the proper extractor.
 # Note that this new recording is now "on disk" and not "in memory" as the Numpy recording.
-# This meand that the loading is "lazy" and the data are not loaded in memory.
+# This means that the loading is "lazy" and the data are not loaded in memory.
 
 recording2 = se.BinaryRecordingExtractor(file_paths, sampling_frequency, num_channels, traces0.dtype)
 print(recording2)
@@ -93,7 +93,7 @@ print(traces0.shape)
 print(traces1_short.shape)
 
 ##############################################################################
-# A recording internaly has :code:`channel_ids`: these are a vector that can have
+# A recording internally has :code:`channel_ids`: these are a vector that can have
 # dtype int or str:
 
 print('chan_ids (dtype=int):', recording.get_channel_ids())
@@ -117,7 +117,7 @@ recording4 = recording3.channel_slice(channel_ids=['a', 'c', 'e'])
 print(recording4)
 print(recording4.get_channel_ids())
 
-# which is equivalent to 
+# which is equivalent to
 from spikeinterface import ChannelSliceRecording
 
 recording4 = ChannelSliceRecording(recording3, channel_ids=['a', 'c', 'e'])
@@ -138,7 +138,7 @@ print(recordings[2].get_channel_ids())
 #  * a dict
 #  * a json file
 #  * a pickle file
-# 
+#
 # The "dump" operation is lazy, i.e., the traces are not exported.
 # Only the information about how to reconstruct the recording are dumped:
 

--- a/examples/modules/core/plot_3_handle_probe_info.py
+++ b/examples/modules/core/plot_3_handle_probe_info.py
@@ -47,7 +47,7 @@ plot_probe(recording_2_shanks.get_probe())
 
 ###############################################################################
 # Now let's check what we have loaded. The `group_mode='by_shank'` automatically
-# seta the 'group' property depending on the shank id.
+# set the 'group' property depending on the shank id.
 # We can use this information to split the recording in two sub recordings:
 
 print(recording_2_shanks)

--- a/examples/modules/core/plot_4_waveform_extractor.py
+++ b/examples/modules/core/plot_4_waveform_extractor.py
@@ -9,7 +9,7 @@ The `WaveformExtractor` class:
   * randomly samples a subset spikes with max_spikes_per_unit
   * extracts all waveforms snippets for each unit
   * saves waveforms in a local folder
-  * can load stored waforms
+  * can load stored waveforms
   * retrieves template (average or median waveform) for each unit
 
 Here the how!
@@ -39,7 +39,7 @@ sorting = se.MEArecSortingExtractor(local_path)
 print(recording)
 
 ###############################################################################
-# The MEArec dataset already contains a probe object that you can retreive
+# The MEArec dataset already contains a probe object that you can retrieve
 # an plot:
 
 probe = recording.get_probe()
@@ -59,7 +59,7 @@ we = extract_waveforms(recording, sorting, folder,
 print(we)
 
 ###############################################################################
-# Alternativelt, the :code:`WaveformExtractor` object can be instantiated
+# Alternatively, the :code:`WaveformExtractor` object can be instantiated
 # directly. In this case, we need to :code:`set_params()` to set the desired
 # parameters:
 

--- a/examples/modules/core/plot_5_append_concatenate_segments.py
+++ b/examples/modules/core/plot_5_append_concatenate_segments.py
@@ -11,7 +11,7 @@ Similarly to `NEO <https://github.com/NeuralEnsemble/python-neo>`_ we define eac
   1. append_recordings()/append_sortings()/append_events()
   2. concatenate_recordings()/ concatenate_sortings()/ concatenate_events()
 
-Here is the differemce. Imagine we have 2 recordings with 2 and 3 segments respectively:
+Here is the difference. Imagine we have 2 recordings with 2 and 3 segments respectively:
 
   1. In case 1. (append) we will end up with one recording with 5 segments.
   2. In case 2. (concatenate) we will end up with one recording with 1 "big" segment

--- a/examples/modules/extractors/plot_1_read_various_formats.py
+++ b/examples/modules/extractors/plot_1_read_various_formats.py
@@ -4,7 +4,7 @@ Read various format into SI
 
 :code:`spikeinterface` can read various format of "recording" (traces) and "sorting" (spike train) data.
 
-Internally, to read differents formats, :code:`spikeinterface` either uses:
+Internally, to read different formats, :code:`spikeinterface` either uses:
   * a wrapper to the `neo <https://github.com/NeuralEnsemble/python-neo>`_ rawio classes
   * or a direct implementation
 
@@ -22,7 +22,7 @@ import spikeinterface as si
 import spikeinterface.extractors as se
 
 ##############################################################################
-# Let's download some datasets in differents formats from the
+# Let's download some datasets in different formats from the
 # `ephy_testing_data <https://gin.g-node.org/NeuralEnsemble/ephy_testing_data>`_ repo:
 #   * MEArec: an simulator format which is hdf5-based. It contains both a "recording" and a "sorting" in the same file.
 #   * Spike2: file from spike2 devices. It contains "recording" information only.
@@ -35,7 +35,7 @@ mearec_folder_path = si.download_dataset(remote_path='mearec/mearec_test_10s.h5'
 print(mearec_folder_path)
 
 ##############################################################################
-# Now that we have downloaded the files ww need let's load them into SI.
+# Now that we have downloaded the files let's load them into SI.
 #
 # The :code:`read_spike2` function returns one object, a :code:`RecordingExtractor`.
 #

--- a/examples/modules/sorters/plot_1_sorters_example.py
+++ b/examples/modules/sorters/plot_1_sorters_example.py
@@ -33,7 +33,7 @@ pprint(ss.installed_sorters())
 ##############################################################################
 # Change sorter parameters
 # -----------------------------------
-# 
+#
 
 default_TDC_params = ss.TridesclousSorter.default_params()
 pprint(default_TDC_params)

--- a/examples/modules/sorters/plot_2_using_the_launcher.py
+++ b/examples/modules/sorters/plot_2_using_the_launcher.py
@@ -11,7 +11,7 @@ import spikeinterface.extractors as se
 import spikeinterface.sorters as ss
 
 ##############################################################################
-# First, let's create the usueal toy example:
+# First, let's create the usual toy example:
 
 recording, sorting_true = se.toy_example(duration=10, seed=0, num_segments=1)
 print(recording)

--- a/examples/modules/sorters/plot_3_sorting_by_group.py
+++ b/examples/modules/sorters/plot_3_sorting_by_group.py
@@ -67,7 +67,7 @@ recordings = recording_4_tetrodes.split_by(property='group')
 print(recordings)
 
 ##############################################################################
-# We can also get a dict instead of the list wich is easier to handle group keys.
+# We can also get a dict instead of the list which is easier to handle group keys.
 
 recordings = recording_4_tetrodes.split_by(property='group', outputs='dict')
 print(recordings)
@@ -75,8 +75,8 @@ print(recordings)
 
 ##############################################################################
 # We can now use the `run_sorters()` function instead of the `run_sorter()`.
-# This function can run several sorters on serveral recording with diffrents parralell engine.
-#  here we use imple 'loop' but we could use also  'joblib' or 'dask' for multi process or multi node computing.
+# This function can run several sorters on several recording with different parallel engines.
+#  here we use engine 'loop' but we could use also  'joblib' or 'dask' for multi process or multi node computing.
 #  have a look to the documentation of this function that handle many cases.
 
 sorter_list = ['tridesclous']
@@ -85,7 +85,7 @@ results = ss.run_sorters(sorter_list, recordings, working_folder,
             engine='loop', with_output=True, mode_if_folder_exists='overwrite')
 
 ##############################################################################
-#  the ouput is a dict with all combinason of (group, sorter_name)
+#  the output is a dict with all combinations of (group, sorter_name)
 
 from pprint import pprint
 pprint(results)

--- a/examples/modules/sorters/plot_4_sorting_concatenated_recordings.py
+++ b/examples/modules/sorters/plot_4_sorting_concatenated_recordings.py
@@ -31,7 +31,7 @@ import spikeinterface.full as si
 recording_single, _ = si.toy_example(duration=10, num_channels=4, dumpable=True, num_segments=1)
 print(recording_single)
 
-# make dimpable
+# make dumpable
 recording_single = recording_single.save()
 
 ##############################################################################

--- a/examples/modules/widgets/plot_1_rec_gallery.py
+++ b/examples/modules/widgets/plot_1_rec_gallery.py
@@ -39,7 +39,7 @@ w_ts.figure.suptitle("Recording by group")
 w_ts.ax.set_ylabel("Channel_ids")
 
 ##############################################################################
-# We can also use the 'map' mode uselfull for high channel count
+# We can also use the 'map' mode useful for high channel count
 
 w_ts = sw.plot_timeseries(recording, mode='map', time_range=(5, 8),
         show_channel_ids=True, order_channel_by_depth=True)

--- a/examples/modules/widgets/plot_3_waveforms_gallery.py
+++ b/examples/modules/widgets/plot_3_waveforms_gallery.py
@@ -23,8 +23,8 @@ print(sorting)
 ##############################################################################
 # Extract spike waveforms
 # -----------------------
-# 
-# For convinience metris are computed on the WaveformExtractor object that gather recording/sorting and
+#
+# For convenience, metrics are computed on the WaveformExtractor object that gather recording/sorting and
 # extracted waveforms in a single object
 
 folder = 'waveforms_mearec'
@@ -61,7 +61,7 @@ sw.plot_unit_probe_map(we, unit_ids=unit_ids)
 ##############################################################################
 # plot_unit_waveform_density_map()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# 
+#
 # This is your best friend to check over merge
 
 unit_ids = sorting.unit_ids[:4]


### PR DESCRIPTION
I was reading through the documentation & examples for the new version of SpikeInterface, and noticed a few typos, etc, 
so I thought I'd do a quick sweep and offer a fix for them. 

Note: I only meant to fix the typos, but I noticed on the diffs that a setting in my text editor has also removed trailing whitespace - sorry if that's annoying. 