### PR TITLE
Add sampling freq to `times_kwarg` of NwbRecordingExtractor

### DIFF
--- a/spikeinterface/extractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors.py
@@ -106,7 +106,7 @@ class NwbRecordingExtractor(BaseRecording):
             sampling_frequency = 1. / np.median(np.diff(timestamps[:samples_for_rate_estimation]))
 
         if load_time_vector and timestamps is not None:
-            times_kwargs = dict(time_vector=self._es.timestamps)
+            times_kwargs = dict(sampling_frequency=sampling_frequency, time_vector=self._es.timestamps)
         else:
             times_kwargs = dict(sampling_frequency=sampling_frequency, t_start=t_start)
 


### PR DESCRIPTION
Sampling frequency is either obtained from the NWB file or estimated during instantiation. In that case, we may as well add it to `times_kwargs` for generating the recording segment. This isn't just optional - if we don't do this, we get problems. For example, when we concatenate NWB recordings that was generated with `load_time_vector=True`, the `times` are discarded, and as a result the recording segments have no time information (both `time_vector` and `sampling_frequency` are not set). 