### PR TITLE
Add 'missing_value' to set_property

### DIFF
--- a/spikeinterface/comparison/multicomparisons.py
+++ b/spikeinterface/comparison/multicomparisons.py
@@ -218,7 +218,7 @@ class AgreementSortingExtractor(BaseSorting):
             for k in ('agreement_number', 'avg_agreement', 'unit_ids'):
                 values = [self._msc._new_units[unit_id][k]
                           for unit_id in unit_ids]
-                self.set_property(k, values)
+                self.set_property(k, values, ids=unit_ids)
 
         sorting_segment = AgreementSortingSegment(multisortingcomparison)
         self.add_sorting_segment(sorting_segment)

--- a/spikeinterface/comparison/multicomparisons.py
+++ b/spikeinterface/comparison/multicomparisons.py
@@ -218,7 +218,7 @@ class AgreementSortingExtractor(BaseSorting):
             for k in ('agreement_number', 'avg_agreement', 'unit_ids'):
                 values = [self._msc._new_units[unit_id][k]
                           for unit_id in unit_ids]
-                self.set_property(k, values, ids=unit_ids)
+                self.set_property(k, values)
 
         sorting_segment = AgreementSortingSegment(multisortingcomparison)
         self.add_sorting_segment(sorting_segment)

--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -170,9 +170,8 @@ class BaseExtractor:
                 # create the property with nan or empty
                 shape = (size,) + values.shape[1:]
                 if values.dtype.kind not in ('f', 'S', 'U'):
-                    raise Exception("For values dtypes other than float or sting, the missing value cannot "
-                                    "be automatically inferred. Please specify it with the 'missing_value' "
-                                    "argument.")
+                    raise Exception("For values dtypes other than float, string or unicode, the missing value cannot "
+                                    "be automatically inferred. Please specify it with the 'missing_value' argument.")
                 if values.dtype.kind in ('b', 'c', 'u', 'i', 'f', 'S', 'U'):
                     dtype = values.dtype
                 else:

--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -186,23 +186,12 @@ class BaseExtractor:
                             missing_value = default_missing_values[dtype_kind]
                     else:
                         assert dtype_kind == np.array(missing_value).dtype.kind, ("Mismatch between values and "
-                                                                                "missing_value types. Provide a "
-                                                                                "missing_value with the same type as "
-                                                                                "the values.")
+                                                                                  "missing_value types. Provide a "
+                                                                                  "missing_value with the same type "
+                                                                                  "as the values.")
                         
                     empty_values = np.zeros(shape, dtype=dtype)
                     empty_values[:] = missing_value
-
-                    if dtype_kind in default_missing_values.keys() and missing_value is None:
-                        empty_values = np.zeros(shape, dtype=dtype)
-                        empty_values[:] = default_missing_values[dtype_kind]
-                        # empty_values = np.ones(shape, dtype=dtype) np.array([defau] * size)
-                    elif missing_value is not None:
-                        if dtype.kind != np.array(missing_value).dtype.kind:
-                            raise Exception("Mismatch between values and missing_value types. Provide a missing_value "
-                                            "with the same type as the values.")
-                        empty_values = np.zeros(shape, dtype=dtype)  
-                        empty_values = np.array([missing_value] * len(empty_values)).astype(dtype)
                     self._properties[key] = empty_values
 
                 indices = self.ids_to_indices(ids)

--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -163,6 +163,9 @@ class BaseExtractor:
 
         size = self._main_ids.size
         values = np.asarray(values)
+        dtype = values.dtype
+        dtype_kind = dtype.kind
+        
         if ids is None:
             assert values.shape[0] == size
             self._properties[key] = values
@@ -174,8 +177,7 @@ class BaseExtractor:
                 if key not in self._properties:
                     # create the property with nan or empty
                     shape = (size,) + values.shape[1:]
-                    dtype = values.dtype
-                    dtype_kind = dtype.kind
+                    
         
                     if missing_value is None:
                         if dtype_kind not in default_missing_values.keys():
@@ -193,6 +195,9 @@ class BaseExtractor:
                     empty_values = np.zeros(shape, dtype=dtype)
                     empty_values[:] = missing_value
                     self._properties[key] = empty_values
+                else:
+                    assert dtype_kind == self._properties[key].dtype.kind, ("Mismatch between existing property dtype "
+                                                                            "values dtype.")
 
                 indices = self.ids_to_indices(ids)
                 self._properties[key][indices] = values

--- a/spikeinterface/core/old_api_utils.py
+++ b/spikeinterface/core/old_api_utils.py
@@ -1,6 +1,7 @@
 from typing import Union
 
 import numpy as np
+import warnings
 from spikeinterface.core import (BaseRecording, BaseSorting,
                                  BaseRecordingSegment, BaseSortingSegment)
 
@@ -324,8 +325,13 @@ def copy_properties(oldapi_extractor, new_extractor, skip_properties=None):
     for property_name, prop_dict in properties.items():
         property_ids = prop_dict["ids"]
         property_values = prop_dict["values"]
-        new_extractor.set_property(key=property_name,
-                                   values=property_values, ids=property_ids)
+        
+        try:
+            new_extractor.set_property(key=property_name,
+                                       values=property_values, 
+                                       ids=property_ids)
+        except Exception as e:
+            warnings.warn(f"Property {property_name} cannot be ported to new API due to missing values.")
 
 
 def find_old_gains_offsets_recursively(oldapi_extractor_dict):

--- a/spikeinterface/core/old_api_utils.py
+++ b/spikeinterface/core/old_api_utils.py
@@ -323,13 +323,21 @@ def copy_properties(oldapi_extractor, new_extractor, skip_properties=None):
             properties[prop_name]["values"].append(prop_value)
 
     for property_name, prop_dict in properties.items():
-        property_ids = prop_dict["ids"]
-        property_values = prop_dict["values"]
+        property_ids = np.array(prop_dict["ids"])
+        property_values = np.array(prop_dict["values"])
+        missing_value = None
         
+        # For back-compatibility, incomplete int/uint properties are upcast to float
+        # and missing_value is set to np.nan
+        if len(property_ids) < len(get_ids()):
+            if property_values.dtype.kind in ("u", "i"):
+                property_values = property_values.astype("float")
+                missing_value = np.nan
         try:
             new_extractor.set_property(key=property_name,
                                        values=property_values, 
-                                       ids=property_ids)
+                                       ids=property_ids,
+                                       missing_value=missing_value)
         except Exception as e:
             warnings.warn(f"Property {property_name} cannot be ported to new API due to missing values.")
 

--- a/spikeinterface/core/tests/test_baserecording.py
+++ b/spikeinterface/core/tests/test_baserecording.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import Path
 import pytest
 import numpy as np
+from numpy.testing import assert_raises
 
 from probeinterface import Probe
 
@@ -63,26 +64,19 @@ def test_BaseRecording():
     rec.set_property('string_property', ["ciao", "bello"], ids=[0, 1])
     values = rec.get_property('string_property')
     assert values[2] == ""
-    print("Str properties", values)
     
-    rec.set_property('string_property_nan', ["ciao", "bello"], ids=[0, 1], missing_value=np.nan)
-    values = rec.get_property('string_property_nan')
-    assert np.isnan(values[2])
-    print("Str properties nan", values)
+    # setting an different type raises an error
+    assert_raises(Exception, rec.set_property, key='string_property_nan', values=["ciao", "bello"], ids=[0, 1], 
+                  missing_value=np.nan)
     
-    rec.set_property('int_property', [5, 6], ids=[1, 2], missing_value=200)
-    values = rec.get_property('int_property')
-    # since nan is the missing value, the values should be cast to float
-    assert values.dtype.kind == "i"
-    assert values[0] == 200
-    print("Int properties", values)
+    # int properties without missing values raise an error
+    assert_raises(Exception, rec.set_property, key='int_property', values=[5, 6], ids=[1, 2], missing_value=200)
     
-    rec.set_property('int_property_nan', [5, 6], ids=[1, 2], missing_value=np.nan)
+    rec.set_property('int_property_nan', np.array([5, 6]).astype("float"), ids=[1, 2], missing_value=np.nan)
     values = rec.get_property('int_property_nan')
-    # since nan is the missing value, the values should be cast to object
-    assert values.dtype.kind == "O"
+    # since the missing value has a different type, the values should be cast to object
+    assert values.dtype.kind == "f"
     assert np.isnan(values[0])
-    print("Int properties nan", values)
     
     times0 = rec.get_times(segment_index=0)
 

--- a/spikeinterface/core/tests/test_baserecording.py
+++ b/spikeinterface/core/tests/test_baserecording.py
@@ -70,13 +70,11 @@ def test_BaseRecording():
                   missing_value=np.nan)
     
     # int properties without missing values raise an error
-    assert_raises(Exception, rec.set_property, key='int_property', values=[5, 6], ids=[1, 2], missing_value=200)
+    assert_raises(Exception, rec.set_property, key='int_property', values=[5, 6], ids=[1, 2])
     
-    rec.set_property('int_property_nan', np.array([5, 6]).astype("float"), ids=[1, 2], missing_value=np.nan)
-    values = rec.get_property('int_property_nan')
-    # since the missing value has a different type, the values should be cast to object
-    assert values.dtype.kind == "f"
-    assert np.isnan(values[0])
+    rec.set_property('int_property', [5, 6], ids=[1, 2], missing_value=200)
+    values = rec.get_property('int_property')
+    assert values.dtype.kind == "i"
     
     times0 = rec.get_times(segment_index=0)
 

--- a/spikeinterface/core/tests/test_baserecording.py
+++ b/spikeinterface/core/tests/test_baserecording.py
@@ -59,6 +59,31 @@ def test_BaseRecording():
     values = rec.get_property('quality')
     assert np.all(values[:2] == [1., 3.3, ])
     
+    # missing property
+    rec.set_property('string_property', ["ciao", "bello"], ids=[0, 1])
+    values = rec.get_property('string_property')
+    assert values[2] == ""
+    print("Str properties", values)
+    
+    rec.set_property('string_property_nan', ["ciao", "bello"], ids=[0, 1], missing_value=np.nan)
+    values = rec.get_property('string_property_nan')
+    assert np.isnan(values[2])
+    print("Str properties nan", values)
+    
+    rec.set_property('int_property', [5, 6], ids=[1, 2], missing_value=200)
+    values = rec.get_property('int_property')
+    # since nan is the missing value, the values should be cast to float
+    assert values.dtype.kind == "i"
+    assert values[0] == 200
+    print("Int properties", values)
+    
+    rec.set_property('int_property_nan', [5, 6], ids=[1, 2], missing_value=np.nan)
+    values = rec.get_property('int_property_nan')
+    # since nan is the missing value, the values should be cast to object
+    assert values.dtype.kind == "O"
+    assert np.isnan(values[0])
+    print("Int properties nan", values)
+    
     times0 = rec.get_times(segment_index=0)
 
     # dump/load dict


### PR DESCRIPTION
This PR allows for better control of missing values when setting properties by adding the argument `missing_value`

Note that in case the missing value and the values have different dtypes, the property dtype is set to `object`