### PR TITLE
Make waveform cache to memory optional

### DIFF
--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -63,7 +63,7 @@ class WaveformExtractor:
         self.sorting = sorting
         self.folder = Path(folder)
 
-        # cache in memory/memmap
+        # cache in memory
         self._waveforms = {}
         self._template_cache = {}
         self._params = {}


### PR DESCRIPTION
Fixes https://github.com/SpikeInterface/spikeinterface/issues/331 and https://github.com/SpikeInterface/spikeinterface/issues/442

Added `cache` and `memmap` options for `get_waveforms`

Using the code from @Dradeliomecus [here](https://github.com/SpikeInterface/spikeinterface/issues/331#issue-1036047654) for a 300s 64-chan recording, with 60 units:

## With `cache=True` and `memmap=True`

```
wvf_extractor = spikeinterface.WaveformExtractor.create(rec, sort, "test_mem", remove_if_exists=True)
wvf_extractor.set_params(ms_before=4.0, ms_after=8.0, max_spikes_per_unit=None)
wvf_extractor.run_extract_waveforms(n_jobs=4, total_memory='2G', progress_bar=True)

print("Memory usage of wvf_extractor: {0:.5f} GB\n".format(getsize(wvf_extractor) / 1024**3))

for unit_id in sort.get_unit_ids():
    print("Extracting unit", unit_id)

    wvfs = wvf_extractor.get_waveforms(unit_id, cache=True, memmap=True)
    # Do stuff
    del wvfs

    print("Memory usage of wvf_extractor: {0:.5f} GB\n".format(getsize(wvf_extractor) / 1024**3))
```

Output:
```
Memory usage of wvf_extractor: 0.00064 GB

Extracting unit 0
Memory usage of wvf_extractor: 0.00064 GB

Extracting unit 1
Memory usage of wvf_extractor: 0.00064 GB

Extracting unit 2
Memory usage of wvf_extractor: 0.00064 GB

Extracting unit 3
Memory usage of wvf_extractor: 0.00064 GB

Extracting unit 4
Memory usage of wvf_extractor: 0.00064 GB

Extracting unit 5
Memory usage of wvf_extractor: 0.00064 GB

Extracting unit 6
Memory usage of wvf_extractor: 0.00064 GB

Extracting unit 7
Memory usage of wvf_extractor: 0.00064 GB

Extracting unit 8
Memory usage of wvf_extractor: 0.00064 GB

Extracting unit 9
Memory usage of wvf_extractor: 0.00064 GB

Extracting unit 10
Memory usage of wvf_extractor: 0.00065 GB

Extracting unit 11
Memory usage of wvf_extractor: 0.00065 GB

Extracting unit 12
Memory usage of wvf_extractor: 0.00065 GB

Extracting unit 13
Memory usage of wvf_extractor: 0.00065 GB

Extracting unit 14
Memory usage of wvf_extractor: 0.00065 GB

Extracting unit 15
Memory usage of wvf_extractor: 0.00065 GB

Extracting unit 16
Memory usage of wvf_extractor: 0.00065 GB

Extracting unit 17
Memory usage of wvf_extractor: 0.00065 GB

Extracting unit 18
Memory usage of wvf_extractor: 0.00065 GB

Extracting unit 19
Memory usage of wvf_extractor: 0.00065 GB

Extracting unit 20
Memory usage of wvf_extractor: 0.00065 GB

Extracting unit 21
Memory usage of wvf_extractor: 0.00065 GB

Extracting unit 22
Memory usage of wvf_extractor: 0.00065 GB

Extracting unit 23
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 24
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 25
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 26
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 27
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 28
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 29
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 30
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 31
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 32
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 33
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 34
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 35
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 36
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 37
Memory usage of wvf_extractor: 0.00066 GB

Extracting unit 38
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 39
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 40
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 41
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 42
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 43
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 44
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 45
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 46
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 47
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 48
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 49
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 50
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 51
Memory usage of wvf_extractor: 0.00067 GB

Extracting unit 52
Memory usage of wvf_extractor: 0.00068 GB

Extracting unit 53
Memory usage of wvf_extractor: 0.00068 GB

Extracting unit 54
Memory usage of wvf_extractor: 0.00068 GB

Extracting unit 55
Memory usage of wvf_extractor: 0.00068 GB

Extracting unit 56
Memory usage of wvf_extractor: 0.00068 GB

Extracting unit 57
Memory usage of wvf_extractor: 0.00068 GB

Extracting unit 58
Memory usage of wvf_extractor: 0.00068 GB

Extracting unit 59
Memory usage of wvf_extractor: 0.00068 GB
```

## With `cache=True` and `memmap=False`
```
wvf_extractor = spikeinterface.WaveformExtractor.create(rec, sort, "test_mem", remove_if_exists=True)
wvf_extractor.set_params(ms_before=4.0, ms_after=8.0, max_spikes_per_unit=None)
wvf_extractor.run_extract_waveforms(n_jobs=4, total_memory='2G', progress_bar=True)

print("Memory usage of wvf_extractor: {0:.5f} GB\n".format(getsize(wvf_extractor) / 1024**3))

for unit_id in sort.get_unit_ids():
    print("Extracting unit", unit_id)

    wvfs = wvf_extractor.get_waveforms(unit_id, cache=True, memmap=False)
    # Do stuff
    del wvfs

    print("Memory usage of wvf_extractor: {0:.5f} GB\n".format(getsize(wvf_extractor) / 1024**3))
```

Output
```
Memory usage of wvf_extractor: 0.00064 GB

Extracting unit 0
Memory usage of wvf_extractor: 0.12097 GB

Extracting unit 1
Memory usage of wvf_extractor: 0.24234 GB

Extracting unit 2
Memory usage of wvf_extractor: 0.35787 GB

Extracting unit 3
Memory usage of wvf_extractor: 0.47889 GB

Extracting unit 4
Memory usage of wvf_extractor: 0.60283 GB

Extracting unit 5
Memory usage of wvf_extractor: 0.72059 GB

Extracting unit 6
Memory usage of wvf_extractor: 0.84006 GB

Extracting unit 7
Memory usage of wvf_extractor: 0.96194 GB

Extracting unit 8
Memory usage of wvf_extractor: 1.08331 GB

Extracting unit 9
Memory usage of wvf_extractor: 1.20175 GB

Extracting unit 10
Memory usage of wvf_extractor: 1.32278 GB

Extracting unit 11
Memory usage of wvf_extractor: 1.44122 GB

Extracting unit 12
Memory usage of wvf_extractor: 1.56448 GB

Extracting unit 13
Memory usage of wvf_extractor: 1.68412 GB

Extracting unit 14
Memory usage of wvf_extractor: 1.80429 GB

Extracting unit 15
Memory usage of wvf_extractor: 1.92531 GB

Extracting unit 16
Memory usage of wvf_extractor: 2.04496 GB

Extracting unit 17
Memory usage of wvf_extractor: 2.16237 GB

Extracting unit 18
Memory usage of wvf_extractor: 2.28425 GB

Extracting unit 19
Memory usage of wvf_extractor: 2.40407 GB

Extracting unit 20
Memory usage of wvf_extractor: 2.52321 GB

Extracting unit 21
Memory usage of wvf_extractor: 2.64406 GB

Extracting unit 22
Memory usage of wvf_extractor: 2.76302 GB

Extracting unit 23
Memory usage of wvf_extractor: 2.88352 GB

Extracting unit 24
Memory usage of wvf_extractor: 3.00300 GB

Extracting unit 25
Memory usage of wvf_extractor: 3.12265 GB

Extracting unit 26
Memory usage of wvf_extractor: 3.24521 GB

Extracting unit 27
Memory usage of wvf_extractor: 3.36830 GB

Extracting unit 28
Memory usage of wvf_extractor: 3.48846 GB

Extracting unit 29
Memory usage of wvf_extractor: 3.60879 GB

Extracting unit 30
Memory usage of wvf_extractor: 3.73016 GB

Extracting unit 31
Memory usage of wvf_extractor: 3.85067 GB

Extracting unit 32
Memory usage of wvf_extractor: 3.97066 GB

Extracting unit 33
Memory usage of wvf_extractor: 4.09185 GB

Extracting unit 34
Memory usage of wvf_extractor: 4.21373 GB

Extracting unit 35
Memory usage of wvf_extractor: 4.33595 GB

Extracting unit 36
Memory usage of wvf_extractor: 4.45646 GB

Extracting unit 37
Memory usage of wvf_extractor: 4.57628 GB

Extracting unit 38
Memory usage of wvf_extractor: 4.69696 GB

Extracting unit 39
Memory usage of wvf_extractor: 4.81695 GB

Extracting unit 40
Memory usage of wvf_extractor: 4.94089 GB

Extracting unit 41
Memory usage of wvf_extractor: 5.06174 GB

Extracting unit 42
Memory usage of wvf_extractor: 5.18293 GB

Extracting unit 43
Memory usage of wvf_extractor: 5.30155 GB

Extracting unit 44
Memory usage of wvf_extractor: 5.42188 GB

Extracting unit 45
Memory usage of wvf_extractor: 5.54514 GB

Extracting unit 46
Memory usage of wvf_extractor: 5.66702 GB

Extracting unit 47
Memory usage of wvf_extractor: 5.78461 GB

Extracting unit 48
Memory usage of wvf_extractor: 5.90511 GB

Extracting unit 49
Memory usage of wvf_extractor: 6.02425 GB

Extracting unit 50
Memory usage of wvf_extractor: 6.14407 GB

Extracting unit 51
Memory usage of wvf_extractor: 6.26629 GB

Extracting unit 52
Memory usage of wvf_extractor: 6.38576 GB

Extracting unit 53
Memory usage of wvf_extractor: 6.50455 GB

Extracting unit 54
Memory usage of wvf_extractor: 6.62849 GB

Extracting unit 55
Memory usage of wvf_extractor: 6.74934 GB

Extracting unit 56
Memory usage of wvf_extractor: 6.86968 GB

Extracting unit 57
Memory usage of wvf_extractor: 6.98984 GB

Extracting unit 58
Memory usage of wvf_extractor: 7.11155 GB

Extracting unit 59
Memory usage of wvf_extractor: 7.23377 GB
```