### PR TITLE
HS2 version>=0.3.99

### DIFF
--- a/TODO_big_refactoring.txt
+++ b/TODO_big_refactoring.txt
@@ -3,15 +3,12 @@ Here the TODO list for the NEW spikeinterface API
 core:
     * add kachery extractor (jeremy)
     * save features as np (sam)
-    * waveform_extractor improve cache option
-    * time vector
     * binary_interface()
     * rescaler / dtype
 
 
 extractors:
 
-    * nwb: reader/writer (with multi segment) (ben?)
     * BiocamRecordingExtractor  : need to be done in neo
     * OpenEphysSortingExtractor : need to be done in neo
 
@@ -43,9 +40,6 @@ sorters:
   * install all files *.m, *.prm
 
 
-widgets:
-  * fix plot_multicomp_graph()
-
 
 examples:
 
@@ -66,7 +60,6 @@ doc:
 
 Linked projects:
 
-  * herdingspikes: new API transpose and multi segment (cole)
   * mountainsort4: new API transpose and multi segment (jeremy)
   * spikeforest: new API transpose and multi segment (jeremy)
   * tridesclous integrate recording extractor

--- a/spikeinterface/sorters/herdingspikes/herdingspikes.py
+++ b/spikeinterface/sorters/herdingspikes/herdingspikes.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import copy
+from packaging import version
 
 from ..basesorter import BaseSorter
 from ..utils import RecordingExtractorOldAPI
@@ -146,6 +147,13 @@ class HerdingspikesSorter(BaseSorter):
     def _run_from_folder(cls, output_folder, params, verbose):
         import herdingspikes as hs
         import spikeinterface.toolkit as st
+
+        hs_version = version.parse(hs.__version__)
+
+        if hs_version >= version.parse("0.4.0"):
+            new_api = True
+        else:
+            new_api = False
 
         recording = load_extractor(output_folder / 'spikeinterface_recording.json')
 

--- a/spikeinterface/sorters/herdingspikes/herdingspikes.py
+++ b/spikeinterface/sorters/herdingspikes/herdingspikes.py
@@ -150,7 +150,7 @@ class HerdingspikesSorter(BaseSorter):
 
         hs_version = version.parse(hs.__version__)
 
-        if hs_version >= version.parse("0.4.0"):
+        if hs_version >= version.parse("0.3.99"):
             new_api = True
         else:
             new_api = False
@@ -170,12 +170,16 @@ class HerdingspikesSorter(BaseSorter):
                 median=0.0, q1=0.05, q2=0.95
             )
 
-        print('Herdingspikes use the OLD spikeextractors with RecordingExtractorOldAPI')
-        old_api_recording = RecordingExtractorOldAPI(recording)
+        if new_api:
+            recording_to_hs = recording
+        else:
+            print('herdingspikes version<0.3.99 uses the OLD spikeextractors with RecordingExtractorOldAPI.\n'
+                  'Consider updating herdingspikes (pip install herdingspikes>=0.3.99)')
+            recording_to_hs = RecordingExtractorOldAPI(recording)
 
         # this should have its name changed
         Probe = hs.probe.RecordingExtractor(
-            old_api_recording,
+            recording_to_hs,
             masked_channels=p['probe_masked_channels'],
             inner_radius=p['probe_inner_radius'],
             neighbor_radius=p['probe_neighbor_radius'],


### PR DESCRIPTION
Update Herdingspikes wrapper to work both with:

- version < 0.3.99 (uses `OldAPIRecordingExtractor`)
- version >= 0.3.99 (uses new API directly)

