### PR TITLE
support for structs in matlab files

### DIFF
--- a/spikeinterface/extractors/matlabhelpers.py
+++ b/spikeinterface/extractors/matlabhelpers.py
@@ -69,11 +69,22 @@ class MatlabHelper:
                 return d[keys.popleft()]
             else:
                 return _drill(d[keys.popleft()], keys)
+        def _h52dict(h5group):
+            dout = {}
+            for fieldname in h5group:
+                if isinstance(h5group[fieldname], h5py.Group):
+                    dout[fieldname] = _h52dict(h5group)
+                else:
+                    dout[fieldname] = h5group[fieldname][()]
+            return dout
 
         if self._old_style_mat:
             return _drill(self._data, deque(fieldname.split("/")))
         else:
-            return self._data[fieldname][()]
+            if isinstance(self._data[fieldname], h5py.Group):
+                return _h52dict(self._data[fieldname])
+            else:
+                return self._data[fieldname][()]
 
     @classmethod
     def write_dict_to_mat(cls, mat_file_path, dict_to_write, version='7.3'):  # field must be a dict


### PR DESCRIPTION
Hi guys, related to the issue #316 ,the matlab helper doesn't work when a struct is the variable to get from the matfile.

This is just a WIP of the code and at least the wave_clus extractor will have to ve changed (simplified), removing [this ](https://github.com/SpikeInterface/spikeinterface/blob/fcb94ef848d68ad875cc47c60bc1d5433a895d64/spikeinterface/extractors/waveclustextractors.py#L20) awful line. Before that I need to add a way to convert the output of loadmat for structs to a dictionary :worried: 