### PR TITLE
Add split recording class and function

### DIFF
--- a/spikeinterface/comparison/basecomparison.py
+++ b/spikeinterface/comparison/basecomparison.py
@@ -175,8 +175,8 @@ class BaseMultiComparison(BaseComparison):
         self._new_units = {}
 
         # save new units
-        self.subgraphs = (self.clean_graph.subgraph(c).copy()
-                          for c in nx.connected_components(self.clean_graph))
+        self.subgraphs = [self.clean_graph.subgraph(c).copy()
+                          for c in nx.connected_components(self.clean_graph)]
         for new_unit, sg in enumerate(self.subgraphs):
             edges = list(sg.edges(data=True))
             if len(edges) > 0:

--- a/spikeinterface/core/__init__.py
+++ b/spikeinterface/core/__init__.py
@@ -32,7 +32,7 @@ from .unitsaggregationsorting import UnitsAggregationSorting, aggregate_units
 from .segmentutils import (
     append_recordings, AppendSegmentRecording,
     concatenate_recordings, ConcatenateSegmentRecording,
-    split_recording, SplitSegmentRecording,
+    split_recording, select_segment_recording, SelectSegmentRecording,
     append_sortings, AppendSegmentSorting, 
     split_sorting, SplitSegmentSorting)
 

--- a/spikeinterface/core/__init__.py
+++ b/spikeinterface/core/__init__.py
@@ -32,6 +32,7 @@ from .unitsaggregationsorting import UnitsAggregationSorting, aggregate_units
 from .segmentutils import (
     append_recordings, AppendSegmentRecording,
     concatenate_recordings, ConcatenateSegmentRecording,
+    split_recording, SplitSegmentRecording,
     append_sortings, AppendSegmentSorting, 
     split_sorting, SplitSegmentSorting)
 

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -165,7 +165,7 @@ class BaseRecording(BaseExtractor):
                           'times are not always propagated to across preprocessing'
                           'Use use this carefully!')
 
-    _job_keys = ['n_jobs', 'total_memory', 'chunk_size', 'chunk_memory', 'progress_bar', 'verbose']
+    _job_keys = ['n_jobs', 'total_memory', 'chunk_size', 'chunk_memory', 'chunk_duration', 'progress_bar', 'verbose']
 
     def _save(self, format='binary', **save_kwargs):
         """

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -621,6 +621,23 @@ class BaseRecording(BaseExtractor):
             elif outputs == 'dict':
                 recordings[value] = subrec
         return recordings
+    
+    def select_segments(self, segment_indices):
+        """
+        Return a recording with the segments specified by 'segment_indices'
+
+        Parameters
+        ----------
+        segment_indices : list of int
+            List of segment indices to keep in the returned recording
+
+        Returns
+        -------
+        SelectSegmentRecording
+            The recording with the selected segments
+        """
+        from .segmentutils import SelectSegmentRecording
+        return SelectSegmentRecording(self, segment_indices=segment_indices)
 
     def planarize(self, axes: str = "xy"):
         """

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -8,6 +8,7 @@ from probeinterface import Probe, ProbeGroup, write_probeinterface, read_probein
 
 from .base import BaseExtractor, BaseSegment
 from .core_tools import write_binary_recording, write_memory_recording, write_traces_to_zarr, check_json
+from .job_tools import job_keys
 
 from warnings import warn
 
@@ -165,8 +166,6 @@ class BaseRecording(BaseExtractor):
                           'times are not always propagated to across preprocessing'
                           'Use use this carefully!')
 
-    _job_keys = ['n_jobs', 'total_memory', 'chunk_size', 'chunk_memory', 'chunk_duration', 'progress_bar', 'verbose']
-
     def _save(self, format='binary', **save_kwargs):
         """
         This function replaces the old CacheRecordingExtractor, but enables more engines
@@ -193,7 +192,7 @@ class BaseRecording(BaseExtractor):
             if dtype is None:
                 dtype = self.get_dtype()
 
-            job_kwargs = {k: save_kwargs[k] for k in self._job_keys if k in save_kwargs}
+            job_kwargs = {k: save_kwargs[k] for k in job_keys if k in save_kwargs}
             write_binary_recording(self, file_paths=file_paths, dtype=dtype, **job_kwargs)
 
             from .binaryrecordingextractor import BinaryRecordingExtractor
@@ -204,7 +203,7 @@ class BaseRecording(BaseExtractor):
                                               offset_to_uV=self.get_channel_offsets())
 
         elif format == 'memory':
-            job_kwargs = {k: save_kwargs[k] for k in self._job_keys if k in save_kwargs}
+            job_kwargs = {k: save_kwargs[k] for k in job_keys if k in save_kwargs}
             traces_list = write_memory_recording(self, dtype=None, **job_kwargs)
             from .numpyextractors import NumpyRecording
 
@@ -228,7 +227,7 @@ class BaseRecording(BaseExtractor):
             filters = save_kwargs.get('filters', None)
 
             job_kwargs = {k: save_kwargs[k]
-                          for k in self._job_keys if k in save_kwargs}
+                          for k in job_keys if k in save_kwargs}
             write_traces_to_zarr(self, zarr_root=zarr_root, zarr_path=zarr_path, dataset_paths=dataset_paths,
                                  dtype=dtype, compressor=compressor, filters=filters, **job_kwargs)
 

--- a/spikeinterface/core/job_tools.py
+++ b/spikeinterface/core/job_tools.py
@@ -27,6 +27,9 @@ _shared_job_kwargs_doc = \
             * progress_bar: bool
                 If True, a progress bar is printed
     """
+    
+job_keys = ['n_jobs', 'total_memory', 'chunk_size', 'chunk_memory', 'chunk_duration', 'progress_bar', 'verbose']
+
 
 
 def divide_segment_into_chunks(num_frames, chunk_size):

--- a/spikeinterface/core/segmentutils.py
+++ b/spikeinterface/core/segmentutils.py
@@ -20,7 +20,8 @@ def _check_sampling_frequencies(sampling_frequency_list, sampling_frequency_max_
     freq_0 = sampling_frequency_list[0]
     max_diff = max( abs(freq - freq_0) for freq in sampling_frequency_list)
     if max_diff > sampling_frequency_max_diff:
-        raise ValueError(f"Sampling frequencies across datasets differ by `{max_diff}`Hz which is more than `sampling_frequency_max_diff`={sampling_frequency_max_diff}Hz")
+        raise ValueError(f"Sampling frequencies across datasets differ by `{max_diff}`Hz which is more than "
+                         f"`sampling_frequency_max_diff`={sampling_frequency_max_diff}Hz")
     elif max_diff > 0:
         diff_sec = 24 * 3600 * max_diff / freq_0 
         import warnings
@@ -139,7 +140,8 @@ class ConcatenateSegmentRecording(BaseRecording):
                     assert d['t_start'] is None, ("ConcatenateSegmentRecording does not handle t_start. "
                                                   "Use ignore_times=True to ignore time information.")
                 parent_segments.append(parent_segment)
-        rec_seg = ProxyConcatenateRecordingSegment(parent_segments, one_rec.get_sampling_frequency(), ignore_times=ignore_times)
+        rec_seg = ProxyConcatenateRecordingSegment(parent_segments, one_rec.get_sampling_frequency(), 
+                                                   ignore_times=ignore_times)
         self.add_recording_segment(rec_seg)
 
         self._kwargs = {'recording_list': [rec.to_dict() for rec in recording_list],
@@ -217,7 +219,7 @@ def concatenate_recordings(*args, **kwargs):
 concatenate_recordings.__doc__ == ConcatenateSegmentRecording.__doc__
 
 
-class SplitSegmentRecording(BaseRecording):
+class SelectSegmentRecording(BaseRecording):
     """
     Return a new recording with a single segment from a multi-segment recording.
 
@@ -260,9 +262,16 @@ def split_recording(recording: BaseRecording):
     """
     recording_list = []
     for segment_index in range(recording.get_num_segments()):
-        rec_mono = SplitSegmentRecording(recording=recording, segment_index=segment_index)
+        rec_mono = SelectSegmentRecording(recording=recording, segment_index=segment_index)
         recording_list.append(rec_mono)
     return recording_list
+
+
+def select_segment_recording(*args, **kwargs):
+    return SelectSegmentRecording(*args, **kwargs)
+
+
+select_segment_recording.__doc__ = SelectSegmentRecording.__doc__
 
 
 class AppendSegmentSorting(BaseSorting):

--- a/spikeinterface/core/segmentutils.py
+++ b/spikeinterface/core/segmentutils.py
@@ -14,6 +14,8 @@ import numpy as np
 from .baserecording import BaseRecording, BaseRecordingSegment
 from .basesorting import BaseSorting, BaseSortingSegment
 
+from typing import List
+
 
 def _check_sampling_frequencies(sampling_frequency_list, sampling_frequency_max_diff):
     assert sampling_frequency_max_diff >= 0
@@ -227,23 +229,24 @@ class SelectSegmentRecording(BaseRecording):
     ----------
     recording : BaseRecording
         The multi-segment recording
-    segment_index : int
-        The segment index to select
+    segment_indices : list of int
+        The segment indices to select
     """
 
-    def __init__(self, recording: BaseRecording, segment_index: int):
+    def __init__(self, recording: BaseRecording, segment_indices: List[int]):
         BaseRecording.__init__(self, recording.get_sampling_frequency(), 
                                recording.channel_ids, recording.get_dtype())
         recording.copy_metadata(self)
         
         num_segments = recording.get_num_segments()
-        assert segment_index < num_segments, f"'segment_index' must be between 0 and {num_segments - 1}"
+        assert len(segment_indices) < num_segments, f"'segment_index' must be between 0 and {num_segments - 1}"
 
-        rec_seg = recording._recording_segments[segment_index]
-        self.add_recording_segment(rec_seg)
+        for segment_index in segment_indices:
+            rec_seg = recording._recording_segments[segment_index]
+            self.add_recording_segment(rec_seg)
 
         self._kwargs = {'recording': recording.to_dict(),
-                        'segment_index': segment_index}
+                        'segment_indices': segment_indices}
         
 
 def split_recording(recording: BaseRecording):
@@ -262,7 +265,8 @@ def split_recording(recording: BaseRecording):
     """
     recording_list = []
     for segment_index in range(recording.get_num_segments()):
-        rec_mono = SelectSegmentRecording(recording=recording, segment_index=segment_index)
+        rec_mono = SelectSegmentRecording(
+            recording=recording, segment_indices=[segment_index])
         recording_list.append(rec_mono)
     return recording_list
 

--- a/spikeinterface/core/tests/test_segmentutils.py
+++ b/spikeinterface/core/tests/test_segmentutils.py
@@ -4,7 +4,8 @@ import numpy as np
 from spikeinterface.core import (
     append_recordings, AppendSegmentRecording,
     concatenate_recordings, ConcatenateSegmentRecording,
-    append_sortings, AppendSegmentSorting)
+    append_sortings, AppendSegmentSorting,
+    split_recording, split_sorting)
 
 from spikeinterface.core import NumpyRecording, NumpySorting
 
@@ -52,6 +53,19 @@ def test_append_concatenate_recordings():
     assert traces.shape == (4450, 5)
     assert traces[0, 0] == 50
     assert traces[-1, 0] == 499
+
+
+def test_split_recordings():
+    traces = np.zeros((1000, 5), dtype='float64')
+    traces[:] = np.arange(1000)[:, None]
+    sampling_frequency = 30000
+    rec0 = NumpyRecording([traces] * 3, sampling_frequency)
+    
+    rec_list = split_recording(rec0)
+    
+    for i, rec in enumerate(rec_list):
+        assert rec.get_num_segments() == 1
+        assert np.allclose(rec.get_traces(), rec0.get_traces(segment_index=i))
 
 
 def test_append_sortings():

--- a/spikeinterface/core/tests/test_segmentutils.py
+++ b/spikeinterface/core/tests/test_segmentutils.py
@@ -5,7 +5,7 @@ from spikeinterface.core import (
     append_recordings, AppendSegmentRecording,
     concatenate_recordings, ConcatenateSegmentRecording,
     append_sortings, AppendSegmentSorting,
-    split_recording, split_sorting)
+    split_recording, select_segment_recording, split_sorting)
 
 from spikeinterface.core import NumpyRecording, NumpySorting
 
@@ -62,10 +62,14 @@ def test_split_recordings():
     rec0 = NumpyRecording([traces] * 3, sampling_frequency)
     
     rec_list = split_recording(rec0)
+    rec1 = select_segment_recording(rec0, segment_index=1)
     
     for i, rec in enumerate(rec_list):
         assert rec.get_num_segments() == 1
         assert np.allclose(rec.get_traces(), rec0.get_traces(segment_index=i))
+        
+    assert rec1.get_num_segments() == 1
+    assert np.allclose(rec1.get_traces(), rec0.get_traces(segment_index=1))
 
 
 def test_append_sortings():

--- a/spikeinterface/core/tests/test_segmentutils.py
+++ b/spikeinterface/core/tests/test_segmentutils.py
@@ -62,14 +62,18 @@ def test_split_recordings():
     rec0 = NumpyRecording([traces] * 3, sampling_frequency)
     
     rec_list = split_recording(rec0)
-    rec1 = select_segment_recording(rec0, segment_index=1)
-    
+    rec1 = select_segment_recording(rec0, segment_indices=[1])
+    rec2 = rec0.select_segments(segment_indices=[1, 2])
+
     for i, rec in enumerate(rec_list):
         assert rec.get_num_segments() == 1
         assert np.allclose(rec.get_traces(), rec0.get_traces(segment_index=i))
         
     assert rec1.get_num_segments() == 1
     assert np.allclose(rec1.get_traces(), rec0.get_traces(segment_index=1))
+    
+    assert np.allclose(rec2.get_traces(segment_index=0), rec0.get_traces(segment_index=1))
+    assert np.allclose(rec2.get_traces(segment_index=1), rec0.get_traces(segment_index=2))
 
 
 def test_append_sortings():

--- a/spikeinterface/core/tests/test_segmentutils.py
+++ b/spikeinterface/core/tests/test_segmentutils.py
@@ -64,6 +64,7 @@ def test_split_recordings():
     rec_list = split_recording(rec0)
     rec1 = select_segment_recording(rec0, segment_indices=[1])
     rec2 = rec0.select_segments(segment_indices=[1, 2])
+    rec3 = select_segment_recording(rec0, segment_indices=2)
 
     for i, rec in enumerate(rec_list):
         assert rec.get_num_segments() == 1
@@ -74,6 +75,7 @@ def test_split_recordings():
     
     assert np.allclose(rec2.get_traces(segment_index=0), rec0.get_traces(segment_index=1))
     assert np.allclose(rec2.get_traces(segment_index=1), rec0.get_traces(segment_index=2))
+    assert np.allclose(rec3.get_traces(), rec0.get_traces(segment_index=2))
 
 
 def test_append_sortings():

--- a/spikeinterface/toolkit/postprocessing/template_metrics.py
+++ b/spikeinterface/toolkit/postprocessing/template_metrics.py
@@ -78,7 +78,7 @@ def calculate_template_metrics(waveform_extractor, feature_names=None, peak_sign
                                                               outputs='id')
 
         template_metrics = pd.DataFrame(
-            index=unit_ids, columns=[feature_names])
+            index=unit_ids, columns=feature_names)
     else:
         extremum_channels_ids = get_template_channel_sparsity(
             waveform_extractor, **sparsity_dict)


### PR DESCRIPTION
New functions to split multi-segment recordings into a list of mono-segments:

- Return a list of mono-segment recordings
`recording_list = si.split_recording(rec_multi)`

- Return a single mono segment recording
`recording_mono = si.select_segment_recording(rec_multi, segment_index=1)`