### PR TITLE
Fix OldToNewRecording data type

### DIFF
--- a/spikeinterface/core/old_api_utils.py
+++ b/spikeinterface/core/old_api_utils.py
@@ -171,7 +171,7 @@ class OldToNewRecording(BaseRecording):
     def __init__(self, oldapi_recording_extractor):
         BaseRecording.__init__(self, oldapi_recording_extractor.get_sampling_frequency(),
                                oldapi_recording_extractor.get_channel_ids(),
-                               oldapi_recording_extractor.get_dtype())
+                               oldapi_recording_extractor.get_dtype(return_scaled=False))
 
         # set is_dumpable to False to use dumping mechanism of old extractor
         self.is_dumpable = False


### PR DESCRIPTION
The default for `RecordingExtractor.get_dtype()` utilizes `return_scaled=True`, making all dtypes from old extractors that have gains/offsets set upcast to float despite underlying storage. This branch fixes the issue, but keeping as draft until downstream tests (https://github.com/catalystneuro/nwb-conversion-tools/pull/384) confirm roundtrip works.