### PR TITLE
Fix filtering for uint signals

### DIFF
--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -136,7 +136,9 @@ class BaseRecording(BaseExtractor):
             # TODO save propreties as npz!!!!!
             folder = save_kwargs['folder']
             file_paths = [folder / f'traces_cached_seg{i}.raw' for i in range(self.get_num_segments())]
-            dtype = save_kwargs.get('dtype', 'float32')
+            dtype = save_kwargs.get('dtype', None)
+            if dtype is None:
+                dtype = self.get_dtype()
 
             job_kwargs = {k: save_kwargs[k] for k in self._job_keys if k in save_kwargs}
             write_binary_recording(self, file_paths=file_paths, dtype=dtype, **job_kwargs)

--- a/spikeinterface/toolkit/preprocessing/filter.py
+++ b/spikeinterface/toolkit/preprocessing/filter.py
@@ -65,40 +65,39 @@ class FilterRecording(BasePreprocessor):
         coeff = scipy.signal.iirfilter(N, Wn, analog=False, btype=btype, ftype=ftype, output=filter_mode)
 
         if dtype is None:
-            dtype_base = recording.get_dtype()
-        else:
-            dtype_base = dtype
-        dtype_base, force_traces_dtype = _correct_uint(dtype_base)
+            dtype = recording.get_dtype()
+        dtype = _correct_uint(dtype)
 
-        BasePreprocessor.__init__(self, recording, dtype=dtype_base)
+        BasePreprocessor.__init__(self, recording, dtype=dtype)
         self.annotate(is_filtered=True)
 
         margin = int(margin_ms * sf / 1000.)
         for parent_segment in recording._recording_segments:
             self.add_recording_segment(FilterRecordingSegment(parent_segment, coeff, filter_mode, margin,
-                                                              dtype_base, force_traces_dtype))
+                                                              dtype))
 
         self._kwargs = dict(recording=recording.to_dict(), band=band, btype=btype,
                             filter_order=filter_order, ftype=ftype, filter_mode=filter_mode, margin_ms=margin_ms)
 
 
 class FilterRecordingSegment(BasePreprocessorSegment):
-    def __init__(self, parent_recording_segment, coeff, filter_mode, margin, dtype, force_traces_dtype):
+    def __init__(self, parent_recording_segment, coeff, filter_mode, margin, dtype):
         BasePreprocessorSegment.__init__(self, parent_recording_segment)
 
         self.coeff = coeff
         self.filter_mode = filter_mode
         self.margin = margin
         self.dtype = dtype
-        self.force_traces_dtype = force_traces_dtype
 
     def get_traces(self, start_frame, end_frame, channel_indices):
         traces_chunk, left_margin, right_margin = get_chunk_with_margin(self.parent_recording_segment,
                                                                         start_frame, end_frame, channel_indices,
                                                                         self.margin)
 
-        if self.force_traces_dtype is not None:
-            traces_chunk = traces_chunk.astype(self.force_traces_dtype)
+        traces_dtype = traces_chunk.dtype
+        # if uint --> force int
+        if traces_dtype.kind == "u":
+            traces_chunk = traces_chunk.astype("float32")
 
         if self.filter_mode == 'sos':
             filtered_traces = scipy.signal.sosfiltfilt(self.coeff, traces_chunk, axis=0)
@@ -168,10 +167,8 @@ class NotchFilterRecording(BasePreprocessor):
         coeff = scipy.signal.iirnotch(freq / fn, q)
 
         if dtype is None:
-            dtype_base = recording.get_dtype()
-        else:
-            dtype_base = dtype
-        dtype_base, force_traces_dtype = _correct_uint(dtype_base)
+            dtype = recording.get_dtype()
+        dtype = _correct_uint(dtype)
 
         BasePreprocessor.__init__(self, recording, dtype=dtype)
         self.annotate(is_filtered=True)
@@ -179,8 +176,7 @@ class NotchFilterRecording(BasePreprocessor):
         sf = recording.get_sampling_frequency()
         margin = int(margin_ms * sf / 1000.)
         for parent_segment in recording._recording_segments:
-            self.add_recording_segment(FilterRecordingSegment(parent_segment, coeff, 'ba', margin, dtype_base,
-                                                              force_traces_dtype))
+            self.add_recording_segment(FilterRecordingSegment(parent_segment, coeff, 'ba', margin, dtype))
 
         self._kwargs = dict(recording=recording.to_dict(), freq=freq, q=q, margin_ms=margin_ms)
 
@@ -215,10 +211,8 @@ notch_filter.__doc__ = NotchFilterRecording.__doc__.format(_common_filter_docs)
 def _correct_uint(dtype):
     dtype = np.dtype(dtype)
 
-    force_traces_dtype = None
     # if uint --> force int
     if dtype.kind == "u":
         dtype = np.dtype(dtype.str.replace("u", "i"))
-        force_traces_dtype = dtype
 
-    return dtype, force_traces_dtype
+    return dtype

--- a/spikeinterface/toolkit/preprocessing/filter.py
+++ b/spikeinterface/toolkit/preprocessing/filter.py
@@ -167,7 +167,14 @@ class NotchFilterRecording(BasePreprocessor):
         fn = 0.5 * float(recording.get_sampling_frequency())
         coeff = scipy.signal.iirnotch(freq / fn, q)
 
-        dtype = fix_dtype(recording, dtype)
+        if dtype is None:
+            dtype = recording.get_dtype()
+        dtype = np.dtype(dtype)
+
+        # if uint --> unsupported
+        if dtype.kind == "u":
+            raise TypeError("The notch filter only supports signed types. Use the 'dtype' argument"
+                            "to specify a signed type (e.g. 'int16', 'float32'")
 
         BasePreprocessor.__init__(self, recording, dtype=dtype)
         self.annotate(is_filtered=True)

--- a/spikeinterface/toolkit/preprocessing/tests/test_filter.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_filter.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 import pytest
 import numpy as np
 from numpy.testing import assert_array_almost_equal
@@ -25,10 +25,9 @@ def test_filter():
     trace1 = rec2_cached1.get_traces(segment_index=0)
 
     # other filtering types
-    rec3 = filter(rec, band=[40., 60.], btype='bandstop')
-    rec4 = filter(rec, band=500., btype='highpass', filter_mode='ba', filter_order=2)
+    rec3 = filter(rec, band=500., btype='highpass', filter_mode='ba', filter_order=2)
 
-    rec5 = notch_filter(rec, freq=3000, q=30, margin_ms=5.)
+    rec4 = notch_filter(rec, freq=3000, q=30, margin_ms=5.)
 
 
 def test_filter_unsigned():
@@ -41,10 +40,12 @@ def test_filter_unsigned():
     traces2 = rec2.get_traces()
     assert not np.issubdtype(traces2.dtype, np.unsignedinteger)
 
-    rec3 = notch_filter(rec, freq=300., q=10)
-    assert not np.issubdtype(rec3.get_dtype(), np.unsignedinteger)
-    traces3 = rec3.get_traces()
-    assert not np.issubdtype(traces3.dtype, np.unsignedinteger)
+    # notch filter note supported for unsigned
+    with pytest.raises(TypeError):
+        rec3 = notch_filter(rec, freq=300., q=10)
+
+    # this is ok
+    rec3 = notch_filter(rec, freq=300., q=10, dtype="float32")
 
 
 @pytest.mark.skip('OpenCL not tested')

--- a/spikeinterface/toolkit/preprocessing/tests/test_filter.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_filter.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from spikeinterface.core.testing_tools import generate_recording
+from spikeinterface import NumpyRecording
 
 from spikeinterface.toolkit.preprocessing import filter, bandpass_filter, notch_filter
 
@@ -29,13 +30,21 @@ def test_filter():
 
     rec5 = notch_filter(rec, freq=3000, q=30, margin_ms=5.)
 
-    # import matplotlib.pyplot as plt
-    # from spikeinterface.widgets import plot_timeseries
-    # plot_timeseries(rec, segment_index=0)
-    # plot_timeseries(rec2, segment_index=0)
-    # plot_timeseries(rec3, segment_index=0)
-    # plot_timeseries(rec4, segment_index=0)
-    # plt.show()
+
+def test_filter_unsigned():
+    traces = np.random.randint(1, 1000, (5000, 4), dtype="uint16")
+    rec = NumpyRecording(traces_list=traces, sampling_frequency=1000)
+    rec = rec.save()
+
+    rec2 = bandpass_filter(rec, freq_min=10., freq_max=300.)
+    assert not np.issubdtype(rec2.get_dtype(), np.unsignedinteger)
+    traces2 = rec2.get_traces()
+    assert not np.issubdtype(traces2.dtype, np.unsignedinteger)
+
+    rec3 = notch_filter(rec, freq=300., q=10)
+    assert not np.issubdtype(rec3.get_dtype(), np.unsignedinteger)
+    traces3 = rec3.get_traces()
+    assert not np.issubdtype(traces3.dtype, np.unsignedinteger)
 
 
 @pytest.mark.skip('OpenCL not tested')
@@ -70,4 +79,4 @@ def test_filter_opencl():
 
 if __name__ == '__main__':
     # test_filter()
-    test_filter_opencl()
+    test_filter_unsigned()


### PR DESCRIPTION
uint traces must be converted to int upon retrieval before filtering and this was not done automatically.

