### PR TITLE
Modify nwb recorder extractor for loading channel name property as channel_ids when available

### DIFF
--- a/spikeinterface/core/testing.py
+++ b/spikeinterface/core/testing.py
@@ -6,10 +6,7 @@ def check_recordings_equal(RX1, RX2, return_scaled=True, force_dtype=None):
     for segment_idx in range(RX1.get_num_segments()):
         N = RX1.get_num_frames(segment_idx)
         # get_channel_ids
-        if np.issubdtype(RX1.get_channel_ids().dtype, np.character):
-            assert np.array_equal(RX1.get_channel_ids(), RX2.get_channel_ids())
-        else:
-            assert np.allclose(RX1.get_channel_ids(), RX2.get_channel_ids())
+        assert np.array_equal(RX1.get_channel_ids(), RX2.get_channel_ids())
         # get_num_channels
         assert np.allclose(RX1.get_num_channels(), RX2.get_num_channels())
         # get_num_frames

--- a/spikeinterface/core/testing.py
+++ b/spikeinterface/core/testing.py
@@ -1,13 +1,15 @@
 import numpy as np
 
-
 def check_recordings_equal(RX1, RX2, return_scaled=True, force_dtype=None):
     assert RX1.get_num_segments() == RX2.get_num_segments()
 
     for segment_idx in range(RX1.get_num_segments()):
         N = RX1.get_num_frames(segment_idx)
         # get_channel_ids
-        assert np.allclose(RX1.get_channel_ids(), RX2.get_channel_ids())
+        if np.issubdtype(RX1.get_channel_ids().dtype, np.character):
+            assert np.array_equal(RX1.get_channel_ids(), RX2.get_channel_ids())
+        else:
+            assert np.allclose(RX1.get_channel_ids(), RX2.get_channel_ids())
         # get_num_channels
         assert np.allclose(RX1.get_num_channels(), RX2.get_num_channels())
         # get_num_frames

--- a/spikeinterface/extractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors.py
@@ -126,11 +126,8 @@ class NwbRecordingExtractor(BaseRecording):
         if "channel_name" in self._nwbfile.electrodes.colnames:
             channel_ids = self._es.electrodes["channel_name"][:].astype("str")
         else:
-            channel_ids = [self._es.electrodes.table.id[x]
-                        for x in self._es.electrodes.data]
+            channel_ids = [self._es.electrodes.table.id[x] for x in self._es.electrodes.data]
 
-        dtype = self._es.data.dtype
-        np.issubdtype
         BaseRecording.__init__(self, channel_ids=channel_ids, sampling_frequency=sampling_frequency, dtype=dtype)
         recording_segment = NwbRecordingSegment(nwbfile=self._nwbfile,
                                                 electrical_series_name=self._electrical_series_name,

--- a/spikeinterface/extractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors.py
@@ -128,6 +128,7 @@ class NwbRecordingExtractor(BaseRecording):
         else:
             channel_ids = [self._es.electrodes.table.id[x] for x in self._es.electrodes.data]
 
+        dtype = self._es.data.dtype
         BaseRecording.__init__(self, channel_ids=channel_ids, sampling_frequency=sampling_frequency, dtype=dtype)
         recording_segment = NwbRecordingSegment(nwbfile=self._nwbfile,
                                                 electrical_series_name=self._electrical_series_name,

--- a/spikeinterface/extractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors.py
@@ -123,11 +123,14 @@ class NwbRecordingExtractor(BaseRecording):
             unique_grp_names = list(np.unique(self._nwbfile.electrodes['group_name'][:]))
 
         # Fill channel properties dictionary from electrodes table
-        channel_ids = [self._es.electrodes.table.id[x]
-                       for x in self._es.electrodes.data]
+        if "channel_name" in self._nwbfile.electrodes.colnames:
+            channel_ids = self._es.electrodes["channel_name"][:].astype("str")
+        else:
+            channel_ids = [self._es.electrodes.table.id[x]
+                        for x in self._es.electrodes.data]
 
         dtype = self._es.data.dtype
-
+        np.issubdtype
         BaseRecording.__init__(self, channel_ids=channel_ids, sampling_frequency=sampling_frequency, dtype=dtype)
         recording_segment = NwbRecordingSegment(nwbfile=self._nwbfile,
                                                 electrical_series_name=self._electrical_series_name,


### PR DESCRIPTION
PR for the issue as described in https://github.com/catalystneuro/nwb-conversion-tools/issues/429. The idea is that when channel_name is available as a column in the `nwb_extractor` this property is the one that will get loaded as channel_ids instead of `nwb_file.electrodes.id`. 

Similar work should be done for the units table in another PR.

