### PR TITLE
Handle computing of nearest neighbor metrics for units with few spikes

### DIFF
--- a/spikeinterface/toolkit/qualitymetrics/pca_metrics.py
+++ b/spikeinterface/toolkit/qualitymetrics/pca_metrics.py
@@ -347,7 +347,9 @@ def nearest_neighbors_isolation(waveform_extractor: si.WaveformExtractor, this_u
     
     # if target unit has fewer than `min_spikes_for_nn` spikes, print out a warning and return NaN
     if n_spikes_all_units[all_units_ids==this_unit_id] < min_spikes_for_nn:
-        print(f'Warning: unit {this_unit_id} has too few spikes; returning NaN as the quality metric...')
+        print(f'Warning: unit {this_unit_id} has fewer spikes than ',
+              f'specified by `min_spikes_for_nn` ({min_spikes_for_nn}); ',
+              'returning NaN as the quality metric...')
         return np.NaN
     else:
         # first remove the units with too few spikes
@@ -469,7 +471,9 @@ def nearest_neighbors_noise_overlap(waveform_extractor: si.WaveformExtractor,
     
     # if target unit has fewer than `min_spikes_for_nn` spikes, print out a warning and return NaN
     if n_spikes_all_units[all_units_ids==this_unit_id] < min_spikes_for_nn:
-        print(f'Warning: unit {this_unit_id} has too few spikes; returning NaN as the quality metric...')
+        print(f'Warning: unit {this_unit_id} has fewer spikes than ',
+              f'specified by `min_spikes_for_nn` ({min_spikes_for_nn}); ',
+              'returning NaN as the quality metric...')
         return np.NaN
     else:
         # get random snippets from the recording to create a noise cluster
@@ -542,7 +546,7 @@ def _subtract_clip_component(clip1, component):
     return V1.reshape(clip1.shape)
 
 
-def _compute_isolation(pcs_target_unit, pcs_other_unit, n_neighbors:int):
+def _compute_isolation(pcs_target_unit, pcs_other_unit, n_neighbors: int):
     """Computes the isolation score used for nn_isolation and nn_noise_overlap
 
     Parameters

--- a/spikeinterface/toolkit/qualitymetrics/pca_metrics.py
+++ b/spikeinterface/toolkit/qualitymetrics/pca_metrics.py
@@ -19,7 +19,8 @@ _possible_pc_metric_names = ['isolation_distance', 'l_ratio', 'd_prime',
 
 
 def calculate_pc_metrics(pca, metric_names=None, max_spikes_for_nn=10000,
-                         n_neighbors=4, n_components=10, radius_um=100, seed=0):
+                         min_spikes_for_nn=10, n_neighbors=4, n_components=10,
+                         radius_um=100, seed=0):
     """Calculate principal component derived metrics.
 
     Parameters
@@ -32,6 +33,9 @@ def calculate_pc_metrics(pca, metric_names=None, max_spikes_for_nn=10000,
     max_spikes_for_nn : int, optional, default: 10000
         The maximum number of spikes to use per cluster.
         This is used for the nearest neighbors isolation and noise overlap measures.
+    min_spikes_for_nn : int, optional, default: 10
+        The minimum number of spikes each cluster must have for metric computation.
+        If less than this value, numpy.NaN is returned as the metric.
     n_neighbors : int, optional, default: 4
         The number of neighbors to use.
         This is used for the nearest neighbors isolation and noise overlap measures.
@@ -103,14 +107,14 @@ def calculate_pc_metrics(pca, metric_names=None, max_spikes_for_nn=10000,
 
         if 'nn_isolation' in metric_names:
             nn_isolation = nearest_neighbors_isolation(we, unit_id, max_spikes_for_nn,
-                                                       n_neighbors, n_components,
-                                                       radius_um, seed)
+                                                       min_spikes_for_nn, n_neighbors,
+                                                       n_components,radius_um, seed)
             pc_metrics['nn_isolation'][unit_id] = nn_isolation
 
         if 'nn_noise_overlap' in metric_names:
             nn_noise_overlap = nearest_neighbors_noise_overlap(we, unit_id, max_spikes_for_nn,
-                                                               n_neighbors, n_components,
-                                                               radius_um, seed)
+                                                               min_spikes_for_nn, n_neighbors,
+                                                               n_components, radius_um, seed)
             pc_metrics['nn_noise_overlap'][unit_id] = nn_noise_overlap
 
     return pc_metrics

--- a/spikeinterface/toolkit/qualitymetrics/tests/test_quality_metric_calculator.py
+++ b/spikeinterface/toolkit/qualitymetrics/tests/test_quality_metric_calculator.py
@@ -86,9 +86,9 @@ def test_compute_quality_metrics_peak_sign():
     metrics_inv = compute_quality_metrics(
         we_inv, metric_names=['snr', 'amplitude_cutoff'], peak_sign="pos")
 
-    assert np.allclose(metrics["snr"].values, metrics_inv["snr"].values)
+    assert np.allclose(metrics["snr"].values, metrics_inv["snr"].values, atol=1e-4)
     assert np.allclose(metrics["amplitude_cutoff"].values,
-                       metrics_inv["amplitude_cutoff"].values)
+                       metrics_inv["amplitude_cutoff"].values, atol=1e-4)
 
 
 def test_select_units():


### PR DESCRIPTION
* Add a new parameter to `nearest_neighbors_isolation` and `nearest_neighbors_noise_overlap` functions called `min_spikes_for_nn`
* Units with fewer spikes than `min_spikes_for_nn` (small clusters) are given `np.NaN` as the metric and a warning is printed
* `min_spikes_for_nn` is set to 10 by default
* Metrics are computed for units with more spikes than `min_spikes_for_nn` but after first excluding the small clusters (since nearest neighbor metrics do pairwise comparison across all clusters)