### PR TITLE
Add quality metrics and SI unit ids to phy tsv

### DIFF
--- a/spikeinterface/extractors/phykilosortextractors.py
+++ b/spikeinterface/extractors/phykilosortextractors.py
@@ -93,7 +93,12 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
             assert "id" in cluster_info.columns, "Couldn't find cluster ids in the tsv files!"
             cluster_info["cluster_id"] = cluster_info["id"]
             del cluster_info["id"]
-        unit_ids = cluster_info["cluster_id"].values
+
+        if 'si_unit_id' in cluster_info.columns:
+            unit_ids = cluster_info["si_unit_id"].values
+            del cluster_info["si_unit_id"]
+        else:
+            unit_ids = cluster_info["cluster_id"].values
 
         BaseSorting.__init__(self, sampling_frequency, unit_ids)
 


### PR DESCRIPTION
Partially implements suggestions in https://github.com/SpikeInterface/spikeinterface/issues/402

- when "quality_metrics" extension is present, add metrics to Phy tsv files
- save an extra tsv with "si_unit_id". This keeps track of the SI unit id (e.g. #0 in mearec) and loads unit back from this column (if existing)