### PR TITLE
Matlab Compiled IronClust

### DIFF
--- a/spikeinterface/sorters/ironclust/ironclust.py
+++ b/spikeinterface/sorters/ironclust/ironclust.py
@@ -157,9 +157,8 @@ class IronClustSorter(BaseSorter):
     @classmethod
     def get_sorter_version(cls):
         if cls.is_compiled:
-            version_filename = Path('/opt') / 'version.txt'
-        else:
-            version_filename = Path(os.environ["IRONCLUST_PATH"]) / 'matlab' / 'version.txt'
+            return 'compiled'
+        version_filename = Path(os.environ["IRONCLUST_PATH"]) / 'matlab' / 'version.txt'
         if version_filename.is_file():
             with open(str(version_filename), mode='r', encoding='utf8') as f:
                 line = f.readline()

--- a/spikeinterface/sorters/ironclust/ironclust.py
+++ b/spikeinterface/sorters/ironclust/ironclust.py
@@ -59,7 +59,6 @@ class IronClustSorter(BaseSorter):
     ironclust_path: Union[str, None] = os.getenv('IRONCLUST_PATH', None)
 
     requires_locations = True
-    is_compiled = check_compiled()
 
     _default_params = {
         'detect_sign': -1,  # Use -1, 0, or 1, depending on the sign of the spikes in the recording
@@ -150,13 +149,13 @@ class IronClustSorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
-        if cls.is_compiled:
+        if check_compiled():
             return True
         return check_if_installed(cls.ironclust_path)
 
-    @classmethod
-    def get_sorter_version(cls):
-        if cls.is_compiled:
+    @staticmethod
+    def get_sorter_version():
+        if check_compiled():
             return 'compiled'
         version_filename = Path(os.environ["IRONCLUST_PATH"]) / 'matlab' / 'version.txt'
         if version_filename.is_file():
@@ -224,7 +223,7 @@ class IronClustSorter(BaseSorter):
         if verbose:
             print('Running ironclust in {tmpdir}...'.format(tmpdir=str(tmpdir)))
 
-        if cls.is_compiled:
+        if check_compiled():
             shell_cmd = '''
                 #!/bin/bash
                 p_ironclust {tmpdir} {dataset_dir}/raw.mda {dataset_dir}/geom.csv '' '' {tmpdir}/firings.mda {dataset_dir}/argfile.txt


### PR DESCRIPTION
Check/run compiled ironclust in docker image after internal discussions for #471

Points to discuss in this Draft PR:
- Sorter logs is supressed somewhere, I couldn't manage to show it to the end user (is this a python Docker SDK thing? Is this related to ShellScript?
 - What if the user somehow has the `p_ironclust` command in shell? Should we change the approach in check_compiled function?
 - We need to find a way to pass local spikeinterface to pip install [here](https://github.com/Tauffer-Consulting/spikeinterface/blob/matlab-docker-integration/spikeinterface/sorters/runsorter.py#L285)