### PR TITLE
Support rel z in nwb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy
 neo>=0.10.2
 joblib
 tqdm
-probeinterface>=0.2.7
+probeinterface>=0.2.8

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -7,7 +7,7 @@ import numpy as np
 from probeinterface import Probe, ProbeGroup, write_probeinterface, read_probeinterface
 
 from .base import BaseExtractor, BaseSegment
-from .core_tools import write_binary_recording, write_memory_recording
+from .core_tools import write_binary_recording, write_memory_recording, apply_dimensions_to_positions
 
 from warnings import warn
 
@@ -416,8 +416,17 @@ class BaseRecording(BaseExtractor):
         return probegroup
 
     def set_dummy_probe_from_locations(self, locations, shape="circle", shape_params={"radius": 1}):
-        probe = Probe()
-        probe.set_contacts(locations, shapes=shape, shape_params=shape_params)
+        ndim = locations.shape[1]
+        plane_axes = None
+        if ndim == 3:
+            # probeinterface 3d probes need plane_axes
+            num_channels = locations.shape[0]
+            plane_axes = np.zeros((num_channels, 2, 3))
+            plane_axes[:, 0] = [1, 0, 0] * num_channels
+            plane_axes[:, 1] = [0, 1, 0] * num_channels
+        probe = Probe(ndim=ndim)
+        probe.set_contacts(locations, shapes=shape, shape_params=shape_params, 
+                           plane_axes=plane_axes)
         probe.set_device_channel_indices(np.arange(self.get_num_channels()))
         self.set_probe(probe, in_place=True)
 
@@ -426,23 +435,7 @@ class BaseRecording(BaseExtractor):
             raise ValueError('set_channel_locations(..) destroy the probe description, prefer set_probes(..)')
         self.set_property('location', locations, ids=channel_ids)
 
-    def get_channel_locations(self, channel_ids=None, dimensions: str='xy'):
-        def apply_dimensions_to_positions(positions: np.ndarray):
-            if dimensions == 'xy':
-                assert positions.shape[1] >=2, f'positions.shape[1] must be at least 2'
-                return positions[:, [0, 1]]
-            elif dimensions == 'xz':
-                assert positions.shape[1] >=3, f'positions.shape[1] must be at least 3'
-                return positions[:, [0, 2]]
-            elif dimensions == 'yz':
-                assert positions.shape[1] >=3, f'positions.shape[1] must be at least 3'
-                return positions[:, [1, 2]]
-            elif dimensions == 'xyz':
-                assert positions.shape[1] >=3, f'positions.shape[1] must be at least 3'
-                return positions[:, [0, 1, 2]]
-            else:
-                raise Exception(f'Invalid dimensions parameter: {dimensions}')
-
+    def get_channel_locations(self, channel_ids=None, dimensions: str = 'xy'):
         if channel_ids is None:
             channel_ids = self.get_channel_ids()
         channel_indices = self.ids_to_indices(channel_ids)
@@ -470,14 +463,17 @@ class BaseRecording(BaseExtractor):
                                             for cp in probe_j.contact_positions])):
                             raise Exception("Probes are overlapping! Retrieve locations of single probes separately")
                 all_positions = np.vstack([probe.contact_positions for probe in all_probes])
-                positions = all_positions[channel_indices]  
-            return apply_dimensions_to_positions(positions)
+                positions = all_positions[channel_indices]
+            return apply_dimensions_to_positions(positions, dimensions)
         else:
             locations = self.get_property('location')
             if locations is None:
                 raise Exception('There are no channel locations')
             locations = np.asarray(locations)[channel_indices]
-            return apply_dimensions_to_positions(locations)
+            return apply_dimensions_to_positions(locations, dimensions)
+
+    def has_3d_locations(self):
+        return self.get_property('location').shape[1] == 3
 
     def clear_channel_locations(self, channel_ids=None):
         if channel_ids is None:
@@ -556,6 +552,48 @@ class BaseRecording(BaseExtractor):
             elif outputs == 'dict':
                 recordings[value] = subrec
         return recordings
+
+    def planarize(self, dimensions: str = "xy"):
+        """
+        Returns a Recording with a 2D probe from one with a 3D probe
+
+        Parameters
+        ----------
+        dimensions : str, optional
+            The dimensions to keep, by default "xy"
+
+        Returns
+        -------
+        BaseRecording
+            The recording with 2D positions
+        """
+        assert self.has_3d_locations, "The 'planarize' function needs a recording with 3d locations"
+        assert len(dimensions) == 2, "You need to specify 2 dimensions (e.g. 'xy', 'zy')"
+
+        probe3d = self.get_probe()
+        positions3d = probe3d.contact_positions
+        probe2d = Probe(ndim=2, si_units=probe3d.si_units)
+
+        # contacts
+        positions2d = apply_dimensions_to_positions(positions3d, dimensions)
+
+        probe2d.set_contacts(
+            positions=positions2d,
+            shapes=probe3d.contact_shapes.copy(),
+            shape_params=probe3d.contact_shape_params.copy())
+
+        # shape
+        if probe3d.probe_planar_contour is not None:
+            vertices3d = probe3d.probe_planar_contour
+            vertices2d = apply_dimensions_to_positions(vertices3d, dimensions)
+            probe2d.set_planar_contour(vertices2d)
+
+        probe2d.set_device_channel_indices(probe3d.device_channel_indices)
+
+        recording2d = self.clone()
+        recording2d.set_probe(probe2d, in_place=True)
+
+        return recording2d
 
 
 class BaseRecordingSegment(BaseSegment):

--- a/spikeinterface/core/core_tools.py
+++ b/spikeinterface/core/core_tools.py
@@ -146,6 +146,19 @@ def read_binary_recording(file, num_chan, dtype, time_axis=0, offset=0):
     return samples
 
 
+def apply_dimensions_to_positions(positions: np.ndarray, dimensions: str):
+    dim_map = {"x": 0, "y": 1, "z": 2}
+
+    dims = []
+    for dim in dimensions:
+        assert dim in dim_map, "'dimensions' can contain 'x', 'y', or 'z' only!"
+        dims.append(dim_map[dim])
+    dims = np.array(dims)
+
+    assert positions.shape[1] >= len(dims), "Inconsistent shapes between positions and dimensions"
+    return positions[:, dims]
+
+
 # used by write_binary_recording + ChunkRecordingExecutor
 def _init_binary_worker(recording, rec_memmaps_dict, dtype):
     # create a local dict per worker

--- a/spikeinterface/core/core_tools.py
+++ b/spikeinterface/core/core_tools.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+import sys
 import datetime
 
 import numpy as np
@@ -144,19 +145,6 @@ def read_binary_recording(file, num_chan, dtype, time_axis=0, offset=0):
     else:
         samples = np.memmap(file, np.dtype(dtype), mode='r', offset=offset, shape=(num_chan, nsamples)).T
     return samples
-
-
-def apply_dimensions_to_positions(positions: np.ndarray, dimensions: str):
-    dim_map = {"x": 0, "y": 1, "z": 2}
-
-    dims = []
-    for dim in dimensions:
-        assert dim in dim_map, "'dimensions' can contain 'x', 'y', or 'z' only!"
-        dims.append(dim_map[dim])
-    dims = np.array(dims)
-
-    assert positions.shape[1] >= len(dims), "Inconsistent shapes between positions and dimensions"
-    return positions[:, dims]
 
 
 # used by write_binary_recording + ChunkRecordingExecutor

--- a/spikeinterface/core/testing_tools.py
+++ b/spikeinterface/core/testing_tools.py
@@ -9,7 +9,8 @@ def generate_recording(
         num_channels=2,
         sampling_frequency=30000.,  # in Hz
         durations=[10.325, 3.5],  #  in s for 2 segments
-        set_probe=True
+        set_probe=True,
+        ndim=2
 ):
     num_segments = len(durations)
     num_timepoints = [int(sampling_frequency * d) for d in durations]
@@ -24,9 +25,11 @@ def generate_recording(
 
     if set_probe:
         probe = generate_linear_probe(num_elec=num_channels)
+        if ndim == 3:
+            probe = probe.to_3d()
         probe.set_device_channel_indices(np.arange(num_channels))
         recording.set_probe(probe, in_place=True)
-
+        probe = generate_linear_probe(num_elec=num_channels)
     return recording
 
 

--- a/spikeinterface/core/tests/test_baserecording.py
+++ b/spikeinterface/core/tests/test_baserecording.py
@@ -19,6 +19,7 @@ if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
 else:
     cache_folder = Path("cache_folder") / "core"
+    cache_folder.mkdir(exist_ok=True, parents=True)
 
 
 def test_BaseRecording():
@@ -204,19 +205,19 @@ def test_BaseRecording():
     rec_3d = generate_recording(ndim=3, num_channels=30)
     locations_3d = rec_3d.get_property("location")
 
-    locations_xy = rec_3d.get_channel_locations(dimensions="xy")
+    locations_xy = rec_3d.get_channel_locations(axes="xy")
     assert np.allclose(locations_xy, locations_3d[:, [0, 1]])
 
-    locations_xz = rec_3d.get_channel_locations(dimensions="xz")
+    locations_xz = rec_3d.get_channel_locations(axes="xz")
     assert np.allclose(locations_xz, locations_3d[:, [0, 2]])
 
-    locations_zy = rec_3d.get_channel_locations(dimensions="zy")
+    locations_zy = rec_3d.get_channel_locations(axes="zy")
     assert np.allclose(locations_zy, locations_3d[:, [2, 1]])
 
-    locations_xzy = rec_3d.get_channel_locations(dimensions="xzy")
+    locations_xzy = rec_3d.get_channel_locations(axes="xzy")
     assert np.allclose(locations_xzy, locations_3d[:, [0, 2, 1]])
 
-    rec_2d = rec_3d.planarize(dimensions="zy")
+    rec_2d = rec_3d.planarize(axes="zy")
     assert np.allclose(rec_2d.get_channel_locations(), locations_3d[:, [2, 1]])
 
 

--- a/spikeinterface/core/tests/test_baserecording.py
+++ b/spikeinterface/core/tests/test_baserecording.py
@@ -13,6 +13,8 @@ from probeinterface import Probe
 from spikeinterface.core import BinaryRecordingExtractor, NumpyRecording, load_extractor
 from spikeinterface.core.base import BaseExtractor
 
+from spikeinterface.core.testing_tools import generate_recording
+
 if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
 else:
@@ -197,6 +199,25 @@ def test_BaseRecording():
     assert np.allclose(times1, rec2.get_times(1))
     rec3 = load_extractor(folder)
     assert np.allclose(times1, rec3.get_times(1))
+
+    # test 3d probe
+    rec_3d = generate_recording(ndim=3, num_channels=30)
+    locations_3d = rec_3d.get_property("location")
+
+    locations_xy = rec_3d.get_channel_locations(dimensions="xy")
+    assert np.allclose(locations_xy, locations_3d[:, [0, 1]])
+
+    locations_xz = rec_3d.get_channel_locations(dimensions="xz")
+    assert np.allclose(locations_xz, locations_3d[:, [0, 2]])
+
+    locations_zy = rec_3d.get_channel_locations(dimensions="zy")
+    assert np.allclose(locations_zy, locations_3d[:, [2, 1]])
+
+    locations_xzy = rec_3d.get_channel_locations(dimensions="xzy")
+    assert np.allclose(locations_xzy, locations_3d[:, [0, 2, 1]])
+
+    rec_2d = rec_3d.planarize(dimensions="zy")
+    assert np.allclose(rec_2d.get_channel_locations(), locations_3d[:, [2, 1]])
 
 
 if __name__ == '__main__':

--- a/spikeinterface/extractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors.py
@@ -142,8 +142,9 @@ class NwbRecordingExtractor(BaseRecording):
         properties = dict()
         for es_ind, (channel_id, electrode_table_index) in enumerate(zip(channel_ids, self._es.electrodes.data)):
             if 'rel_x' in self._nwbfile.electrodes:
-                ndim = 2 # assume 2 dimensions
-                if 'rel_z' in self._nwbfile.electrodes: ndim = 3 # if we have rel_z, it is 3 dimensions
+                ndim = 2  # assume 2 dimensions
+                if 'rel_z' in self._nwbfile.electrodes:
+                    ndim = 3  # if we have rel_z, it is 3 dimensions
 
                 if 'location' not in properties:
                     properties['location'] = np.zeros((self.get_num_channels(), ndim), dtype=float)


### PR DESCRIPTION
Based on https://github.com/SpikeInterface/spikeinterface/pull/536

- Added tests
- Added `planarize()` function in `BaseRecording`
- Improved `apply_dimensions_to_positions()` function to handle any combination of x-y-z
- Fixed `set_dummy_probe_from_locations` when locations are 3d by adding mock `plane_axes`


@magland I was not able to push directly on your fork for some reason. So let me know if this looks good for you and @lfrank