### PR TITLE
Add test files and PyCharm config to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# PyCharm configuration
+.idea
+
 # Rope project settings
 .ropeproject
 
@@ -176,3 +179,52 @@ examples/modules/comparison/tmp_*
 examples/modules/comparison/a_study_folder/*
 examples/modules/toolkit/phy/*
 examples/modules/toolkit/tmp_*
+
+# Files and folders generated during tests
+all_pc1.npy
+all_pc2.npy
+binary01.raw
+binary02.raw
+herdingspikes_output/
+local_cache/
+mdatest/
+mearec_GT_report/
+mearec_test/
+mearec_waveforms/
+phy_output/
+phy_output_radius/
+phy_output_rm/
+phy_output_thr/
+rec/
+saved_multisorting_comparison/
+sort/
+sorting_tdc_local/
+spykingcircus_output/
+test_BaseSorting.npz
+test_BinaryRecordingExtractor_0.raw
+test_BinaryRecordingExtractor_1.raw
+test_BinaryRecordingExtractor_copied_0.raw
+test_BinaryRecordingExtractor_copied_1.raw
+test_NpzSortingExtractor.npz
+test_NpzSortingExtractor_copy.npz
+test_extract_waveforms_returnscaled/
+test_extract_waveforms_sparsity/
+test_groundtruthstudy/
+test_run_sorter_by_property/
+test_run_sorters_dict/
+test_run_sorters_list/
+test_studytools/
+toy_rec/
+toy_rec_1seg/
+toy_rec_2seg/
+toy_sort/
+toy_sorting/
+toy_sorting_1seg/
+toy_sorting_2seg/
+toy_waveforms/
+toy_waveforms_1seg/
+toy_waveforms_2seg/
+tridesclous_output/
+waveforms/
+waveforms_mearec/
+waveforms_rm/


### PR DESCRIPTION
To cleanup the version control and prevent test files to be accidentally added to the history, this PR lists all current test files in the gitignore as well as hidden PyCharm config folders