### PR TITLE
Implement filter_units() in waveform extractor and extensions

### DIFF
--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -8,8 +8,10 @@ from spikeinterface import WaveformExtractor, extract_waveforms
 
 def _clean_all():
     folders = ["wf_rec1", "wf_rec2", "wf_rec3", "wf_sort2", "wf_sort3",
-               "test_waveform_extractor",
-               "test_extract_waveforms_1job", "test_extract_waveforms_2job"]
+               "test_waveform_extractor", "we_filt",
+               "test_extract_waveforms_1job", "test_extract_waveforms_2job",
+               "test_extract_waveforms_returnscaled",
+               "test_extract_waveforms_sparsity"]
     for folder in folders:
         if Path(folder).exists():
             shutil.rmtree(folder)
@@ -74,6 +76,15 @@ def test_WaveformExtractor():
     wf_segment = we.get_template_segment(unit_id=0, segment_index=0)
     assert wf_segment.shape == (210, 2)
     assert wf_segment.shape == (210, 2)
+    
+    
+    # test filter units
+    keep_units = sorting.get_unit_ids()[::2]
+    wf_filt = we.filter_units(keep_units, "we_filt")
+    for unit in wf_filt.sorting.get_unit_ids():
+        assert unit in keep_units
+    filtered_templates = wf_filt.get_all_templates()
+    assert len(filtered_templates) == len(keep_units)
 
 
 def test_extract_waveforms():

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -963,8 +963,13 @@ class BaseWaveformExtractorExtension:
         shutil.copyfile(self.extension_folder / "params.json",
                         new_ext_folder / "params.json")
         # specific files must be copied in subclass
+        self._specific_filter_units(unit_ids=unit_ids, 
+                                    new_waveforms_folder=new_waveforms_folder)
+        
+    def _specific_filter_units(self, unit_ids, new_waveforms_folder):
+        # must be implemented in subclass
+        raise NotImplementedError
 
-    
     def set_params(self, **params):
         """
         Set parameters for the extension and

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -343,11 +343,9 @@ class WaveformExtractor:
         
         for ext_name in self.get_available_extension_names():
             ext = self.load_extension(ext_name)
-            ext._filter_units(unit_ids, new_folder)
+            ext.filter_units(unit_ids, new_folder)
                     
         we = WaveformExtractor.load_from_folder(new_folder)
-        for ext_name in self.get_available_extension_names():
-            we.load_extension(ext_name)
         return we
             
 
@@ -957,9 +955,15 @@ class BaseWaveformExtractorExtension:
         # must be implemented in subclass
         raise NotImplementedError
     
-    def _filter_units(self, unit_ids, new_waveforms_folder):
-        # must be implemented in subclass
-        raise NotImplementedError
+    def filter_units(self, unit_ids, new_waveforms_folder):
+        # creaste new extension folder
+        new_ext_folder = new_waveforms_folder / self.extension_name
+        new_ext_folder.mkdir()
+        # copy parameter file
+        shutil.copyfile(self.extension_folder / "params.json",
+                        new_ext_folder / "params.json")
+        # specific files must be copied in subclass
+
     
     def set_params(self, **params):
         """

--- a/spikeinterface/toolkit/postprocessing/principal_component.py
+++ b/spikeinterface/toolkit/postprocessing/principal_component.py
@@ -65,22 +65,16 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         
         return params
     
-    def _filter_units(self, unit_ids, new_waveforms_folder):
-        # creaste new extension folder
-        new_pca_folder = new_waveforms_folder / self.extension_name
-        new_pca_folder.mkdir()
-        # copy parameter file
-        shutil.copyfile(self.extension_folder / "params.json",
-                        new_pca_folder / "params.json")
-
+    def filter_units(self, unit_ids, new_waveforms_folder):
+        super().filter_units(unit_ids, new_waveforms_folder)
         # populate folder
         pca_files = [f for f in (
             self.extension_folder).iterdir() if f.suffix == ".npy"]
         for unit in unit_ids:
             for pca_file in pca_files:
                 if f"{unit}" in pca_file.name:
-                    shutil.copyfile(
-                        pca_file, new_pca_folder / pca_file.name)
+                    shutil.copyfile(pca_file, new_waveforms_folder / 
+                                    self.extension_name / pca_file.name)
 
     def get_projections(self, unit_id):
         """

--- a/spikeinterface/toolkit/postprocessing/principal_component.py
+++ b/spikeinterface/toolkit/postprocessing/principal_component.py
@@ -65,8 +65,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         
         return params
     
-    def filter_units(self, unit_ids, new_waveforms_folder):
-        super().filter_units(unit_ids, new_waveforms_folder)
+    def _specific_filter_units(self, unit_ids, new_waveforms_folder):
         # populate folder
         pca_files = [f for f in (
             self.extension_folder).iterdir() if f.suffix == ".npy"]

--- a/spikeinterface/toolkit/postprocessing/principal_component.py
+++ b/spikeinterface/toolkit/postprocessing/principal_component.py
@@ -64,6 +64,23 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
                       dtype=np.dtype(dtype).str)
         
         return params
+    
+    def _filter_units(self, unit_ids, new_waveforms_folder):
+        # creaste new extension folder
+        new_pca_folder = new_waveforms_folder / self.extension_name
+        new_pca_folder.mkdir()
+        # copy parameter file
+        shutil.copyfile(self.extension_folder / "params.json",
+                        new_pca_folder / "params.json")
+
+        # populate folder
+        pca_files = [f for f in (
+            self.extension_folder).iterdir() if f.suffix == ".npy"]
+        for unit in unit_ids:
+            for pca_file in pca_files:
+                if f"{unit}" in pca_file.name:
+                    shutil.copyfile(
+                        pca_file, new_pca_folder / pca_file.name)
 
     def get_projections(self, unit_id):
         """

--- a/spikeinterface/toolkit/postprocessing/principal_component.py
+++ b/spikeinterface/toolkit/postprocessing/principal_component.py
@@ -70,11 +70,17 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         # populate folder
         pca_files = [f for f in (
             self.extension_folder).iterdir() if f.suffix == ".npy"]
+        pca_model_files = [f for f in (
+            self.extension_folder).iterdir() if f.suffix == ".pkl"]
         for unit in unit_ids:
             for pca_file in pca_files:
                 if f"{unit}" in pca_file.name:
                     shutil.copyfile(pca_file, new_waveforms_folder / 
                                     self.extension_name / pca_file.name)
+        for pca_model_file in pca_model_files:
+            shutil.copyfile(pca_model_file, new_waveforms_folder /
+                            self.extension_name / pca_model_file.name)
+                
 
     def get_projections(self, unit_id):
         """

--- a/spikeinterface/toolkit/postprocessing/spike_amplitudes.py
+++ b/spikeinterface/toolkit/postprocessing/spike_amplitudes.py
@@ -72,7 +72,7 @@ class SpikeAmplitudesCalculator(BaseWaveformExtractorExtension):
     def _reset(self):
         self._amplitudes = None
     
-    def _filter_units(self, unit_ids, new_waveforms_folder):
+    def _specific_filter_units(self, unit_ids, new_waveforms_folder):
         # load filter and save amplitude files
         for seg_index in range(self.waveform_extractor.recording.get_num_segments()):
             amp_file_name = f"amplitude_segment_{seg_index}.npy"

--- a/spikeinterface/toolkit/postprocessing/spike_amplitudes.py
+++ b/spikeinterface/toolkit/postprocessing/spike_amplitudes.py
@@ -72,8 +72,7 @@ class SpikeAmplitudesCalculator(BaseWaveformExtractorExtension):
     def _reset(self):
         self._amplitudes = None
     
-    def filter_units(self, unit_ids, new_waveforms_folder):
-        super().filter_units(unit_ids, new_waveforms_folder)
+    def _filter_units(self, unit_ids, new_waveforms_folder):
         # load filter and save amplitude files
         for seg_index in range(self.waveform_extractor.recording.get_num_segments()):
             amp_file_name = f"amplitude_segment_{seg_index}.npy"

--- a/spikeinterface/toolkit/postprocessing/spike_amplitudes.py
+++ b/spikeinterface/toolkit/postprocessing/spike_amplitudes.py
@@ -71,15 +71,9 @@ class SpikeAmplitudesCalculator(BaseWaveformExtractorExtension):
 
     def _reset(self):
         self._amplitudes = None
-        
-    def _filter_units(self, unit_ids, new_waveforms_folder):
-        # creaste new extension folder
-        new_amp_folder = new_waveforms_folder / self.extension_name
-        new_amp_folder.mkdir()
-        # copy parameter file
-        shutil.copyfile(self.extension_folder / "params.json",
-                        new_amp_folder / "params.json")
-
+    
+    def filter_units(self, unit_ids, new_waveforms_folder):
+        super().filter_units(unit_ids, new_waveforms_folder)
         # load filter and save amplitude files
         for seg_index in range(self.waveform_extractor.recording.get_num_segments()):
             amp_file_name = f"amplitude_segment_{seg_index}.npy"

--- a/spikeinterface/toolkit/postprocessing/tests/test_principal_component.py
+++ b/spikeinterface/toolkit/postprocessing/tests/test_principal_component.py
@@ -11,7 +11,8 @@ from spikeinterface.toolkit.postprocessing import WaveformPrincipalComponent, co
 
 def setup_module():
     for folder in ('toy_rec_1seg', 'toy_sorting_1seg', 'toy_waveforms_1seg',
-                   'toy_rec_2seg', 'toy_sorting_2seg', 'toy_waveforms_2seg'):
+                   'toy_rec_2seg', 'toy_sorting_2seg', 'toy_waveforms_2seg',
+                   'toy_waveforms_1seg_filt'):
         if Path(folder).is_dir():
             shutil.rmtree(folder)
 
@@ -155,7 +156,15 @@ def test_pca_models_and_project_new():
     new_proj = pc_concatenated.project_new(new_waveforms)
 
     assert new_proj.shape == (100, n_components)
+    
 
+def test_filter_units():
+    we = WaveformExtractor.load_from_folder('toy_waveforms_1seg')
+    pc = compute_principal_components(we, load_if_exists=True)
+
+    keep_units = we.sorting.get_unit_ids()[::2]
+    we_filt = we.filter_units(keep_units, 'toy_waveforms_1seg_filt')
+    assert "principal_components" in we_filt.get_available_extension_names()
 
 if __name__ == '__main__':
     #~ setup_module()

--- a/spikeinterface/toolkit/postprocessing/tests/test_spike_amplitudes.py
+++ b/spikeinterface/toolkit/postprocessing/tests/test_spike_amplitudes.py
@@ -2,13 +2,14 @@ import numpy as np
 from pathlib import Path
 import shutil
 
-from spikeinterface import download_dataset, extract_waveforms
+from spikeinterface import download_dataset, extract_waveforms, WaveformExtractor
 import spikeinterface.extractors as se
 from spikeinterface.toolkit import compute_spike_amplitudes, SpikeAmplitudesCalculator
 
 
 def _clean_all():
-    folders = ["mearec_waveforms", "mearec_waveforms_scaled", "mearec_waveforms_all"]
+    folders = ["mearec_waveforms", "mearec_waveforms_scaled", "mearec_waveforms_all",
+               "mearec_waveforms_filt"]
     for folder in folders:
         if Path(folder).exists():
             shutil.rmtree(folder)
@@ -51,7 +52,7 @@ def test_compute_spike_amplitudes():
                                   overwrite=True, return_scaled=True)
 
     amplitudes_scaled = compute_spike_amplitudes(we_scaled, peak_sign='neg', outputs='concatenated', chunk_size=10000, n_jobs=1,
-                                             return_scaled=True)
+                                                 return_scaled=True)
     amplitudes_unscaled = compute_spike_amplitudes(we_scaled, peak_sign='neg', outputs='concatenated', chunk_size=10000,
                                                n_jobs=1, return_scaled=False)
 
@@ -88,6 +89,14 @@ def test_compute_spike_amplitudes_parallel():
     # assert np.array_equal(amplitudes1, amplitudes2)
     # shutil.rmtree(folder)
 
+
+def test_filter_units():
+    we = WaveformExtractor.load_from_folder('mearec_waveforms')
+    amps = compute_spike_amplitudes(we, load_if_exists=True)
+
+    keep_units = we.sorting.get_unit_ids()[::2]
+    we_filt = we.filter_units(keep_units, 'mearec_waveforms_filt')
+    assert "spike_amplitudes" in we_filt.get_available_extension_names()
 
 if __name__ == '__main__':
     # test_compute_spike_amplitudes()

--- a/spikeinterface/toolkit/qualitymetrics/quality_metric_calculator.py
+++ b/spikeinterface/toolkit/qualitymetrics/quality_metric_calculator.py
@@ -1,5 +1,7 @@
-from copy import deepcopy
+import numpy as np
 import pandas as pd
+import shutil
+from copy import deepcopy
 
 from spikeinterface.core.waveform_extractor import WaveformExtractor, BaseWaveformExtractorExtension
 
@@ -67,7 +69,19 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
 
     def _reset(self):
         self._metrics = None
+        
+    def _filter_units(self, unit_ids, new_waveforms_folder):
+        # creaste new extension folder
+        new_qm_folder = new_waveforms_folder / self.extension_name
+        new_qm_folder.mkdir()
+        # copy parameter file
+        shutil.copyfile(self.extension_folder / "params.json",
+                        new_qm_folder / "params.json")
 
+        # filter metrics dataframe
+        new_metrics = self._metrics.loc[np.array(unit_ids)]
+        new_metrics.to_csv(new_qm_folder / 'metrics.csv')
+        
     def compute_metrics(self):
         """
         Computes quality metrics

--- a/spikeinterface/toolkit/qualitymetrics/quality_metric_calculator.py
+++ b/spikeinterface/toolkit/qualitymetrics/quality_metric_calculator.py
@@ -70,17 +70,11 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
     def _reset(self):
         self._metrics = None
         
-    def _filter_units(self, unit_ids, new_waveforms_folder):
-        # creaste new extension folder
-        new_qm_folder = new_waveforms_folder / self.extension_name
-        new_qm_folder.mkdir()
-        # copy parameter file
-        shutil.copyfile(self.extension_folder / "params.json",
-                        new_qm_folder / "params.json")
-
+    def filter_units(self, unit_ids, new_waveforms_folder):
+        super().filter_units(unit_ids, new_waveforms_folder)
         # filter metrics dataframe
         new_metrics = self._metrics.loc[np.array(unit_ids)]
-        new_metrics.to_csv(new_qm_folder / 'metrics.csv')
+        new_metrics.to_csv(new_waveforms_folder / self.extension_name / 'metrics.csv')
         
     def compute_metrics(self):
         """

--- a/spikeinterface/toolkit/qualitymetrics/quality_metric_calculator.py
+++ b/spikeinterface/toolkit/qualitymetrics/quality_metric_calculator.py
@@ -70,8 +70,7 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
     def _reset(self):
         self._metrics = None
         
-    def filter_units(self, unit_ids, new_waveforms_folder):
-        super().filter_units(unit_ids, new_waveforms_folder)
+    def _specific_filter_units(self, unit_ids, new_waveforms_folder):
         # filter metrics dataframe
         new_metrics = self._metrics.loc[np.array(unit_ids)]
         new_metrics.to_csv(new_waveforms_folder / self.extension_name / 'metrics.csv')

--- a/spikeinterface/toolkit/qualitymetrics/tests/test_quality_metric_calculator.py
+++ b/spikeinterface/toolkit/qualitymetrics/tests/test_quality_metric_calculator.py
@@ -12,7 +12,7 @@ from spikeinterface.toolkit.qualitymetrics import compute_quality_metrics, Quali
 
 
 def setup_module():
-    for folder in ('toy_rec', 'toy_sorting', 'toy_waveforms'):
+    for folder in ('toy_rec', 'toy_sorting', 'toy_waveforms', 'toy_waveforms_filt'):
         if Path(folder).is_dir():
             shutil.rmtree(folder)
 
@@ -55,6 +55,13 @@ def test_compute_quality_metrics():
     # print(qmc._metrics)
 
 
+def test_filter_units():
+    we = WaveformExtractor.load_from_folder('toy_waveforms')
+    qm = compute_quality_metrics(we, load_if_exists=True)
+
+    keep_units = we.sorting.get_unit_ids()[::2]
+    we_filt = we.filter_units(keep_units, 'toy_waveforms_filt')
+    assert "quality_metrics" in we_filt.get_available_extension_names()
 
 if __name__ == '__main__':
     setup_module()


### PR DESCRIPTION
With `we.filter_units(unit_ids, new_folder)` one can create a new `WaveformExtractor` object only with the selected units. All the registered extensions will also automatically copy the correct info about the selected units in the new folder.

- [x] add tests