### PR TITLE
Fix peak sign for amplitude cutoffs

### DIFF
--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -266,8 +266,6 @@ class BaseExtractor:
             # include only main properties
             dump_dict['properties'] = {k: self._properties.get(k, None) for k in self._main_properties}
 
-        # TODO include features
-
         if relative_to is not None:
             relative_to = Path(relative_to).absolute()
             assert relative_to.is_dir(), "'relative_to' must be an existing directory"

--- a/spikeinterface/toolkit/preprocessing/normalize_scale.py
+++ b/spikeinterface/toolkit/preprocessing/normalize_scale.py
@@ -97,7 +97,7 @@ class ScaleRecording(BasePreprocessor):
     ----------
     recording: RecordingExtractor
         The recording extractor to be transformed
-    scalar: float or array
+    gain: float or array
         Scalar for the traces of the recording extractor or array with scalars for each channel
     offset: float or array
         Offset for the traces of the recording extractor or array with offsets for each channel
@@ -139,7 +139,7 @@ class ScaleRecording(BasePreprocessor):
             rec_segment = ScaleRecordingSegment(parent_segment, gain, offset)
             self.add_recording_segment(rec_segment)
 
-        self._kwargs = dict(recording=recording.to_dict(), gain=gain, offset=offset, dtype=dtype)
+        self._kwargs = dict(recording=recording.to_dict(), gain=gain, offset=offset, dtype=np.dtype(dtype).str)
 
 
 class CenterRecording(BasePreprocessor):

--- a/spikeinterface/toolkit/qualitymetrics/misc_metrics.py
+++ b/spikeinterface/toolkit/qualitymetrics/misc_metrics.py
@@ -232,19 +232,22 @@ def compute_amplitudes_cutoff(waveform_extractor, peak_sign='neg',
         chan_id = extremum_channels_ids[unit_id]
         chan_ind = recording.id_to_index(chan_id)
         amplitudes = waveforms[:, before, chan_ind]
+        
+        # change amplitudes signs in case peak_sign is pos
+        if peak_sign == "pos":
+            amplitudes = -amplitudes
 
         h, b = np.histogram(amplitudes, num_histogram_bins, density=True)
 
         # TODO : change with something better scipy.ndimage.filters.gaussian_filter1d
         pdf = scipy.ndimage.filters.gaussian_filter1d(h, histogram_smoothing_value)
         support = b[:-1]
-
-        peak_index = np.argmax(pdf)
-        G = np.argmin(np.abs(pdf[peak_index:] - pdf[0])) + peak_index
-
         bin_size = np.mean(np.diff(support))
+        peak_index = np.argmax(pdf)
+        
+        G = np.argmin(np.abs(pdf[peak_index:] - pdf[0])) + peak_index
         fraction_missing = np.sum(pdf[G:]) * bin_size
-
+    
         fraction_missing = np.min([fraction_missing, 0.5])
 
         all_fraction_missing[unit_id] = fraction_missing


### PR DESCRIPTION
Fixes https://github.com/SpikeInterface/spikeinterface/issues/421

Plus a small fix to make the `scale` recording object dumpable (save dtype string in kwargs)