### PR TITLE
support for some systems

### DIFF
--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -412,7 +412,7 @@ class WaveformExtractor:
                 raise Exception('Waveforms not extracted yet: '
                                 'please do WaveformExtractor.run_extract_waveforms() first')
             if memmap:
-                wfs = np.load(waveform_file, mmap_mode="r")
+                wfs = np.load(str(waveform_file), mmap_mode="r")
             else:
                 wfs = np.load(waveform_file)
             if cache:

--- a/spikeinterface/core/waveform_tools.py
+++ b/spikeinterface/core/waveform_tools.py
@@ -166,7 +166,7 @@ def _init_worker_waveform_extractor(recording, unit_ids, spikes, wfs_arrays_info
         # For OSX and windows : need to re open all npy files in r+ mode for each worker
         wfs_arrays = {}
         for unit_id, filename in wfs_arrays_info.items():
-            wfs_arrays[unit_id] = np.load(filename, mmap_mode='r+')
+            wfs_arrays[unit_id] = np.load(str(filename), mmap_mode='r+')
     elif mode == 'shared_memory':
 
         from multiprocessing.shared_memory import SharedMemory

--- a/spikeinterface/toolkit/postprocessing/principal_component.py
+++ b/spikeinterface/toolkit/postprocessing/principal_component.py
@@ -266,7 +266,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
                 shape = (n_spike, p['n_components'])
             proj = np.zeros(shape, dtype=p['dtype'])
             np.save(projection_file, proj)
-            comp = np.load(projection_file, mmap_mode='r+')
+            comp = np.load(str(projection_file), mmap_mode='r+')
             projection_memmap[unit_id] = comp
 
         # run ...


### PR DESCRIPTION
Hi guys, in some system like mine the following code doesn't work:

```
import numpy as np
from pathlib import Path

np.save('test.npy',np.arange(2))
wfs = np.load(Path('casa3.npy'), mmap_mode="r+")
```

The pull request just cast to str the Path before the np.load.

In my system: 

OS: Windows 7
Python: 3.8.12 
Numpy: 1.22.2