### PR TITLE
Add `SplitSegmentSorting`

### DIFF
--- a/spikeinterface/core/__init__.py
+++ b/spikeinterface/core/__init__.py
@@ -31,7 +31,8 @@ from .unitsaggregationsorting import UnitsAggregationSorting, aggregate_units
 from .segmentutils import (
     append_recordings, AppendSegmentRecording,
     concatenate_recordings, ConcatenateSegmentRecording,
-    append_sortings, AppendSegmentSorting)
+    append_sortings, AppendSegmentSorting, 
+    split_sorting, SplitSegmentSorting)
 
 # default folder
 from .default_folders import (set_global_tmp_folder, get_global_tmp_folder,

--- a/spikeinterface/core/segmentutils.py
+++ b/spikeinterface/core/segmentutils.py
@@ -270,7 +270,7 @@ def append_sortings(*args, **kwargs):
 append_sortings.__doc__ == AppendSegmentSorting.__doc__
 
 # Q: should this take as input a concatenated recording or just a list of recordings?
-class SplitSorting(BaseSorting):
+class SplitSegmentSorting(BaseSorting):
     """Splits a sorting with a single segment to multiple segments
     based on the given list of recordings (must be in order)
 
@@ -302,3 +302,8 @@ class SplitSorting(BaseSorting):
 
         self._kwargs = {'parent_sorting': parent_sorting,
                         'recording_list': [recording.to_dict() for recording in recording_list]}
+        
+def split_sorting(*args, **kwargs):
+    return SplitSegmentSorting(*args, **kwargs)
+
+split_sorting.__doc__ == SplitSegmentSorting.__doc__

--- a/spikeinterface/core/segmentutils.py
+++ b/spikeinterface/core/segmentutils.py
@@ -295,9 +295,9 @@ class SplitSegmentSorting(BaseSorting):
         
         cumsum_num_samples = np.cumsum(num_samples)
         for idx in range(len(cumsum_num_samples)-1):
-            parent_sorting.frame_slice(start_frame=cumsum_num_samples[idx],
-                                       end_frame=cumsum_num_samples[idx+1])
-            sliced_segment = parent_sorting._sorting_segments[0]
+            sliced_parent_sorting = parent_sorting.frame_slice(start_frame=cumsum_num_samples[idx],
+                                                               end_frame=cumsum_num_samples[idx+1])
+            sliced_segment = sliced_parent_sorting._sorting_segments[0]
             self.add_sorting_segment(sliced_segment)
 
         self._kwargs = {'parent_sorting': parent_sorting,

--- a/spikeinterface/core/segmentutils.py
+++ b/spikeinterface/core/segmentutils.py
@@ -1,12 +1,12 @@
 """
-Implementation if utils class to manipulate segment with 2 diffrents concept:
-  * append_recordings/append_sortings/append_events
-  * concatenate_recordings/ concatenate_sortings/ concatenate_events
+Implementation of utils class to manipulate segments with 2 differents concept:
+  * append_recordings / append_sortings / append_events
+  * concatenate_recordings / concatenate_sortings / concatenate_events
 
 
-For instance:
-  * append_recording: given one recording with 2 segments and one recording with 3 segments give one recording with 5 segments
-  * conatenate_recording: given a list of several recording with several segment give one recording with one segment that sum the total duration
+Example:
+  * append_recording: given one recording with 2 segments and one recording with 3 segments, returns one recording with 5 segments
+  * concatenate_recording: given a list of several recordings (each with possibly multiple segments), returns one recording with one segment that is a concatenation of all the segments
 
 """
 import numpy as np
@@ -34,8 +34,9 @@ def _check_sampling_frequencies(sampling_frequency_list, sampling_frequency_max_
 
 class AppendSegmentRecording(BaseRecording):
     """
-    Return a recording that "appends" all segments from all recording
-    into one recording multi segment.
+    Takes as input a list of parent recordings each with multiple segments and
+    returns a single multi-segment recording that "appends" all segments from
+    all parent recordings.
 
     For instance, given one recording with 2 segments and one recording with
     3 segments, this class will give one recording with 5 segments
@@ -60,13 +61,12 @@ class AppendSegmentRecording(BaseRecording):
         ok1 = all(dtype == rec.get_dtype() for rec in recording_list)
         ok2 = all(np.array_equal(channel_ids, rec.channel_ids) for rec in recording_list)
         if not (ok1 and ok2):
-            raise ValueError("Recording don't have the same dtype/channel_ids")
+            raise ValueError("Recording don't have the same dtype or channel_ids")
         _check_sampling_frequencies(
             [rec.get_sampling_frequency() for rec in recording_list],
             sampling_frequency_max_diff
         )
         
-
         BaseRecording.__init__(self, sampling_frequency, channel_ids, dtype)
         rec0.copy_metadata(self)
 

--- a/spikeinterface/core/segmentutils.py
+++ b/spikeinterface/core/segmentutils.py
@@ -99,14 +99,16 @@ append_recordings.__doc__ == AppendSegmentRecording.__doc__
 
 class ConcatenateSegmentRecording(BaseRecording):
     """
-    Return a recording that "concatenates" all segments from all recording
-    into one recording mono segment. The operation is lazy.
+    Return a recording that "concatenates" all segments from all parent recordings
+    into one recording with a single segment. The operation is lazy.
 
     For instance, given one recording with 2 segments and one recording with
-    3 segments, this class will give one recording with 1 segment
+    3 segments, this class will give one recording with one large segment
+    made by concatenating the 5 segments.
 
-    You can only concatenate segments if:
-      * all segments DO NOT have times
+    Time information is lost upon concatenation. By default `ignore_times` is True.
+    If it is False, you get an error unless:
+      * all segments DO NOT have times, AND
       * all segment have t_start=None
 
     Parameters

--- a/spikeinterface/core/segmentutils.py
+++ b/spikeinterface/core/segmentutils.py
@@ -277,7 +277,7 @@ class SplitSorting(BaseSorting):
     Parameters
     ----------
     parent_sorting : BaseSorting
-        sorting with a single segment (e.g. from sorting concatenated recording)
+        Sorting with a single segment (e.g. from sorting concatenated recording)
     recording_list : list
         List of recordings whose lengths will be used to split the sorting
         into smaller segments
@@ -293,10 +293,10 @@ class SplitSorting(BaseSorting):
             for recording_segment in recording._recording_segments:
                 num_samples.append(recording_segment.get_num_samples())
         
-        cum_num_samples = np.cumsum(num_samples)
-        for idx in range(len(cum_num_samples)-1):
-            parent_sorting.frame_slice(start_frame=cum_num_samples[idx],
-                                       end_frame=cum_num_samples[idx+1])
+        cumsum_num_samples = np.cumsum(num_samples)
+        for idx in range(len(cumsum_num_samples)-1):
+            parent_sorting.frame_slice(start_frame=cumsum_num_samples[idx],
+                                       end_frame=cumsum_num_samples[idx+1])
             sliced_segment = parent_sorting._sorting_segments[0]
             self.add_sorting_segment(sliced_segment)
 

--- a/spikeinterface/core/segmentutils.py
+++ b/spikeinterface/core/segmentutils.py
@@ -277,7 +277,7 @@ class SplitSegmentSorting(BaseSorting):
     ----------
     parent_sorting : BaseSorting
         Sorting with a single segment (e.g. from sorting concatenated recording)
-    recording_list : list of recordings, ConcatenateSegmentRecording, or None
+    recording_or_recording_list : list of recordings, ConcatenateSegmentRecording, or None
         If list of recordings, uses the lengths of those recordings to split the sorting
         into smaller segments
         If ConcatenateSegmentRecording, uses the associated list of recordings to split

--- a/spikeinterface/core/segmentutils.py
+++ b/spikeinterface/core/segmentutils.py
@@ -1,5 +1,5 @@
 """
-Implementation of utils class to manipulate segments with 2 differents concept:
+Implementation of utils class to manipulate segments with 2 different concept:
   * append_recordings / append_sortings / append_events
   * concatenate_recordings / concatenate_sortings / concatenate_events
 

--- a/spikeinterface/extractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors.py
@@ -106,7 +106,7 @@ class NwbRecordingExtractor(BaseRecording):
             sampling_frequency = 1. / np.median(np.diff(timestamps[:samples_for_rate_estimation]))
 
         if load_time_vector and timestamps is not None:
-            times_kwargs = dict(time_vector=self._es.timestamps)
+            times_kwargs = dict(sampling_frequency=sampling_frequency, time_vector=self._es.timestamps)
         else:
             times_kwargs = dict(sampling_frequency=sampling_frequency, t_start=t_start)
 

--- a/spikeinterface/extractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors.py
@@ -106,7 +106,7 @@ class NwbRecordingExtractor(BaseRecording):
             sampling_frequency = 1. / np.median(np.diff(timestamps[:samples_for_rate_estimation]))
 
         if load_time_vector and timestamps is not None:
-            times_kwargs = dict(sampling_frequency=sampling_frequency, time_vector=self._es.timestamps)
+            times_kwargs = dict(time_vector=self._es.timestamps)
         else:
             times_kwargs = dict(sampling_frequency=sampling_frequency, t_start=t_start)
 


### PR DESCRIPTION
per our discussion @alejoe91 @samuelgarcia: This is a new class that takes a sorting with a single segment and a list of recordings and returns a sorting with multiple segments, each defined by the length of the recordings in the list. This would be useful for getting back the times of the spikes after sorting a concatenated recording, which removes time information. Please take a look. 