### PR TITLE
Allow any filter in spikeinterface

### DIFF
--- a/spikeinterface/toolkit/preprocessing/filter.py
+++ b/spikeinterface/toolkit/preprocessing/filter.py
@@ -68,12 +68,14 @@ class FilterRecording(BasePreprocessor):
                 Wn = float(band) / sf * 2
             N = filter_order
             # self.coeff is 'sos' or 'ab' style
-            coeff = scipy.signal.iirfilter(N, Wn, analog=False, btype=btype, ftype=ftype, output=filter_mode)
-        if not isinstance(coeff, list):
-            if filter_mode == 'ba':
-                coeff = [c.tolist() for c in coeff]
-            else:
-                coeff = coeff.tolist()
+            filter_coeff = scipy.signal.iirfilter(N, Wn, analog=False, btype=btype, ftype=ftype, output=filter_mode)
+        else:
+            filter_coeff = coeff
+            if not isinstance(coeff, list):
+                if filter_mode == 'ba':
+                    coeff = [c.tolist() for c in coeff]
+                else:
+                    coeff = coeff.tolist()
         dtype = fix_dtype(recording, dtype)
 
         BasePreprocessor.__init__(self, recording, dtype=dtype)
@@ -84,7 +86,7 @@ class FilterRecording(BasePreprocessor):
 
         margin = int(margin_ms * sf / 1000.)
         for parent_segment in recording._recording_segments:
-            self.add_recording_segment(FilterRecordingSegment(parent_segment, coeff, filter_mode, margin,
+            self.add_recording_segment(FilterRecordingSegment(parent_segment, filter_coeff, filter_mode, margin,
                                                               dtype))
 
         self._kwargs = dict(recording=recording.to_dict(), band=band, btype=btype,

--- a/spikeinterface/toolkit/preprocessing/filter.py
+++ b/spikeinterface/toolkit/preprocessing/filter.py
@@ -57,10 +57,10 @@ class FilterRecording(BasePreprocessor):
                  coeff=None, dtype=None):
 
         assert filter_mode in ('sos', 'ba')
+        sf = recording.get_sampling_frequency()
         if coeff is None:
             assert btype in ('bandpass', 'highpass')
             # coefficient
-            sf = recording.get_sampling_frequency()
             if btype in ('bandpass', 'bandstop'):
                 assert len(band) == 2
                 Wn = [e / sf * 2 for e in band]
@@ -84,7 +84,8 @@ class FilterRecording(BasePreprocessor):
                                                               dtype))
 
         self._kwargs = dict(recording=recording.to_dict(), band=band, btype=btype,
-                            filter_order=filter_order, ftype=ftype, filter_mode=filter_mode, margin_ms=margin_ms)
+                            filter_order=filter_order, ftype=ftype, filter_mode=filter_mode, coeff=coeff,
+                            margin_ms=margin_ms)
 
 
 class FilterRecordingSegment(BasePreprocessorSegment):

--- a/spikeinterface/toolkit/preprocessing/filter.py
+++ b/spikeinterface/toolkit/preprocessing/filter.py
@@ -69,7 +69,11 @@ class FilterRecording(BasePreprocessor):
             N = filter_order
             # self.coeff is 'sos' or 'ab' style
             coeff = scipy.signal.iirfilter(N, Wn, analog=False, btype=btype, ftype=ftype, output=filter_mode)
-
+        if not isinstance(coeff, list):
+            if filter_mode == 'ba':
+                coeff = [c.tolist() for c in coeff]
+            else:
+                coeff = coeff.tolist()
         dtype = fix_dtype(recording, dtype)
 
         BasePreprocessor.__init__(self, recording, dtype=dtype)

--- a/spikeinterface/toolkit/preprocessing/filter.py
+++ b/spikeinterface/toolkit/preprocessing/filter.py
@@ -37,8 +37,8 @@ class FilterRecording(BasePreprocessor):
         Margin in ms on border to avoid border effect
     filter_mode: str 'sos' or 'ba'
         Filter form of the filter coefficients:
-        - second-order sections (default): ‘sos’
-        - numerator/denominator: ‘ba’
+        - second-order sections (default): 'sos'
+        - numerator/denominator: 'ba'
     coef: ndarray or None
         Filter coefficients in the filter_mode form. 
     dtype: dtype or None
@@ -54,10 +54,10 @@ class FilterRecording(BasePreprocessor):
 
     def __init__(self, recording, band=[300., 6000.], btype='bandpass',
                  filter_order=5, ftype='butter', filter_mode='sos', margin_ms=5.0,
-                 coef=None, dtype=None):
+                 coeff=None, dtype=None):
 
         assert filter_mode in ('sos', 'ba')
-        if coef is None:
+        if coeff is None:
             assert btype in ('bandpass', 'highpass')
             # coefficient
             sf = recording.get_sampling_frequency()

--- a/spikeinterface/toolkit/preprocessing/filter.py
+++ b/spikeinterface/toolkit/preprocessing/filter.py
@@ -35,6 +35,12 @@ class FilterRecording(BasePreprocessor):
         Type of the filter ('bandpass', 'highpass')
     margin_ms: float
         Margin in ms on border to avoid border effect
+    filter_mode: str 'sos' or 'ba'
+        Filter form of the filter coefficients:
+        - second-order sections (default): ‘sos’
+        - numerator/denominator: ‘ba’
+    coef: ndarray or None
+        Filter coefficients in the filter_mode form. 
     dtype: dtype or None
         The dtype of the returned traces. If None, the dtype of the parent recording is used
     {}
@@ -48,21 +54,21 @@ class FilterRecording(BasePreprocessor):
 
     def __init__(self, recording, band=[300., 6000.], btype='bandpass',
                  filter_order=5, ftype='butter', filter_mode='sos', margin_ms=5.0,
-                 dtype=None):
+                 coef=None, dtype=None):
 
-        assert btype in ('bandpass', 'highpass')
         assert filter_mode in ('sos', 'ba')
-
-        # coefficient
-        sf = recording.get_sampling_frequency()
-        if btype in ('bandpass', 'bandstop'):
-            assert len(band) == 2
-            Wn = [e / sf * 2 for e in band]
-        else:
-            Wn = float(band) / sf * 2
-        N = filter_order
-        # self.coeff is 'sos' or 'ab' style
-        coeff = scipy.signal.iirfilter(N, Wn, analog=False, btype=btype, ftype=ftype, output=filter_mode)
+        if coef is None:
+            assert btype in ('bandpass', 'highpass')
+            # coefficient
+            sf = recording.get_sampling_frequency()
+            if btype in ('bandpass', 'bandstop'):
+                assert len(band) == 2
+                Wn = [e / sf * 2 for e in band]
+            else:
+                Wn = float(band) / sf * 2
+            N = filter_order
+            # self.coeff is 'sos' or 'ab' style
+            coeff = scipy.signal.iirfilter(N, Wn, analog=False, btype=btype, ftype=ftype, output=filter_mode)
 
         dtype = fix_dtype(recording, dtype)
 

--- a/spikeinterface/toolkit/preprocessing/tests/test_filter.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_filter.py
@@ -6,7 +6,7 @@ from spikeinterface.core.testing_tools import generate_recording
 from spikeinterface import NumpyRecording
 
 from spikeinterface.toolkit.preprocessing import filter, bandpass_filter, notch_filter
-
+from scipy.signal import iirfilter
 
 def test_filter():
     rec = generate_recording()
@@ -29,6 +29,16 @@ def test_filter():
 
     rec4 = notch_filter(rec, freq=3000, q=30, margin_ms=5.)
     
+    # filter from coefficients
+    coeff = iirfilter(8, [0.02, 0.4], rs=30, btype='band', analog=False, ftype='cheby2', output='sos')
+    rec5 = filter(rec, coeff=coeff, filter_mode='sos')
+
+    # compute by chunk
+    rec5_cached0 = rec5.save(chunk_size=100000, verbose=False, progress_bar=True)
+
+    trace50 = rec5.get_traces(segment_index=0)
+    trace51 = rec5_cached0.get_traces(segment_index=0)
+
     assert np.allclose(rec.get_times(0), rec2.get_times(0))
 
 


### PR DESCRIPTION
Just a WIP to discuss. related to #363 
I guess this is the simplest change to allow any filter in spikeinterface

I don't know the details of self._kwargs, should I create the dict with only the used inputs inside the if statement? (discarting filter_order, band, etc and adding coef) or just adding coeff to the current line?
