### PR TITLE
Relax requirement on t_start for concatenate_recordings

### DIFF
--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -578,7 +578,7 @@ class BaseRecordingSegment(BaseSegment):
     def get_times_kwargs(self):
         # useful for other internal RecordingSegment
         d = dict(sampling_frequency=self.sampling_frequency, t_start=self.t_start,
-                        time_vector=self.time_vector)
+                 time_vector=self.time_vector)
         return d
 
     def sample_index_to_time(self, sample_ind):

--- a/spikeinterface/core/segmentutils.py
+++ b/spikeinterface/core/segmentutils.py
@@ -92,9 +92,11 @@ class ConcatenateSegmentRecording(BaseRecording):
     ----------
     recording_list : list of BaseRecording
         A list of recordings
+    ignore_times: bool
+        If True (default), time information (t_start, time_vector) is ignored when concatenating recordings.
     """
 
-    def __init__(self, recording_list):
+    def __init__(self, recording_list, ignore_times=True):
 
         one_rec = append_recordings(recording_list)
 
@@ -103,27 +105,32 @@ class ConcatenateSegmentRecording(BaseRecording):
         self.recording_list = recording_list
 
         parent_segments = []
-        reset_t_start = False
         for rec in recording_list:
             for parent_segment in rec._recording_segments:
                 d = parent_segment.get_times_kwargs()
-                assert d['time_vector'] is None, 'ConcatenateSegmentRecording does not handle time_vector'
-                if d['t_start'] is not None:
-                    reset_t_start = True
+                if not ignore_times:
+                    assert d['time_vector'] is None, ("ConcatenateSegmentRecording does not handle time_vector. "
+                                                      "Use ignore_times=True to ignore time information.")
+                    assert d['t_start'] is None, ("ConcatenateSegmentRecording does not handle t_start. "
+                                                  "Use ignore_times=True to ignore time information.")
+                else:
+                    if d['time_vector'] is not None or d['t_start'] is not None:
+                        warnings.warn("Time information (t_start/time_vector) are not known. They will be ignored for "
+                                      "concatenation")
                 parent_segments.append(parent_segment)
-        rec_seg = ProxyConcatenateRecordingSegment(parent_segments, reset_t_start=reset_t_start)
+        rec_seg = ProxyConcatenateRecordingSegment(parent_segments, ignore_times=ignore_times)
         self.add_recording_segment(rec_seg)
 
-        self._kwargs = {'recording_list': [rec.to_dict() for rec in recording_list]}
+        self._kwargs = {'recording_list': [rec.to_dict() for rec in recording_list],
+                        'ignore_times': ignore_times}
 
 
 class ProxyConcatenateRecordingSegment(BaseRecordingSegment):
-    def __init__(self, parent_segments, reset_t_start=False):
-        # get time kwargs
+    def __init__(self, parent_segments, ignore_times=True):
         d = parent_segments[0].get_times_kwargs()
-        if reset_t_start:
-            warnings.warn('ConcatenateSegmentRecording does not handle t_start. It will be set to None')
-            d["t_start"] = None
+        if ignore_times:
+            d['t_start'] = None
+            d['time_vector'] = None
         BaseRecordingSegment.__init__(self, **d)
         self.parent_segments = parent_segments
         self.all_length = [rec_seg.get_num_samples() for rec_seg in self.parent_segments]

--- a/spikeinterface/core/segmentutils.py
+++ b/spikeinterface/core/segmentutils.py
@@ -110,8 +110,8 @@ class ConcatenateSegmentRecording(BaseRecording):
                 assert d['time_vector'] is None, 'ConcatenateSegmentRecording does not handle time_vector'
                 if d['t_start'] is not None:
                     reset_t_start = True
-                parent_segments.append(parent_segment, reset_t_start)
-        rec_seg = ProxyConcatenateRecordingSegment(parent_segments)
+                parent_segments.append(parent_segment)
+        rec_seg = ProxyConcatenateRecordingSegment(parent_segments, reset_t_start=reset_t_start)
         self.add_recording_segment(rec_seg)
 
         self._kwargs = {'recording_list': [rec.to_dict() for rec in recording_list]}

--- a/spikeinterface/core/segmentutils.py
+++ b/spikeinterface/core/segmentutils.py
@@ -10,11 +10,9 @@ For instance:
 
 """
 import numpy as np
-import warnings
 
 from .baserecording import BaseRecording, BaseRecordingSegment
 from .basesorting import BaseSorting, BaseSortingSegment
-from .baseevent import BaseEvent, BaseEventSegment
 
 
 class AppendSegmentRecording(BaseRecording):
@@ -113,10 +111,6 @@ class ConcatenateSegmentRecording(BaseRecording):
                                                       "Use ignore_times=True to ignore time information.")
                     assert d['t_start'] is None, ("ConcatenateSegmentRecording does not handle t_start. "
                                                   "Use ignore_times=True to ignore time information.")
-                else:
-                    if d['time_vector'] is not None or d['t_start'] is not None:
-                        warnings.warn("Time information (t_start/time_vector) are not known. They will be ignored for "
-                                      "concatenation")
                 parent_segments.append(parent_segment)
         rec_seg = ProxyConcatenateRecordingSegment(parent_segments, ignore_times=ignore_times)
         self.add_recording_segment(rec_seg)


### PR DESCRIPTION
Most of the recordings are NEO-based ans with `t_start` set to 0. Currently, this prevents concatenation. This PR relaxes the assertion on `t_start=None` to a warning and resets the `t_start` of the `ProxyConcatenateRecordingSegment` to `None` in case