### PR TITLE
New to old sorting

### DIFF
--- a/spikeinterface/core/__init__.py
+++ b/spikeinterface/core/__init__.py
@@ -50,4 +50,4 @@ from .waveform_extractor import WaveformExtractor, extract_waveforms
 from .datasets import download_dataset
 
 from .old_api_utils import (create_recording_from_old_extractor, create_sorting_from_old_extractor,
-                            create_extractor_from_new_recording)
+                            create_extractor_from_new_recording, create_extractor_from_new_sorting)

--- a/spikeinterface/core/old_api_utils.py
+++ b/spikeinterface/core/old_api_utils.py
@@ -45,46 +45,163 @@ class NewToOldRecording:
         v = values[ind[0]]
         return v
 
-
 def create_extractor_from_new_recording(new_recording):
     old_recording = NewToOldRecording(new_recording)
     return old_recording
+
 class NewToOldSorting:
     """
     This class mimic the old API of spikeextractors with:
-      * reversed shape (channels, samples):
       * unique segment
     """
+    extractor_name = 'NewToOldSorting'
+    is_writable = False
 
     def __init__(self, sorting):
         assert sorting.get_num_segments() == 1
         self._sorting = sorting
+        self._sampling_frequency = sorting.get_sampling_frequency()
+        self.is_dumpable = False
 
-    def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        traces = self._recording.get_traces(channel_ids=channel_ids,
-                                            start_frame=start_frame, end_frame=end_frame,
-                                            segment_index=0)
-        return traces.T
+    def get_unit_ids(self):
+        """This function returns a list of ids (ints) for each unit in the sorsted result.
 
-    def get_num_frames(self):
-        return self._recording.get_num_frames(segment_index=0)
+        Returns
+        -------
+        unit_ids: array_like
+            A list of the unit ids in the sorted result (ints).
+        """
+        return self._sorting.get_unit_ids()   
 
-    def get_num_channels(self):
-        return self._recording.get_num_channels()
+    def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
+        """This function extracts spike frames from the specified unit.
+        It will return spike frames from within three ranges:
+
+            [start_frame, t_start+1, ..., end_frame-1]
+            [start_frame, start_frame+1, ..., final_unit_spike_frame - 1]
+            [0, 1, ..., end_frame-1]
+            [0, 1, ..., final_unit_spike_frame - 1]
+
+        if both start_frame and end_frame are given, if only start_frame is
+        given, if only end_frame is given, or if neither start_frame or end_frame
+        are given, respectively. Spike frames are returned in the form of an
+        array_like of spike frames. In this implementation, start_frame is inclusive
+        and end_frame is exclusive conforming to numpy standards.
+
+        Parameters
+        ----------
+        unit_id: int
+            The id that specifies a unit in the recording
+        start_frame: int
+            The frame above which a spike frame is returned  (inclusive)
+        end_frame: int
+            The frame below which a spike frame is returned  (exclusive)
+
+        Returns
+        -------
+        spike_train: numpy.ndarray
+            An 1D array containing all the frames for each spike in the
+            specified unit given the range of start and end frames
+        """
+        return self._sorting.get_unit_spike_train(unit_id=unit_id, segment_index=0,
+                                                  start_frame=start_frame, end_frame=end_frame)        
+    
+    def get_units_spike_train(self, unit_ids=None, start_frame=None, end_frame=None):
+        """This function extracts spike frames from the specified units.
+
+        Parameters
+        ----------
+        unit_ids: array_like
+            The unit ids from which to return spike trains. If None, all unit
+            spike trains will be returned
+        start_frame: int
+            The frame above which a spike frame is returned  (inclusive)
+        end_frame: int
+            The frame below which a spike frame is returned  (exclusive)
+
+        Returns
+        -------
+        spike_train: numpy.ndarray
+            An 2D array containing all the frames for each spike in the
+            specified units given the range of start and end frames
+        """
+        if unit_ids is None:
+            unit_ids = self.get_unit_ids()
+        spike_trains = [self.get_unit_spike_train(uid, start_frame, end_frame) for uid in unit_ids]
+        return spike_trains
 
     def get_sampling_frequency(self):
-        return self._recording.get_sampling_frequency()
+        """
+        It returns the sampling frequency.
 
-    def get_channel_ids(self):
-        return self._recording.get_channel_ids()
+        Returns
+        -------
+        sampling_frequency: float
+            The sampling frequency
+        """
+        return self._sampling_frequency
 
-    def get_channel_property(self, channel_id, property):
-        rec = self._recording
-        values = rec.get_property(property)
-        ind = rec.ids_to_indices([channel_id])
-        v = values[ind[0]]
-        return v
+    def set_sampling_frequency(self, sampling_frequency):
+        """
+        It sets the sorting extractor sampling frequency.
 
+        Parameters
+        ----------
+        sampling_frequency: float
+            The sampling frequency
+        """
+        self._sampling_frequency = sampling_frequency
+    
+    def set_times(self, times):
+        """This function sets the sorting times to convert spike trains to seconds
+
+        Parameters
+        ----------
+        times: array-like
+            The times in seconds for each frame
+        """
+        max_frames = np.array([np.max(self.get_unit_spike_train(u)) for u in self.get_unit_ids()])
+        assert np.all(max_frames < len(times)), "The length of 'times' should be greater than the maximum " \
+                                                     "spike frame index"
+        self._times = times.astype('float64')
+
+    def frame_to_time(self, frames):
+        """This function converts user-inputed frame indexes to times with units of seconds.
+
+        Parameters
+        ----------
+        frames: float or array-like
+            The frame or frames to be converted to times
+
+        Returns
+        -------
+        times: float or array-like
+            The corresponding times in seconds
+        """
+        # Default implementation
+        if self._times is None:
+            return np.round(frames / self.get_sampling_frequency(), 6)
+        else:
+            return self._times[frames]
+
+    def time_to_frame(self, times):
+        """This function converts a user-inputted times (in seconds) to a frame indexes.
+
+        Parameters
+        ----------
+        times: float or array-like
+            The times (in seconds) to be converted to frame indexes
+
+        Returns
+        -------
+        frames: float or array-like
+            The corresponding frame indexes
+        """
+        # Default implementation
+        if self._times is None:
+            return np.round(times * self.get_sampling_frequency()).astype('int64')
+        else:
+            return np.searchsorted(self._times, times).astype('int64')
 
 def create_extractor_from_new_sorting(new_sorting):
     old_sorting = NewToOldSorting(new_sorting)
@@ -92,7 +209,6 @@ def create_extractor_from_new_sorting(new_sorting):
 
 _old_to_new_property_map = {'gain': {'name': 'gain_to_uV', 'skip_if_value': 1},
                             'offset': {'name': 'offset_to_uV', 'skip_if_value': 0}}
-
 
 class OldToNewRecording(BaseRecording):
     """Wrapper class to convert old RecordingExtractor to a

--- a/spikeinterface/core/old_api_utils.py
+++ b/spikeinterface/core/old_api_utils.py
@@ -153,69 +153,6 @@ class NewToOldSorting:
         """
         return self._sampling_frequency
 
-    def set_sampling_frequency(self, sampling_frequency):
-        """
-        It sets the sorting extractor sampling frequency.
-
-        Parameters
-        ----------
-        sampling_frequency: float
-            The sampling frequency
-        """
-        self._sampling_frequency = sampling_frequency
-
-    def set_times(self, times):
-        """This function sets the sorting times to convert spike trains to seconds
-
-        Parameters
-        ----------
-        times: array-like
-            The times in seconds for each frame
-        """
-        max_frames = np.array([np.max(self.get_unit_spike_train(u)) for u in self.get_unit_ids()])
-        assert np.all(max_frames < len(times)), "The length of 'times' should be greater than the maximum " \
-                                                "spike frame index"
-        self._times = times.astype('float64')
-
-    def frame_to_time(self, frames):
-        """This function converts user-inputed frame indexes to times with units of seconds.
-
-        Parameters
-        ----------
-        frames: float or array-like
-            The frame or frames to be converted to times
-
-        Returns
-        -------
-        times: float or array-like
-            The corresponding times in seconds
-        """
-        # Default implementation
-        if self._times is None:
-            return np.round(frames / self.get_sampling_frequency(), 6)
-        else:
-            return self._times[frames]
-
-    def time_to_frame(self, times):
-        """This function converts a user-inputted times (in seconds) to a frame indexes.
-
-        Parameters
-        ----------
-        times: float or array-like
-            The times (in seconds) to be converted to frame indexes
-
-        Returns
-        -------
-        frames: float or array-like
-            The corresponding frame indexes
-        """
-        # Default implementation
-        if self._times is None:
-            return np.round(times * self.get_sampling_frequency()).astype('int64')
-        else:
-            return np.searchsorted(self._times, times).astype('int64')
-
-
 def create_extractor_from_new_sorting(new_sorting):
     old_sorting = NewToOldSorting(new_sorting)
     return old_sorting

--- a/spikeinterface/core/old_api_utils.py
+++ b/spikeinterface/core/old_api_utils.py
@@ -66,10 +66,11 @@ class NewToOldSorting:
         self.is_dumpable = False
 
         unit_map = {}
-        if isinstance(self._sorting.get_unit_ids()[0], (int, np.integer)):
+        if np.all([isinstance(unit_id, int)] for unit_id in self._sorting.get_unit_ids()):
             for u in self._sorting.get_unit_ids():
                 unit_map[u] = u
         else:
+            print("Some unit IDs are not int but all unit IDs must be int in the old API SortingExtractor. Converting unit IDs to index...")
             for i_u, u in enumerate(self._sorting.get_unit_ids()):
                 unit_map[i_u] = u
         self._unit_map = unit_map

--- a/spikeinterface/core/old_api_utils.py
+++ b/spikeinterface/core/old_api_utils.py
@@ -49,7 +49,46 @@ class NewToOldRecording:
 def create_extractor_from_new_recording(new_recording):
     old_recording = NewToOldRecording(new_recording)
     return old_recording
+class NewToOldSorting:
+    """
+    This class mimic the old API of spikeextractors with:
+      * reversed shape (channels, samples):
+      * unique segment
+    """
 
+    def __init__(self, sorting):
+        assert sorting.get_num_segments() == 1
+        self._sorting = sorting
+
+    def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
+        traces = self._recording.get_traces(channel_ids=channel_ids,
+                                            start_frame=start_frame, end_frame=end_frame,
+                                            segment_index=0)
+        return traces.T
+
+    def get_num_frames(self):
+        return self._recording.get_num_frames(segment_index=0)
+
+    def get_num_channels(self):
+        return self._recording.get_num_channels()
+
+    def get_sampling_frequency(self):
+        return self._recording.get_sampling_frequency()
+
+    def get_channel_ids(self):
+        return self._recording.get_channel_ids()
+
+    def get_channel_property(self, channel_id, property):
+        rec = self._recording
+        values = rec.get_property(property)
+        ind = rec.ids_to_indices([channel_id])
+        v = values[ind[0]]
+        return v
+
+
+def create_extractor_from_new_sorting(new_sorting):
+    old_sorting = NewToOldSorting(new_sorting)
+    return old_sorting
 
 _old_to_new_property_map = {'gain': {'name': 'gain_to_uV', 'skip_if_value': 1},
                             'offset': {'name': 'offset_to_uV', 'skip_if_value': 0}}


### PR DESCRIPTION
Final addition (hopefully) to `old_api_utils`: added a class to make an old sorting extractor from a new sorting. Need this because old sorting doesn't have segments and some method names are different (e.g. old `get_units_spike_train` vs. new `get_all_spike_trains`). Mostly copied from `spikeextractors` repo.