### PR TITLE
Enhance container handling

### DIFF
--- a/spikeinterface/core/datasets.py
+++ b/spikeinterface/core/datasets.py
@@ -6,13 +6,15 @@ from .default_folders import get_global_dataset_folder, is_set_global_dataset_fo
 
 try:
     import datalad.api
-
+    from datalad.support.gitrepo import GitRepo
     HAVE_DATALAD = True
 except:
     HAVE_DATALAD = False
 
 
 def download_dataset(repo=None, remote_path=None, local_folder=None, update_if_exists=False):
+    assert HAVE_DATALAD, 'You need to install datalad'
+
     if repo is None:
         #  print('Use gin NeuralEnsemble/ephy_testing_data')
         repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
@@ -24,20 +26,25 @@ def download_dataset(repo=None, remote_path=None, local_folder=None, update_if_e
         #  print(f'Local folder is {base_local_folder}, Use set_global_dataset_folder() to set it globally')
         local_folder = base_local_folder / repo.split('/')[-1]
 
-    if local_folder.exists():
+    if local_folder.exists() and GitRepo.is_valid_repo(local_folder):
         dataset = datalad.api.Dataset(path=local_folder)
-        if update_if_exists:
-            dataset.update(merge=True)
+        # make sure git repo is in clean state
+        repo = dataset.repo
+        repo.call_git(['checkout', '--force', 'master'])
+        dataset.update(merge=True)
     else:
         dataset = datalad.api.install(path=local_folder,
-                                      source='https://gin.g-node.org/NeuralEnsemble/ephy_testing_data')
+                                      source=repo)
 
     if remote_path is None:
         print('Bad boy: you have to provide "remote_path"')
         return
 
+    local_path = local_folder / remote_path
+
     dataset.get(remote_path)
 
-    local_path = local_folder / remote_path
+    # unlocking is necessary for binding volume to containers
+    dataset.unlock(remote_path, recursive=True)
 
     return local_path

--- a/spikeinterface/core/datasets.py
+++ b/spikeinterface/core/datasets.py
@@ -12,7 +12,8 @@ except:
     HAVE_DATALAD = False
 
 
-def download_dataset(repo=None, remote_path=None, local_folder=None, update_if_exists=False):
+def download_dataset(repo=None, remote_path=None, local_folder=None, update_if_exists=False,
+                     unlock=False):
     assert HAVE_DATALAD, 'You need to install datalad'
 
     if repo is None:
@@ -30,8 +31,9 @@ def download_dataset(repo=None, remote_path=None, local_folder=None, update_if_e
         dataset = datalad.api.Dataset(path=local_folder)
         # make sure git repo is in clean state
         repo = dataset.repo
-        repo.call_git(['checkout', '--force', 'master'])
-        dataset.update(merge=True)
+        if update_if_exists:
+            repo.call_git(['checkout', '--force', 'master'])
+            dataset.update(merge=True)
     else:
         dataset = datalad.api.install(path=local_folder,
                                       source=repo)
@@ -45,6 +47,7 @@ def download_dataset(repo=None, remote_path=None, local_folder=None, update_if_e
     dataset.get(remote_path)
 
     # unlocking is necessary for binding volume to containers
-    dataset.unlock(remote_path, recursive=True)
+    if unlock:
+        dataset.unlock(remote_path, recursive=True)
 
     return local_path

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -289,22 +289,27 @@ run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
     need_si_install = 'ModuleNotFoundError' in res_output
 
     if need_si_install:
+        # downgrade pip version to avoid dependency issues during installations
+        # see https://github.com/SpikeInterface/spikeinterface-dockerfiles/pull/14
+        cmd = 'pip install --no-input pip==21.2.4'
+        res_output = container_client.run_command(cmd)
         if 'dev' in si_version:
             if verbose:
                 print(
                     f"Installing spikeinterface from sources in {container_image}")
             # TODO later check output
-            cmd = 'pip install --upgrade --force MEArec'
+            print(container_client.run_command('pip list'))
+            cmd = 'pip install --upgrade --no-input MEArec'
             res_output = container_client.run_command(cmd)
-            cmd = 'pip install -e git+https://github.com/SpikeInterface/spikeinterface.git#egg=spikeinterface[full]'
+            cmd = 'pip install --upgrade --no-input git+https://github.com/SpikeInterface/spikeinterface.git#egg=spikeinterface[full]'
             res_output = container_client.run_command(cmd)
-            cmd = 'pip install --upgrade --force https://github.com/NeuralEnsemble/python-neo/archive/master.zip'
+            cmd = 'pip install --upgrade --no-input https://github.com/NeuralEnsemble/python-neo/archive/master.zip'
             res_output = container_client.run_command(cmd)
         else:
             if verbose:
                 print(
                     f"Installing spikeinterface=={si_version} in {container_image}")
-            cmd = f'pip install --upgrade --force spikeinterface[full]=={si_version}'
+            cmd = f'pip install --upgrade --no-input spikeinterface[full]=={si_version}'
             res_output = container_client.run_command(cmd)
     else:
         # TODO version checking

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -298,7 +298,6 @@ run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
                 print(
                     f"Installing spikeinterface from sources in {container_image}")
             # TODO later check output
-            print(container_client.run_command('pip list'))
             cmd = 'pip install --upgrade --no-input MEArec'
             res_output = container_client.run_command(cmd)
             cmd = 'pip install --upgrade --no-input git+https://github.com/SpikeInterface/spikeinterface.git#egg=spikeinterface[full]'

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -220,7 +220,7 @@ class ContainerClient:
 
 def run_sorter_container(sorter_name, recording, mode, container_image, output_folder=None,
                          remove_existing_folder=True, delete_output_folder=False,
-                         verbose=False, raise_error=True, with_output=True, **sorter_params):
+                         verbose=False, raise_error=True, with_output=False, **sorter_params):
     # common code for docker and singularity
 
     assert platform.system() in ('Linux', 'Darwin'), \

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -283,7 +283,7 @@ run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
     # check if container contains spikeinterface already
     cmd_1 = ['python', '-c', 'import spikeinterface; print(spikeinterface.__version__)']
     cmd_2 = ['python', '-c', 'from spikeinterface.sorters import run_sorter_local']
-    res_output = []
+    res_output = ''
     for cmd in [cmd_1, cmd_2]:
         res_output += container_client.run_command(cmd)
     need_si_install = 'ModuleNotFoundError' in res_output

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -289,10 +289,6 @@ run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
     need_si_install = 'ModuleNotFoundError' in res_output
 
     if need_si_install:
-        # downgrade pip version to avoid dependency issues during installations
-        # see https://github.com/SpikeInterface/spikeinterface-dockerfiles/pull/14
-        cmd = 'pip install --no-input pip==21.2.4'
-        res_output = container_client.run_command(cmd)
         if 'dev' in si_version:
             if verbose:
                 print(

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -220,7 +220,7 @@ class ContainerClient:
 
 def run_sorter_container(sorter_name, recording, mode, container_image, output_folder=None,
                          remove_existing_folder=True, delete_output_folder=False,
-                         verbose=False, raise_error=True, with_output=False, **sorter_params):
+                         verbose=False, raise_error=True, with_output=True, **sorter_params):
     # common code for docker and singularity
 
     assert platform.system() in ('Linux', 'Darwin'), \

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -285,7 +285,7 @@ run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
     cmd_2 = ['python', '-c', 'from spikeinterface.sorters import run_sorter_local']
     res_output = ''
     for cmd in [cmd_1, cmd_2]:
-        res_output += container_client.run_command(cmd)
+        res_output += str(container_client.run_command(cmd))
     need_si_install = 'ModuleNotFoundError' in res_output
 
     if need_si_install:

--- a/spikeinterface/sorters/tests/test_runsorter.py
+++ b/spikeinterface/sorters/tests/test_runsorter.py
@@ -47,9 +47,6 @@ def test_run_sorter_singularity():
     mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5', unlock=True)
     output_folder='sorting_tdc_singularity'
 
-    #  test for sam localy
-    # mearec_filename = '/mnt/data/sam/DataSpikeSorting/mearec_test_10s.h5'
-    # output_folder = '/mnt/data/sam/DataSpikeSorting/tdc_singularity_mearec_test_10s'
 
     recording, sorting_true = read_mearec(mearec_filename)
 

--- a/spikeinterface/sorters/tests/test_runsorter.py
+++ b/spikeinterface/sorters/tests/test_runsorter.py
@@ -3,9 +3,10 @@ import pytest
 
 from spikeinterface import download_dataset
 from spikeinterface.extractors import read_mearec
-from spikeinterface.sorters import run_sorter, run_sorter_container
+from spikeinterface.sorters import run_sorter
 
-ON_GITHUB = os.getenv('GITHUB_ACTIONS')
+ON_GITHUB = bool(os.getenv('GITHUB_ACTIONS'))
+
 
 def test_run_sorter_local():
     local_path = download_dataset(remote_path='mearec/mearec_test_10s.h5')

--- a/spikeinterface/sorters/tests/test_runsorter.py
+++ b/spikeinterface/sorters/tests/test_runsorter.py
@@ -1,10 +1,11 @@
+import os
 import pytest
-from pathlib import Path
 
 from spikeinterface import download_dataset
 from spikeinterface.extractors import read_mearec
 from spikeinterface.sorters import run_sorter, run_sorter_container
 
+ON_GITHUB = os.getenv('GITHUB_ACTIONS')
 
 def test_run_sorter_local():
     local_path = download_dataset(remote_path='mearec/mearec_test_10s.h5')
@@ -19,7 +20,7 @@ def test_run_sorter_local():
     print(sorting)
 
 
-@pytest.mark.skip("Docker tests don't run with pytest : test it manually")
+@pytest.mark.skipif(ON_GITHUB, "Docker tests don't run on github: test locally")
 def test_run_sorter_docker():
     mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5')
 
@@ -38,7 +39,7 @@ def test_run_sorter_docker():
     print(sorting)
 
 
-@pytest.mark.skip("Singularity tests don't run with pytest : test it manually")
+@pytest.mark.skipif(ON_GITHUB, "Singularity tests don't run on github: test it locally")
 def test_run_sorter_singularity():
     #mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5')
 

--- a/spikeinterface/sorters/tests/test_runsorter.py
+++ b/spikeinterface/sorters/tests/test_runsorter.py
@@ -23,7 +23,7 @@ def test_run_sorter_local():
 
 @pytest.mark.skipif(ON_GITHUB, reason="Docker tests don't run on github: test locally")
 def test_run_sorter_docker():
-    mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5')
+    mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5', unlock=True)
     recording, sorting_true = read_mearec(mearec_filename)
 
     sorter_params = {'detect_threshold': 4.9}
@@ -39,7 +39,7 @@ def test_run_sorter_docker():
 
 @pytest.mark.skipif(ON_GITHUB, reason="Singularity tests don't run on github: test it locally")
 def test_run_sorter_singularity():
-    mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5')
+    mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5', unlock=True)
     recording, sorting_true = read_mearec(mearec_filename)
 
     sorter_params = {'detect_threshold': 4.9}

--- a/spikeinterface/sorters/tests/test_runsorter.py
+++ b/spikeinterface/sorters/tests/test_runsorter.py
@@ -23,16 +23,13 @@ def test_run_sorter_local():
 @pytest.mark.skipif(ON_GITHUB, "Docker tests don't run on github: test locally")
 def test_run_sorter_docker():
     mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5')
-
-    base_folder = Path('/data_local/DataSpikeSorting/mearec')
-    mearec_filename = base_folder / 'recordings_collision_10cells_Neuronexus-32_180s.h5'
     recording, sorting_true = read_mearec(mearec_filename)
 
     sorter_params = {'detect_threshold': 4.9}
 
     docker_image = 'spikeinterface/tridesclous-base:1.6.4'
 
-    sorting = run_sorter('tridesclous', recording, output_folder=base_folder/'sorting_tdc_docker',
+    sorting = run_sorter('tridesclous', recording, output_folder='sorting_tdc_docker',
                          remove_existing_folder=True, delete_output_folder=False,
                          verbose=True, raise_error=True, docker_image=docker_image,
                          **sorter_params)
@@ -41,18 +38,14 @@ def test_run_sorter_docker():
 
 @pytest.mark.skipif(ON_GITHUB, "Singularity tests don't run on github: test it locally")
 def test_run_sorter_singularity():
-    #mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5')
-
-    base_folder = Path('/mnt/data/sam/DataSpikeSorting/mearec')
-    mearec_filename = base_folder / 'recordings_collision_10cells_Neuronexus-32_180s.h5'
-
+    mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5')
     recording, sorting_true = read_mearec(mearec_filename)
 
     sorter_params = {'detect_threshold': 4.9}
 
     singularity_image = 'spikeinterface/tridesclous-base:1.6.4'
 
-    sorting = run_sorter('tridesclous', recording, output_folder=base_folder/'sorting_tdc_singularity',
+    sorting = run_sorter('tridesclous', recording, output_folder='sorting_tdc_singularity',
                          remove_existing_folder=True, delete_output_folder=False,
                          verbose=True, raise_error=True, singularity_image=singularity_image,
                          **sorter_params)
@@ -60,6 +53,6 @@ def test_run_sorter_singularity():
 
 
 if __name__ == '__main__':
-    # test_run_sorter_local()
-    # test_run_sorter_docker()
+    test_run_sorter_local()
+    test_run_sorter_docker()
     test_run_sorter_singularity()

--- a/spikeinterface/sorters/tests/test_runsorter.py
+++ b/spikeinterface/sorters/tests/test_runsorter.py
@@ -33,8 +33,10 @@ def test_run_sorter_docker():
     sorting = run_sorter('tridesclous', recording, output_folder='sorting_tdc_docker',
                          remove_existing_folder=True, delete_output_folder=False,
                          verbose=True, raise_error=True, docker_image=docker_image,
-                         **sorter_params)
-    print(sorting)
+                         with_output=False, **sorter_params)
+    assert sorting is None
+    # TODO: Add another run with `with_output=True` and check sorting result
+
 
 
 @pytest.mark.skipif(ON_GITHUB, reason="Singularity tests don't run on github: test it locally")

--- a/spikeinterface/sorters/tests/test_runsorter.py
+++ b/spikeinterface/sorters/tests/test_runsorter.py
@@ -54,6 +54,10 @@ def test_run_sorter_singularity():
                          **sorter_params)
     print(sorting)
 
+    # basic check to confirm sorting was successful
+    assert 'Tridesclous' in sorting.to_dict()['class']
+    assert len(sorting.get_unit_ids()) > 0
+
 
 if __name__ == '__main__':
     test_run_sorter_local()

--- a/spikeinterface/sorters/tests/test_runsorter.py
+++ b/spikeinterface/sorters/tests/test_runsorter.py
@@ -26,9 +26,6 @@ def test_run_sorter_docker():
     mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5', unlock=True)
     output_folder='sorting_tdc_docker'
 
-    #  test for sam localy
-    # mearec_filename = '/data_local/DataSpikeSorting/mearec_test_10s.h5'
-    # output_folder = '/data_local/DataSpikeSorting/tdc_docker_mearec_test_10s'
 
     recording, sorting_true = read_mearec(mearec_filename)
 

--- a/spikeinterface/sorters/tests/test_runsorter.py
+++ b/spikeinterface/sorters/tests/test_runsorter.py
@@ -51,8 +51,8 @@ def test_run_sorter_singularity():
     output_folder='sorting_tdc_singularity'
 
     #  test for sam localy
-    # mearec_filename = '/data_local/DataSpikeSorting/mearec_test_10s.h5'
-    # output_folder = '/data_local/DataSpikeSorting/tdc_singularity_mearec_test_10s'
+    # mearec_filename = '/mnt/data/sam/DataSpikeSorting/mearec_test_10s.h5'
+    # output_folder = '/mnt/data/sam/DataSpikeSorting/tdc_singularity_mearec_test_10s'
 
     recording, sorting_true = read_mearec(mearec_filename)
 
@@ -73,5 +73,5 @@ def test_run_sorter_singularity():
 
 if __name__ == '__main__':
     # test_run_sorter_local()
-    test_run_sorter_docker()
-    # test_run_sorter_singularity()
+    # test_run_sorter_docker()
+    test_run_sorter_singularity()

--- a/spikeinterface/sorters/tests/test_runsorter.py
+++ b/spikeinterface/sorters/tests/test_runsorter.py
@@ -24,13 +24,19 @@ def test_run_sorter_local():
 @pytest.mark.skipif(ON_GITHUB, reason="Docker tests don't run on github: test locally")
 def test_run_sorter_docker():
     mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5', unlock=True)
+    output_folder='sorting_tdc_docker'
+
+    #  test for sam localy
+    # mearec_filename = '/data_local/DataSpikeSorting/mearec_test_10s.h5'
+    # output_folder = '/data_local/DataSpikeSorting/tdc_docker_mearec_test_10s'
+
     recording, sorting_true = read_mearec(mearec_filename)
 
     sorter_params = {'detect_threshold': 4.9}
 
-    docker_image = 'spikeinterface/tridesclous-base:1.6.4'
+    docker_image = 'spikeinterface/tridesclous-base:1.6.4-1'
 
-    sorting = run_sorter('tridesclous', recording, output_folder='sorting_tdc_docker',
+    sorting = run_sorter('tridesclous', recording, output_folder=output_folder,
                          remove_existing_folder=True, delete_output_folder=False,
                          verbose=True, raise_error=True, docker_image=docker_image,
                          with_output=False, **sorter_params)
@@ -42,13 +48,19 @@ def test_run_sorter_docker():
 @pytest.mark.skipif(ON_GITHUB, reason="Singularity tests don't run on github: test it locally")
 def test_run_sorter_singularity():
     mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5', unlock=True)
+    output_folder='sorting_tdc_singularity'
+
+    #  test for sam localy
+    # mearec_filename = '/data_local/DataSpikeSorting/mearec_test_10s.h5'
+    # output_folder = '/data_local/DataSpikeSorting/tdc_singularity_mearec_test_10s'
+
     recording, sorting_true = read_mearec(mearec_filename)
 
     sorter_params = {'detect_threshold': 4.9}
 
-    singularity_image = 'spikeinterface/tridesclous-base:1.6.4'
+    singularity_image = 'spikeinterface/tridesclous-base:1.6.4-1'
 
-    sorting = run_sorter('tridesclous', recording, output_folder='sorting_tdc_singularity',
+    sorting = run_sorter('tridesclous', recording, output_folder=output_folder,
                          remove_existing_folder=True, delete_output_folder=False,
                          verbose=True, raise_error=True, singularity_image=singularity_image,
                          **sorter_params)
@@ -60,6 +72,6 @@ def test_run_sorter_singularity():
 
 
 if __name__ == '__main__':
-    test_run_sorter_local()
+    # test_run_sorter_local()
     test_run_sorter_docker()
-    test_run_sorter_singularity()
+    # test_run_sorter_singularity()

--- a/spikeinterface/sorters/tests/test_runsorter.py
+++ b/spikeinterface/sorters/tests/test_runsorter.py
@@ -20,7 +20,7 @@ def test_run_sorter_local():
     print(sorting)
 
 
-@pytest.mark.skipif(ON_GITHUB, "Docker tests don't run on github: test locally")
+@pytest.mark.skipif(ON_GITHUB, reason="Docker tests don't run on github: test locally")
 def test_run_sorter_docker():
     mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5')
     recording, sorting_true = read_mearec(mearec_filename)
@@ -36,7 +36,7 @@ def test_run_sorter_docker():
     print(sorting)
 
 
-@pytest.mark.skipif(ON_GITHUB, "Singularity tests don't run on github: test it locally")
+@pytest.mark.skipif(ON_GITHUB, reason="Singularity tests don't run on github: test it locally")
 def test_run_sorter_singularity():
     mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5')
     recording, sorting_true = read_mearec(mearec_filename)


### PR DESCRIPTION
- Skip container tests only on github, but not locally
- Use public test file for container tests to make local test runs comparable
- Pull docker images if these are not  yet available locally
- Extend check if spikeinterface  installation in container is functional