### PR TITLE
Fix Nwb 3d locs, scale preproc, and **plot_kwargs

### DIFF
--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -489,8 +489,12 @@ class BaseRecording(BaseExtractor):
             If ndim is 3, indicates the axes that define the plane of the electrodes, by default "xy"
         """
         ndim = locations.shape[1]
-        probe = Probe(ndim=ndim)
-        probe.set_contacts(locations, shapes=shape, shape_params=shape_params)
+        probe = Probe(ndim=2)
+        if ndim == 3:
+            locations_2d = select_axes(locations, axes)
+        else:
+            locations_2d = locations
+        probe.set_contacts(locations_2d, shapes=shape, shape_params=shape_params)
         probe.set_device_channel_indices(np.arange(self.get_num_channels()))
 
         if ndim == 3:

--- a/spikeinterface/toolkit/preprocessing/normalize_scale.py
+++ b/spikeinterface/toolkit/preprocessing/normalize_scale.py
@@ -75,13 +75,10 @@ class NormalizeByQuantileRecording(BasePreprocessor):
             gain = gain[None, :]
             offset = offset[None, :]
 
-        gain = gain.astype(recording.get_dtype())
-        offset = offset.astype(recording.get_dtype())
-
         BasePreprocessor.__init__(self, recording)
 
         for parent_segment in recording._recording_segments:
-            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset)
+            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset, dtype=recording.get_dtype())
             self.add_recording_segment(rec_segment)
 
         self._kwargs = dict(recording=recording.to_dict(), scale=scale, median=median,
@@ -158,14 +155,12 @@ class CenterRecording(BasePreprocessor):
         elif mode == 'median':
             offset = -np.median(random_data, axis=0)
         offset = offset[None, :]
-        offset = offset.astype(recording.get_dtype())
-
-        gain = np.ones(offset.shape, dtype=offset.dtype)
+        gain = np.ones(offset.shape)
 
         BasePreprocessor.__init__(self, recording)
 
         for parent_segment in recording._recording_segments:
-            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset)
+            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset, dtype=recording.get_dtype())
             self.add_recording_segment(rec_segment)
 
         self._kwargs = dict(recording=recording.to_dict(), mode=mode,

--- a/spikeinterface/toolkit/preprocessing/normalize_scale.py
+++ b/spikeinterface/toolkit/preprocessing/normalize_scale.py
@@ -11,12 +11,12 @@ class ScaleRecordingSegment(BasePreprocessorSegment):
         BasePreprocessorSegment.__init__(self, parent_recording_segment)
         self.gain = gain
         self.offset = offset
-        self.dtype = dtype
+        self._dtype = dtype
 
     def get_traces(self, start_frame, end_frame, channel_indices):
         traces = self.parent_recording_segment.get_traces(start_frame, end_frame, channel_indices)
         scaled_traces = traces * self.gain[:, channel_indices] + self.offset[:, channel_indices]
-        return scaled_traces.astype(self.dtype)
+        return scaled_traces.astype(self._dtype)
 
 
 class NormalizeByQuantileRecording(BasePreprocessor):
@@ -82,11 +82,11 @@ class NormalizeByQuantileRecording(BasePreprocessor):
         BasePreprocessor.__init__(self, recording, dtype=dtype)
 
         for parent_segment in recording._recording_segments:
-            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset, dtype=self.dtype)
+            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset, dtype=self._dtype)
             self.add_recording_segment(rec_segment)
 
         self._kwargs = dict(recording=recording.to_dict(), scale=scale, median=median,
-                            q1=q1, q2=q2, mode=mode, dtype=np.dtype(self.dtype).str)
+                            q1=q1, q2=q2, mode=mode, dtype=np.dtype(self._dtype).str)
         self._kwargs.update(random_chunk_kwargs)
 
 
@@ -140,11 +140,11 @@ class ScaleRecording(BasePreprocessor):
         BasePreprocessor.__init__(self, recording, dtype=dtype)
 
         for parent_segment in recording._recording_segments:
-            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset, self.dtype)
+            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset, self._dtype)
             self.add_recording_segment(rec_segment)
 
         self._kwargs = dict(recording=recording.to_dict(), gain=gain, 
-                            offset=offset, dtype=np.dtype(self.dtype).str)
+                            offset=offset, dtype=np.dtype(self._dtype).str)
 
 
 class CenterRecording(BasePreprocessor):
@@ -184,10 +184,10 @@ class CenterRecording(BasePreprocessor):
         BasePreprocessor.__init__(self, recording, dtype=dtype)
 
         for parent_segment in recording._recording_segments:
-            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset, dtype=self.dtype)
+            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset, dtype=self._dtype)
             self.add_recording_segment(rec_segment)
 
-        self._kwargs = dict(recording=recording.to_dict(), mode=mode)
+        self._kwargs = dict(recording=recording.to_dict(), mode=mode, dtype=np.dtype(self._dtype).str)
         self._kwargs.update(random_chunk_kwargs)
 
 

--- a/spikeinterface/widgets/timeseries.py
+++ b/spikeinterface/widgets/timeseries.py
@@ -47,14 +47,13 @@ class TimeseriesWidget(BaseWidget):
     """
 
     def __init__(self, recording, segment_index=None, channel_ids=None, order_channel_by_depth=False,
-                 time_range=None,
-                 mode='auto', cmap='RdBu', show_channel_ids=False,
-                 color_groups=False, color=None,
-                 figure=None, ax=None):
+                 time_range=None, mode='auto', cmap='RdBu', show_channel_ids=False,
+                 color_groups=False, color=None, figure=None, ax=None, **plot_kwargs):
         BaseWidget.__init__(self, figure, ax)
         self.recording = recording
         self._sampling_frequency = recording.get_sampling_frequency()
         self.visible_channel_ids = channel_ids
+        self._plot_kwargs = plot_kwargs
 
         if segment_index is None:
             nseg = recording.get_num_segments()
@@ -165,7 +164,7 @@ class TimeseriesWidget(BaseWidget):
                     color = self._colors[group_color_idx]
                 else:
                     color = self._color
-                self._plots[m] = ax.plot(times, self._plot_offsets[m] + chunk0[:, im], color=color)
+                self._plots[m] = ax.plot(times, self._plot_offsets[m] + chunk0[:, im], color=color, **self._plot_kwargs)
                 offset0 = offset0 - self._vspacing
 
             if self.show_channel_ids:


### PR DESCRIPTION
Fixes:
- https://github.com/SpikeInterface/probeinterface/issues/101 for loading NWBfiles with 3d location
- `scale` preprocessing would set gains to 0 if gain < 1and dtype = int16 --> moved casting to segment
- Added `**plot_kwargs` to `lot_timeseries`