### PR TITLE
Propagate is_dumpable correctly

### DIFF
--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -181,7 +181,7 @@ class BaseExtractor:
 
     def copy_metadata(self, other, only_main=False, ids=None):
         """
-        Copy annotations/properties/features to another extractor.
+        Copy annotations/properties/is_dumpable to another extractor.
 
         If 'only main' is True, then only "main" annotations/properties/features one are copied.
         """
@@ -194,19 +194,17 @@ class BaseExtractor:
         if only_main:
             ann_keys = BaseExtractor._main_annotations
             prop_keys = BaseExtractor._main_properties
-            # feat_keys = BaseExtractor._main_features
         else:
             ann_keys = self._annotations.keys()
             prop_keys = self._properties.keys()
-            # TODO include features
-            # feat_keys = ExtractorBase._features.keys()
 
         other._annotations = deepcopy({k: self._annotations[k] for k in ann_keys})
         for k in prop_keys:
             values = self._properties[k]
             if values is not None:
                 other.set_property(k, values[inds])
-        # TODO: copy features also
+        
+        other.is_dumpable = self.is_dumpable
 
     def to_dict(self, include_annotations=False, include_properties=False, include_features=False,
                 relative_to=None, folder_metadata=None):

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -24,8 +24,6 @@ class BaseRecording(BaseExtractor):
     def __init__(self, sampling_frequency: float, channel_ids: List, dtype):
         BaseExtractor.__init__(self, channel_ids)
 
-        self.is_dumpable = True
-
         self._sampling_frequency = sampling_frequency
         self._dtype = np.dtype(dtype)
 

--- a/spikeinterface/core/channelsaggregationrecording.py
+++ b/spikeinterface/core/channelsaggregationrecording.py
@@ -85,6 +85,10 @@ class ChannelsAggregationRecording(BaseRecording):
             parent_segments = [rec._recording_segments[i_seg] for rec in recording_list]
             sub_segment = ChannelsAggregationRecordingSegment(channel_map, parent_segments)
             self.add_recording_segment(sub_segment)
+            
+        # set is_dumpable
+        if not np.all([rec.is_dumpable for sort in recording_list]):
+            self.is_dumpable = False
 
         self._recordings = recording_list
         self._kwargs = {'recording_list': [rec.to_dict() for rec in recording_list],

--- a/spikeinterface/core/channelslicerecording.py
+++ b/spikeinterface/core/channelslicerecording.py
@@ -45,12 +45,13 @@ class ChannelSliceRecording(BaseRecording):
 
         # copy annotation and properties
         parent_recording.copy_metadata(self, only_main=False, ids=self._channel_ids)
-
+        
         # change the wiring of the probe
         contact_vector = self.get_property('contact_vector')
         if contact_vector is not None:
             contact_vector['device_channel_indices'] = np.arange(len(channel_ids), dtype='int64')
             self.set_property('contact_vector', contact_vector)
+            
 
         # update dump dict
         self._kwargs = {'parent_recording': parent_recording.to_dict(), 'channel_ids': channel_ids,

--- a/spikeinterface/core/frameslicerecording.py
+++ b/spikeinterface/core/frameslicerecording.py
@@ -34,7 +34,7 @@ class FrameSliceRecording(BaseRecording):
                                sampling_frequency=parent_recording.get_sampling_frequency(),
                                channel_ids=channel_ids,
                                dtype=parent_recording.get_dtype())
-
+        
         # link recording segment
         parent_segment = parent_recording._recording_segments[0]
         sub_segment = FrameSliceRecordingSegment(parent_segment, int(start_frame), int(end_frame))
@@ -42,7 +42,7 @@ class FrameSliceRecording(BaseRecording):
 
         # copy properties and annotations
         parent_recording.copy_metadata(self)
-
+        
         # update dump dict
         self._kwargs = {'parent_recording': parent_recording.to_dict(), 'start_frame': int(start_frame),
                         'end_frame': int(end_frame)}

--- a/spikeinterface/core/unitsaggregationsorting.py
+++ b/spikeinterface/core/unitsaggregationsorting.py
@@ -66,6 +66,10 @@ class UnitsAggregationSorting(BaseSorting):
             parent_segments = [sort._sorting_segments[i_seg] for sort in sorting_list]
             sub_segment = UnitsAggregationSortingSegment(unit_map, parent_segments)
             self.add_sorting_segment(sub_segment)
+        
+        # set is_dumpable
+        if not np.all([sort.is_dumpable for sort in sorting_list]):
+            self.is_dumpable = False
 
         self._sortings = sorting_list
         self._kwargs = {'sorting_list': [sort.to_dict() for sort in sorting_list],


### PR DESCRIPTION
Fixes: https://github.com/SpikeInterface/spikeinterface/issues/425#issuecomment-1005998317

The `copy_metadata` now propagates `is_dumpable` too