### PR TITLE
Adding sparsity to pca

### DIFF
--- a/spikeinterface/toolkit/postprocessing/principal_component.py
+++ b/spikeinterface/toolkit/postprocessing/principal_component.py
@@ -369,7 +369,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
 
         # save
         mode = p["mode"]
-        for chan_ind, chan_id in enumerate(channel_ids):
+        for chan_ind, chan_id in enumerate(we.recording.channel_ids):
             pca = pca_model[chan_ind]
             with (self.extension_folder / f"pca_model_{mode}_{chan_id}.pkl").open("wb") as f:
                 pickle.dump(pca, f)


### PR DESCRIPTION
This PR adds the possibility to add a sparsity mask for PCA. This could be useful to speed up the computations, but also if we want to compute PCA during the clustering step via the same object. In such a mode, evey unit_id can be a channel, and thus we want to compute the PCA only within a given neighboorhood. 
This is working for the channel_by modes. For the concatenated mode, currently, this is not working, but one could also think about setting to 0 all the values outside the mask before transforming the data. I'll do that I think, let me know what do you think. At least, this make the object more consistent with the waveform_extractor, that have this notion of sparsity