### PR TITLE
PhySorting fix spike train dimensions

### DIFF
--- a/spikeinterface/extractors/phykilosortextractors.py
+++ b/spikeinterface/extractors/phykilosortextractors.py
@@ -87,7 +87,12 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
                         cluster_info = cluster_info.query(f"group != '{exclude_group}'")
 
         if keep_good_only and "KSLabel" in cluster_info.columns:
-            cluster_info = cluster_info.query(f"KSLabel != 'good'")
+            cluster_info = cluster_info.query("KSLabel != 'good'")
+
+        if "cluster_id" not in cluster_info.columns:
+            assert "id" in cluster_info.columns, "Couldn't find cluster ids in the tsv files!"
+            cluster_info["cluster_id"] = cluster_info["id"]
+            del cluster_info["id"]
         unit_ids = cluster_info["cluster_id"].values
 
         BaseSorting.__init__(self, sampling_frequency, unit_ids)
@@ -117,7 +122,7 @@ class PhySortingSegment(BaseSortingSegment):
             spike_times = spike_times[spike_times >= start_frame]
         if end_frame is not None:
             spike_times = spike_times[spike_times < end_frame]
-        return spike_times.copy()
+        return spike_times.copy().squeeze()
 
 
 class PhySortingExtractor(BasePhyKilosortSortingExtractor):


### PR DESCRIPTION
Fixes: https://github.com/SpikeInterface/spikeinterface/issues/382

@szbalazs98 the problem was that the PhySortingExtractor returned an extra dimension for the spik trains (e.g. `(num_spikes, 1)`) and that was messing up other stuff.

I also fixed the `id` VS `cluster_id` problem: the code looks for `cluster_id`, but if not found `id` is used. Can you test this?