### PR TITLE
Remove container after run sorter in docker mode

### DIFF
--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -198,6 +198,7 @@ class ContainerClient:
     def stop(self):
         if self.mode == 'docker':
             self.docker_container.stop()
+            self.docker_container.remove(force=True)
         elif self.mode == 'singularity':
             self.client_instance.stop()
 


### PR DESCRIPTION
Multiple runs on docker-based sorters leads to accumulation of stopped containers in host machine

The proposal here is to remove the container whenever we stop the container_client

Please let me know if it's possible/relevant to do a similar thing in singularity mode