### PR TITLE
Fix for channels_indices that are 2D sometimes

### DIFF
--- a/spikeinterface/toolkit/preprocessing/common_reference.py
+++ b/spikeinterface/toolkit/preprocessing/common_reference.py
@@ -115,7 +115,7 @@ class CommonReferenceRecordingSegment(BasePreprocessorSegment):
     def get_traces(self, start_frame, end_frame, channel_indices):
         # need input trace
         all_traces = self.parent_recording_segment.get_traces(start_frame, end_frame, slice(None))
-        _channel_indices = np.arange(all_traces.shape[1])[channel_indices]
+        _channel_indices = np.arange(all_traces.shape[1])[channel_indices].flatten()
 
         if self.reference == 'global':
             out_traces = np.hstack([


### PR DESCRIPTION
This fixes the problem I have that sometimes, channel_indices are 2D arrays (tested with mearecrawio), and thus CAR is crashing because dimensions are too large. This solves my problems in sortingcomponent too, with get_chunk_with_margin