### PR TITLE
Update Mountainsort4 and HerdingSpikes to new API

### DIFF
--- a/spikeinterface/sorters/herdingspikes/herdingspikes.py
+++ b/spikeinterface/sorters/herdingspikes/herdingspikes.py
@@ -147,7 +147,7 @@ class HerdingspikesSorter(BaseSorter):
         import herdingspikes as hs
         import spikeinterface.toolkit as st
 
-        hs_version = version.parse(hs.__version)
+        hs_version = version.parse(hs.__version__)
 
         if hs_version >= version.parse("0.4.0"):
             new_api = True

--- a/spikeinterface/sorters/mountainsort4/mountainsort4.py
+++ b/spikeinterface/sorters/mountainsort4/mountainsort4.py
@@ -92,7 +92,7 @@ class Mountainsort4Sorter(BaseSorter):
     def _run_from_folder(cls, output_folder, params, verbose):
         import mountainsort4
 
-        ms4_version = version.parse(mountainsort4.__version)
+        ms4_version = version.parse(mountainsort4.__version__)
 
         if ms4_version >= version.parse("1.1.0"):
             new_api = True


### PR DESCRIPTION
It's still compatible with old versions, but new implementation depends on:

- MS4: https://github.com/magland/mountainsort4/pull/2
- Herdingspikes: https://github.com/mhhennig/HS2/pull/54