### PR TITLE
Add with_channel_ids for several widgets that use plot_probe

### DIFF
--- a/spikeinterface/widgets/activity.py
+++ b/spikeinterface/widgets/activity.py
@@ -31,6 +31,8 @@ class PeakActivityMapWidget(BaseWidget):
         Plot rates with contact colors
     with_interpolated_map: bool (default True)
         Plot rates with interpolated map
+    with_channel_ids: bool False default
+        add channel ids text on the probe
     figure: matplotlib figure
         The figure to be used. If not given a figure is created
     ax: matplotlib axis
@@ -45,6 +47,7 @@ class PeakActivityMapWidget(BaseWidget):
     def __init__(self, recording, peaks=None, detect_peaks_kwargs={},
                  weight_with_amplitudes=True, bin_duration_s=None,
                  with_contact_color=True, with_interpolated_map=True,
+                 with_channel_ids=False, with_color_bar=True,
                  figure=None, ax=None):
         BaseWidget.__init__(self, figure, ax)
 
@@ -57,6 +60,7 @@ class PeakActivityMapWidget(BaseWidget):
         self.bin_duration_s = bin_duration_s
         self.with_contact_color = with_contact_color
         self.with_interpolated_map = with_interpolated_map
+        self.with_channel_ids = with_channel_ids
 
     def plot(self):
         rec = self.recording
@@ -101,9 +105,15 @@ class PeakActivityMapWidget(BaseWidget):
 
         artists = ()
         if self.with_contact_color:
+            text_on_contact = None
+            if self.with_channel_ids:
+                text_on_contact = self.recording.channel_ids
+            
+                
             poly, poly_contour = plot_probe(probe, ax=self.ax, contacts_values=rates,
                                             probe_shape_kwargs={'facecolor': 'w', 'alpha': .1},
-                                            contacts_kargs={'alpha': 1.}
+                                            contacts_kargs={'alpha': 1.},
+                                            text_on_contact=text_on_contact,
                                             )
             artists = artists + (poly, poly_contour)
 

--- a/spikeinterface/widgets/activity.py
+++ b/spikeinterface/widgets/activity.py
@@ -32,7 +32,7 @@ class PeakActivityMapWidget(BaseWidget):
     with_interpolated_map: bool (default True)
         Plot rates with interpolated map
     with_channel_ids: bool False default
-        add channel ids text on the probe
+        Add channel ids text on the probe
     figure: matplotlib figure
         The figure to be used. If not given a figure is created
     ax: matplotlib axis

--- a/spikeinterface/widgets/drift.py
+++ b/spikeinterface/widgets/drift.py
@@ -3,7 +3,6 @@ import matplotlib.pylab as plt
 
 from .basewidget import BaseWidget
 
-from probeinterface.plotting import plot_probe
 
 
 class DriftOverTimeWidget(BaseWidget):

--- a/spikeinterface/widgets/probemap.py
+++ b/spikeinterface/widgets/probemap.py
@@ -17,7 +17,7 @@ class ProbeMapWidget(BaseWidget):
     channel_ids: list
         The channel ids to display
     with_channel_ids: bool False default
-        add channel ids text on the probe
+        Add channel ids text on the probe
     figure: matplotlib figure
         The figure to be used. If not given a figure is created
     ax: matplotlib axis

--- a/spikeinterface/widgets/probemap.py
+++ b/spikeinterface/widgets/probemap.py
@@ -16,6 +16,8 @@ class ProbeMapWidget(BaseWidget):
         The recording extractor object
     channel_ids: list
         The channel ids to display
+    with_channel_ids: bool False default
+        add channel ids text on the probe
     figure: matplotlib figure
         The figure to be used. If not given a figure is created
     ax: matplotlib axis
@@ -28,7 +30,7 @@ class ProbeMapWidget(BaseWidget):
         The output widget
     """
 
-    def __init__(self, recording, channel_ids=None, figure=None, ax=None,
+    def __init__(self, recording, channel_ids=None, with_channel_ids=False, figure=None, ax=None,
                  **plot_probe_kwargs):
         BaseWidget.__init__(self, figure, ax)
 
@@ -36,12 +38,18 @@ class ProbeMapWidget(BaseWidget):
             recording = recording.channel_slice(channel_ids)
         self._recording = recording
         self._probegroup = recording.get_probegroup()
+        self.with_channel_ids = with_channel_ids
         self._plot_probe_kwargs = plot_probe_kwargs
 
     def plot(self):
         self._do_plot()
 
     def _do_plot(self):
+        text_on_contact = None
+        if self.with_channel_ids and len(self._probegroup.probes) == 1:
+            # text on contact work only for one probe
+            text_on_contact = self._recording.channel_ids
+        self._plot_probe_kwargs['text_on_contact'] = text_on_contact
         plot_probe_group(self._probegroup, ax=self.ax, same_axes=True, **self._plot_probe_kwargs)
 
 

--- a/spikeinterface/widgets/tests/test_widgets.py
+++ b/spikeinterface/widgets/tests/test_widgets.py
@@ -49,7 +49,9 @@ class TestWidgets(unittest.TestCase):
         sw.plot_rasters(self._sorting)
 
     def test_plot_probe_map(self):
+        
         sw.plot_probe_map(self._rec)
+        sw.plot_probe_map(self._rec, with_channel_ids=True)
 
     # TODO
     # def test_spectrum(self):
@@ -77,7 +79,7 @@ class TestWidgets(unittest.TestCase):
         sw.plot_unit_templates(self._we)
 
     def test_plot_unit_probe_map(self):
-        sw.plot_unit_probe_map(self._we)
+        sw.plot_unit_probe_map(self._we, with_channel_ids=True)
         sw.plot_unit_probe_map(self._we, animated=True)
 
     def test_plot_units_depth_vs_amplitude(self):
@@ -95,7 +97,7 @@ class TestWidgets(unittest.TestCase):
         sw.plot_principal_component(self._we)
 
     def test_plot_unit_localization(self):
-        sw.plot_unit_localization(self._we)
+        sw.plot_unit_localization(self._we, with_channel_ids=True)
         sw.plot_unit_localization(self._we, method='monopolar_triangulation')
 
     def test_autocorrelograms(self):
@@ -122,7 +124,7 @@ class TestWidgets(unittest.TestCase):
                                 scatter_plot_kwargs={'color': 'r'})
 
     def test_plot_peak_activity_map(self):
-        sw.plot_peak_activity_map(self._rec)
+        sw.plot_peak_activity_map(self._rec, with_channel_ids=True)
         sw.plot_peak_activity_map(self._rec, bin_duration_s=1.)
 
     def test_confusion(self):
@@ -156,7 +158,7 @@ if __name__ == '__main__':
 
     #~ mytest.test_timeseries()
     #~ mytest.test_rasters()
-    #~ mytest.test_plot_probe_map()
+    mytest.test_plot_probe_map()
     #~ mytest.test_unitwaveforms()
     #~ mytest.test_plot_unit_waveform_density_map()
     # mytest.test_unittemplates()
@@ -172,13 +174,13 @@ if __name__ == '__main__':
     #~ mytest.test_isi_distribution()
 
     #~ mytest.test_plot_drift_over_time()
-    #  mytest.test_plot_peak_activity_map()
+    #~ mytest.test_plot_peak_activity_map()
 
     # mytest.test_confusion()
     # mytest.test_agreement()
     #~ mytest.test_multicomp_graph()
     #  mytest.test_sorting_performance()
 
-    mytest.test_plot_unit_summary()
+    #~ mytest.test_plot_unit_summary()
 
     plt.show()

--- a/spikeinterface/widgets/unitlocalization.py
+++ b/spikeinterface/widgets/unitlocalization.py
@@ -29,6 +29,8 @@ class UnitLocalizationWidget(BaseWidget):
     unit_colors: None or dict
         A dict key is unit_id and value is any color format handled by matplotlib.
         If None, then the get_unit_colors() is internally used.
+    with_channel_ids: bool False default
+        add channel ids text on the probe        
     figure: matplotlib figure
         The figure to be used. If not given a figure is created
     ax: matplotlib axis
@@ -42,7 +44,7 @@ class UnitLocalizationWidget(BaseWidget):
 
     def __init__(self, waveform_extractor, unit_location=None,
                  method='center_of_mass', method_kwargs={},
-                 unit_colors=None,
+                 unit_colors=None, with_channel_ids=False,
                  figure=None, ax=None):
         BaseWidget.__init__(self, figure, ax)
 
@@ -54,6 +56,8 @@ class UnitLocalizationWidget(BaseWidget):
         if unit_colors is None:
             unit_colors = get_unit_colors(waveform_extractor.sorting)
         self.unit_colors = unit_colors
+        
+        self.with_channel_ids = with_channel_ids
 
     def plot(self):
         we = self.waveform_extractor
@@ -69,9 +73,15 @@ class UnitLocalizationWidget(BaseWidget):
         contacts_kargs = dict(alpha=1., edgecolor='k', lw=0.5)
         
         for probe in probegroup.probes:
+
+            text_on_contact = None
+            if self.with_channel_ids:
+                text_on_contact = self.waveform_extractor.recording.channel_ids
+            
             poly_contact, poly_contour = plot_probe(probe, ax=ax,
                                                     contacts_colors='w', contacts_kargs=contacts_kargs,
-                                                    probe_shape_kwargs=probe_shape_kwargs)
+                                                    probe_shape_kwargs=probe_shape_kwargs,
+                                                    text_on_contact=text_on_contact)
             poly_contact.set_zorder(2)
             if poly_contour is not None:
                 poly_contour.set_zorder(1)

--- a/spikeinterface/widgets/unitprobemap.py
+++ b/spikeinterface/widgets/unitprobemap.py
@@ -22,11 +22,12 @@ class UnitProbeMapWidget(BaseWidget):
         The channel ids to display
     animated: True/False
         animation for amplitude on time
-        
+    with_channel_ids: bool False default
+        add channel ids text on the probe
     """
 
     def __init__(self, waveform_extractor, unit_ids=None, channel_ids=None,
-                 animated=None, colorbar=True,
+                 animated=None, with_channel_ids=False, colorbar=True,
                  ncols=5,  axes=None):
 
         self.waveform_extractor = waveform_extractor
@@ -38,6 +39,7 @@ class UnitProbeMapWidget(BaseWidget):
         self.channel_ids = channel_ids
 
         self.animated = animated
+        self.with_channel_ids = with_channel_ids
         self.colorbar = colorbar
         
         probes = waveform_extractor.recording.get_probes()
@@ -68,8 +70,12 @@ class UnitProbeMapWidget(BaseWidget):
                 contacts_values = np.zeros(template.shape[1])
             else:
                 contacts_values = np.max(np.abs(template), axis=0)
+            text_on_contact = None
+            if self.with_channel_ids:
+                text_on_contact = self.channel_ids
             poly_contact, poly_contour = plot_probe(probe, contacts_values=contacts_values,
-                                                    ax=ax, probe_shape_kwargs=probe_shape_kwargs)
+                                                    ax=ax, probe_shape_kwargs=probe_shape_kwargs,
+                                                    text_on_contact=text_on_contact)
 
             poly_contact.set_zorder(2)
             if poly_contour is not None:


### PR DESCRIPTION
plot_probe can plott the contact_id and also the device_channel_index but it is sometimes more convinient to plot the also the channel_ids. 
Here a PR for this

This depend on https://github.com/SpikeInterface/probeinterface/pull/93

Plot channel_ids on the probe for:
  * PeakActivityMapWidget