### PR TITLE
Fix filtering units when units>10

### DIFF
--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -34,7 +34,7 @@ def test_WaveformExtractor():
     recording.annotate(is_filtered=True)
     folder_rec = "wf_rec1"
     recording = recording.save(folder=folder_rec)
-    sorting = generate_sorting(num_units=5, sampling_frequency=sampling_frequency, durations=durations)
+    sorting = generate_sorting(num_units=15, sampling_frequency=sampling_frequency, durations=durations)
 
     # test with dump !!!!
     recording = recording.save()

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -30,11 +30,14 @@ def test_WaveformExtractor():
     sampling_frequency = 30000.
 
     # 2 segments
-    recording = generate_recording(num_channels=2, durations=durations, sampling_frequency=sampling_frequency)
+    num_channels = 2
+    recording = generate_recording(num_channels=num_channels, durations=durations, 
+                                   sampling_frequency=sampling_frequency)
     recording.annotate(is_filtered=True)
     folder_rec = "wf_rec1"
     recording = recording.save(folder=folder_rec)
-    sorting = generate_sorting(num_units=15, sampling_frequency=sampling_frequency, durations=durations)
+    num_units = 15
+    sorting = generate_sorting(num_units=num_units, sampling_frequency=sampling_frequency, durations=durations)
 
     # test with dump !!!!
     recording = recording.save()
@@ -53,7 +56,7 @@ def test_WaveformExtractor():
 
     wfs = we.get_waveforms(0)
     assert wfs.shape[0] <= 500
-    assert wfs.shape[1:] == (210, 2)
+    assert wfs.shape[1:] == (210, num_channels)
 
     wfs, sampled_index = we.get_waveforms(0, with_index=True)
 
@@ -65,17 +68,17 @@ def test_WaveformExtractor():
     template = we.get_template(0)
     assert template.shape == (210, 2)
     templates = we.get_all_templates()
-    assert templates.shape == (5, 210, 2)
+    assert templates.shape == (num_units, 210, num_channels)
 
     wf_std = we.get_template(0, mode='std')
-    assert wf_std.shape == (210, 2)
+    assert wf_std.shape == (210, num_channels)
     wfs_std = we.get_all_templates(mode='std')
-    assert wfs_std.shape == (5, 210, 2)
+    assert wfs_std.shape == (num_units, 210, num_channels)
 
 
     wf_segment = we.get_template_segment(unit_id=0, segment_index=0)
-    assert wf_segment.shape == (210, 2)
-    assert wf_segment.shape == (210, 2)
+    assert wf_segment.shape == (210, num_channels)
+    assert wf_segment.shape == (210, num_channels)
     
     
     # test filter units
@@ -84,7 +87,7 @@ def test_WaveformExtractor():
     for unit in wf_filt.sorting.get_unit_ids():
         assert unit in keep_units
     filtered_templates = wf_filt.get_all_templates()
-    assert len(filtered_templates) == len(keep_units)
+    assert filtered_templates.shape == (len(keep_units), 210, num_channels)
 
 
 def test_extract_waveforms():

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -337,7 +337,7 @@ class WaveformExtractor:
         waveforms_files = [f for f in (self.folder / "waveforms").iterdir() if f.suffix == ".npy"]
         for unit in sorting.get_unit_ids():
             for wf_file in waveforms_files:
-                if f"{unit}" in wf_file.name:
+                if f"waveforms_{unit}.npy" in wf_file.name or f'sampled_index_{unit}.npy' in wf_file.name:
                     shutil.copyfile(
                         wf_file, new_waveforms_folder / wf_file.name)
         

--- a/spikeinterface/toolkit/postprocessing/principal_component.py
+++ b/spikeinterface/toolkit/postprocessing/principal_component.py
@@ -73,7 +73,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
             self.extension_folder).iterdir() if f.suffix == ".pkl"]
         for unit in unit_ids:
             for pca_file in pca_files:
-                if f"{unit}" in pca_file.name:
+                if f"pca_{unit}.npy" in pca_file.name:
                     shutil.copyfile(pca_file, new_waveforms_folder / 
                                     self.extension_name / pca_file.name)
         for pca_model_file in pca_model_files:


### PR DESCRIPTION
There was a bug in copying the files. Now both WaveformExtractor and WaveformPrincipalComponent check for entire file names.