### PR TITLE
refactor waveform template cache : add disk persistency

### DIFF
--- a/examples/modules/core/plot_4_waveform_extractor.py
+++ b/examples/modules/core/plot_4_waveform_extractor.py
@@ -66,7 +66,7 @@ print(we)
 folder = 'waveform_folder2'
 we = WaveformExtractor.create(recording, sorting, folder, remove_if_exists=True)
 we.set_params(ms_before=3., ms_after=4., max_spikes_per_unit=1000)
-we.run(n_jobs=1, chunk_size=30000, progress_bar=True)
+we.run_extract_waveforms(n_jobs=1, chunk_size=30000, progress_bar=True)
 print(we)
 
 ###############################################################################

--- a/spikeinterface/comparison/groundtruthstudy.py
+++ b/spikeinterface/comparison/groundtruthstudy.py
@@ -209,7 +209,7 @@ class GroundTruthStudy:
             shutil.rmtree(waveform_folder)
         we = WaveformExtractor.create(rec, gt_sorting, waveform_folder)
         we.set_params(ms_before=ms_before, ms_after=ms_after, max_spikes_per_unit=max_spikes_per_unit)
-        we.run(n_jobs=n_jobs, total_memory=total_memory)
+        we.run_extract_waveforms(n_jobs=n_jobs, total_memory=total_memory)
 
         # metrics
         metrics = compute_quality_metrics(we, metric_names=metric_names)

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -46,8 +46,8 @@ def test_WaveformExtractor():
 
     we.set_params(ms_before=3., ms_after=4., max_spikes_per_unit=500)
 
-    we.run(n_jobs=1, chunk_size=30000)
-    we.run(n_jobs=4, chunk_size=30000, progress_bar=True)
+    we.run_extract_waveforms(n_jobs=1, chunk_size=30000)
+    we.run_extract_waveforms(n_jobs=4, chunk_size=30000, progress_bar=True)
 
     wfs = we.get_waveforms(0)
     assert wfs.shape[0] <= 500
@@ -177,6 +177,7 @@ def test_sparsity():
 
 
 if __name__ == '__main__':
+    setup_module()
     test_WaveformExtractor()
-    # test_extract_waveforms()
-    # test_sparsity()
+    test_extract_waveforms()
+    test_sparsity()

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -70,15 +70,9 @@ def test_WaveformExtractor():
     wfs_std = we.get_all_templates(mode='std')
     assert wfs_std.shape == (5, 210, 2)
 
-    wf_qnt = we.get_template(0, mode='quantile', quantile_value=0.9)
-    assert wf_qnt.shape == (210, 2)
-    wf_qnt = we.get_all_templates(mode='quantile')
-    assert wf_qnt.shape == (5, 210, 2)
 
     wf_segment = we.get_template_segment(unit_id=0, segment_index=0)
     assert wf_segment.shape == (210, 2)
-    wf_segment = we.get_template_segment(unit_id=0, segment_index=1,
-                                         quantile_value=0.9, mode='quantile')
     assert wf_segment.shape == (210, 2)
 
 

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -374,7 +374,7 @@ class WaveformExtractor:
 
         return templates
 
-    def get_template(self, unit_id, mode='median', quantile_value=None, sparsity=None):
+    def get_template(self, unit_id, mode='average', quantile_value=None, sparsity=None):
         """
         Return template (average waveform).
 
@@ -383,7 +383,7 @@ class WaveformExtractor:
         unit_id: int or str
             Unit id to retrieve waveforms for
         mode: str
-            'mean', 'median' (default), 'std'(standard deviation), 'quantile'
+            'average' (default), 'median' , 'std'(standard deviation), 'quantile'
         quantile_value: float
             quantile value for argument to np.quantile
         sparsity: dict or None

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -37,7 +37,7 @@ class WaveformExtractor:
     
     >>> # Compute
     >>> we = we.set_params(...)
-    >>> we = we.run(...)
+    >>> we = we.run_extract_waveforms(...)
     
     >>> # Retrieve
     >>> waveforms = we.get_waveforms(unit_id)
@@ -61,13 +61,12 @@ class WaveformExtractor:
         self.recording = recording
         self.sorting = sorting
         self.folder = Path(folder)
-
+        
+        
+        
         # cache in memory
         self._waveforms = {}
-        self._template_std = {}
-        self._template_average = {}
-        self._template_median = {}
-        self._template_quantile = {}
+        self._template_cache = {}
         self._params = {}
 
         if (self.folder / 'params.json').is_file():
@@ -91,6 +90,13 @@ class WaveformExtractor:
         recording = load_extractor(folder / 'recording.json')
         sorting = load_extractor(folder / 'sorting.json')
         we = cls(recording, sorting, folder)
+
+        for mode in ['average', 'std', 'mad']:
+            # load cached templates
+            template_file = folder / f'templates_{mode}.npy'
+            if template_file.is_file():
+                we._template_cache[mode] = np.load(template_file)
+
         return we
 
     @classmethod
@@ -112,15 +118,17 @@ class WaveformExtractor:
 
     def _reset(self):
         self._waveforms = {}
-        self._template_std = {}
-        self._template_average = {}
-        self._template_median = {}
-        self._template_quantile = {}
+        self._template_cache = {}
         self._params = {}
 
         waveform_folder = self.folder / 'waveforms'
         if waveform_folder.is_dir():
             shutil.rmtree(waveform_folder)
+        for mode in ['average', 'std', 'mad']:
+            template_file = self.folder / f'templates_{mode}.npy'
+            if template_file.is_file():
+                template_file.unlink()
+
         waveform_folder.mkdir()
 
     def set_params(self, ms_before=1., ms_after=2., max_spikes_per_unit=500, return_scaled=False, dtype=None):
@@ -217,7 +225,7 @@ class WaveformExtractor:
         if wfs is None:
             waveform_file = self.folder / 'waveforms' / f'waveforms_{unit_id}.npy'
             if not waveform_file.is_file():
-                raise Exception('waveforms not extracted yet : please do WaveformExtractor.run() fisrt')
+                raise Exception('waveforms not extracted yet : please do WaveformExtractor.run_extract_waveforms() fisrt')
 
             wfs = np.load(waveform_file)
             self._waveforms[unit_id] = wfs
@@ -272,10 +280,101 @@ class WaveformExtractor:
             The returned waveform (num_spikes, num_samples, num_channels)
         """
         wfs, index_ar = self.get_waveforms(unit_id, with_index=True, sparsity=sparsity)
-        segment_index_ar = np.array([i[1] for i in index_ar])
-        return wfs[segment_index_ar == segment_index, :, :]
+        mask = index_ar['segment_index'] == segment_index
+        return wfs[mask, :, :]
+    
+    def precompute_templates(self, modes=('average', ), quantile_value=None):
+        """
+        Precompute all template for different "modes":
+          * average
+          * std
+          * median
+          * quantile
+        
+        The results is cache in memory as 3d ndarray (nunits, nsamples, nchans)
+        and also saved as npy file in the folder to avoid recomputation each time.
+        
+        Quantile is cached in memory but not persistent on the disk.
+        
+        """
+        # TODO : run this in parralel
+        
+        dtype = self._params['dtype']
+        unit_ids = self.sorting.unit_ids
+        num_chans = self.recording.get_num_channels()
+        
+        for mode in modes:
+            templates = np.zeros((len(unit_ids), self.nsamples, num_chans), dtype=dtype)
+            if mode ==  'quantile':
+                key = (mode, quantile_value)
+            else:
+                key = mode
+            self._template_cache[key] = templates
 
-    def get_template(self, unit_id, mode='median', quantile_value=0.5, sparsity=None):
+        for i, unit_id in enumerate(unit_ids):
+            wfs = self.get_waveforms(unit_id)
+            for mode in modes:
+                if mode == 'median':
+                    arr = np.median(wfs, axis=0)
+                elif mode == 'average':
+                    arr = np.average(wfs, axis=0)
+                elif mode == 'std':
+                    arr = np.std(wfs, axis=0)
+                elif mode == 'quantile':
+                    assert quantile_value is not None
+                    arr = np.quantile(wfs, quantile_value, axis=0)
+                else:
+                    raise ValueError('mode must in median/average/std/quantile')
+
+                if mode ==  'quantile':
+                    key = (mode, quantile_value)
+                else:
+                    key = mode
+                self._template_cache[key][i, :, :] = arr
+
+        for mode in modes:
+            if mode ==  'quantile':
+                # not cahced to disk
+                continue
+            templates = self._template_cache[mode]
+            template_file = self.folder / f'templates_{mode}.npy'
+            np.save(template_file, templates)
+
+    def get_all_templates(self, unit_ids=None, mode='median', quantile_value=0.5):
+        """
+        Return  templates (average waveform) for multiple units.
+
+        Parameters
+        ----------
+        unit_ids: list or None
+            Unit ids to retrieve waveforms for
+        mode: str
+            'mean' or 'median' (default), 'std', 'quantile'
+        quantile_value: float
+            quantile value as argument to np.quantile
+
+        Returns
+        -------
+        templates: np.array
+            The returned templates (num_units, num_samples, num_channels)
+        """
+        if mode ==  'quantile':
+            key = (mode, quantile_value)
+        else:
+            key = mode
+
+        if key not in self._template_cache:
+            self.precompute_templates(modes=[mode], quantile_value=quantile_value)
+        
+        templates = self._template_cache[key]
+
+        if unit_ids is not None:
+            unit_indices = self.sorting.ids_to_indices(unit_ids)
+            templates = templates[unit_indices, :, :]
+
+        return templates
+
+    def get_template(self, unit_id, mode='median', quantile_value=None, sparsity=None):
         """
         Return template (average waveform).
 
@@ -300,75 +399,33 @@ class WaveformExtractor:
         assert mode in ('median', 'average', 'std', 'quantile')
         assert unit_id in self.sorting.unit_ids
 
+        if mode ==  'quantile':
+            key = (mode, quantile_value)
+        else:
+            key = mode
+        
+        if key in self._template_cache:
+            # already in the global cache
+            templates = self._template_cache[key]
+            unit_ind = self.sorting.id_to_index(unit_id)
+            template = templates[unit_ind, :, :]
+            if sparsity is not None:
+                chan_inds = self.recording.ids_to_indices(sparsity[unit_id])
+                template = template[:, chan_inds]
+            return template
+        
+        # compute from waveforms
+        wfs = self.get_waveforms(unit_id, sparsity=sparsity)
         if mode == 'median':
-            if unit_id in self._template_median and sparsity is None:
-                return self._template_median[unit_id]
-            else:
-                wfs = self.get_waveforms(unit_id, sparsity=sparsity)
-                template = np.median(wfs, axis=0)
-                if sparsity is None:
-                    self._template_median[unit_id] = template
-                return template
+            template = np.median(wfs, axis=0)
         elif mode == 'average':
-            if unit_id in self._template_average and sparsity is None:
-                return self._template_average[unit_id]
-            else:
-                wfs = self.get_waveforms(unit_id, sparsity=sparsity)
-                template = np.average(wfs, axis=0)
-                if sparsity is None:
-                    self._template_average[unit_id] = template
-                return template
+            template = np.average(wfs, axis=0)
         elif mode == 'std':
-            if unit_id in self._template_std and sparsity is None:
-                return self._template_std[unit_id]
-            else:
-                wfs = self.get_waveforms(unit_id, sparsity=sparsity)
-                template = np.std(wfs, axis=0)
-                if sparsity is None:
-                    self._template_std[unit_id] = template
-                return template
+            template = np.std(wfs, axis=0)
         elif mode == 'quantile':
-            if quantile_value in self._template_quantile and unit_id in self._template_quantile[quantile_value]\
-                    and sparsity is None:
-                return self._template_quantile[quantile_value][unit_id]
-            else:
-                wfs = self.get_waveforms(unit_id, sparsity=sparsity)
-                template = np.quantile(wfs, quantile_value, axis=0)
-                if sparsity is None:
-                    if quantile_value not in self._template_quantile:
-                        self._template_quantile[quantile_value] = dict()
-                    self._template_quantile[quantile_value][unit_id] = template
-                return template
-
-    def get_all_templates(self, unit_ids=None, mode='median', quantile_value=0.5):
-        """
-        Return  templates (average waveform) for multiple units.
-
-        Parameters
-        ----------
-        unit_ids: list or None
-            Unit ids to retrieve waveforms for
-        mode: str
-            'mean' or 'median' (default), 'std', 'quantile'
-        quantile_value: float
-            quantile value as argument to np.quantile
-
-        Returns
-        -------
-        templates: np.array
-            The returned templates (num_units, num_samples, num_channels)
-        """
-        if unit_ids is None:
-            unit_ids = self.sorting.unit_ids
-        num_chans = self.recording.get_num_channels()
-
-        dtype = self._params['dtype']
-        templates = np.zeros((len(unit_ids), self.nsamples, num_chans), dtype=dtype)
-
-        for i, unit_id in enumerate(unit_ids):
-            templates[i, :, :] = self.get_template(unit_id, mode=mode, quantile_value=quantile_value)
-
-        return templates
+            assert quantile_value is not None, 'enter quantile value'
+            template = np.quantile(wfs, quantile_value, axis=0)
+        return template
 
     def get_template_segment(self, unit_id, segment_index, quantile_value=None, mode='median',
                              sparsity=None):
@@ -433,7 +490,7 @@ class WaveformExtractor:
 
         return selected_spikes
 
-    def run(self, **job_kwargs):
+    def run_extract_waveforms(self, **job_kwargs):
         p = self._params
         sampling_frequency = self.recording.get_sampling_frequency()
         num_chans = self.recording.get_num_channels()
@@ -607,6 +664,7 @@ def _waveform_extractor_chunk(segment_index, start_frame, end_frame, worker_ctx)
 
 def extract_waveforms(recording, sorting, folder,
                       load_if_exists=False,
+                      precompute_template=('average', ),
                       ms_before=3., ms_after=4.,
                       max_spikes_per_unit=500,
                       overwrite=False,
@@ -628,6 +686,8 @@ def extract_waveforms(recording, sorting, folder,
     load_if_exists: bool
         If True and waveforms have already been extracted in the specified folder, they are loaded
         and not recomputed.
+    precompute_template: None or list
+        Precompute average/std/median for template. If None not precompute.
     ms_before: float
         Time in ms to cut before spike peak
     ms_after: float
@@ -642,6 +702,7 @@ def extract_waveforms(recording, sorting, folder,
         If True and recording has gain_to_uV/offset_to_uV properties, waveforms are converted to uV.
     dtype: dtype or None
         Dtype of the output waveforms. If None, the recording dtype is maintained.
+
 
     {}
 
@@ -661,7 +722,10 @@ def extract_waveforms(recording, sorting, folder,
         we = WaveformExtractor.create(recording, sorting, folder)
         we.set_params(ms_before=ms_before, ms_after=ms_after, max_spikes_per_unit=max_spikes_per_unit, dtype=dtype,
                       return_scaled=return_scaled)
-        we.run(**job_kwargs)
+        we.run_extract_waveforms(**job_kwargs)
+
+        if precompute_template is not None:
+            we.precompute_templates(modes=precompute_template)
 
     return we
 

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -9,6 +9,7 @@ from .base import load_extractor
 from .core_tools import check_json
 from .job_tools import ChunkRecordingExecutor, ensure_n_jobs, _shared_job_kwargs_doc
 
+_possible_template_modes = ('average', 'std', 'median')
 
 class WaveformExtractor:
     """
@@ -91,7 +92,7 @@ class WaveformExtractor:
         sorting = load_extractor(folder / 'sorting.json')
         we = cls(recording, sorting, folder)
 
-        for mode in ['average', 'std', 'mad']:
+        for mode in _possible_template_modes:
             # load cached templates
             template_file = folder / f'templates_{mode}.npy'
             if template_file.is_file():
@@ -124,7 +125,7 @@ class WaveformExtractor:
         waveform_folder = self.folder / 'waveforms'
         if waveform_folder.is_dir():
             shutil.rmtree(waveform_folder)
-        for mode in ['average', 'std', 'mad']:
+        for mode in _possible_template_modes:
             template_file = self.folder / f'templates_{mode}.npy'
             if template_file.is_file():
                 template_file.unlink()
@@ -369,7 +370,7 @@ class WaveformExtractor:
         template: np.array
             The returned template (num_samples, num_channels)
         """
-        assert mode in ('median', 'average', 'std', )
+        assert mode in _possible_template_modes
         assert unit_id in self.sorting.unit_ids
 
         key = mode

--- a/spikeinterface/toolkit/postprocessing/template_tools.py
+++ b/spikeinterface/toolkit/postprocessing/template_tools.py
@@ -31,7 +31,7 @@ def get_template_amplitudes(waveform_extractor, peak_sign='neg', mode='extremum'
     peak_values = {}
 
     for unit_id in unit_ids:
-        template = waveform_extractor.get_template(unit_id)
+        template = waveform_extractor.get_template(unit_id, mode='average')
 
         if mode == 'extremum':
             if peak_sign == 'both':
@@ -214,7 +214,7 @@ def get_template_extremum_channel_peak_shift(waveform_extractor, peak_sign='neg'
         chan_id = extremum_channels_ids[unit_id]
         chan_ind = recording.id_to_index(chan_id)
 
-        template = waveform_extractor.get_template(unit_id)
+        template = waveform_extractor.get_template(unit_id, mode='average')
 
         if peak_sign == 'both':
             peak_pos = np.argmax(np.abs(template[:, chan_ind]))
@@ -252,7 +252,7 @@ def get_template_extremum_amplitude(waveform_extractor, peak_sign='neg'):
 
     unit_amplitudes = {}
     for unit_id in unit_ids:
-        template = waveform_extractor.get_template(unit_id)
+        template = waveform_extractor.get_template(unit_id, mode='average')
         chan_id = extremum_channels_ids[unit_id]
         chan_ind = waveform_extractor.recording.id_to_index(chan_id)
         unit_amplitudes[unit_id] = template[before, chan_ind]

--- a/spikeinterface/toolkit/postprocessing/tests/test_template_tools.py
+++ b/spikeinterface/toolkit/postprocessing/tests/test_template_tools.py
@@ -26,7 +26,7 @@ def setup_module():
 
     we = WaveformExtractor.create(recording, sorting, 'toy_waveforms')
     we.set_params(ms_before=3., ms_after=4., max_spikes_per_unit=500)
-    we.run(n_jobs=1, chunk_size=30000)
+    we.run_extract_waveforms(n_jobs=1, chunk_size=30000)
 
 
 def test_get_template_amplitudes():

--- a/spikeinterface/toolkit/qualitymetrics/tests/test_pca_metrics.py
+++ b/spikeinterface/toolkit/qualitymetrics/tests/test_pca_metrics.py
@@ -22,7 +22,7 @@ def setup_module():
 
     we = WaveformExtractor.create(recording, sorting, 'toy_waveforms')
     we.set_params(ms_before=3., ms_after=4., max_spikes_per_unit=500)
-    we.run(n_jobs=1, chunk_size=30000)
+    we.run_extract_waveforms(n_jobs=1, chunk_size=30000)
 
     pca = WaveformPrincipalComponent(we)
     pca.set_params(n_components=5, mode='by_channel_local')

--- a/spikeinterface/toolkit/qualitymetrics/tests/test_quality_metric_calculator.py
+++ b/spikeinterface/toolkit/qualitymetrics/tests/test_quality_metric_calculator.py
@@ -22,7 +22,7 @@ def setup_module():
 
     we = WaveformExtractor.create(recording, sorting, 'toy_waveforms')
     we.set_params(ms_before=3., ms_after=4., max_spikes_per_unit=500)
-    we.run(n_jobs=1, chunk_size=30000)
+    we.run_extract_waveforms(n_jobs=1, chunk_size=30000)
 
 
 def test_compute_quality_metrics():


### PR DESCRIPTION
refactor waveform template cache : add disk persistency

Now templates are cache all togoether not one by one.
And they are persistent on disk.

Note that this PR do not change the API only the internal way of caching templates