### PR TITLE
Handle h5py dataset timestamps

### DIFF
--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -564,11 +564,8 @@ class BaseRecordingSegment(BaseSegment):
 
     def get_times(self):
         if self.time_vector is not None:
-            # import h5py
             if isinstance(self.time_vector, np.ndarray):
                 return self.time_vector
-            # elif isinstance(self.time_vector, h5py.Dataset):
-            #     return self.time_vector[:]
             else:
                 return np.array(self.time_vector)
         else:

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -564,13 +564,13 @@ class BaseRecordingSegment(BaseSegment):
 
     def get_times(self):
         if self.time_vector is not None:
-            import h5py
+            # import h5py
             if isinstance(self.time_vector, np.ndarray):
                 return self.time_vector
-            elif isinstance(self.time_vector, h5py.Dataset):
-                return self.time_vector[:]
+            # elif isinstance(self.time_vector, h5py.Dataset):
+            #     return self.time_vector[:]
             else:
-                return self.time_vector.asarray()
+                return np.array(self.time_vector)
         else:
             time_vector = np.arange(self.get_num_samples(), dtype='float64')
             time_vector /= self.sampling_frequency

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -564,8 +564,11 @@ class BaseRecordingSegment(BaseSegment):
 
     def get_times(self):
         if self.time_vector is not None:
+            import h5py
             if isinstance(self.time_vector, np.ndarray):
                 return self.time_vector
+            elif isinstance(self.time_vector, h5py.Dataset):
+                return self.time_vector[:]
             else:
                 return self.time_vector.asarray()
         else:


### PR DESCRIPTION
The timestamps for nwbextractor is of type h5py Dataset which cannot be converted to numpy array by `.asarray()`. I added a line to check the type of the timestamps and use a different method to return it in the case it is a h5py Dataset. 