### PR TITLE
Refactor tests

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -25,4 +25,4 @@ jobs:
           pip install -e .
       - name: Test core with pytest
         run: |
-          pytest -v -m core
+          pytest -v spikeinterface/core

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -25,4 +25,4 @@ jobs:
           pip install -e .
       - name: Test core with pytest
         run: |
-          pytest spikeinterface/core
+          pytest -v -m core

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -75,10 +75,36 @@ jobs:
           key: ${{ runner.os }}-datasets-${{ steps.vars.outputs.HASH_EPHY_DATASET }}
           restore-keys: |
             ${{ runner.os }}-datasets
-      - name: Test with pytest
+      - name: Test core
         run: |
           source ~/test_env/bin/activate
-          pytest
+          pytest -v -m core
+      # TODO run module tests only if last commit has changed files in them
+      - name: Test extractors
+        run: |
+          source ~/test_env/bin/activate
+          pytest -v -m extractors
+      - name: Test toolkit
+        run: |
+          source ~/test_env/bin/activate
+          pytest -v -m toolkit
+      - name: Test sorters
+        run: |
+          source ~/test_env/bin/activate
+          pytest -v -m sorters
+      - name: Test exporters
+        run: |
+          source ~/test_env/bin/activate
+          pytest -v -m exporters
+      - name: Test widgets
+        run: |
+          source ~/test_env/bin/activate
+          pytest -v -m widgets
+      - name: Test sortingcomponents
+        run: |
+          source ~/test_env/bin/activate
+          pytest -v -m sortingcomponents
+
 
           
 # only on ubuntu because of spkyking-circus and mpich

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,7 +24,7 @@ jobs:
           pip install -e .
       - name: Test core with pytest
         run: |
-          pytest -v -m core
+          pytest -v spikeinterface/core
       - name: Publish on PyPI
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,7 +24,7 @@ jobs:
           pip install -e .
       - name: Test core with pytest
         run: |
-          pytest spikeinterface/core
+          pytest -v -m core
       - name: Publish on PyPI
         env:
           TWINE_USERNAME: __token__

--- a/conftest.py
+++ b/conftest.py
@@ -34,6 +34,7 @@ def pytest_collection_modifyitems(config, items):
 
 
 def pytest_sessionfinish(session, exitstatus):
-    # teardown_stuff
-    if pytest.global_test_folder.is_dir():
-        shutil.rmtree(pytest.global_test_folder)
+    # teardown_stuff only if tests passed
+    if exitstatus == 0:
+        if pytest.global_test_folder.is_dir():
+            shutil.rmtree(pytest.global_test_folder)

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+import shutil
+from pathlib import Path
+
+
+# define marks
+mark_names = ["core", "extractors", "toolkit", "sorters",
+              "comparison", "widgets", "exporters", "sortingcomponents"]
+
+
+# define global test folder
+def pytest_sessionstart(session):
+    # setup_stuff
+    pytest.global_test_folder = Path(__file__).parent / "test_folder"
+    if pytest.global_test_folder.is_dir():
+        shutil.rmtree(pytest.global_test_folder)
+    pytest.global_test_folder.mkdir()
+
+    for mark_name in mark_names:
+        (pytest.global_test_folder / mark_name).mkdir()
+
+
+def pytest_collection_modifyitems(config, items):
+    # python 3.4/3.5 compat: rootdir = pathlib.Path(str(config.rootdir))
+    rootdir = Path(config.rootdir)
+
+    for item in items:
+        rel_path = Path(item.fspath).relative_to(rootdir)
+
+        for mark_name in mark_names:
+            if f"/{mark_name}/" in str(rel_path):
+                mark = getattr(pytest.mark, mark_name)
+                item.add_marker(mark)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    # teardown_stuff
+    if pytest.global_test_folder.is_dir():
+        shutil.rmtree(pytest.global_test_folder)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+markers =
+    core
+    extractors
+    toolkit
+    sorters
+    comparison
+    exporters
+    widgets
+    sortingcomponents

--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -637,7 +637,7 @@ class BaseExtractor:
                         print(f'Use cache_folder={folder}')
         else:
             folder = Path(folder)
-        assert not folder.exists(), f'folder {folder} already exists, choose enother name'
+        assert not folder.exists(), f'folder {folder} already exists, choose another name'
         folder.mkdir(parents=True, exist_ok=False)
 
         # dump provenance

--- a/spikeinterface/core/tests/test_baserecording.py
+++ b/spikeinterface/core/tests/test_baserecording.py
@@ -13,22 +13,10 @@ from probeinterface import Probe
 from spikeinterface.core import BinaryRecordingExtractor, NumpyRecording, load_extractor
 from spikeinterface.core.base import BaseExtractor
 
-
-# file and folder created
-
-
-def _clean_all():
-    cache_folder = './my_cache_folder'
-    if Path(cache_folder).exists():
-        shutil.rmtree(cache_folder)
-
-
-def setup_module():
-    _clean_all()
-
-
-def teardown_module():
-    _clean_all()
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "core"
+else:
+    cache_folder = Path("cache_folder") / "core"
 
 
 def test_BaseRecording():
@@ -38,17 +26,20 @@ def test_BaseRecording():
     sampling_frequency = 10000
     dtype = 'int16'
 
-    file_paths = [f'test_base_recording_{i}.raw' for i in range(num_seg)]
+    file_paths = [cache_folder / f'test_base_recording_{i}.raw' for i in range(num_seg)]
     for i in range(num_seg):
-        a = np.memmap(file_paths[i], dtype=dtype, mode='w+', shape=(num_samples, num_chan))
+        a = np.memmap(file_paths[i], dtype=dtype,
+                      mode='w+', shape=(num_samples, num_chan))
         a[:] = np.random.randn(*a.shape).astype(dtype)
-    rec = BinaryRecordingExtractor(file_paths, sampling_frequency, num_chan, dtype)
+    rec = BinaryRecordingExtractor(
+        file_paths, sampling_frequency, num_chan, dtype)
 
     assert rec.get_num_segments() == 2
     assert rec.get_num_channels() == 3
 
     assert np.all(rec.ids_to_indices([0, 1, 2]) == [0, 1, 2])
-    assert np.all(rec.ids_to_indices([0, 1, 2], prefer_slice=True) == slice(0, 3, None))
+    assert np.all(rec.ids_to_indices(
+        [0, 1, 2], prefer_slice=True) == slice(0, 3, None))
 
     # annotations / properties
     rec.annotate(yep='yop')
@@ -59,23 +50,24 @@ def test_BaseRecording():
     rec.set_property('quality', [1., 3.3, np.nan])
     values = rec.get_property('quality')
     assert np.all(values[:2] == [1., 3.3, ])
-    
+
     # missing property
     rec.set_property('string_property', ["ciao", "bello"], ids=[0, 1])
     values = rec.get_property('string_property')
     assert values[2] == ""
-    
+
     # setting an different type raises an error
-    assert_raises(Exception, rec.set_property, key='string_property_nan', values=["ciao", "bello"], ids=[0, 1], 
+    assert_raises(Exception, rec.set_property, key='string_property_nan', values=["ciao", "bello"], ids=[0, 1],
                   missing_value=np.nan)
-    
+
     # int properties without missing values raise an error
-    assert_raises(Exception, rec.set_property, key='int_property', values=[5, 6], ids=[1, 2])
-    
+    assert_raises(Exception, rec.set_property,
+                  key='int_property', values=[5, 6], ids=[1, 2])
+
     rec.set_property('int_property', [5, 6], ids=[1, 2], missing_value=200)
     values = rec.get_property('int_property')
     assert values.dtype.kind == "i"
-    
+
     times0 = rec.get_times(segment_index=0)
 
     # dump/load dict
@@ -84,27 +76,27 @@ def test_BaseRecording():
     rec3 = load_extractor(d)
 
     # dump/load json
-    rec.dump_to_json('test_BaseRecording.json')
-    rec2 = BaseExtractor.load('test_BaseRecording.json')
-    rec3 = load_extractor('test_BaseRecording.json')
+    rec.dump_to_json(cache_folder / 'test_BaseRecording.json')
+    rec2 = BaseExtractor.load(cache_folder / 'test_BaseRecording.json')
+    rec3 = load_extractor(cache_folder / 'test_BaseRecording.json')
 
     # dump/load pickle
-    rec.dump_to_pickle('test_BaseRecording.pkl')
-    rec2 = BaseExtractor.load('test_BaseRecording.pkl')
-    rec3 = load_extractor('test_BaseRecording.pkl')
+    rec.dump_to_pickle(cache_folder / 'test_BaseRecording.pkl')
+    rec2 = BaseExtractor.load(cache_folder / 'test_BaseRecording.pkl')
+    rec3 = load_extractor(cache_folder / 'test_BaseRecording.pkl')
 
     # dump/load dict - relative
-    d = rec.to_dict(relative_to=".")
-    rec2 = BaseExtractor.from_dict(d, base_folder=".")
-    rec3 = load_extractor(d, base_folder=".")
+    d = rec.to_dict(relative_to=cache_folder)
+    rec2 = BaseExtractor.from_dict(d, base_folder=cache_folder)
+    rec3 = load_extractor(d, base_folder=cache_folder)
 
     # dump/load json
-    rec.dump_to_json('test_BaseRecording_rel.json', relative_to=".")
-    rec2 = BaseExtractor.load('test_BaseRecording_rel.json', base_folder=".")
-    rec3 = load_extractor('test_BaseRecording_rel.json', base_folder=".")
+    rec.dump_to_json(cache_folder / 'test_BaseRecording_rel.json', relative_to=cache_folder)
+    rec2 = BaseExtractor.load(cache_folder / 'test_BaseRecording_rel.json', base_folder=cache_folder)
+    rec3 = load_extractor(
+        cache_folder / 'test_BaseRecording_rel.json', base_folder=cache_folder)
 
     # cache to binary
-    cache_folder = Path('./my_cache_folder')
     folder = cache_folder / 'simple_recording'
     rec.save(format='binary', folder=folder)
     rec2 = BaseExtractor.load_from_folder(folder)
@@ -118,7 +110,7 @@ def test_BaseRecording():
     assert np.array_equal(groups, [0, 0, 1])
 
     # but also possible
-    rec3 = BaseExtractor.load('./my_cache_folder/simple_recording')
+    rec3 = BaseExtractor.load(cache_folder / 'simple_recording')
 
     # cache to memory
     rec4 = rec3.save(format='memory')
@@ -135,7 +127,8 @@ def test_BaseRecording():
     # set/get Probe only 2 channels
     probe = Probe(ndim=2)
     positions = [[0., 0.], [0., 15.], [0, 30.]]
-    probe.set_contacts(positions=positions, shapes='circle', shape_params={'radius': 5})
+    probe.set_contacts(positions=positions, shapes='circle',
+                       shape_params={'radius': 5})
     probe.set_device_channel_indices([2, -1, 0])
     probe.create_auto_shape()
 
@@ -182,31 +175,29 @@ def test_BaseRecording():
     rec_int16.set_property('offset_to_uV', [0.] * 5)
     traces_float32 = rec_int16.get_traces(return_scaled=True)
     assert traces_float32.dtype == 'float32'
-    
+
     # test with t_start
-    rec = BinaryRecordingExtractor(file_paths, sampling_frequency, num_chan, dtype, t_starts=np.arange(num_seg)*10.)
+    rec = BinaryRecordingExtractor(
+        file_paths, sampling_frequency, num_chan, dtype, t_starts=np.arange(num_seg)*10.)
     times1 = rec.get_times(1)
     folder = cache_folder / 'recording_with_t_start'
     rec2 = rec.save(folder=folder)
     assert np.allclose(times1, rec2.get_times(1))
-    
+
     # test with time_vector
-    rec = BinaryRecordingExtractor(file_paths, sampling_frequency, num_chan, dtype)
-    rec.set_times(np.arange(num_samples) / sampling_frequency + 30., segment_index=0)
-    rec.set_times(np.arange(num_samples) / sampling_frequency + 40., segment_index=1)
+    rec = BinaryRecordingExtractor(
+        file_paths, sampling_frequency, num_chan, dtype)
+    rec.set_times(np.arange(num_samples) /
+                  sampling_frequency + 30., segment_index=0)
+    rec.set_times(np.arange(num_samples) /
+                  sampling_frequency + 40., segment_index=1)
     times1 = rec.get_times(1)
     folder = cache_folder / 'recording_with_times'
     rec2 = rec.save(folder=folder)
     assert np.allclose(times1, rec2.get_times(1))
     rec3 = load_extractor(folder)
     assert np.allclose(times1, rec3.get_times(1))
-    
-    
-
-
-    
 
 
 if __name__ == '__main__':
-    _clean_all()
     test_BaseRecording()

--- a/spikeinterface/core/tests/test_baserecording.py
+++ b/spikeinterface/core/tests/test_baserecording.py
@@ -13,7 +13,7 @@ from probeinterface import Probe
 from spikeinterface.core import BinaryRecordingExtractor, NumpyRecording, load_extractor
 from spikeinterface.core.base import BaseExtractor
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
 else:
     cache_folder = Path("cache_folder") / "core"

--- a/spikeinterface/core/tests/test_basesorting.py
+++ b/spikeinterface/core/tests/test_basesorting.py
@@ -12,7 +12,7 @@ from spikeinterface.core.base import BaseExtractor
 
 from spikeinterface.core.testing_tools import create_sorting_npz
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
 else:
     cache_folder = Path("cache_folder") / "core"

--- a/spikeinterface/core/tests/test_basesorting.py
+++ b/spikeinterface/core/tests/test_basesorting.py
@@ -12,24 +12,15 @@ from spikeinterface.core.base import BaseExtractor
 
 from spikeinterface.core.testing_tools import create_sorting_npz
 
-
-def _clean_all():
-    cache_folder = './my_cache_folder'
-    if Path(cache_folder).exists():
-        shutil.rmtree(cache_folder)
-
-
-def setup_module():
-    _clean_all()
-
-
-def teardown_module():
-    _clean_all()
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "core"
+else:
+    cache_folder = Path("cache_folder") / "core"
 
 
 def test_BaseSorting():
     num_seg = 2
-    file_path = 'test_BaseSorting.npz'
+    file_path = cache_folder / 'test_BaseSorting.npz'
 
     create_sorting_npz(num_seg, file_path)
 
@@ -53,17 +44,17 @@ def test_BaseSorting():
     sorting3 = load_extractor(d)
 
     # dump/load json
-    sorting.dump_to_json('test_BaseSorting.json')
-    sorting2 = BaseExtractor.load('test_BaseSorting.json')
-    sorting3 = load_extractor('test_BaseSorting.json')
+    sorting.dump_to_json(cache_folder / 'test_BaseSorting.json')
+    sorting2 = BaseExtractor.load(cache_folder / 'test_BaseSorting.json')
+    sorting3 = load_extractor(cache_folder / 'test_BaseSorting.json')
 
     # dump/load pickle
-    sorting.dump_to_pickle('test_BaseSorting.pkl')
-    sorting2 = BaseExtractor.load('test_BaseSorting.pkl')
-    sorting3 = load_extractor('test_BaseSorting.pkl')
+    sorting.dump_to_pickle(cache_folder / 'test_BaseSorting.pkl')
+    sorting2 = BaseExtractor.load(cache_folder / 'test_BaseSorting.pkl')
+    sorting3 = load_extractor(cache_folder / 'test_BaseSorting.pkl')
 
     # cache
-    folder = Path('./my_cache_folder') / 'simple_sorting'
+    folder = cache_folder / 'simple_sorting'
     sorting.save(folder=folder)
     sorting2 = BaseExtractor.load_from_folder(folder)
     # but also possible
@@ -71,11 +62,10 @@ def test_BaseSorting():
 
     spikes = sorting.get_all_spike_trains()
     # print(spikes)
-    
+
     spikes = sorting.to_spike_vector()
     # print(spikes)
 
 
 if __name__ == '__main__':
-    _clean_all()
     test_BaseSorting()

--- a/spikeinterface/core/tests/test_binaryrecordingextractor.py
+++ b/spikeinterface/core/tests/test_binaryrecordingextractor.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from spikeinterface.core import BinaryRecordingExtractor
 
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
 else:
     cache_folder = Path("cache_folder") / "core"

--- a/spikeinterface/core/tests/test_binaryrecordingextractor.py
+++ b/spikeinterface/core/tests/test_binaryrecordingextractor.py
@@ -5,6 +5,12 @@ from pathlib import Path
 from spikeinterface.core import BinaryRecordingExtractor
 
 
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "core"
+else:
+    cache_folder = Path("cache_folder") / "core"
+
+
 def test_BinaryRecordingExtractor():
     num_seg = 2
     num_chan = 3
@@ -12,17 +18,23 @@ def test_BinaryRecordingExtractor():
     sampling_frequency = 10000
     dtype = 'int16'
 
-    file_paths = [f'test_BinaryRecordingExtractor_{i}.raw' for i in range(num_seg)]
+    file_paths = [
+        cache_folder / f'test_BinaryRecordingExtractor_{i}.raw' for i in range(num_seg)]
     for i in range(num_seg):
-        np.memmap(file_paths[i], dtype=dtype, mode='w+', shape=(num_samples, num_chan))
+        np.memmap(file_paths[i], dtype=dtype, mode='w+',
+                  shape=(num_samples, num_chan))
 
-    rec = BinaryRecordingExtractor(file_paths, sampling_frequency, num_chan, dtype)
+    rec = BinaryRecordingExtractor(
+        file_paths, sampling_frequency, num_chan, dtype)
     print(rec)
 
-    file_paths = [f'test_BinaryRecordingExtractor_copied_{i}.raw' for i in range(num_seg)]
+    file_paths = [
+        cache_folder / f'test_BinaryRecordingExtractor_copied_{i}.raw' for i in range(num_seg)]
     BinaryRecordingExtractor.write_recording(rec, file_paths)
 
-    assert Path('test_BinaryRecordingExtractor_copied_0.raw').is_file()
+    file_paths = [
+        cache_folder / f'test_BinaryRecordingExtractor_{i}.raw' for i in range(num_seg)]
+    assert (cache_folder / 'test_BinaryRecordingExtractor_copied_0.raw').is_file()
 
 
 if __name__ == '__main__':

--- a/spikeinterface/core/tests/test_channelsaggregationrecording.py
+++ b/spikeinterface/core/tests/test_channelsaggregationrecording.py
@@ -11,9 +11,12 @@ def test_channelsaggregationrecording():
     # single segments
     durations = [10, 4]
     num_seg = len(durations)
-    recording1 = generate_recording(num_channels=num_channels, durations=durations, set_probe=False)
-    recording2 = generate_recording(num_channels=num_channels, durations=durations, set_probe=False)
-    recording3 = generate_recording(num_channels=num_channels, durations=durations, set_probe=False)
+    recording1 = generate_recording(
+        num_channels=num_channels, durations=durations, set_probe=False)
+    recording2 = generate_recording(
+        num_channels=num_channels, durations=durations, set_probe=False)
+    recording3 = generate_recording(
+        num_channels=num_channels, durations=durations, set_probe=False)
 
     num_channels = len(recording1.get_channel_ids())
 
@@ -25,19 +28,23 @@ def test_channelsaggregationrecording():
     recording_agg = aggregate_channels([recording1, recording2, recording3])
     print(recording_agg)
     assert len(recording_agg.get_channel_ids()) == 3 * num_channels
-    
+
     assert np.allclose(recording_agg.get_times(0), recording1.get_times(0))
-    
+
     # test traces
     channel_ids = recording1.get_channel_ids()
 
     for seg in range(num_seg):
         # single channels
-        traces1_1 = recording1.get_traces(channel_ids=[channel_ids[1]], segment_index=seg)
-        traces2_0 = recording2.get_traces(channel_ids=[channel_ids[0]], segment_index=seg)
-        traces3_2 = recording3.get_traces(channel_ids=[channel_ids[2]], segment_index=seg)
+        traces1_1 = recording1.get_traces(
+            channel_ids=[channel_ids[1]], segment_index=seg)
+        traces2_0 = recording2.get_traces(
+            channel_ids=[channel_ids[0]], segment_index=seg)
+        traces3_2 = recording3.get_traces(
+            channel_ids=[channel_ids[2]], segment_index=seg)
 
-        assert np.allclose(traces1_1, recording_agg.get_traces(channel_ids=[channel_ids[1]], segment_index=seg))
+        assert np.allclose(traces1_1, recording_agg.get_traces(
+            channel_ids=[channel_ids[1]], segment_index=seg))
         assert np.allclose(traces2_0, recording_agg.get_traces(channel_ids=[num_channels + channel_ids[0]],
                                                                segment_index=seg))
         assert np.allclose(traces3_2, recording_agg.get_traces(channel_ids=[2 * num_channels + channel_ids[2]],
@@ -47,15 +54,19 @@ def test_channelsaggregationrecording():
         traces2 = recording2.get_traces(segment_index=seg)
         traces3 = recording3.get_traces(segment_index=seg)
 
-        assert np.allclose(traces1, recording_agg.get_traces(channel_ids=[0, 1, 2], segment_index=seg))
-        assert np.allclose(traces2, recording_agg.get_traces(channel_ids=[3, 4, 5], segment_index=seg))
-        assert np.allclose(traces3, recording_agg.get_traces(channel_ids=[6, 7, 8], segment_index=seg))
+        assert np.allclose(traces1, recording_agg.get_traces(
+            channel_ids=[0, 1, 2], segment_index=seg))
+        assert np.allclose(traces2, recording_agg.get_traces(
+            channel_ids=[3, 4, 5], segment_index=seg))
+        assert np.allclose(traces3, recording_agg.get_traces(
+            channel_ids=[6, 7, 8], segment_index=seg))
 
     # test rename channels
     renamed_channel_ids = [f"#Channel {i}" for i in range(3 * num_channels)]
     recording_agg_renamed = aggregate_channels([recording1, recording2, recording3],
                                                renamed_channel_ids=renamed_channel_ids)
-    assert all(chan in renamed_channel_ids for chan in recording_agg_renamed.get_channel_ids())
+    assert all(
+        chan in renamed_channel_ids for chan in recording_agg_renamed.get_channel_ids())
 
     # test properties
     # complete property
@@ -72,7 +83,8 @@ def test_channelsaggregationrecording():
     recording1.set_property("quality", ["good"]*num_channels)
     recording2.set_property("quality", ["bad"]*num_channels)
 
-    recording_agg_prop = aggregate_channels([recording1, recording2, recording3])
+    recording_agg_prop = aggregate_channels(
+        [recording1, recording2, recording3])
     assert "brain_area" in recording_agg_prop.get_property_keys()
     assert "quality" not in recording_agg_prop.get_property_keys()
     print(recording_agg_prop.get_property("brain_area"))

--- a/spikeinterface/core/tests/test_channelslicerecording.py
+++ b/spikeinterface/core/tests/test_channelslicerecording.py
@@ -9,24 +9,25 @@ import probeinterface as pi
 from spikeinterface.core import ChannelSliceRecording, BinaryRecordingExtractor
 
 
-def _clean_all():
-    cache_folder = './my_cache_folder'
-    if Path(cache_folder).exists():
-        shutil.rmtree(cache_folder)
-
-
 def test_ChannelSliceRecording():
+    if getattr(pytest, "global_test_folder"):
+        cache_folder = pytest.global_test_folder / "core"
+    else:
+        cache_folder = Path("cache_folder") / "core"
+
     num_seg = 2
     num_chan = 3
     num_samples = 30
     sampling_frequency = 10000
     dtype = 'int16'
 
-    file_paths = [f'test_BinaryRecordingExtractor_{i}.raw' for i in range(num_seg)]
+    file_paths = [cache_folder / f'test_BinaryRecordingExtractor_{i}.raw' for i in range(num_seg)]
     for i in range(num_seg):
-        traces = np.memmap(file_paths[i], dtype=dtype, mode='w+', shape=(num_samples, num_chan))
+        traces = np.memmap(
+            file_paths[i], dtype=dtype, mode='w+', shape=(num_samples, num_chan))
         traces[:] = np.arange(3)[None, :]
-    rec = BinaryRecordingExtractor(file_paths, sampling_frequency, num_chan, dtype)
+    rec = BinaryRecordingExtractor(
+        file_paths, sampling_frequency, num_chan, dtype)
 
     # keep original ids
     rec_sliced = ChannelSliceRecording(rec, channel_ids=[0, 2])
@@ -37,11 +38,12 @@ def test_ChannelSliceRecording():
     assert traces.shape[1] == 2
     traces = rec_sliced.get_traces(segment_index=1, channel_ids=[2, 0])
     assert traces.shape[1] == 2
-    
+
     assert np.allclose(rec_sliced.get_times(0), rec.get_times(0))
-    
+
     # with channel ids renaming
-    rec_sliced2 = ChannelSliceRecording(rec, channel_ids=[0, 2], renamed_channel_ids=[3, 4])
+    rec_sliced2 = ChannelSliceRecording(
+        rec, channel_ids=[0, 2], renamed_channel_ids=[3, 4])
     assert np.all(rec_sliced2.get_channel_ids() == [3, 4])
     traces = rec_sliced2.get_traces(segment_index=1)
     assert traces.shape[1] == 2
@@ -57,10 +59,10 @@ def test_ChannelSliceRecording():
     probe = pi.generate_linear_probe(num_elec=num_chan)
     probe.set_device_channel_indices(np.arange(num_chan))
     rec_p = rec.set_probe(probe)
-    rec_sliced3 = ChannelSliceRecording(rec_p, channel_ids=[0, 2], renamed_channel_ids=[3, 4])
+    rec_sliced3 = ChannelSliceRecording(
+        rec_p, channel_ids=[0, 2], renamed_channel_ids=[3, 4])
     probe3 = rec_sliced3.get_probe()
     locations3 = probe3.contact_positions
-    cache_folder = Path('./my_cache_folder')
     folder = cache_folder / 'sliced_recording'
     rec_saved = rec_sliced3.save(folder=folder, chunk_size=10, n_jobs=2)
     probe = rec_saved.get_probe()
@@ -71,5 +73,4 @@ def test_ChannelSliceRecording():
 
 
 if __name__ == '__main__':
-    _clean_all()
     test_ChannelSliceRecording()

--- a/spikeinterface/core/tests/test_channelslicerecording.py
+++ b/spikeinterface/core/tests/test_channelslicerecording.py
@@ -10,7 +10,7 @@ from spikeinterface.core import ChannelSliceRecording, BinaryRecordingExtractor
 
 
 def test_ChannelSliceRecording():
-    if getattr(pytest, "global_test_folder"):
+    if hasattr(pytest, "global_test_folder"):
         cache_folder = pytest.global_test_folder / "core"
     else:
         cache_folder = Path("cache_folder") / "core"

--- a/spikeinterface/core/tests/test_core_tools.py
+++ b/spikeinterface/core/tests/test_core_tools.py
@@ -1,4 +1,6 @@
 import platform
+import pytest
+from pathlib import Path
 
 from spikeinterface.core.testing_tools import generate_recording
 
@@ -12,6 +14,12 @@ except:
     HAVE_SHAREDMEMORY = False
 
 
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "core"
+else:
+    cache_folder = Path("cache_folder") / "core"
+
+
 def test_write_binary_recording():
     # 2 segments
     recording = generate_recording(num_channels=2, durations=[10.325, 3.5])
@@ -19,19 +27,19 @@ def test_write_binary_recording():
     recording = recording.save()
 
     # write with loop
-    write_binary_recording(recording, file_paths=['binary01.raw', 'binary02.raw'], dtype=None,
-                           verbose=True, n_jobs=1)
+    write_binary_recording(recording, file_paths=[cache_folder / 'binary01.raw', cache_folder / 'binary02.raw'],
+                           dtype=None, verbose=True, n_jobs=1)
 
-    write_binary_recording(recording, file_paths=['binary01.raw', 'binary02.raw'], dtype=None,
-                           verbose=True, n_jobs=1, chunk_memory='100k', progress_bar=True)
-
-    # write parrallel
-    write_binary_recording(recording, file_paths=['binary01.raw', 'binary02.raw'], dtype=None,
-                           verbose=False, n_jobs=2, chunk_memory='100k')
+    write_binary_recording(recording, file_paths=[cache_folder / 'binary01.raw', cache_folder / 'binary02.raw'],
+                           dtype=None, verbose=True, n_jobs=1, chunk_memory='100k', progress_bar=True)
 
     # write parrallel
-    write_binary_recording(recording, file_paths=['binary01.raw', 'binary02.raw'], dtype=None,
-                           verbose=False, n_jobs=2, total_memory='200k', progress_bar=True)
+    write_binary_recording(recording, file_paths=[cache_folder / 'binary01.raw', cache_folder / 'binary02.raw'],
+                           dtype=None, verbose=False, n_jobs=2, chunk_memory='100k')
+
+    # write parrallel
+    write_binary_recording(recording, file_paths=[cache_folder / 'binary01.raw', cache_folder / 'binary02.raw'],
+                           dtype=None, verbose=False, n_jobs=2, total_memory='200k', progress_bar=True)
 
 
 def test_write_memory_recording():

--- a/spikeinterface/core/tests/test_core_tools.py
+++ b/spikeinterface/core/tests/test_core_tools.py
@@ -14,7 +14,7 @@ except:
     HAVE_SHAREDMEMORY = False
 
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
 else:
     cache_folder = Path("cache_folder") / "core"

--- a/spikeinterface/core/tests/test_datasets.py
+++ b/spikeinterface/core/tests/test_datasets.py
@@ -1,8 +1,4 @@
-import shutil
-from pathlib import Path
 import pytest
-import numpy as np
-
 from spikeinterface.core.datasets import HAVE_DATALAD
 from spikeinterface.core import download_dataset
 
@@ -13,7 +9,8 @@ def test_download_dataset():
     remote_path = 'mearec'
 
     # local_folder automatic
-    local_path = download_dataset(repo=repo, remote_path=remote_path, local_folder=None)
+    local_path = download_dataset(
+        repo=repo, remote_path=remote_path, local_folder=None)
     # print(local_path)
 
 

--- a/spikeinterface/core/tests/test_frameslicesorting.py
+++ b/spikeinterface/core/tests/test_frameslicesorting.py
@@ -4,13 +4,15 @@ from spikeinterface.core.testing_tools import generate_sorting
 def test_FrameSliceSorting():
     fs = 30000
     duration = 10
-    sort = generate_sorting(num_units=10,  durations=[duration], sampling_frequency=fs)
+    sort = generate_sorting(num_units=10,  durations=[
+                            duration], sampling_frequency=fs)
 
     mid_frame = (duration * fs) // 2
     # duration of all slices is mid_frame. Spike trains are re-referenced to the start_time
     sub_sort = sort.frame_slice(None, None)
     for u in sort.get_unit_ids():
-        assert len(sort.get_unit_spike_train(u)) == len(sub_sort.get_unit_spike_train(u))
+        assert len(sort.get_unit_spike_train(u)) == len(
+            sub_sort.get_unit_spike_train(u))
 
     sub_sort = sort.frame_slice(None, mid_frame)
     for u in sort.get_unit_ids():
@@ -20,7 +22,8 @@ def test_FrameSliceSorting():
     for u in sort.get_unit_ids():
         assert max(sub_sort.get_unit_spike_train(u)) <= mid_frame
 
-    sub_sort = sort.frame_slice(mid_frame - mid_frame // 2, mid_frame + mid_frame // 2)
+    sub_sort = sort.frame_slice(
+        mid_frame - mid_frame // 2, mid_frame + mid_frame // 2)
     for u in sort.get_unit_ids():
         assert max(sub_sort.get_unit_spike_train(u)) <= mid_frame
 

--- a/spikeinterface/core/tests/test_job_tools.py
+++ b/spikeinterface/core/tests/test_job_tools.py
@@ -42,7 +42,8 @@ def test_ensure_chunk_size():
     # make dumpable
     recording = recording.save()
 
-    chunk_size = ensure_chunk_size(recording, total_memory="512M", chunk_size=None, chunk_memory=None, n_jobs=2)
+    chunk_size = ensure_chunk_size(
+        recording, total_memory="512M", chunk_size=None, chunk_memory=None, n_jobs=2)
     assert chunk_size == 32000000
 
     chunk_size = ensure_chunk_size(recording, chunk_memory="256M")
@@ -56,7 +57,8 @@ def test_ensure_chunk_size():
 
 
 def func(segment_index, start_frame, end_frame, worker_ctx):
-    import os, time
+    import os
+    import time
     #  print('func', segment_index, start_frame, end_frame, worker_ctx, os.getpid())
     time.sleep(0.010)
     # time.sleep(1.0)

--- a/spikeinterface/core/tests/test_npzsortingextractor.py
+++ b/spikeinterface/core/tests/test_npzsortingextractor.py
@@ -1,13 +1,18 @@
 import pytest
-import numpy as np
+from pathlib import Path
 
 from spikeinterface.core import NpzSortingExtractor
 from spikeinterface.core.testing_tools import create_sorting_npz
 
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "core"
+else:
+    cache_folder = Path("cache_folder") / "core"
+
 
 def test_NpzSortingExtractor():
     num_seg = 2
-    file_path = 'test_NpzSortingExtractor.npz'
+    file_path = cache_folder / 'test_NpzSortingExtractor.npz'
 
     create_sorting_npz(num_seg, file_path)
 
@@ -15,9 +20,10 @@ def test_NpzSortingExtractor():
 
     for segment_index in range(num_seg):
         for unit_id in (0, 1, 2):
-            st = sorting.get_unit_spike_train(unit_id, segment_index=segment_index)
+            st = sorting.get_unit_spike_train(
+                unit_id, segment_index=segment_index)
 
-    file_path_copy = 'test_NpzSortingExtractor_copy.npz'
+    file_path_copy = cache_folder / 'test_NpzSortingExtractor_copy.npz'
     NpzSortingExtractor.write_sorting(sorting, file_path_copy)
     sorting_copy = NpzSortingExtractor(file_path_copy)
 

--- a/spikeinterface/core/tests/test_npzsortingextractor.py
+++ b/spikeinterface/core/tests/test_npzsortingextractor.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from spikeinterface.core import NpzSortingExtractor
 from spikeinterface.core.testing_tools import create_sorting_npz
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
 else:
     cache_folder = Path("cache_folder") / "core"

--- a/spikeinterface/core/tests/test_numpy_extractors.py
+++ b/spikeinterface/core/tests/test_numpy_extractors.py
@@ -8,7 +8,7 @@ from spikeinterface.core import NumpyRecording, NumpySorting, NumpyEvent
 from spikeinterface.core.testing_tools import create_sorting_npz
 from spikeinterface.core import NpzSortingExtractor
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
 else:
     cache_folder = Path("cache_folder") / "core"

--- a/spikeinterface/core/tests/test_numpy_extractors.py
+++ b/spikeinterface/core/tests/test_numpy_extractors.py
@@ -8,20 +8,10 @@ from spikeinterface.core import NumpyRecording, NumpySorting, NumpyEvent
 from spikeinterface.core.testing_tools import create_sorting_npz
 from spikeinterface.core import NpzSortingExtractor
 
-cache_folder = Path('./my_cache_folder')
-
-
-def _clean_all():
-    if cache_folder.exists():
-        shutil.rmtree(cache_folder)
-
-
-def setup_module():
-    _clean_all()
-
-
-def teardown_module():
-    _clean_all()
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "core"
+else:
+    cache_folder = Path("cache_folder") / "core"
 
 
 def test_NumpyRecording():
@@ -33,7 +23,7 @@ def test_NumpyRecording():
 
     rec = NumpyRecording(timeseries_list, sampling_frequency)
     print(rec)
-    
+
     times1 = rec.get_times(1)
 
     rec.save(folder=cache_folder / 'test_NumpyRecording')
@@ -57,13 +47,14 @@ def test_NumpySorting():
     print(sorting)
     assert sorting.get_num_segments() == 1
 
-    sorting = NumpySorting.from_times_labels([times] * 3, [labels] * 3, sampling_frequency)
+    sorting = NumpySorting.from_times_labels(
+        [times] * 3, [labels] * 3, sampling_frequency)
     # print(sorting)
     assert sorting.get_num_segments() == 3
 
     # from other extracrtor
     num_seg = 2
-    file_path = 'test_NpzSortingExtractor.npz'
+    file_path = cache_folder / 'test_NpzSortingExtractor.npz'
     create_sorting_npz(num_seg, file_path)
     other_sorting = NpzSortingExtractor(file_path)
 
@@ -110,7 +101,6 @@ def test_NumpyEvent():
 
 
 if __name__ == '__main__':
-    _clean_all()
     test_NumpyRecording()
     test_NumpySorting()
     test_NumpyEvent()

--- a/spikeinterface/core/tests/test_segmentutils.py
+++ b/spikeinterface/core/tests/test_segmentutils.py
@@ -15,7 +15,7 @@ def test_append_concatenate_recordings():
     sampling_frequency = 30000
     rec0 = NumpyRecording([traces] * 3, sampling_frequency)
     rec1 = NumpyRecording([traces] * 2, sampling_frequency)
-    
+
     # append
     rec = append_recordings([rec0, rec1])
     #  print(rec)
@@ -61,8 +61,10 @@ def test_append_sortings():
     labels[0::3] = 0
     labels[1::3] = 1
     labels[2::3] = 2
-    sorting0 = NumpySorting.from_times_labels([times] * 3, [labels] * 3, sampling_frequency)
-    sorting1 = NumpySorting.from_times_labels([times] * 2, [labels] * 2, sampling_frequency)
+    sorting0 = NumpySorting.from_times_labels(
+        [times] * 3, [labels] * 3, sampling_frequency)
+    sorting1 = NumpySorting.from_times_labels(
+        [times] * 2, [labels] * 2, sampling_frequency)
 
     sorting = append_sortings([sorting0, sorting1])
     # print(sorting)

--- a/spikeinterface/core/tests/test_time_handling.py
+++ b/spikeinterface/core/tests/test_time_handling.py
@@ -5,7 +5,7 @@ import numpy as np
 from spikeinterface.core.testing_tools import generate_recording, generate_sorting
 
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
 else:
     cache_folder = Path("cache_folder") / "core"

--- a/spikeinterface/core/tests/test_time_handling.py
+++ b/spikeinterface/core/tests/test_time_handling.py
@@ -1,26 +1,17 @@
-import shutil
+import pytest
 from pathlib import Path
 import numpy as np
 
 from spikeinterface.core.testing_tools import generate_recording, generate_sorting
 
 
-def _clean_all():
-    cache_folder = './my_cache_folder'
-    if Path(cache_folder).exists():
-        shutil.rmtree(cache_folder)
-
-
-def setup_module():
-    _clean_all()
-
-
-def teardown_module():
-    _clean_all()
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "core"
+else:
+    cache_folder = Path("cache_folder") / "core"
 
 
 def test_time_handling():
-    cache_folder = Path('./my_cache_folder')
     durations = [[10], [10, 5]]
 
     # test multi-segment
@@ -81,5 +72,4 @@ def test_frame_slicing():
 
 
 if __name__ == '__main__':
-    _clean_all()
     test_frame_slicing()

--- a/spikeinterface/core/tests/test_unitsaggregationsorting.py
+++ b/spikeinterface/core/tests/test_unitsaggregationsorting.py
@@ -1,17 +1,22 @@
 import pytest
 import numpy as np
+from pathlib import Path
 
 from spikeinterface.core import aggregate_units
 
-from spikeinterface.core import NpzSortingExtractor, load_extractor
-from spikeinterface.core.base import BaseExtractor
-
+from spikeinterface.core import NpzSortingExtractor
 from spikeinterface.core.testing_tools import create_sorting_npz
+
+
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "core"
+else:
+    cache_folder = Path("cache_folder") / "core"
 
 
 def test_unitsaggregationsorting():
     num_seg = 2
-    file_path = 'test_BaseSorting.npz'
+    file_path = cache_folder / 'test_BaseSorting.npz'
 
     create_sorting_npz(num_seg, file_path)
 
@@ -30,10 +35,14 @@ def test_unitsaggregationsorting():
     unit_ids = sorting1.get_unit_ids()
 
     for seg in range(num_seg):
-        spiketrain1_1 = sorting1.get_unit_spike_train(unit_ids[1], segment_index=seg)
-        spiketrains2_0 = sorting2.get_unit_spike_train(unit_ids[0], segment_index=seg)
-        spiketrains3_2 = sorting3.get_unit_spike_train(unit_ids[2], segment_index=seg)
-        assert np.allclose(spiketrain1_1, sorting_agg.get_unit_spike_train(unit_ids[1], segment_index=seg))
+        spiketrain1_1 = sorting1.get_unit_spike_train(
+            unit_ids[1], segment_index=seg)
+        spiketrains2_0 = sorting2.get_unit_spike_train(
+            unit_ids[0], segment_index=seg)
+        spiketrains3_2 = sorting3.get_unit_spike_train(
+            unit_ids[2], segment_index=seg)
+        assert np.allclose(spiketrain1_1, sorting_agg.get_unit_spike_train(
+            unit_ids[1], segment_index=seg))
         assert np.allclose(spiketrains2_0, sorting_agg.get_unit_spike_train(num_units + unit_ids[0],
                                                                             segment_index=seg))
         assert np.allclose(spiketrains3_2, sorting_agg.get_unit_spike_train(2 * num_units + unit_ids[2],
@@ -41,8 +50,10 @@ def test_unitsaggregationsorting():
 
     # test rename units
     renamed_unit_ids = [f"#Unit {i}" for i in range(3 * num_units)]
-    sorting_agg_renamed = aggregate_units([sorting1, sorting2, sorting3], renamed_unit_ids=renamed_unit_ids)
-    assert all(unit in renamed_unit_ids for unit in sorting_agg_renamed.get_unit_ids())
+    sorting_agg_renamed = aggregate_units(
+        [sorting1, sorting2, sorting3], renamed_unit_ids=renamed_unit_ids)
+    assert all(
+        unit in renamed_unit_ids for unit in sorting_agg_renamed.get_unit_ids())
 
     # test properties
 
@@ -64,6 +75,7 @@ def test_unitsaggregationsorting():
     assert "brain_area" in sorting_agg_prop.get_property_keys()
     assert "quality" not in sorting_agg_prop.get_property_keys()
     print(sorting_agg_prop.get_property("brain_area"))
+
 
 if __name__ == '__main__':
     test_unitsaggregationsorting()

--- a/spikeinterface/core/tests/test_unitsaggregationsorting.py
+++ b/spikeinterface/core/tests/test_unitsaggregationsorting.py
@@ -8,7 +8,7 @@ from spikeinterface.core import NpzSortingExtractor
 from spikeinterface.core.testing_tools import create_sorting_npz
 
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
 else:
     cache_folder = Path("cache_folder") / "core"

--- a/spikeinterface/core/tests/test_unitsselectionsorting.py
+++ b/spikeinterface/core/tests/test_unitsselectionsorting.py
@@ -10,7 +10,7 @@ from spikeinterface.core.base import BaseExtractor
 from spikeinterface.core.testing_tools import create_sorting_npz
 
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
 else:
     cache_folder = Path("cache_folder") / "core"

--- a/spikeinterface/core/tests/test_unitsselectionsorting.py
+++ b/spikeinterface/core/tests/test_unitsselectionsorting.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+from pathlib import Path
 
 from spikeinterface.core import UnitsSelectionSorting
 
@@ -9,9 +10,15 @@ from spikeinterface.core.base import BaseExtractor
 from spikeinterface.core.testing_tools import create_sorting_npz
 
 
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "core"
+else:
+    cache_folder = Path("cache_folder") / "core"
+
+
 def test_unitsselectionsorting():
     num_seg = 2
-    file_path = 'test_BaseSorting.npz'
+    file_path = cache_folder / 'test_BaseSorting.npz'
 
     create_sorting_npz(num_seg, file_path)
 

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -1,3 +1,4 @@
+import pytest
 from pathlib import Path
 import shutil
 import numpy as np
@@ -6,23 +7,10 @@ from spikeinterface.core.testing_tools import generate_recording, generate_sorti
 from spikeinterface import WaveformExtractor, extract_waveforms
 
 
-def _clean_all():
-    folders = ["wf_rec1", "wf_rec2", "wf_rec3", "wf_sort2", "wf_sort3",
-               "test_waveform_extractor", "we_filt",
-               "test_extract_waveforms_1job", "test_extract_waveforms_2job",
-               "test_extract_waveforms_returnscaled",
-               "test_extract_waveforms_sparsity"]
-    for folder in folders:
-        if Path(folder).exists():
-            shutil.rmtree(folder)
-
-
-def setup_module():
-    _clean_all()
-
-
-def teardown_module():
-    _clean_all()
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "core"
+else:
+    cache_folder = Path("cache_folder") / "core"
 
 
 def test_WaveformExtractor():
@@ -31,19 +19,20 @@ def test_WaveformExtractor():
 
     # 2 segments
     num_channels = 2
-    recording = generate_recording(num_channels=num_channels, durations=durations, 
+    recording = generate_recording(num_channels=num_channels, durations=durations,
                                    sampling_frequency=sampling_frequency)
     recording.annotate(is_filtered=True)
-    folder_rec = "wf_rec1"
+    folder_rec = cache_folder / "wf_rec1"
     recording = recording.save(folder=folder_rec)
     num_units = 15
-    sorting = generate_sorting(num_units=num_units, sampling_frequency=sampling_frequency, durations=durations)
+    sorting = generate_sorting(
+        num_units=num_units, sampling_frequency=sampling_frequency, durations=durations)
 
     # test with dump !!!!
     recording = recording.save()
     sorting = sorting.save()
 
-    folder = Path('test_waveform_extractor')
+    folder = cache_folder / 'test_waveform_extractor'
     if folder.is_dir():
         shutil.rmtree(folder)
 
@@ -75,15 +64,13 @@ def test_WaveformExtractor():
     wfs_std = we.get_all_templates(mode='std')
     assert wfs_std.shape == (num_units, 210, num_channels)
 
-
     wf_segment = we.get_template_segment(unit_id=0, segment_index=0)
     assert wf_segment.shape == (210, num_channels)
     assert wf_segment.shape == (210, num_channels)
-    
-    
+
     # test filter units
     keep_units = sorting.get_unit_ids()[::2]
-    wf_filt = we.select_units(keep_units, "we_filt")
+    wf_filt = we.select_units(keep_units, cache_folder / "we_filt")
     for unit in wf_filt.sorting.get_unit_ids():
         assert unit in keep_units
     filtered_templates = wf_filt.get_all_templates()
@@ -96,23 +83,26 @@ def test_extract_waveforms():
     durations = [30, 40]
     sampling_frequency = 30000.
 
-    recording = generate_recording(num_channels=2, durations=durations, sampling_frequency=sampling_frequency)
+    recording = generate_recording(
+        num_channels=2, durations=durations, sampling_frequency=sampling_frequency)
     recording.annotate(is_filtered=True)
-    folder_rec = "wf_rec2"
+    folder_rec = cache_folder / "wf_rec2"
     recording = recording.save(folder=folder_rec)
-    sorting = generate_sorting(num_units=5, sampling_frequency=sampling_frequency, durations=durations)
-    folder_sort = "wf_sort2"
+    sorting = generate_sorting(
+        num_units=5, sampling_frequency=sampling_frequency, durations=durations)
+    folder_sort = cache_folder / "wf_sort2"
     sorting = sorting.save(folder=folder_sort)
     # test without dump !!!!
     #  recording = recording.save()
     #  sorting = sorting.save()
 
-    folder1 = Path('test_extract_waveforms_1job')
+    folder1 = cache_folder / 'test_extract_waveforms_1job'
     if folder1.is_dir():
         shutil.rmtree(folder1)
-    we1 = extract_waveforms(recording, sorting, folder1, max_spikes_per_unit=None, return_scaled=False)
+    we1 = extract_waveforms(recording, sorting, folder1,
+                            max_spikes_per_unit=None, return_scaled=False)
 
-    folder2 = Path('test_extract_waveforms_2job')
+    folder2 = cache_folder / 'test_extract_waveforms_2job'
     if folder2.is_dir():
         shutil.rmtree(folder2)
     we2 = extract_waveforms(recording, sorting, folder2, n_jobs=2, total_memory="10M", max_spikes_per_unit=None,
@@ -122,7 +112,7 @@ def test_extract_waveforms():
     wf2 = we2.get_waveforms(0)
     assert np.array_equal(wf1, wf2)
 
-    folder3 = Path('test_extract_waveforms_returnscaled')
+    folder3 = cache_folder / 'test_extract_waveforms_returnscaled'
     if folder3.is_dir():
         shutil.rmtree(folder3)
 
@@ -141,18 +131,21 @@ def test_sparsity():
     durations = [30]
     sampling_frequency = 30000.
 
-    recording = generate_recording(num_channels=10, durations=durations, sampling_frequency=sampling_frequency)
+    recording = generate_recording(
+        num_channels=10, durations=durations, sampling_frequency=sampling_frequency)
     recording.annotate(is_filtered=True)
-    folder_rec = "wf_rec3"
+    folder_rec = cache_folder / "wf_rec3"
     recording = recording.save(folder=folder_rec)
-    sorting = generate_sorting(num_units=5, sampling_frequency=sampling_frequency, durations=durations)
-    folder_sort = "wf_sort3"
+    sorting = generate_sorting(
+        num_units=5, sampling_frequency=sampling_frequency, durations=durations)
+    folder_sort = cache_folder / "wf_sort3"
     sorting = sorting.save(folder=folder_sort)
 
-    folder = Path('test_extract_waveforms_sparsity')
+    folder = cache_folder / 'test_extract_waveforms_sparsity'
     if folder.is_dir():
         shutil.rmtree(folder)
-    we = extract_waveforms(recording, sorting, folder, max_spikes_per_unit=None)
+    we = extract_waveforms(recording, sorting, folder,
+                           max_spikes_per_unit=None)
 
     # sparsity: same number of channels
     num_channels = 3
@@ -161,9 +154,12 @@ def test_sparsity():
     sparsity_diff = {}
 
     for unit in sorting.get_unit_ids():
-        sparsity_same[unit] = np.random.permutation(recording.get_channel_ids())[:num_channels]
-        rand_channel_num = np.random.randint(channel_bounds[0], channel_bounds[1])
-        sparsity_diff[unit] = np.random.permutation(recording.get_channel_ids())[:rand_channel_num]
+        sparsity_same[unit] = np.random.permutation(
+            recording.get_channel_ids())[:num_channels]
+        rand_channel_num = np.random.randint(
+            channel_bounds[0], channel_bounds[1])
+        sparsity_diff[unit] = np.random.permutation(
+            recording.get_channel_ids())[:rand_channel_num]
 
     print(sparsity_same)
     print(sparsity_diff)
@@ -185,25 +181,26 @@ def test_sparsity():
 def test_portability():
     durations = [30, 40]
     sampling_frequency = 30000.
-    
-    folder_to_move = Path("original_folder")
+
+    folder_to_move = cache_folder / "original_folder"
     if folder_to_move.is_dir():
         shutil.rmtree(folder_to_move)
     folder_to_move.mkdir()
-    folder_moved = Path("moved_folder")
+    folder_moved = cache_folder / "moved_folder"
     if folder_moved.is_dir():
         shutil.rmtree(folder_moved)
     # folder_moved.mkdir()
-        
+
     # 2 segments
     num_channels = 2
-    recording = generate_recording(num_channels=num_channels, durations=durations, 
+    recording = generate_recording(num_channels=num_channels, durations=durations,
                                    sampling_frequency=sampling_frequency)
     recording.annotate(is_filtered=True)
     folder_rec = folder_to_move / "rec"
     recording = recording.save(folder=folder_rec)
     num_units = 15
-    sorting = generate_sorting(num_units=num_units, sampling_frequency=sampling_frequency, durations=durations)
+    sorting = generate_sorting(
+        num_units=num_units, sampling_frequency=sampling_frequency, durations=durations)
     folder_sort = folder_to_move / "sort"
     sorting = sorting.save(folder=folder_sort)
 
@@ -212,13 +209,15 @@ def test_portability():
         shutil.rmtree(wf_folder)
 
     # save with relative paths
-    we = extract_waveforms(recording, sorting, wf_folder, use_relative_path=True)
+    we = extract_waveforms(recording, sorting, wf_folder,
+                           use_relative_path=True)
 
     # move all to a separate folder
     shutil.copytree(folder_to_move, folder_moved)
     wf_folder_moved = folder_moved / "waveform_extractor"
-    we_loaded = extract_waveforms(recording, sorting, wf_folder_moved, load_if_exists=True)
-    
+    we_loaded = extract_waveforms(
+        recording, sorting, wf_folder_moved, load_if_exists=True)
+
     assert we_loaded.recording is not None
     assert we_loaded.sorting is not None
 
@@ -226,7 +225,6 @@ def test_portability():
         we.recording.get_channel_ids(), we_loaded.recording.get_channel_ids())
     assert np.allclose(
         we.sorting.get_unit_ids(), we_loaded.sorting.get_unit_ids())
-
 
     for unit in we.sorting.get_unit_ids():
         wf = we.get_waveforms(unit_id=unit)
@@ -236,7 +234,6 @@ def test_portability():
 
 
 if __name__ == '__main__':
-    setup_module()
     test_WaveformExtractor()
     test_extract_waveforms()
     test_sparsity()

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -7,7 +7,7 @@ from spikeinterface.core.testing_tools import generate_recording, generate_sorti
 from spikeinterface import WaveformExtractor, extract_waveforms
 
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
 else:
     cache_folder = Path("cache_folder") / "core"

--- a/spikeinterface/core/tests/test_waveform_tools.py
+++ b/spikeinterface/core/tests/test_waveform_tools.py
@@ -9,7 +9,7 @@ from spikeinterface.core.testing_tools import generate_recording, generate_sorti
 from spikeinterface.core.waveform_tools import allocate_waveforms, distribute_waveforms_to_buffers
 
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
 else:
     cache_folder = Path("cache_folder") / "core"

--- a/spikeinterface/core/tests/test_waveform_tools.py
+++ b/spikeinterface/core/tests/test_waveform_tools.py
@@ -1,3 +1,4 @@
+import pytest
 from pathlib import Path
 import shutil
 import platform
@@ -5,23 +6,13 @@ import platform
 import numpy as np
 
 from spikeinterface.core.testing_tools import generate_recording, generate_sorting
-#~ from spikeinterface import WaveformExtractor, extract_waveforms
 from spikeinterface.core.waveform_tools import allocate_waveforms, distribute_waveforms_to_buffers
 
 
-def _clean_all():
-    folders = ["wf_rec1", "test_waveform_tools", "test_waveform_tools_sparse",]
-    for folder in folders:
-        if Path(folder).exists():
-            shutil.rmtree(folder)
-
-
-def setup_module():
-    _clean_all()
-
-
-def teardown_module():
-    _clean_all()
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "core"
+else:
+    cache_folder = Path("cache_folder") / "core"
 
 
 def _check_all_wf_equal(list_wfs_arrays):
@@ -33,92 +24,92 @@ def _check_all_wf_equal(list_wfs_arrays):
 
 def test_waveform_tools():
 
-
     durations = [30, 40]
     sampling_frequency = 30000.
 
     # 2 segments
     num_channels = 2
-    recording = generate_recording(num_channels=num_channels, durations=durations, 
+    recording = generate_recording(num_channels=num_channels, durations=durations,
                                    sampling_frequency=sampling_frequency)
     recording.annotate(is_filtered=True)
-    folder_rec = "wf_rec1"
-    #~ recording = recording.save(folder=folder_rec)
     num_units = 15
-    sorting = generate_sorting(num_units=num_units, sampling_frequency=sampling_frequency, durations=durations)
+    sorting = generate_sorting(
+        num_units=num_units, sampling_frequency=sampling_frequency, durations=durations)
 
     # test with dump !!!!
     recording = recording.save()
     sorting = sorting.save()
 
-    
-
-    #~ we = WaveformExtractor.create(recording, sorting, folder)
-    
     nbefore = int(3. * sampling_frequency / 1000.)
     nafter = int(4. * sampling_frequency / 1000.)
-    
+
     dtype = recording.get_dtype()
     return_scaled = False
-    
+
     spikes = sorting.to_spike_vector()
-    
+
     unit_ids = sorting.unit_ids
 
     some_job_kwargs = [
         {},
-        {'n_jobs': 1, 'chunk_size': 3000, 'progress_bar':True},
-        {'n_jobs': 2, 'chunk_size': 3000, 'progress_bar':True},
+        {'n_jobs': 1, 'chunk_size': 3000, 'progress_bar': True},
+        {'n_jobs': 2, 'chunk_size': 3000, 'progress_bar': True},
     ]
-    
-    # memmap mode 
+
+    # memmap mode
     list_wfs = []
     for j, job_kwargs in enumerate(some_job_kwargs):
-        wf_folder = Path(f'test_waveform_tools_{j}')
+        wf_folder = cache_folder / f'test_waveform_tools_{j}'
         if wf_folder.is_dir():
             shutil.rmtree(wf_folder)
         wf_folder.mkdir()
-        wfs_arrays, wfs_arrays_info = allocate_waveforms(recording, spikes, unit_ids, nbefore, nafter, mode='memmap', folder=wf_folder, dtype=dtype)
-        distribute_waveforms_to_buffers(recording, spikes, unit_ids, wfs_arrays_info, nbefore, nafter, return_scaled, **job_kwargs)
+        wfs_arrays, wfs_arrays_info = allocate_waveforms(recording, spikes, unit_ids, nbefore, nafter, mode='memmap',
+                                                         folder=wf_folder, dtype=dtype)
+        distribute_waveforms_to_buffers(recording, spikes, unit_ids, wfs_arrays_info,
+                                        nbefore, nafter, return_scaled, **job_kwargs)
         for unit_ind, unit_id in enumerate(unit_ids):
             wf = wfs_arrays[unit_id]
             assert wf.shape[0] == np.sum(spikes['unit_ind'] == unit_ind)
-        list_wfs.append({unit_id: wfs_arrays[unit_id].copy() for unit_id in unit_ids})
+        list_wfs.append(
+            {unit_id: wfs_arrays[unit_id].copy() for unit_id in unit_ids})
     _check_all_wf_equal(list_wfs)
-    
 
     # memory
     if platform.system() != 'Windows':
         # shared memory on windows is buggy...
         list_wfs = []
         for job_kwargs in some_job_kwargs:
-            wfs_arrays, wfs_arrays_info = allocate_waveforms(recording, spikes, unit_ids, nbefore, nafter, mode='shared_memory', folder=None, dtype=dtype)
-            distribute_waveforms_to_buffers(recording, spikes, unit_ids, wfs_arrays_info, nbefore, nafter, return_scaled, mode='shared_memory', **job_kwargs)
+            wfs_arrays, wfs_arrays_info = allocate_waveforms(recording, spikes, unit_ids,
+                                                             nbefore, nafter, mode='shared_memory', folder=None,
+                                                             dtype=dtype)
+            distribute_waveforms_to_buffers(recording, spikes, unit_ids, wfs_arrays_info,
+                                            nbefore, nafter, return_scaled, mode='shared_memory', **job_kwargs)
             for unit_ind, unit_id in enumerate(unit_ids):
                 wf = wfs_arrays[unit_id]
                 assert wf.shape[0] == np.sum(spikes['unit_ind'] == unit_ind)
-            list_wfs.append({unit_id: wfs_arrays[unit_id].copy() for unit_id in unit_ids})
+            list_wfs.append(
+                {unit_id: wfs_arrays[unit_id].copy() for unit_id in unit_ids})
             # to avoid warning we need to first destroy arrays then sharedmemm object
             del wfs_arrays
             del wfs_arrays_info
         _check_all_wf_equal(list_wfs)
 
-    
     # with sparsity
-    wf_folder = Path('test_waveform_tools_sparse')
+    wf_folder = cache_folder / 'test_waveform_tools_sparse'
     if wf_folder.is_dir():
         shutil.rmtree(wf_folder)
     wf_folder.mkdir()
-    
-    
-    sparsity_mask = np.random.randint(0, 2, size=(unit_ids.size, recording.channel_ids.size), dtype='bool')
-    
-    wfs_arrays, wfs_arrays_info = allocate_waveforms(recording, spikes, unit_ids, nbefore, nafter, mode='memmap', folder=wf_folder, dtype=dtype, sparsity_mask=sparsity_mask)
-    job_kwargs = {'n_jobs': 1, 'chunk_size': 3000, 'progress_bar':True}
-    distribute_waveforms_to_buffers(recording, spikes, unit_ids, wfs_arrays_info, nbefore, nafter, return_scaled, sparsity_mask=sparsity_mask, **job_kwargs)
-    
+
+    sparsity_mask = np.random.randint(0, 2, size=(
+        unit_ids.size, recording.channel_ids.size), dtype='bool')
+
+    wfs_arrays, wfs_arrays_info = allocate_waveforms(recording, spikes, unit_ids, nbefore, nafter,
+                                                     mode='memmap', folder=wf_folder, dtype=dtype,
+                                                     sparsity_mask=sparsity_mask)
+    job_kwargs = {'n_jobs': 1, 'chunk_size': 3000, 'progress_bar': True}
+    distribute_waveforms_to_buffers(recording, spikes, unit_ids, wfs_arrays_info,
+                                    nbefore, nafter, return_scaled, sparsity_mask=sparsity_mask, **job_kwargs)
+
 
 if __name__ == '__main__':
-    setup_module()
     test_waveform_tools()
-    

--- a/spikeinterface/exporters/tests/test_export_to_phy.py
+++ b/spikeinterface/exporters/tests/test_export_to_phy.py
@@ -8,7 +8,7 @@ from spikeinterface import extract_waveforms, download_dataset
 import spikeinterface.extractors as se
 from spikeinterface.exporters import export_to_phy
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "exporters"
 else:
     cache_folder = Path("cache_folder") / "exporters"

--- a/spikeinterface/exporters/tests/test_export_to_phy.py
+++ b/spikeinterface/exporters/tests/test_export_to_phy.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 import shutil
 from pathlib import Path
 
@@ -8,10 +8,10 @@ from spikeinterface import extract_waveforms, download_dataset
 import spikeinterface.extractors as se
 from spikeinterface.exporters import export_to_phy
 
-def setup_module():
-    for folder in ('waveforms', 'waveforms_rm', 'phy_output', 'phy_output_rm', 'rec', 'sort'):
-        if Path(folder).is_dir():
-            shutil.rmtree(folder)
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "exporters"
+else:
+    cache_folder = Path("cache_folder") / "exporters"
 
 
 def test_export_to_phy():
@@ -21,8 +21,8 @@ def test_export_to_phy():
     recording = se.MEArecRecordingExtractor(local_path)
     sorting = se.MEArecSortingExtractor(local_path)
 
-    waveform_folder = Path('waveforms')
-    output_folder = Path('phy_output')
+    waveform_folder = cache_folder / 'waveforms'
+    output_folder = cache_folder / 'phy_output'
 
     for f in (waveform_folder, output_folder):
         if f.is_dir():
@@ -43,12 +43,12 @@ def test_export_to_phy_by_property():
     recording.set_channel_groups([0, 0, 0, 0, 1, 1, 1, 1])
     sorting.set_property("group", [0, 0, 1, 1])
 
-    waveform_folder = Path('waveforms')
-    waveform_folder_rm = Path('waveforms_rm')
-    output_folder = Path('phy_output')
-    output_folder_rm = Path('phy_output_rm')
-    rec_folder = Path("rec")
-    sort_folder = Path("sort")
+    waveform_folder = cache_folder / 'waveforms'
+    waveform_folder_rm = cache_folder / 'waveforms_rm'
+    output_folder = cache_folder / 'phy_output'
+    output_folder_rm = cache_folder / 'phy_output_rm'
+    rec_folder = cache_folder / 'rec'
+    sort_folder = cache_folder / 'sort'
 
     for f in (waveform_folder, waveform_folder_rm, output_folder, output_folder_rm, rec_folder, sort_folder):
         if f.is_dir():
@@ -92,9 +92,9 @@ def test_export_to_phy_by_sparsity():
     recording = se.MEArecRecordingExtractor(local_path)
     sorting = se.MEArecSortingExtractor(local_path)
 
-    waveform_folder = Path('waveforms')
-    output_folder_radius = Path('phy_output_radius')
-    output_folder_thr = Path('phy_output_thr')
+    waveform_folder = cache_folder / 'waveforms'
+    output_folder_radius = cache_folder / 'phy_output_radius'
+    output_folder_thr = cache_folder / 'phy_output_thr'
 
     for f in (waveform_folder, output_folder_radius, output_folder_thr):
         if f.is_dir():

--- a/spikeinterface/exporters/tests/test_report.py
+++ b/spikeinterface/exporters/tests/test_report.py
@@ -9,7 +9,7 @@ import spikeinterface.extractors as se
 from spikeinterface.exporters import export_report
 
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "exporters"
 else:
     cache_folder = Path("cache_folder") / "exporters"

--- a/spikeinterface/exporters/tests/test_report.py
+++ b/spikeinterface/exporters/tests/test_report.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 import shutil
 from pathlib import Path
 
@@ -9,14 +9,20 @@ import spikeinterface.extractors as se
 from spikeinterface.exporters import export_report
 
 
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "exporters"
+else:
+    cache_folder = Path("cache_folder") / "exporters"
+
+
 def test_export_report():
     repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
     remote_path = 'mearec/mearec_test_10s.h5'
     local_path = download_dataset(repo=repo, remote_path=remote_path, local_folder=None)
     recording, sorting = se.read_mearec(local_path)
 
-    waveform_folder = Path('waveforms')
-    output_folder = Path('mearec_GT_report')
+    waveform_folder = cache_folder / 'waveforms'
+    output_folder = cache_folder / 'mearec_GT_report'
 
     for f in (waveform_folder, output_folder):
         if f.is_dir():

--- a/spikeinterface/extractors/mdaextractors.py
+++ b/spikeinterface/extractors/mdaextractors.py
@@ -186,7 +186,7 @@ class MdaSortingExtractor(BaseSorting):
         firings[1, :] = all_times
         firings[2, :] = all_labels
 
-        writemda64(firings, save_path)
+        writemda64(firings, str(save_path))
 
 
 class MdaSortingSegment(BaseSortingSegment):

--- a/spikeinterface/extractors/tests/common_tests.py
+++ b/spikeinterface/extractors/tests/common_tests.py
@@ -1,5 +1,3 @@
-import pytest
-
 import numpy as np
 
 from spikeinterface import download_dataset, get_global_dataset_folder

--- a/spikeinterface/extractors/tests/test_mdaextractors.py
+++ b/spikeinterface/extractors/tests/test_mdaextractors.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from spikeinterface.core.testing import check_recordings_equal, check_sortings_equal
 from spikeinterface.extractors import toy_example, MdaRecordingExtractor, MdaSortingExtractor
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "extractors"
 else:
     cache_folder = Path("cache_folder") / "extractors"

--- a/spikeinterface/extractors/tests/test_mdaextractors.py
+++ b/spikeinterface/extractors/tests/test_mdaextractors.py
@@ -1,21 +1,27 @@
 import pytest
-import numpy as np
-
+from pathlib import Path
 from spikeinterface.core.testing import check_recordings_equal, check_sortings_equal
 from spikeinterface.extractors import toy_example, MdaRecordingExtractor, MdaSortingExtractor
+
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "extractors"
+else:
+    cache_folder = Path("cache_folder") / "extractors"
 
 
 def test_mda_extractors():
     rec, sort = toy_example(num_segments=1, num_units=10)
 
-    MdaRecordingExtractor.write_recording(rec, "mdatest")
-    rec_mda = MdaRecordingExtractor("mdatest")
+    MdaRecordingExtractor.write_recording(rec, cache_folder / "mdatest")
+    rec_mda = MdaRecordingExtractor(cache_folder / "mdatest")
     probe = rec_mda.get_probe()
 
     check_recordings_equal(rec, rec_mda, return_scaled=False)
 
-    MdaSortingExtractor.write_sorting(sort, "mdatest/firings.mda")
-    sort_mda = MdaSortingExtractor("mdatest/firings.mda", sampling_frequency=sort.get_sampling_frequency())
+    MdaSortingExtractor.write_sorting(
+        sort, cache_folder / "mdatest" / "firings.mda")
+    sort_mda = MdaSortingExtractor(
+        cache_folder / "mdatest" / "firings.mda", sampling_frequency=sort.get_sampling_frequency())
 
     check_sortings_equal(sort, sort_mda)
 

--- a/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/spikeinterface/extractors/tests/test_neoextractors.py
@@ -178,6 +178,7 @@ class BiocamRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
 
 
 if __name__ == '__main__':
+    pass
     # test = MearecRecordingTest()
     # test = MearecSortingTest()
     # test = SpikeGLXRecordingTest()

--- a/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/spikeinterface/extractors/tests/test_neoextractors.py
@@ -26,7 +26,7 @@ class SpikeGLXRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     ExtractorClass = SpikeGLXRecordingExtractor
     downloads = ['spikeglx']
     entities = [
-       # TODO need to be back when when fixed in neo
+        # TODO need to be back when when fixed in neo
         #('spikeglx/Noise4Sam_g0', {'stream_id': 'imec0.ap'}),
         #('spikeglx/Noise4Sam_g0', {'stream_id': 'imec0.lf'}),
         #('spikeglx/Noise4Sam_g0', {'stream_id': 'nidq'}),
@@ -153,7 +153,8 @@ class MaxwellRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     downloads = ['maxwell']
     entities = [
         'maxwell/MaxOne_data/Record/000011/data.raw.h5',
-        ('maxwell/MaxTwo_data/Network/000028/data.raw.h5', {'stream_id': 'well0000', 'rec_name': 'rec0000'})
+        ('maxwell/MaxTwo_data/Network/000028/data.raw.h5',
+         {'stream_id': 'well0000', 'rec_name': 'rec0000'})
     ]
 
 
@@ -177,12 +178,12 @@ class BiocamRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
 
 
 if __name__ == '__main__':
-    #~ test = MearecRecordingTest()
-    # ~ test = MearecSortingTest()
-    test = SpikeGLXRecordingTest()
-    #~ test = OpenEphysBinaryRecordingTest()
-    # ~ test = OpenEphysLegacyRecordingTest()
-    #~ test = OpenEphysBinaryEventTest()
+    # test = MearecRecordingTest()
+    # test = MearecSortingTest()
+    # test = SpikeGLXRecordingTest()
+    # test = OpenEphysBinaryRecordingTest()
+    # test = OpenEphysLegacyRecordingTest()
+    # test = OpenEphysBinaryEventTest()
     # test = ItanRecordingTest()
     # test = NeuroScopeRecordingTest()
     # test = PlexonRecordingTest()
@@ -190,10 +191,10 @@ if __name__ == '__main__':
     # test = BlackrockRecordingTest()
     # test = MCSRawRecordingTest()
     # test = KiloSortSortingTest()
-    # ~ test = Spike2RecordingTest()
-    # ~ test = CedRecordingTest()
-    # ~ test = MaxwellRecordingTest()
-    #~ test = SpikeGadgetsRecordingTest()
+    # test = Spike2RecordingTest()
+    # test = CedRecordingTest()
+    # test = MaxwellRecordingTest()
+    # test = SpikeGadgetsRecordingTest()
 
-    test.setUp()
-    test.test_open()
+    # test.setUp()
+    # test.test_open()

--- a/spikeinterface/extractors/tests/test_shybridextractors.py
+++ b/spikeinterface/extractors/tests/test_shybridextractors.py
@@ -2,8 +2,6 @@ import pytest
 from pathlib import Path
 from spikeinterface.core.testing import check_recordings_equal, check_sortings_equal
 from spikeinterface.extractors import toy_example, SHYBRIDRecordingExtractor, SHYBRIDSortingExtractor
-from spikeinterface.extractors.shybridextractors import HAVE_SBEX
-
 
 if getattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "extractors"

--- a/spikeinterface/extractors/tests/test_shybridextractors.py
+++ b/spikeinterface/extractors/tests/test_shybridextractors.py
@@ -1,24 +1,29 @@
 import pytest
-import numpy as np
-
+from pathlib import Path
 from spikeinterface.core.testing import check_recordings_equal, check_sortings_equal
 from spikeinterface.extractors import toy_example, SHYBRIDRecordingExtractor, SHYBRIDSortingExtractor
 from spikeinterface.extractors.shybridextractors import HAVE_SBEX
 
 
-# @pytest.mark.skipif(not HAVE_SBEX, reason='shybrid not installed')
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "extractors"
+else:
+    cache_folder = Path("cache_folder") / "extractors"
+
+
 @pytest.mark.skipif(True, reason='shybrid not tested')
 def test_shybrid_extractors():
     rec, sort = toy_example(num_segments=1, num_units=10)
 
-    SHYBRIDSortingExtractor.write_sorting(sort, "shybridtest")
-    sort_shybrid = SHYBRIDSortingExtractor("shybridtest/initial_sorting.csv",
+    SHYBRIDSortingExtractor.write_sorting(sort, cache_folder / "shybridtest")
+    sort_shybrid = SHYBRIDSortingExtractor(cache_folder / "shybridtest" / "initial_sorting.csv",
                                            sampling_frequency=sort.get_sampling_frequency())
 
     check_sortings_equal(sort, sort_shybrid)
 
-    SHYBRIDRecordingExtractor.write_recording(rec, "shybridtest", initial_sorting_fn="shybridtest/initial_sorting.csv")
-    rec_shybrid = SHYBRIDRecordingExtractor("shybridtest/recording.yml")
+    SHYBRIDRecordingExtractor.write_recording(rec, cache_folder / "shybridtest", 
+                                              initial_sorting_fn=cache_folder / "shybridtest" / "initial_sorting.csv")
+    rec_shybrid = SHYBRIDRecordingExtractor(cache_folder / "shybridtest" / "recording.yml")
     probe = rec_shybrid.get_probe()
 
     check_recordings_equal(rec, rec_shybrid, return_scaled=False)

--- a/spikeinterface/extractors/tests/test_shybridextractors.py
+++ b/spikeinterface/extractors/tests/test_shybridextractors.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from spikeinterface.core.testing import check_recordings_equal, check_sortings_equal
 from spikeinterface.extractors import toy_example, SHYBRIDRecordingExtractor, SHYBRIDSortingExtractor
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "extractors"
 else:
     cache_folder = Path("cache_folder") / "extractors"

--- a/spikeinterface/extractors/tests/test_toy_example.py
+++ b/spikeinterface/extractors/tests/test_toy_example.py
@@ -9,8 +9,6 @@ def test_toy_example():
     assert rec.get_num_segments() == 2
     assert sorting.get_num_segments() == 2
     assert sorting.get_num_units() == 10
-    # print(rec)
-    # print(sorting)
 
     rec, sorting = toy_example(num_segments=1, num_channels=16, num_columns=2)
     assert rec.get_num_segments() == 1
@@ -18,24 +16,8 @@ def test_toy_example():
     print(rec)
     print(sorting)
 
-    # print(rec.get_channel_locations())
-
     probe = rec.get_probe()
     print(probe)
-
-    # import matplotlib.pyplot as plt
-    # rec = rec.save(folder='toy_rec')
-    # sorting = sorting.save(folder='toy_sorting')
-    # fig, ax = plt.subplots()
-    # ax.plot(rec.get_traces())
-    # from spikeinterface.core import extract_waveforms
-    # from spikeinterface.widgets import plot_unit_templates
-    # we = extract_waveforms(rec, sorting, 'toy_waveforms',
-                            # n_jobs=1, total_memory="10M", max_spikes_per_unit=100,
-                            # return_scaled=False)
-    # print(we)
-    # plot_unit_templates(we)
-    # plt.show()
 
 
 if __name__ == '__main__':

--- a/spikeinterface/sorters/tests/common_tests.py
+++ b/spikeinterface/sorters/tests/common_tests.py
@@ -6,7 +6,7 @@ from spikeinterface.extractors import toy_example
 from spikeinterface.sorters import run_sorter
 
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "sorters"
 else:
     cache_folder = Path("cache_folder") / "sorters"

--- a/spikeinterface/sorters/tests/common_tests.py
+++ b/spikeinterface/sorters/tests/common_tests.py
@@ -1,9 +1,15 @@
-import unittest
+import pytest
+from pathlib import Path
+import shutil
 
-from spikeinterface.extractors import toy_example, BinaryRecordingExtractor
-from probeinterface import write_probeinterface, read_probeinterface
-
+from spikeinterface.extractors import toy_example
 from spikeinterface.sorters import run_sorter
+
+
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "sorters"
+else:
+    cache_folder = Path("cache_folder") / "sorters"
 
 
 class SorterCommonTestSuite:
@@ -15,8 +21,13 @@ class SorterCommonTestSuite:
     SorterClass = None
 
     def setUp(self):
-        recording, sorting_gt = toy_example(num_channels=4, duration=60, seed=0, num_segments=1)
-        self.recording = recording.save(verbose=False, format='binary')
+        recording, sorting_gt = toy_example(
+            num_channels=4, duration=60, seed=0, num_segments=1)
+        rec_folder = cache_folder / "rec"
+        if rec_folder.is_dir():
+            shutil.rmtree(rec_folder)
+        self.recording = recording.save(
+            folder=cache_folder / "rec", verbose=False, format='binary')
         print(self.recording)
 
     def test_with_class(self):
@@ -27,13 +38,15 @@ class SorterCommonTestSuite:
 
         sorter_params = SorterClass.default_params()
 
-        output_folder = None
+        output_folder = cache_folder / SorterClass.sorter_name
         verbose = False
         remove_existing_folder = True
         raise_error = True
 
-        output_folder = SorterClass.initialize_folder(recording, output_folder, verbose, remove_existing_folder)
-        SorterClass.set_params_to_folder(recording, output_folder, sorter_params, verbose)
+        output_folder = SorterClass.initialize_folder(
+            recording, output_folder, verbose, remove_existing_folder)
+        SorterClass.set_params_to_folder(
+            recording, output_folder, sorter_params, verbose)
         SorterClass.setup_recording(recording, output_folder, verbose)
         SorterClass.run_from_folder(output_folder, raise_error, verbose)
         sorting = SorterClass.get_result_from_folder(output_folder)
@@ -51,9 +64,11 @@ class SorterCommonTestSuite:
 
         sorter_name = self.SorterClass.sorter_name
 
+        output_folder = cache_folder / sorter_name
+
         sorter_params = self.SorterClass.default_params()
 
-        sorting = run_sorter(sorter_name, recording, output_folder=None,
+        sorting = run_sorter(sorter_name, recording, output_folder=output_folder,
                              remove_existing_folder=True, delete_output_folder=False,
                              verbose=False, raise_error=True, **sorter_params)
 
@@ -61,4 +76,4 @@ class SorterCommonTestSuite:
 
     def test_get_version(self):
         version = self.SorterClass.get_sorter_version()
-        print('test_get_version:s', self.SorterClass.sorter_name, version)
+        print('test_get_versions', self.SorterClass.sorter_name, version)

--- a/spikeinterface/sorters/tests/test_launcher.py
+++ b/spikeinterface/sorters/tests/test_launcher.py
@@ -25,15 +25,9 @@ def test_run_sorters_with_list():
     rec1, _ = toy_example(num_channels=8, duration=30, seed=0, num_segments=1)
 
     # make dumpable
-    rec0_folder = cache_folder / 'rec0'
-    rec1_folder = cache_folder / 'rec1'
-    if rec0_folder.is_dir():
-        shutil.rmtree(rec0_folder)
-    if rec1_folder.is_dir():
-        shutil.rmtree(rec1_folder)
-
-    rec0 = rec0.save(folder=rec0_folder)
-    rec1 = rec1.save(folder=rec1_folder)
+    set_global_tmp_folder(cache_folder)
+    rec0 = rec0.save(name='rec0')
+    rec1 = rec1.save(name='rec1')
 
     recording_list = [rec0, rec1]
     sorter_list = ['tridesclous']
@@ -51,11 +45,8 @@ def test_run_sorter_by_property():
     rec0.set_channel_groups(["0"] * 4 + ["1"] * 4)
 
     # make dumpable
-    rec0_folder = cache_folder / 'rec0'
-    if rec0_folder.is_dir():
-        shutil.rmtree(rec0_folder)
-
-    rec0 = rec0.save(folder=rec0_folder)
+    set_global_tmp_folder(cache_folder)
+    rec0 = rec0.save(name='rec0')
     sorter_name = 'tridesclous'
 
     sorting = run_sorter_by_property(sorter_name, rec0, "group", working_folder,
@@ -72,15 +63,9 @@ def test_run_sorters_with_dict():
     rec1, _ = toy_example(num_channels=8, duration=30, seed=0, num_segments=1)
 
     # make dumpable
-    rec0_folder = cache_folder / 'rec0'
-    rec1_folder = cache_folder / 'rec1'
-    if rec0_folder.is_dir():
-        shutil.rmtree(rec0_folder)
-    if rec1_folder.is_dir():
-        shutil.rmtree(rec1_folder)
-
-    rec0 = rec0.save(folder=rec0_folder)
-    rec1 = rec1.save(folder=rec1_folder)
+    set_global_tmp_folder(cache_folder)
+    rec0 = rec0.save(name='rec0')
+    rec1 = rec1.save(name='rec1')
 
     recording_dict = {'toy_tetrode': rec0, 'toy_octotrode': rec1}
 

--- a/spikeinterface/sorters/tests/test_launcher.py
+++ b/spikeinterface/sorters/tests/test_launcher.py
@@ -46,7 +46,7 @@ def test_run_sorter_by_property():
 
     # make dumpable
     set_global_tmp_folder(cache_folder)
-    rec0 = rec0.save(name='rec0')
+    rec0 = rec0.save(name='rec000')
     sorter_name = 'tridesclous'
 
     sorting = run_sorter_by_property(sorter_name, rec0, "group", working_folder,
@@ -64,8 +64,8 @@ def test_run_sorters_with_dict():
 
     # make dumpable
     set_global_tmp_folder(cache_folder)
-    rec0 = rec0.save(name='rec0')
-    rec1 = rec1.save(name='rec1')
+    rec0 = rec0.save(name='rec00')
+    rec1 = rec1.save(name='rec01')
 
     recording_dict = {'toy_tetrode': rec0, 'toy_octotrode': rec1}
 

--- a/spikeinterface/sorters/tests/test_launcher.py
+++ b/spikeinterface/sorters/tests/test_launcher.py
@@ -1,4 +1,3 @@
-from functools import cache
 import os
 import shutil
 import time

--- a/spikeinterface/sorters/tests/test_launcher.py
+++ b/spikeinterface/sorters/tests/test_launcher.py
@@ -11,7 +11,7 @@ from spikeinterface.extractors import toy_example
 from spikeinterface.sorters import run_sorters, run_sorter_by_property, collect_sorting_outputs
 
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "sorters"
 else:
     cache_folder = Path("cache_folder") / "sorters"
@@ -26,8 +26,15 @@ def test_run_sorters_with_list():
     rec1, _ = toy_example(num_channels=8, duration=30, seed=0, num_segments=1)
 
     # make dumpable
-    rec0 = rec0.save(folder=cache_folder / 'rec0')
-    rec1 = rec1.save(folder=cache_folder / 'rec1')
+    rec0_folder = cache_folder / 'rec0'
+    rec1_folder = cache_folder / 'rec1'
+    if rec0_folder.is_dir():
+        shutil.rmtree(rec0_folder)
+    if rec1_folder.is_dir():
+        shutil.rmtree(rec1_folder)
+
+    rec0 = rec0.save(folder=rec0_folder)
+    rec1 = rec1.save(folder=rec1_folder)
 
     recording_list = [rec0, rec1]
     sorter_list = ['tridesclous']
@@ -45,7 +52,11 @@ def test_run_sorter_by_property():
     rec0.set_channel_groups(["0"] * 4 + ["1"] * 4)
 
     # make dumpable
-    rec0 = rec0.save(folder=cache_folder / 'rec0')
+    rec0_folder = cache_folder / 'rec0'
+    if rec0_folder.is_dir():
+        shutil.rmtree(rec0_folder)
+
+    rec0 = rec0.save(folder=rec0_folder)
     sorter_name = 'tridesclous'
 
     sorting = run_sorter_by_property(sorter_name, rec0, "group", working_folder,
@@ -62,8 +73,15 @@ def test_run_sorters_with_dict():
     rec1, _ = toy_example(num_channels=8, duration=30, seed=0, num_segments=1)
 
     # make dumpable
-    rec0 = rec0.save(folder=cache_folder / 'rec0')
-    rec1 = rec1.save(folder=cache_folder / 'rec1')
+    rec0_folder = cache_folder / 'rec0'
+    rec1_folder = cache_folder / 'rec1'
+    if rec0_folder.is_dir():
+        shutil.rmtree(rec0_folder)
+    if rec1_folder.is_dir():
+        shutil.rmtree(rec1_folder)
+
+    rec0 = rec0.save(folder=rec0_folder)
+    rec1 = rec1.save(folder=rec1_folder)
 
     recording_dict = {'toy_tetrode': rec0, 'toy_octotrode': rec1}
 

--- a/spikeinterface/sorters/tests/test_launcher.py
+++ b/spikeinterface/sorters/tests/test_launcher.py
@@ -1,33 +1,33 @@
+from functools import cache
 import os
 import shutil
 import time
 
 import pytest
+from pathlib import Path
 
 from spikeinterface.core import set_global_tmp_folder
 from spikeinterface.extractors import toy_example
 from spikeinterface.sorters import run_sorters, run_sorter_by_property, collect_sorting_outputs
 
 
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "sorters"
+else:
+    cache_folder = Path("cache_folder") / "sorters"
+
+
 def test_run_sorters_with_list():
-    # This import is to get error on github whenn import fails
-    import tridesclous
-
-    cache_folder = './local_cache'
-    working_folder = 'test_run_sorters_list'
-
-    if os.path.exists(cache_folder):
-        shutil.rmtree(cache_folder)
-    if os.path.exists(working_folder):
+    working_folder = cache_folder / 'test_run_sorters_list'
+    if working_folder.is_dir():
         shutil.rmtree(working_folder)
 
     rec0, _ = toy_example(num_channels=4, duration=30, seed=0, num_segments=1)
     rec1, _ = toy_example(num_channels=8, duration=30, seed=0, num_segments=1)
 
     # make dumpable
-    set_global_tmp_folder(cache_folder)
-    rec0 = rec0.save(name='rec0')
-    rec1 = rec1.save(name='rec1')
+    rec0 = rec0.save(folder=cache_folder / 'rec0')
+    rec1 = rec1.save(folder=cache_folder / 'rec1')
 
     recording_list = [rec0, rec1]
     sorter_list = ['tridesclous']
@@ -37,20 +37,15 @@ def test_run_sorters_with_list():
 
 
 def test_run_sorter_by_property():
-    cache_folder = './local_cache'
-    working_folder = 'test_run_sorter_by_property'
-
-    if os.path.exists(cache_folder):
-        shutil.rmtree(cache_folder)
-    if os.path.exists(working_folder):
+    working_folder = cache_folder / 'test_run_sorter_by_property'
+    if working_folder.is_dir():
         shutil.rmtree(working_folder)
 
     rec0, _ = toy_example(num_channels=8, duration=30, seed=0, num_segments=1)
     rec0.set_channel_groups(["0"] * 4 + ["1"] * 4)
 
     # make dumpable
-    set_global_tmp_folder(cache_folder)
-    rec0 = rec0.save(name='rec0')
+    rec0 = rec0.save(folder=cache_folder / 'rec0')
     sorter_name = 'tridesclous'
 
     sorting = run_sorter_by_property(sorter_name, rec0, "group", working_folder,
@@ -59,25 +54,16 @@ def test_run_sorter_by_property():
 
 
 def test_run_sorters_with_dict():
-    # This import is to get error on github whenn import fails
-    import tridesclous
-    import circus
-
-    cache_folder = './local_cache'
-    working_folder = 'test_run_sorters_dict'
-
-    if os.path.exists(cache_folder):
-        shutil.rmtree(cache_folder)
-    if os.path.exists(working_folder):
+    working_folder = cache_folder / 'test_run_sorters_dict'
+    if working_folder.is_dir():
         shutil.rmtree(working_folder)
 
     rec0, _ = toy_example(num_channels=4, duration=30, seed=0, num_segments=1)
     rec1, _ = toy_example(num_channels=8, duration=30, seed=0, num_segments=1)
 
     # make dumpable
-    set_global_tmp_folder(cache_folder)
-    rec0 = rec0.save(name='rec0')
-    rec1 = rec1.save(name='rec1')
+    rec0 = rec0.save(folder=cache_folder / 'rec0')
+    rec1 = rec1.save(folder=cache_folder / 'rec1')
 
     recording_dict = {'toy_tetrode': rec0, 'toy_octotrode': rec1}
 
@@ -99,29 +85,25 @@ def test_run_sorters_with_dict():
     print(t1 - t0)
     print(results)
 
-    shutil.rmtree(working_folder + '/toy_tetrode/tridesclous')
+    shutil.rmtree(working_folder / 'toy_tetrode' / 'tridesclous')
     run_sorters(sorter_list, recording_dict, working_folder,
                 engine='loop', sorter_params=sorter_params,
                 with_output=False,
                 mode_if_folder_exists='keep')
 
 
-@pytest.mark.skipif(True, reason='This bug with pytest/travis but not run directly')
+@pytest.mark.skipif(True, reason='This is tested locally')
 def test_run_sorters_joblib():
-    cache_folder = './local_cache'
-    working_folder = 'test_run_sorters_joblib'
-    if os.path.exists(cache_folder):
-        shutil.rmtree(cache_folder)
-    if os.path.exists(working_folder):
+    working_folder = cache_folder / 'test_run_sorters_joblib'
+    if working_folder.is_dir():
         shutil.rmtree(working_folder)
-
-    set_global_tmp_folder(cache_folder)
 
     recording_dict = {}
     for i in range(8):
-        rec, _ = toy_example(num_channels=4, duration=30, seed=0, num_segments=1)
+        rec, _ = toy_example(num_channels=4, duration=30,
+                             seed=0, num_segments=1)
         # make dumpable
-        rec = rec.save(name=f'rec_{i}')
+        rec = rec.save(folder=cache_folder / f'rec_{i}')
         recording_dict[f'rec_{i}'] = rec
 
     sorter_list = ['tridesclous', ]
@@ -136,19 +118,17 @@ def test_run_sorters_joblib():
     print(t1 - t0)
 
 
-@pytest.mark.skipif(True, reason='This bug with pytest/travis but not run directly')
+@pytest.mark.skipif(True, reason='This is tested locally')
 def test_run_sorters_dask():
-    cache_folder = './local_cache'
-    working_folder = 'test_run_sorters_dask'
-    if os.path.exists(cache_folder):
-        shutil.rmtree(cache_folder)
-    if os.path.exists(working_folder):
+    working_folder = cache_folder / 'test_run_sorters_dask'
+    if working_folder.is_dir():
         shutil.rmtree(working_folder)
 
     # create recording
     recording_dict = {}
     for i in range(8):
-        rec, _ = toy_example(num_channels=4, duration=30, seed=0, num_segments=1)
+        rec, _ = toy_example(num_channels=4, duration=30,
+                             seed=0, num_segments=1)
         # make dumpable
         rec = rec.save(name=f'rec_{i}')
         recording_dict[f'rec_{i}'] = rec
@@ -160,7 +140,8 @@ def test_run_sorters_dask():
     from dask_jobqueue import SLURMCluster
 
     python = '/home/samuel.garcia/.virtualenvs/py36/bin/python3.6'
-    cluster = SLURMCluster(processes=1, cores=1, memory="12GB", python=python, walltime='12:00:00', )
+    cluster = SLURMCluster(processes=1, cores=1, memory="12GB",
+                           python=python, walltime='12:00:00', )
     cluster.scale(5)
     client = Client(cluster)
 
@@ -175,9 +156,15 @@ def test_run_sorters_dask():
 
 
 def test_collect_sorting_outputs():
-    working_folder = 'test_run_sorters_dict'
+    working_folder = cache_folder / 'test_run_sorters_dict'
     results = collect_sorting_outputs(working_folder)
     print(results)
+
+
+def test_sorter_installation():
+    # This import is to get error on github when import fails
+    import tridesclous
+    import circus
 
 
 if __name__ == '__main__':

--- a/spikeinterface/sorters/tests/test_pykilosort.py
+++ b/spikeinterface/sorters/tests/test_pykilosort.py
@@ -7,7 +7,7 @@ from spikeinterface.sorters.tests.common_tests import SorterCommonTestSuite
 
 
 # This run several tests
-@pytest.mark.skipif(not PyKilosortSorter.is_installed(), reason='tridesclous not installed')
+@pytest.mark.skipif(not PyKilosortSorter.is_installed(), reason='pykilosort not installed')
 class PyKilosortCommonTestSuite(SorterCommonTestSuite, unittest.TestCase):
     SorterClass = PyKilosortSorter
 

--- a/spikeinterface/sorters/tests/test_runsorter.py
+++ b/spikeinterface/sorters/tests/test_runsorter.py
@@ -9,7 +9,7 @@ from spikeinterface.sorters import run_sorter
 ON_GITHUB = bool(os.getenv('GITHUB_ACTIONS'))
 
 
-if getattr(pytest, "global_test_folder"):
+if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "sorters"
 else:
     cache_folder = Path("cache_folder") / "sorters"

--- a/spikeinterface/sorters/tests/test_runsorter.py
+++ b/spikeinterface/sorters/tests/test_runsorter.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from pathlib import Path
 
 from spikeinterface import download_dataset
 from spikeinterface.extractors import read_mearec
@@ -8,13 +9,19 @@ from spikeinterface.sorters import run_sorter
 ON_GITHUB = bool(os.getenv('GITHUB_ACTIONS'))
 
 
+if getattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "sorters"
+else:
+    cache_folder = Path("cache_folder") / "sorters"
+
+
 def test_run_sorter_local():
     local_path = download_dataset(remote_path='mearec/mearec_test_10s.h5')
     recording, sorting_true = read_mearec(local_path)
 
     sorter_params = {'detect_threshold': 4.9}
 
-    sorting = run_sorter('tridesclous', recording, output_folder='sorting_tdc_local',
+    sorting = run_sorter('tridesclous', recording, output_folder=cache_folder / 'sorting_tdc_local',
                          remove_existing_folder=True, delete_output_folder=False,
                          verbose=True, raise_error=True, docker_image=None,
                          **sorter_params)
@@ -23,9 +30,9 @@ def test_run_sorter_local():
 
 @pytest.mark.skipif(ON_GITHUB, reason="Docker tests don't run on github: test locally")
 def test_run_sorter_docker():
-    mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5', unlock=True)
-    output_folder='sorting_tdc_docker'
-
+    mearec_filename = download_dataset(
+        remote_path='mearec/mearec_test_10s.h5', unlock=True)
+    output_folder = cache_folder / 'sorting_tdc_docker'
 
     recording, sorting_true = read_mearec(mearec_filename)
 
@@ -41,12 +48,11 @@ def test_run_sorter_docker():
     # TODO: Add another run with `with_output=True` and check sorting result
 
 
-
 @pytest.mark.skipif(ON_GITHUB, reason="Singularity tests don't run on github: test it locally")
 def test_run_sorter_singularity():
-    mearec_filename = download_dataset(remote_path='mearec/mearec_test_10s.h5', unlock=True)
-    output_folder='sorting_tdc_singularity'
-
+    mearec_filename = download_dataset(
+        remote_path='mearec/mearec_test_10s.h5', unlock=True)
+    output_folder = cache_folder / 'sorting_tdc_singularity'
 
     recording, sorting_true = read_mearec(mearec_filename)
 

--- a/spikeinterface/sorters/tests/test_sorterlist.py
+++ b/spikeinterface/sorters/tests/test_sorterlist.py
@@ -1,5 +1,5 @@
 import os
-import os, getpass
+import getpass
 
 if getpass.getuser() == 'samuel':
     kilosort2_path = '/home/samuel/Documents/Spikeinterface/Kilosort2'
@@ -13,8 +13,6 @@ if getpass.getuser() == 'samuel':
 
     waveclust_path = '/home/samuel/Documents/Spikeinterface/wave_clus/'
     os.environ["WAVECLUS_PATH"] = waveclust_path
-
-import pytest
 
 from spikeinterface.sorters import print_sorter_versions
 

--- a/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -11,14 +11,15 @@ def test_detect_peaks():
 
     repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
     remote_path = 'mearec/mearec_test_10s.h5'
-    local_path = download_dataset(repo=repo, remote_path=remote_path, local_folder=None)
+    local_path = download_dataset(
+        repo=repo, remote_path=remote_path, local_folder=None)
     recording = MEArecRecordingExtractor(local_path)
 
     # by_channel
     peaks = detect_peaks(recording, method='by_channel',
                          peak_sign='neg', detect_threshold=5, n_shifts=2,
                          chunk_size=10000, verbose=1, progress_bar=False)
-    
+
     # by_channel
     sorting = detect_peaks(recording, method='by_channel',
                            peak_sign='neg', detect_threshold=5, n_shifts=2,
@@ -35,41 +36,39 @@ def test_detect_peaks():
     peaks = detect_peaks(recording, method='locally_exclusive',
                          peak_sign='neg', detect_threshold=5, n_shifts=2,
                          chunk_size=10000, verbose=1, progress_bar=True,
-                         localization_dict=dict(method='center_of_mass', local_radius_um=150, ms_before=0.1, ms_after=0.3),
-                         #localization_dict=dict(method='monopolar_triangulation', local_radius_um=150,
-                         #                       ms_before=0.1, ms_after=0.3, max_distance_um=1000)
+                         localization_dict=dict(method='center_of_mass', local_radius_um=150,
+                                                ms_before=0.1, ms_after=0.3),
                          )
     assert 'x' in peaks.dtype.fields
 
-
     # DEBUG
-    #~ sample_inds, chan_inds, amplitudes = peaks['sample_ind'], peaks['channel_ind'], peaks['amplitude']
-    #~ import matplotlib.pyplot as plt
-    #~ import spikeinterface.widgets as sw
-    #~ chan_offset = 500
-    #~ traces = recording.get_traces()
-    #~ traces += np.arange(traces.shape[1])[None, :] * chan_offset
-    #~ fig, ax = plt.subplots()
+    # ~ sample_inds, chan_inds, amplitudes = peaks['sample_ind'], peaks['channel_ind'], peaks['amplitude']
+    # ~ import matplotlib.pyplot as plt
+    # ~ import spikeinterface.widgets as sw
+    # ~ chan_offset = 500
+    # ~ traces = recording.get_traces()
+    # ~ traces += np.arange(traces.shape[1])[None, :] * chan_offset
+    # ~ fig, ax = plt.subplots()
     #~ ax.plot(traces, color='k')
     #~ ax.scatter(sample_inds, chan_inds * chan_offset + amplitudes, color='r')
     #~ plt.show()
 
-    #~ import matplotlib.pyplot as plt
-    #~ import spikeinterface.widgets as sw
-    #~ from probeinterface.plotting import plot_probe
-    #~ probe = recording.get_probe()
-    #~ fig, ax = plt.subplots()
+    # ~ import matplotlib.pyplot as plt
+    # ~ import spikeinterface.widgets as sw
+    # ~ from probeinterface.plotting import plot_probe
+    # ~ probe = recording.get_probe()
+    # ~ fig, ax = plt.subplots()
     #~ plot_probe(probe, ax=ax)
     #~ ax.scatter(peaks['x'], peaks['z'], color='k', s=1, alpha=0.5)
-    #~ # MEArec is "yz" in 2D
-    #~ import MEArec
-    #~ recgen = MEArec.load_recordings(recordings=local_path, return_h5_objects=True,
-    #~ check_suffix=False,
-    #~ load=['recordings', 'spiketrains', 'channel_positions'],
-    #~ load_waveforms=False)
-    #~ soma_positions = np.zeros((len(recgen.spiketrains), 3), dtype='float32')
-    #~ for i, st in enumerate(recgen.spiketrains):
-        #~ soma_positions[i, :] = st.annotations['soma_position']
+    # ~ # MEArec is "yz" in 2D
+    # ~ import MEArec
+    # ~ recgen = MEArec.load_recordings(recordings=local_path, return_h5_objects=True,
+    # ~ check_suffix=False,
+    # ~ load=['recordings', 'spiketrains', 'channel_positions'],
+    # ~ load_waveforms=False)
+    # ~ soma_positions = np.zeros((len(recgen.spiketrains), 3), dtype='float32')
+    # ~ for i, st in enumerate(recgen.spiketrains):
+    # ~ soma_positions[i, :] = st.annotations['soma_position']
     #~ ax.scatter(soma_positions[:, 1], soma_positions[:, 2], color='g', s=20, marker='*')
     #~ plt.show()
 

--- a/spikeinterface/sortingcomponents/tests/test_peak_localization.py
+++ b/spikeinterface/sortingcomponents/tests/test_peak_localization.py
@@ -11,7 +11,8 @@ def test_localize_peaks():
 
     repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
     remote_path = 'mearec/mearec_test_10s.h5'
-    local_path = download_dataset(repo=repo, remote_path=remote_path, local_folder=None)
+    local_path = download_dataset(
+        repo=repo, remote_path=remote_path, local_folder=None)
     recording = MEArecRecordingExtractor(local_path)
 
     peaks = detect_peaks(recording, method='locally_exclusive',
@@ -22,30 +23,28 @@ def test_localize_peaks():
                                     chunk_size=10000, verbose=True, progress_bar=False)
     assert peaks.size == peak_locations.shape[0]
 
-
     peak_locations = localize_peaks(recording, peaks, method='monopolar_triangulation',
                                     n_jobs=1, chunk_size=10000, verbose=True, progress_bar=True)
     assert peaks.size == peak_locations.shape[0]
 
-
     # DEBUG
-    #~ import MEArec
-    #~ recgen = MEArec.load_recordings(recordings=local_path, return_h5_objects=True,
-    #~ check_suffix=False,
-    #~ load=['recordings', 'spiketrains', 'channel_positions'],
-    #~ load_waveforms=False)
-    #~ soma_positions = np.zeros((len(recgen.spiketrains), 3), dtype='float32')
-    #~ for i, st in enumerate(recgen.spiketrains):
-        #~ soma_positions[i, :] = st.annotations['soma_position']
+    # ~ import MEArec
+    # ~ recgen = MEArec.load_recordings(recordings=local_path, return_h5_objects=True,
+    # ~ check_suffix=False,
+    # ~ load=['recordings', 'spiketrains', 'channel_positions'],
+    # ~ load_waveforms=False)
+    # ~ soma_positions = np.zeros((len(recgen.spiketrains), 3), dtype='float32')
+    # ~ for i, st in enumerate(recgen.spiketrains):
+    # ~ soma_positions[i, :] = st.annotations['soma_position']
 
-    #~ import matplotlib.pyplot as plt
-    #~ import spikeinterface.widgets as sw
-    #~ from probeinterface.plotting import plot_probe
-    #~ probe = recording.get_probe()
-    #~ fig, ax = plt.subplots()
+    # ~ import matplotlib.pyplot as plt
+    # ~ import spikeinterface.widgets as sw
+    # ~ from probeinterface.plotting import plot_probe
+    # ~ probe = recording.get_probe()
+    # ~ fig, ax = plt.subplots()
     #~ plot_probe(probe, ax=ax)
     #~ ax.scatter(peak_locations['x'], peak_locations['y'], color='k', s=1, alpha=0.5)
-    #~ # MEArec is "yz" in 2D
+    # ~ # MEArec is "yz" in 2D
     #~ ax.scatter(soma_positions[:, 1], soma_positions[:, 2], color='g', s=20, marker='*')
     #~ plt.show()
 

--- a/spikeinterface/sortingcomponents/tests/test_peak_selection.py
+++ b/spikeinterface/sortingcomponents/tests/test_peak_selection.py
@@ -12,7 +12,8 @@ def test_detect_peaks():
 
     repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
     remote_path = 'mearec/mearec_test_10s.h5'
-    local_path = download_dataset(repo=repo, remote_path=remote_path, local_folder=None)
+    local_path = download_dataset(
+        repo=repo, remote_path=remote_path, local_folder=None)
     recording = MEArecRecordingExtractor(local_path)
 
     # by_channel
@@ -23,12 +24,12 @@ def test_detect_peaks():
                          peak_sign='neg', detect_threshold=5, n_shifts=2,
                          chunk_size=10000, verbose=1, progress_bar=False, noise_levels=noise_levels)
 
-
-
     subset_peaks = select_peaks(peaks, max_peaks_per_channel=100)
-    subset_peaks = select_peaks(peaks, 'smart_sampling', max_peaks_per_channel=100, noise_levels=noise_levels)
+    subset_peaks = select_peaks(
+        peaks, 'smart_sampling', max_peaks_per_channel=100, noise_levels=noise_levels)
 
     assert len(subset_peaks) < len(peaks)
+
 
 if __name__ == '__main__':
     test_detect_peaks()

--- a/spikeinterface/sortingcomponents/tests/test_template_matching.py
+++ b/spikeinterface/sortingcomponents/tests/test_template_matching.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+from pathlib import Path
 
 from spikeinterface import NumpySorting
 from spikeinterface import download_dataset
@@ -9,42 +10,47 @@ from spikeinterface.sortingcomponents import find_spikes_from_templates, templat
 from spikeinterface.toolkit import get_noise_levels
 from spikeinterface.extractors import read_mearec
 
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "sortingcomponents"
+else:
+    cache_folder = Path("cache_folder") / "sortingcomponents"
+
 
 def test_find_spikes_from_templates():
 
     repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
     remote_path = 'mearec/mearec_test_10s.h5'
-    local_path = download_dataset(repo=repo, remote_path=remote_path, local_folder=None)
+    local_path = download_dataset(
+        repo=repo, remote_path=remote_path, local_folder=None)
     recording, gt_sorting = read_mearec(local_path)
 
-    folder = 'waveforms_mearec'
+    folder = cache_folder / 'waveforms_mearec'
     we = extract_waveforms(recording, gt_sorting, folder, load_if_exists=True,
                            ms_before=1, ms_after=2., max_spikes_per_unit=500, return_scaled=False,
                            n_jobs=1, chunk_size=10000)
-    
+
     method_kwargs = {
-        'waveform_extractor' : we,
-        'noise_levels' : get_noise_levels(recording),
+        'waveform_extractor': we,
+        'noise_levels': get_noise_levels(recording),
     }
 
     sampling_frequency = recording.get_sampling_frequency()
 
     result = {}
 
-    
     for method in template_matching_methods.keys():
         spikes = find_spikes_from_templates(recording, method=method, method_kwargs=method_kwargs,
-                        n_jobs=1, chunk_size=30000, progress_bar=True)
+                                            n_jobs=1, chunk_size=30000, progress_bar=True)
 
-        result[method] = NumpySorting.from_times_labels(spikes['sample_ind'], spikes['cluster_ind'], sampling_frequency)
-    
-    
+        result[method] = NumpySorting.from_times_labels(
+            spikes['sample_ind'], spikes['cluster_ind'], sampling_frequency)
+
     # debug
     # import matplotlib.pyplot as plt
     # import spikeinterface.full as si
 
     # metrics = si.compute_quality_metrics(we, metric_names=['snr'], load_if_exists=True, )
-    
+
     # comparisons = {}
     # for method in template_matching_methods.keys():
     #     comp = si.compare_sorter_to_ground_truth(gt_sorting, result[method])
@@ -54,6 +60,7 @@ def test_find_spikes_from_templates():
     #     si.plot_sorting_performance(comp, metrics, performance_name='accuracy', metric_name='snr',)
     #     plt.title(method)
     # plt.show()
+
 
 if __name__ == '__main__':
     test_find_spikes_from_templates()

--- a/spikeinterface/toolkit/postprocessing/tests/test_correlograms.py
+++ b/spikeinterface/toolkit/postprocessing/tests/test_correlograms.py
@@ -9,7 +9,8 @@ from spikeinterface.toolkit import compute_correlograms
 def test_compute_correlograms():
     repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
     remote_path = 'mearec/mearec_test_10s.h5'
-    local_path = download_dataset(repo=repo, remote_path=remote_path, local_folder=None)
+    local_path = download_dataset(
+        repo=repo, remote_path=remote_path, local_folder=None)
     # ~ recording = se.MEArecRecordingExtractor(local_path)
     sorting = se.MEArecSortingExtractor(local_path)
 

--- a/spikeinterface/toolkit/postprocessing/tests/test_spike_amplitudes.py
+++ b/spikeinterface/toolkit/postprocessing/tests/test_spike_amplitudes.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from pathlib import Path
 import shutil
@@ -7,44 +8,37 @@ import spikeinterface.extractors as se
 from spikeinterface.toolkit import compute_spike_amplitudes, SpikeAmplitudesCalculator
 
 
-def _clean_all():
-    folders = ["mearec_waveforms", "mearec_waveforms_scaled", "mearec_waveforms_all",
-               "mearec_waveforms_filt"]
-    for folder in folders:
-        if Path(folder).exists():
-            shutil.rmtree(folder)
-
-
-def setup_module():
-    _clean_all()
-
-
-def teardown_module():
-    _clean_all()
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "toolkit"
+else:
+    cache_folder = Path("cache_folder") / "toolkit"
 
 
 def test_compute_spike_amplitudes():
     repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
     remote_path = 'mearec/mearec_test_10s.h5'
-    local_path = download_dataset(repo=repo, remote_path=remote_path, local_folder=None)
+    local_path = download_dataset(
+        repo=repo, remote_path=remote_path, local_folder=None)
     recording = se.MEArecRecordingExtractor(local_path)
     sorting = se.MEArecSortingExtractor(local_path)
 
-    folder = Path('mearec_waveforms')
+    folder = cache_folder / 'mearec_waveforms'
 
     we = extract_waveforms(recording, sorting, folder,
                            ms_before=1., ms_after=2., max_spikes_per_unit=500,
                            n_jobs=1, chunk_size=30000, load_if_exists=False,
                            overwrite=True)
 
-    amplitudes = compute_spike_amplitudes(we, peak_sign='neg', outputs='concatenated', chunk_size=10000, n_jobs=1)
-    amplitudes = compute_spike_amplitudes(we, peak_sign='neg', outputs='by_unit', chunk_size=10000, n_jobs=1)
+    amplitudes = compute_spike_amplitudes(
+        we, peak_sign='neg', outputs='concatenated', chunk_size=10000, n_jobs=1)
+    amplitudes = compute_spike_amplitudes(
+        we, peak_sign='neg', outputs='by_unit', chunk_size=10000, n_jobs=1)
 
     gain = 0.1
     recording.set_channel_gains(gain)
     recording.set_channel_offsets(0)
 
-    folder = Path('mearec_waveforms_scaled')
+    folder = cache_folder / 'mearec_waveforms_scaled'
 
     we_scaled = extract_waveforms(recording, sorting, folder,
                                   ms_before=1., ms_after=2., max_spikes_per_unit=500,
@@ -54,10 +48,9 @@ def test_compute_spike_amplitudes():
     amplitudes_scaled = compute_spike_amplitudes(we_scaled, peak_sign='neg', outputs='concatenated', chunk_size=10000, n_jobs=1,
                                                  return_scaled=True)
     amplitudes_unscaled = compute_spike_amplitudes(we_scaled, peak_sign='neg', outputs='concatenated', chunk_size=10000,
-                                               n_jobs=1, return_scaled=False)
+                                                   n_jobs=1, return_scaled=False)
 
     assert np.allclose(amplitudes_scaled[0], amplitudes_unscaled[0] * gain)
-
 
     # reload as an extension from we
     assert SpikeAmplitudesCalculator in we.get_available_extensions()
@@ -72,31 +65,36 @@ def test_compute_spike_amplitudes():
 def test_compute_spike_amplitudes_parallel():
     repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
     remote_path = 'mearec/mearec_test_10s.h5'
-    local_path = download_dataset(repo=repo, remote_path=remote_path, local_folder=None)
+    local_path = download_dataset(
+        repo=repo, remote_path=remote_path, local_folder=None)
     recording = se.MEArecRecordingExtractor(local_path)
     sorting = se.MEArecSortingExtractor(local_path)
 
-    folder = Path('mearec_waveforms_all')
+    folder = cache_folder / 'mearec_waveforms_all'
 
     we = extract_waveforms(recording, sorting, folder,
                            ms_before=1., ms_after=2., max_spikes_per_unit=None,
                            n_jobs=1, chunk_size=30000, load_if_exists=True)
 
-    amplitudes1 = compute_spike_amplitudes(we, peak_sign='neg', load_if_exists=False, outputs='concatenated', chunk_size=10000, n_jobs=1)
+    amplitudes1 = compute_spike_amplitudes(
+        we, peak_sign='neg', load_if_exists=False, outputs='concatenated', chunk_size=10000, n_jobs=1)
     # TODO : fix multi processing for spike amplitudes!!!!!!!
-    amplitudes2 = compute_spike_amplitudes(we, peak_sign='neg', load_if_exists=False, outputs='concatenated', chunk_size=10000, n_jobs=2)
-    
+    amplitudes2 = compute_spike_amplitudes(
+        we, peak_sign='neg', load_if_exists=False, outputs='concatenated', chunk_size=10000, n_jobs=2)
+
     assert np.array_equal(amplitudes1[0], amplitudes2[0])
     # shutil.rmtree(folder)
 
 
 def test_select_units():
-    we = WaveformExtractor.load_from_folder('mearec_waveforms')
+    we = WaveformExtractor.load_from_folder(cache_folder / 'mearec_waveforms')
     amps = compute_spike_amplitudes(we, load_if_exists=True)
 
     keep_units = we.sorting.get_unit_ids()[::2]
-    we_filt = we.select_units(keep_units, 'mearec_waveforms_filt')
+    we_filt = we.select_units(
+        keep_units, cache_folder / 'mearec_waveforms_filt')
     assert "spike_amplitudes" in we_filt.get_available_extension_names()
+
 
 if __name__ == '__main__':
     test_compute_spike_amplitudes()

--- a/spikeinterface/toolkit/postprocessing/tests/test_template_metrics.py
+++ b/spikeinterface/toolkit/postprocessing/tests/test_template_metrics.py
@@ -9,23 +9,28 @@ from spikeinterface.extractors import toy_example
 
 from spikeinterface.toolkit.postprocessing import calculate_template_metrics
 
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "toolkit"
+else:
+    cache_folder = Path("cache_folder") / "toolkit"
+
 
 def setup_module():
-    for folder in ('toy_rec', 'toy_sorting', 'toy_waveforms'):
-        if Path(folder).is_dir():
-            shutil.rmtree(folder)
+    for folder_name in ('toy_rec', 'toy_sorting', 'toy_waveforms'):
+        if (cache_folder / folder_name).is_dir():
+            shutil.rmtree(cache_folder / folder_name)
 
     recording, sorting = toy_example(num_segments=2, num_units=10)
-    recording = recording.save(folder='toy_rec')
-    sorting = sorting.save(folder='toy_sorting')
+    recording = recording.save(folder=cache_folder / 'toy_rec')
+    sorting = sorting.save(folder=cache_folder / 'toy_sorting')
 
-    we = extract_waveforms(recording, sorting, 'toy_waveforms',
+    we = extract_waveforms(recording, sorting, cache_folder / 'toy_waveforms',
                            ms_before=3., ms_after=4., max_spikes_per_unit=500,
                            n_jobs=1, chunk_size=30000)
 
 
 def test_calculate_template_metrics():
-    we = WaveformExtractor.load_from_folder('toy_waveforms')
+    we = WaveformExtractor.load_from_folder(cache_folder / 'toy_waveforms')
     features = calculate_template_metrics(we, upsampling_factor=1)
     print(features)
 
@@ -33,7 +38,7 @@ def test_calculate_template_metrics():
     print(features_up)
 
     features_sparse = calculate_template_metrics(we, upsampling_factor=2,
-                                                 sparsity_dict=dict(method="radius", 
+                                                 sparsity_dict=dict(method="radius",
                                                                     radius_um=20))
     print(features_sparse)
 

--- a/spikeinterface/toolkit/postprocessing/tests/test_template_similarity.py
+++ b/spikeinterface/toolkit/postprocessing/tests/test_template_similarity.py
@@ -1,32 +1,36 @@
-import unittest
+import pytest
 import shutil
 from pathlib import Path
-
-import pytest
 
 from spikeinterface import download_dataset, extract_waveforms, WaveformExtractor
 from spikeinterface.extractors import read_mearec
 from spikeinterface.toolkit import compute_template_similarity
 
 
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "toolkit"
+else:
+    cache_folder = Path("cache_folder") / "toolkit"
+
+
 def setup_module():
-    for folder in ('mearec_waveforms'):
-        if Path(folder).is_dir():
-            shutil.rmtree(folder)
+    for folder_name in ('mearec_waveforms'):
+        if (cache_folder / folder_name).is_dir():
+            shutil.rmtree(cache_folder / folder_name)
 
     local_path = download_dataset(remote_path='mearec/mearec_test_10s.h5')
     recording, sorting = read_mearec(local_path)
     print(recording)
     print(sorting)
 
-    we = extract_waveforms(recording, sorting, 'mearec_waveforms',
+    we = extract_waveforms(recording, sorting, cache_folder / 'mearec_waveforms',
                            ms_before=3., ms_after=4., max_spikes_per_unit=500,
                            load_if_exists=True,
                            n_jobs=1, chunk_size=30000)
 
 
 def test_compute_template_similarity():
-    we = WaveformExtractor.load_from_folder('mearec_waveforms')
+    we = WaveformExtractor.load_from_folder(cache_folder / 'mearec_waveforms')
     similarity = compute_template_similarity(we)
 
     # DEBUG

--- a/spikeinterface/toolkit/postprocessing/tests/test_unit_localization.py
+++ b/spikeinterface/toolkit/postprocessing/tests/test_unit_localization.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 import shutil
 from pathlib import Path
 
@@ -9,50 +9,60 @@ from spikeinterface.extractors import toy_example
 from spikeinterface.toolkit.postprocessing import localize_units
 
 
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "toolkit"
+else:
+    cache_folder = Path("cache_folder") / "toolkit"
+
+
 def setup_module():
-    for folder in ('toy_rec', 'toy_sort', 'toy_waveforms', 'toy_waveforms_1'):
-        if Path(folder).is_dir():
-            shutil.rmtree(folder)
+    for folder_name in ('toy_rec', 'toy_sort', 'toy_waveforms', 'toy_waveforms_1'):
+        if (cache_folder / folder_name).is_dir():
+            shutil.rmtree(cache_folder / folder_name)
 
-    recording, sorting = toy_example(num_segments=2, num_units=10, num_channels=4)
+    recording, sorting = toy_example(
+        num_segments=2, num_units=10, num_channels=4)
     recording.set_channel_groups([0, 0, 1, 1])
-    recording = recording.save(folder='toy_rec')
+    recording = recording.save(folder=cache_folder / 'toy_rec')
     sorting.set_property("group", [0, 0, 0, 0, 1, 1, 1, 1, 1, 1])
-    sorting = sorting.save(folder='toy_sort')
+    sorting = sorting.save(folder=cache_folder / 'toy_sort')
 
-    we = WaveformExtractor.create(recording, sorting, 'toy_waveforms')
+    we = WaveformExtractor.create(
+        recording, sorting, cache_folder / 'toy_waveforms')
     we.set_params(ms_before=3., ms_after=4., max_spikes_per_unit=500)
     we.run_extract_waveforms(n_jobs=1, chunk_size=30000)
 
 
 def test_compute_unit_center_of_mass():
-    we = WaveformExtractor.load_from_folder('toy_waveforms')
+    we = WaveformExtractor.load_from_folder(cache_folder / 'toy_waveforms')
 
-    unit_location = localize_units(we, method='center_of_mass',  num_channels=4)
-    unit_location_dict = localize_units(we, method='center_of_mass',  num_channels=4, output='dict')
+    unit_location = localize_units(
+        we, method='center_of_mass',  num_channels=4)
+    unit_location_dict = localize_units(
+        we, method='center_of_mass',  num_channels=4, output='dict')
 
-    #~ import matplotlib.pyplot as plt
-    #~ from probeinterface.plotting import plot_probe
-    #~ fig, ax = plt.subplots()
+    # ~ import matplotlib.pyplot as plt
+    # ~ from probeinterface.plotting import plot_probe
+    # ~ fig, ax = plt.subplots()
     #~ plot_probe(we.recording.get_probe(), ax=ax)
     #~ ax.scatter(unit_location[:, 0], unit_location[:, 1])
     #~ plt.show()
 
 
-
 def test_compute_monopolar_triangulation():
-    we = WaveformExtractor.load_from_folder('toy_waveforms')
-    unit_location = localize_units(we, method='monopolar_triangulation', radius_um=150)
-    unit_location_dict = localize_units(we, method='monopolar_triangulation', radius_um=150, output='dict')
+    we = WaveformExtractor.load_from_folder(cache_folder / 'toy_waveforms')
+    unit_location = localize_units(
+        we, method='monopolar_triangulation', radius_um=150)
+    unit_location_dict = localize_units(
+        we, method='monopolar_triangulation', radius_um=150, output='dict')
 
-
-    #~ import matplotlib.pyplot as plt
-    #~ from probeinterface.plotting import plot_probe
-    #~ fig, ax = plt.subplots()
+    # ~ import matplotlib.pyplot as plt
+    # ~ from probeinterface.plotting import plot_probe
+    # ~ fig, ax = plt.subplots()
     #~ plot_probe(we.recording.get_probe(), ax=ax)
     #~ ax.scatter(unit_location[:, 0], unit_location[:, 1])
-    #~ fig = plt.figure()
-    #~ ax = fig.add_subplot(1, 1, 1, projection='3d')
+    # ~ fig = plt.figure()
+    # ~ ax = fig.add_subplot(1, 1, 1, projection='3d')
     #~ plot_probe(we.recording.get_probe().to_3d(plane='xy'), ax=ax)
     #~ ax.scatter(unit_location[:, 0], unit_location[:, 1], unit_location[:, 2])
     #~ plt.show()

--- a/spikeinterface/toolkit/preprocessing/clip.py
+++ b/spikeinterface/toolkit/preprocessing/clip.py
@@ -9,7 +9,7 @@ class ClipRecording(BasePreprocessor):
     '''
     Limit the values of the data between a_min and a_max. Values exceeding the
     range will be set to the minimum or maximum, respectively.
-    
+
     Parameters
     ----------
     recording: RecordingExtractor
@@ -34,10 +34,12 @@ class ClipRecording(BasePreprocessor):
 
         BasePreprocessor.__init__(self, recording)
         for parent_segment in recording._recording_segments:
-            rec_segment = ClipRecordingSegment(parent_segment, a_min, value_min, a_max, value_max)
+            rec_segment = ClipRecordingSegment(
+                parent_segment, a_min, value_min, a_max, value_max)
             self.add_recording_segment(rec_segment)
 
-        self._kwargs = dict(recording=recording.to_dict(), a_min=a_max, a_max=a_max)
+        self._kwargs = dict(recording=recording.to_dict(),
+                            a_min=a_max, a_max=a_max)
 
 
 class BlankSaturationRecording(BasePreprocessor):
@@ -50,7 +52,7 @@ class BlankSaturationRecording(BasePreprocessor):
     0.1 signal percentile with the largest deviation from the median, or specificed.
     Use this function with caution, as it may clip uncontaminated signals. A warning is
     printed if the data range suggests no artefacts.
-    
+
     Parameters
     ----------
     recording: RecordingExtractor
@@ -58,7 +60,7 @@ class BlankSaturationRecording(BasePreprocessor):
         Minimum value. If `None`, clipping is not performed on lower
         interval edge.
     TODO
-    
+
     Returns
     -------
     rescaled_traces: BlankSaturationRecording
@@ -86,7 +88,8 @@ class BlankSaturationRecording(BasePreprocessor):
         if abs_threshold is None:
             assert quantile_threshold is not None
             assert 0 <= quantile_threshold <= 1
-            q = np.quantile(random_data, [quantile_threshold, 1 - quantile_threshold])
+            q = np.quantile(
+                random_data, [quantile_threshold, 1 - quantile_threshold])
             if direction in ('lower', 'both'):
                 a_min = q[0]
                 value_min = fill_value
@@ -109,7 +112,8 @@ class BlankSaturationRecording(BasePreprocessor):
 
         BasePreprocessor.__init__(self, recording)
         for parent_segment in recording._recording_segments:
-            rec_segment = ClipRecordingSegment(parent_segment, a_min, value_min, a_max, value_max)
+            rec_segment = ClipRecordingSegment(
+                parent_segment, a_min, value_min, a_max, value_max)
             self.add_recording_segment(rec_segment)
 
         self._kwargs = dict(recording=recording.to_dict(), abs_threshold=abs_threshold,
@@ -128,7 +132,8 @@ class ClipRecordingSegment(BasePreprocessorSegment):
         self.value_max = value_max
 
     def get_traces(self, start_frame, end_frame, channel_indices):
-        traces = self.parent_recording_segment.get_traces(start_frame, end_frame, channel_indices)
+        traces = self.parent_recording_segment.get_traces(
+            start_frame, end_frame, channel_indices)
         traces = traces.copy()
 
         if self.a_min is not None:

--- a/spikeinterface/toolkit/preprocessing/tests/test_clip.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_clip.py
@@ -1,6 +1,8 @@
-import unittest
 import pytest
+from pathlib import Path
+import shutil
 
+from spikeinterface import set_global_tmp_folder
 from spikeinterface.core.testing_tools import generate_recording
 
 from spikeinterface.toolkit.preprocessing import clip, blank_staturation
@@ -8,48 +10,55 @@ from spikeinterface.toolkit.preprocessing import clip, blank_staturation
 import numpy as np
 
 
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "toolkit"
+else:
+    cache_folder = Path("cache_folder") / "toolkit"
+
+set_global_tmp_folder(cache_folder)
+
+
 def test_clip():
     rec = generate_recording()
 
-    rec2 = clip(rec, a_min=-2, a_max=3.)
-    rec2.save(verbose=False)
+    rec0 = clip(rec, a_min=-2, a_max=3.)
+    rec0.save(verbose=False)
 
-    rec3 = clip(rec, a_min=-1.5)
-    rec3.save(verbose=False)
+    rec1 = clip(rec, a_min=-1.5)
+    rec1.save(verbose=False)
 
-    traces = rec2.get_traces(segment_index=0, channel_ids=[1])
-    assert traces.shape[1] == 1
+    traces0 = rec0.get_traces(segment_index=0, channel_ids=[1])
+    assert traces0.shape[1] == 1
 
-    # ~ import matplotlib.pyplot as plt
-    # ~ from spikeinterface.widgets import plot_timeseries
-    # ~ fig, ax = plt.subplots()
-    # ~ ax.plot(rec.get_traces(segment_index=0)[:, 0], color='g')
-    # ~ ax.plot(rec2.get_traces(segment_index=0)[:, 0], color='r')
-    # ~ ax.plot(rec3.get_traces(segment_index=0)[:, 0], color='y')
-    # ~ plt.show()
+    assert np.all(-2 <= traces0[0] <= 3)
+
+    traces1 = rec1.get_traces(segment_index=0, channel_ids=[0, 1])
+    assert traces1.shape[1] == 2
+
+    assert np.all(-1.5 <= traces1[1])
 
 
-def test_blank_staturationy():
+def test_blank_staturation():
     rec = generate_recording()
 
-    rec2 = blank_staturation(rec, abs_threshold=3.)
-    rec2.save(verbose=False)
+    rec0 = blank_staturation(rec, abs_threshold=3.)
+    rec0.save(verbose=False)
 
-    rec3 = blank_staturation(rec, quantile_threshold=0.01, direction='both')
-    rec3.save(verbose=False)
+    rec1 = blank_staturation(rec, quantile_threshold=0.01, direction='both',
+                             chunk_size=10000)
+    rec1.save(verbose=False)
 
-    traces = rec2.get_traces(segment_index=0, channel_ids=[1])
-    assert traces.shape[1] == 1
+    traces0 = rec0.get_traces(segment_index=0, channel_ids=[1])
+    assert traces0.shape[1] == 1
+    assert np.all(traces0 < 3.)
 
-    # ~ import matplotlib.pyplot as plt
-    # ~ from spikeinterface.widgets import plot_timeseries
-    # ~ fig, ax = plt.subplots()
-    # ~ ax.plot(rec.get_traces(segment_index=0)[:, 0], color='g')
-    # ~ ax.plot(rec2.get_traces(segment_index=0)[:, 0], color='r')
-    # ~ ax.plot(rec3.get_traces(segment_index=0)[:, 0], color='y')
-    # ~ plt.show()
+    traces1 = rec1.get_traces(segment_index=0, channel_ids=[0])
+    assert traces1.shape[1] == 1
+    # use a smaller value to be sure
+    a_min = rec1._recording_segments[0].a_min
+    assert np.all(traces1 >= a_min)
 
 
 if __name__ == '__main__':
     test_clip()
-    test_blank_staturationy()
+    test_blank_staturation()

--- a/spikeinterface/toolkit/preprocessing/tests/test_common_reference.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_common_reference.py
@@ -1,11 +1,20 @@
-import unittest
 import pytest
+from pathlib import Path
+import shutil
 
+from spikeinterface import set_global_tmp_folder
 from spikeinterface.core.testing_tools import generate_recording
 
 from spikeinterface.toolkit.preprocessing import CommonReferenceRecording, common_reference
 
 import numpy as np
+
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "toolkit"
+else:
+    cache_folder = Path("cache_folder") / "toolkit"
+
+set_global_tmp_folder(cache_folder)
 
 
 def test_common_reference():
@@ -17,16 +26,19 @@ def test_common_reference():
     rec_cmr = common_reference(rec, reference='global', operator='median')
     rec_car = common_reference(rec, reference='global', operator='average')
     rec_sin = common_reference(rec, reference='single', ref_channel_ids=['a'])
-    rec_local_car = common_reference(rec, reference='local', local_radius=(20, 65), operator='median')
-   
+    rec_local_car = common_reference(
+        rec, reference='local', local_radius=(20, 65), operator='median')
+
     rec_cmr.save(verbose=False)
     rec_car.save(verbose=False)
     rec_sin.save(verbose=False)
     rec_local_car.save(verbose=False)
 
     traces = rec.get_traces()
-    assert np.allclose(traces, rec_cmr.get_traces() + np.median(traces, axis=1, keepdims=True), atol=0.01)
-    assert np.allclose(traces, rec_car.get_traces() + np.mean(traces, axis=1, keepdims=True), atol=0.01)
+    assert np.allclose(traces, rec_cmr.get_traces() +
+                       np.median(traces, axis=1, keepdims=True), atol=0.01)
+    assert np.allclose(traces, rec_car.get_traces() +
+                       np.mean(traces, axis=1, keepdims=True), atol=0.01)
     assert not np.all(rec_sin.get_traces()[0])
     assert np.allclose(rec_sin.get_traces()[:, 1], traces[:, 1] - traces[:, 0])
 

--- a/spikeinterface/toolkit/preprocessing/tests/test_filter.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_filter.py
@@ -1,12 +1,22 @@
 import pytest
-import pytest
+from pathlib import Path
+import shutil
+
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 from spikeinterface.core.testing_tools import generate_recording
-from spikeinterface import NumpyRecording
+from spikeinterface import NumpyRecording, set_global_tmp_folder
 
 from spikeinterface.toolkit.preprocessing import filter, bandpass_filter, notch_filter
 from scipy.signal import iirfilter
+
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "toolkit"
+else:
+    cache_folder = Path("cache_folder") / "toolkit"
+
+set_global_tmp_folder(cache_folder)
+
 
 def test_filter():
     rec = generate_recording()
@@ -15,9 +25,13 @@ def test_filter():
     rec2 = bandpass_filter(rec, freq_min=300., freq_max=6000.)
 
     # compute by chunk
-    rec2_cached0 = rec2.save(chunk_size=100000, verbose=False, progress_bar=True)
+    rec2_cached0 = rec2.save(
+        chunk_size=100000, verbose=False, progress_bar=True)
+
     # compute by chunkf with joblib
-    rec2_cached1 = rec2.save(total_memory="10k", n_jobs=4, verbose=True)
+    rec2_cached1 = rec2.save(total_memory="10k", n_jobs=4,
+                             verbose=True)
+
     # compute once
     rec2_cached2 = rec2.save(verbose=False)
 
@@ -25,16 +39,19 @@ def test_filter():
     trace1 = rec2_cached1.get_traces(segment_index=0)
 
     # other filtering types
-    rec3 = filter(rec, band=500., btype='highpass', filter_mode='ba', filter_order=2)
+    rec3 = filter(rec, band=500., btype='highpass',
+                  filter_mode='ba', filter_order=2)
 
     rec4 = notch_filter(rec, freq=3000, q=30, margin_ms=5.)
-    
+
     # filter from coefficients
-    coeff = iirfilter(8, [0.02, 0.4], rs=30, btype='band', analog=False, ftype='cheby2', output='sos')
+    coeff = iirfilter(8, [0.02, 0.4], rs=30, btype='band',
+                      analog=False, ftype='cheby2', output='sos')
     rec5 = filter(rec, coeff=coeff, filter_mode='sos')
 
     # compute by chunk
-    rec5_cached0 = rec5.save(chunk_size=100000, verbose=False, progress_bar=True)
+    rec5_cached0 = rec5.save(
+        chunk_size=100000, verbose=False, progress_bar=True)
 
     trace50 = rec5.get_traces(segment_index=0)
     trace51 = rec5_cached0.get_traces(segment_index=0)
@@ -69,17 +86,20 @@ def test_filter_opencl():
         durations=[100.325, ],
         # durations = [10.325, 3.5],
     )
-    rec = rec.save(total_memory="100M", n_jobs=1, progress_bar=True)
+    rec = rec.save(total_memory="100M", n_jobs=1,
+                   progress_bar=True)
 
     print(rec.get_dtype())
     print(rec.is_dumpable)
     # print(rec.to_dict())
 
     rec_filtered = filter(rec, engine='scipy')
-    rec_filtered = rec_filtered.save(chunk_size=1000, progress_bar=True, n_jobs=30)
+    rec_filtered = rec_filtered.save(
+        chunk_size=1000, progress_bar=True, n_jobs=30)
 
     rec2 = filter(rec, engine='opencl')
-    rec2_cached0 = rec2.save(chunk_size=1000, verbose=False, progress_bar=True, n_jobs=1)
+    rec2_cached0 = rec2.save(
+        chunk_size=1000, verbose=False, progress_bar=True, n_jobs=1)
     # rec2_cached0 = rec2.save(chunk_size=1000,verbose=False, progress_bar=True, n_jobs=4)
 
     # import matplotlib.pyplot as plt
@@ -87,7 +107,7 @@ def test_filter_opencl():
     # plot_timeseries(rec, segment_index=0)
     # plot_timeseries(rec_filtered, segment_index=0)
     # plot_timeseries(rec2_cached0, segment_index=0)
-    # plt.show()    
+    # plt.show()
 
 
 if __name__ == '__main__':

--- a/spikeinterface/toolkit/preprocessing/tests/test_normalize_scale.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_normalize_scale.py
@@ -1,11 +1,20 @@
-import unittest
 import pytest
+from pathlib import Path
 
+from spikeinterface import set_global_tmp_folder
 from spikeinterface.core.testing_tools import generate_recording
 
 from spikeinterface.toolkit.preprocessing import normalize_by_quantile, scale, center
 
 import numpy as np
+
+
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "toolkit"
+else:
+    cache_folder = Path("cache_folder") / "toolkit"
+
+set_global_tmp_folder(cache_folder)
 
 
 def test_normalize_by_quantile():
@@ -53,6 +62,5 @@ def test_center():
 
 if __name__ == '__main__':
     test_normalize_by_quantile()
-
     test_scale()
     test_center()

--- a/spikeinterface/toolkit/preprocessing/tests/test_rectify.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_rectify.py
@@ -1,11 +1,20 @@
-import unittest
 import pytest
+from pathlib import Path
 
+from spikeinterface import set_global_tmp_folder
 from spikeinterface.core.testing_tools import generate_recording
 
 from spikeinterface.toolkit.preprocessing import rectify
 
 import numpy as np
+
+
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "toolkit"
+else:
+    cache_folder = Path("cache_folder") / "toolkit"
+
+set_global_tmp_folder(cache_folder)
 
 
 def test_rectify():

--- a/spikeinterface/toolkit/preprocessing/tests/test_remove_artifacts.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_remove_artifacts.py
@@ -1,11 +1,7 @@
-import unittest
-import pytest
+import numpy as np
 
 from spikeinterface.core.testing_tools import generate_recording
-
 from spikeinterface.toolkit.preprocessing import remove_artifacts
-
-import numpy as np
 
 
 def test_remove_artifacts():

--- a/spikeinterface/toolkit/preprocessing/tests/test_remove_bad_channels.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_remove_bad_channels.py
@@ -1,12 +1,9 @@
-import unittest
-import pytest
+import numpy as np
 
 from spikeinterface import NumpyRecording
 from probeinterface import generate_linear_probe
 
 from spikeinterface.toolkit.preprocessing import remove_bad_channels
-
-import numpy as np
 
 
 def test_remove_bad_channels():

--- a/spikeinterface/toolkit/preprocessing/tests/test_tools.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_tools.py
@@ -1,6 +1,3 @@
-import unittest
-import pytest
-
 import numpy as np
 
 from spikeinterface.core.testing_tools import generate_recording

--- a/spikeinterface/toolkit/preprocessing/tests/test_whiten.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_whiten.py
@@ -1,10 +1,17 @@
-import unittest
 import pytest
+from pathlib import Path
 
+from spikeinterface import set_global_tmp_folder
 from spikeinterface.core.testing_tools import generate_recording
 
 from spikeinterface.toolkit.preprocessing import whiten
 
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "toolkit"
+else:
+    cache_folder = Path("cache_folder") / "toolkit"
+
+set_global_tmp_folder(cache_folder)
 
 def test_normalize_by_quantile():
     rec = generate_recording()

--- a/spikeinterface/toolkit/qualitymetrics/tests/test_pca_metrics.py
+++ b/spikeinterface/toolkit/qualitymetrics/tests/test_pca_metrics.py
@@ -1,8 +1,6 @@
-import unittest
+import pytest
 import shutil
 from pathlib import Path
-
-import pytest
 
 from spikeinterface import WaveformExtractor
 from spikeinterface.extractors import toy_example
@@ -10,17 +8,23 @@ from spikeinterface.extractors import toy_example
 from spikeinterface.toolkit.qualitymetrics import compute_quality_metrics, calculate_pc_metrics
 from spikeinterface.toolkit.postprocessing import WaveformPrincipalComponent
 
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "toolkit"
+else:
+    cache_folder = Path("cache_folder") / "toolkit"
+
 
 def setup_module():
-    for folder in ('toy_rec', 'toy_sorting', 'toy_waveforms'):
-        if Path(folder).is_dir():
-            shutil.rmtree(folder)
+    for folder_name in ('toy_rec', 'toy_sorting', 'toy_waveforms'):
+        if (cache_folder / folder_name).is_dir():
+            shutil.rmtree(cache_folder / folder_name)
 
     recording, sorting = toy_example(num_segments=2, num_units=10)
-    recording = recording.save(folder='toy_rec')
-    sorting = sorting.save(folder='toy_sorting')
+    recording = recording.save(folder=cache_folder / 'toy_rec')
+    sorting = sorting.save(folder=cache_folder / 'toy_sorting')
 
-    we = WaveformExtractor.create(recording, sorting, 'toy_waveforms')
+    we = WaveformExtractor.create(
+        recording, sorting, cache_folder / 'toy_waveforms')
     we.set_params(ms_before=3., ms_after=4., max_spikes_per_unit=500)
     we.run_extract_waveforms(n_jobs=1, chunk_size=30000)
 
@@ -30,9 +34,10 @@ def setup_module():
 
 
 def test_calculate_pc_metrics():
-    we = WaveformExtractor.load_from_folder('toy_waveforms')
+    we = WaveformExtractor.load_from_folder(cache_folder / 'toy_waveforms')
     print(we)
-    pca = WaveformPrincipalComponent.load_from_folder('toy_waveforms')
+    pca = WaveformPrincipalComponent.load_from_folder(
+        cache_folder / 'toy_waveforms')
     print(pca)
 
     res = calculate_pc_metrics(pca)

--- a/spikeinterface/toolkit/qualitymetrics/tests/test_quality_metric_calculator.py
+++ b/spikeinterface/toolkit/qualitymetrics/tests/test_quality_metric_calculator.py
@@ -1,9 +1,7 @@
-import unittest
+import pytest
 import shutil
 from pathlib import Path
 import numpy as np
-
-import pytest
 
 from spikeinterface import WaveformExtractor, load_extractor
 from spikeinterface.extractors import toy_example
@@ -13,23 +11,30 @@ from spikeinterface.toolkit.preprocessing import scale
 from spikeinterface.toolkit.qualitymetrics import compute_quality_metrics, QualityMetricCalculator
 
 
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "toolkit"
+else:
+    cache_folder = Path("cache_folder") / "toolkit"
+
+
 def setup_module():
-    for folder in ('toy_rec', 'toy_sorting', 'toy_waveforms', 'toy_waveforms_filt',
-                   'toy_waveforms_inv'):
-        if Path(folder).is_dir():
-            shutil.rmtree(folder)
+    for folder_name in ('toy_rec', 'toy_sorting', 'toy_waveforms', 'toy_waveforms_filt',
+                        'toy_waveforms_inv'):
+        if (cache_folder / folder_name).is_dir():
+            shutil.rmtree(cache_folder / folder_name)
 
     recording, sorting = toy_example(num_segments=2, num_units=10)
-    recording = recording.save(folder='toy_rec')
-    sorting = sorting.save(folder='toy_sorting')
+    recording = recording.save(folder=cache_folder / 'toy_rec')
+    sorting = sorting.save(folder=cache_folder / 'toy_sorting')
 
-    we = WaveformExtractor.create(recording, sorting, 'toy_waveforms')
+    we = WaveformExtractor.create(
+        recording, sorting, cache_folder / 'toy_waveforms')
     we.set_params(ms_before=3., ms_after=4., max_spikes_per_unit=500)
     we.run_extract_waveforms(n_jobs=1, chunk_size=30000)
 
 
 def test_compute_quality_metrics():
-    we = WaveformExtractor.load_from_folder('toy_waveforms')
+    we = WaveformExtractor.load_from_folder(cache_folder / 'toy_waveforms')
     print(we)
 
     # without PC
@@ -53,41 +58,47 @@ def test_compute_quality_metrics():
     assert isinstance(qmc, QualityMetricCalculator)
     assert qmc._metrics is not None
     # print(qmc._metrics)
-    qmc = QualityMetricCalculator.load_from_folder('toy_waveforms')
+    qmc = QualityMetricCalculator.load_from_folder(
+        cache_folder / 'toy_waveforms')
     assert qmc._metrics is not None
     # print(qmc._metrics)
-    
+
 
 def test_compute_quality_metrics_peak_sign():
-    rec = load_extractor('toy_rec')
-    sort = load_extractor('toy_sorting')
-    
+    rec = load_extractor(cache_folder / 'toy_rec')
+    sort = load_extractor(cache_folder / 'toy_sorting')
+
     # invert recording
     rec_inv = scale(rec, gain=-1.)
-    
-    we = WaveformExtractor.load_from_folder('toy_waveforms')
+
+    we = WaveformExtractor.load_from_folder(cache_folder / 'toy_waveforms')
     print(we)
-    
-    we_inv = WaveformExtractor.create(rec_inv, sort, 'toy_waveforms_inv')
+
+    we_inv = WaveformExtractor.create(
+        rec_inv, sort, cache_folder / 'toy_waveforms_inv')
     we_inv.set_params(ms_before=3., ms_after=4., max_spikes_per_unit=500)
     we_inv.run_extract_waveforms(n_jobs=1, chunk_size=30000)
     print(we_inv)
 
     # without PC
-    metrics = compute_quality_metrics(we, metric_names=['snr', 'amplitude_cutoff'], peak_sign="neg")
-    metrics_inv = compute_quality_metrics(we_inv, metric_names=['snr', 'amplitude_cutoff'], peak_sign="pos")
-    
+    metrics = compute_quality_metrics(
+        we, metric_names=['snr', 'amplitude_cutoff'], peak_sign="neg")
+    metrics_inv = compute_quality_metrics(
+        we_inv, metric_names=['snr', 'amplitude_cutoff'], peak_sign="pos")
+
     assert np.allclose(metrics["snr"].values, metrics_inv["snr"].values)
-    assert np.allclose(metrics["amplitude_cutoff"].values, metrics_inv["amplitude_cutoff"].values)
+    assert np.allclose(metrics["amplitude_cutoff"].values,
+                       metrics_inv["amplitude_cutoff"].values)
 
 
 def test_select_units():
-    we = WaveformExtractor.load_from_folder('toy_waveforms')
+    we = WaveformExtractor.load_from_folder(cache_folder / 'toy_waveforms')
     qm = compute_quality_metrics(we, load_if_exists=True)
 
     keep_units = we.sorting.get_unit_ids()[::2]
-    we_filt = we.select_units(keep_units, 'toy_waveforms_filt')
+    we_filt = we.select_units(keep_units, cache_folder / 'toy_waveforms_filt')
     assert "quality_metrics" in we_filt.get_available_extension_names()
+
 
 if __name__ == '__main__':
     setup_module()

--- a/spikeinterface/widgets/tests/test_widgets.py
+++ b/spikeinterface/widgets/tests/test_widgets.py
@@ -1,5 +1,7 @@
 import unittest
+import pytest
 import sys
+from pathlib import Path
 
 if __name__ != '__main__':
     import matplotlib
@@ -14,11 +16,14 @@ import spikeinterface.comparison as sc
 import spikeinterface.toolkit as st
 
 
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "widgets"
+else:
+    cache_folder = Path("cache_folder") / "widgets"
+
+
 class TestWidgets(unittest.TestCase):
     def setUp(self):
-        #~ self._rec, self._sorting = se.toy_example(num_channels=10, duration=10, num_segments=1)
-        #~ self._rec = self._rec.save()
-        #~ self._sorting = self._sorting.save()
         local_path = download_dataset(remote_path='mearec/mearec_test_10s.h5')
         self._rec = se.MEArecRecordingExtractor(local_path)
 
@@ -26,7 +31,7 @@ class TestWidgets(unittest.TestCase):
 
         self.num_units = len(self._sorting.get_unit_ids())
         #  self._we = extract_waveforms(self._rec, self._sorting, './toy_example', load_if_exists=True)
-        self._we = extract_waveforms(self._rec, self._sorting, './mearec_test', load_if_exists=True)
+        self._we = extract_waveforms(self._rec, self._sorting, cache_folder / 'mearec_test', load_if_exists=True)
 
         self._amplitudes = st.compute_spike_amplitudes(self._we, peak_sign='neg', outputs='by_unit')
         self._gt_comp = sc.compare_sorter_to_ground_truth(self._sorting, self._sorting)
@@ -114,7 +119,7 @@ class TestWidgets(unittest.TestCase):
         sw.plot_drift_over_time(self._rec, peaks=peaks, bin_duration_s=1.,
                                 weight_with_amplitudes=False, mode='heatmap')
         sw.plot_drift_over_time(self._rec, peaks=peaks, weight_with_amplitudes=False, mode='scatter',
-                                scatter_plot_kwargs={'color':'r'})
+                                scatter_plot_kwargs={'color': 'r'})
 
     def test_plot_peak_activity_map(self):
         sw.plot_peak_activity_map(self._rec)

--- a/spikeinterface/widgets/tests/test_widgets_utils.py
+++ b/spikeinterface/widgets/tests/test_widgets_utils.py
@@ -1,13 +1,9 @@
-import unittest
-import sys
-
 if __name__ != '__main__':
     import matplotlib
 
     matplotlib.use('Agg')
-import matplotlib.pyplot as plt
 
-from spikeinterface import extract_waveforms, download_dataset
+from spikeinterface import download_dataset
 import spikeinterface.extractors as se
 
 from spikeinterface.widgets.utils import get_unit_colors
@@ -15,7 +11,6 @@ from spikeinterface.widgets.utils import get_unit_colors
 
 def test_get_unit_colors():
     local_path = download_dataset(remote_path='mearec/mearec_test_10s.h5')
-    rec = se.MEArecRecordingExtractor(local_path)
     sorting = se.MEArecSortingExtractor(local_path)
 
     colors = get_unit_colors(sorting)


### PR DESCRIPTION
Refactored all tests and reorganized them using pytest hooks.
Two main changes:
- the `conftest.py` defines a `pytest.global_test_folder` that is used to centralized all files created by tests (and then destroyed in case tests pass)
- the `pytest_collection_modifyitems()` in the same file marks all tests as core, extractors, toolkit, sorters, widgets, exporters, sortingcomponents, so that they can be run separately

This is in preparation to implement actions that only test modules that have been changed in a PR/commit. And also cleans thinks up quite a lot :) and is long overdue