### PR TITLE
Handle artifact removal in which padding around the triggers is zero

### DIFF
--- a/spikeinterface/toolkit/preprocessing/remove_artifacts.py
+++ b/spikeinterface/toolkit/preprocessing/remove_artifacts.py
@@ -18,10 +18,12 @@ class RemoveArtifactsRecording(BasePreprocessor):
         The recording extractor to remove artifacts from
     list_triggers: list of list
         One list per segment of int with the stimulation trigger frames
-    ms_before: float
-        Time interval in ms to remove before the trigger events
-    ms_after: float
-        Time interval in ms to remove after the trigger events
+    ms_before: float or None
+        Time interval in ms to remove before the trigger events. 
+        If None, then also ms_after must be None and a single sample is removed
+    ms_after: float or None
+        Time interval in ms to remove after the trigger events.
+        If None, then also ms_before must be None and a single sample is removed
     mode: str
         Determines what artifacts are replaced by. Can be one of the following:
             
@@ -69,9 +71,17 @@ class RemoveArtifactsRecording(BasePreprocessor):
         assert len(list_triggers) == num_seg
         assert all(isinstance(list_triggers[i], list) for i in range(num_seg))
         assert mode in ('zeros', 'linear', 'cubic')
-
+        if ms_before is None:
+            assert ms_after is None, "To remove a single sample, set both ms_before and ms_after to None"
+        else:
+            ms_before = float(ms_before)
+            ms_after = float(ms_after)
+        
         sf = recording.get_sampling_frequency()
-        pad = [int(ms_before * sf / 1000), int(ms_after * sf / 1000)]
+        if ms_before is not None:
+            pad = [int(ms_before * sf / 1000), int(ms_after * sf / 1000)]
+        else:
+            pad = None
 
         fit_sample_interval = int(fit_sample_spacing * sf / 1000.)
         fit_sample_range = fit_sample_interval * 2 + 1
@@ -85,7 +95,7 @@ class RemoveArtifactsRecording(BasePreprocessor):
 
         list_triggers_int = [[int(trig) for trig in trig_seg] for trig_seg in list_triggers]
         self._kwargs = dict(recording=recording.to_dict(), list_triggers=list_triggers_int,
-                            ms_before=float(ms_before), ms_after=float(ms_after), mode=mode,
+                            ms_before=ms_before, ms_after=ms_after, mode=mode,
                             fit_sample_spacing=fit_sample_spacing)
 
 
@@ -107,24 +117,31 @@ class RemoveArtifactsRecordingSegment(BasePreprocessorSegment):
         if end_frame is None:
             end_frame = self.get_num_samples()
 
-        triggers = self.triggers[(self.triggers > start_frame) & (self.triggers < end_frame)] - start_frame
+        triggers = self.triggers[(self.triggers >= start_frame) & (self.triggers < end_frame)] - start_frame
 
         pad = self.pad
 
         if self.mode == 'zeros':
             for trig in triggers:
-                if trig - pad[0] > 0 and trig + pad[1] < end_frame - start_frame:
-                    traces[trig - pad[0]:trig + pad[1] + 1, :] = 0
-                elif trig - pad[0] <= 0 and trig + pad[1] >= end_frame - start_frame:
-                    traces[:] = 0
-                elif trig - pad[0] <= 0:
-                    traces[:trig + pad[1], :] = 0
-                elif trig + pad[1] >= end_frame - start_frame:
-                    traces[trig - pad[0]:, :] = 0
+                if pad is None:
+                    traces[trig, :] = 0
+                else:
+                    if trig - pad[0] > 0 and trig + pad[1] < end_frame - start_frame:
+                        traces[trig - pad[0]:trig + pad[1] + 1, :] = 0
+                    elif trig - pad[0] <= 0 and trig + pad[1] >= end_frame - start_frame:
+                        traces[:] = 0
+                    elif trig - pad[0] <= 0:
+                        traces[:trig + pad[1], :] = 0
+                    elif trig + pad[1] >= end_frame - start_frame:
+                        traces[trig - pad[0]:, :] = 0
         else:
             for trig in triggers:
-                pre_data_end_idx = trig - pad[0] - 1
-                post_data_start_idx = trig + pad[1] + 1
+                if pad is None:
+                    pre_data_end_idx = trig - 1
+                    post_data_start_idx = trig + 1
+                else:
+                    pre_data_end_idx = trig - pad[0] - 1
+                    post_data_start_idx = trig + pad[1] + 1
 
                 # Generate fit points from the sample points determined
                 #  pre_idx = pre_data_end_idx - self.rev_fit_samples + 1

--- a/spikeinterface/toolkit/preprocessing/remove_artifacts.py
+++ b/spikeinterface/toolkit/preprocessing/remove_artifacts.py
@@ -114,7 +114,7 @@ class RemoveArtifactsRecordingSegment(BasePreprocessorSegment):
         if self.mode == 'zeros':
             for trig in triggers:
                 if trig - pad[0] > 0 and trig + pad[1] < end_frame - start_frame:
-                    traces[trig - pad[0]:trig + pad[1], :] = 0
+                    traces[trig - pad[0]:trig + pad[1] + 1, :] = 0
                 elif trig - pad[0] <= 0 and trig + pad[1] >= end_frame - start_frame:
                     traces[:] = 0
                 elif trig - pad[0] <= 0:

--- a/spikeinterface/toolkit/preprocessing/tests/test_remove_artifacts.py
+++ b/spikeinterface/toolkit/preprocessing/tests/test_remove_artifacts.py
@@ -40,6 +40,17 @@ def test_remove_artifacts():
 
     assert not np.allclose(traces_all_0, traces_all_0_clean)
     assert not np.allclose(traces_all_1, traces_all_1_clean)
+    
+    # test removing single samples
+    rec_rmart_0= remove_artifacts(rec, triggers, ms_before=None, ms_after=None)
+    traces_first_0 = rec_rmart_0.get_traces(start_frame=triggers[0], end_frame=triggers[0] + 1).squeeze()
+    traces_second_0 = rec_rmart_0.get_traces(start_frame=triggers[0], end_frame=triggers[0] + 1).squeeze()
+    assert np.allclose(traces_first_0, np.zeros(rec.get_num_channels()))
+    assert np.allclose(traces_second_0, np.zeros(rec.get_num_channels()))
+
+    rec_rmart_lin = remove_artifacts(rec, triggers, ms_before=None, ms_after=None, mode="linear")
+    rec_rmart_cub = remove_artifacts(rec, triggers, ms_before=None, ms_after=None, mode="cubic")
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@alejoe91

### Issue
We use `RemoveArtifactsRecording` to remove large transients in our recording prior to sorting. To do so, we identify the times in which these artifacts occur by applying a threshold and setting them to zero using `zeros` mode. Because we want only these times to zeroed out, we set the `ms_before` and `ms_after` parameters to zero. But if we do that, `RemoveArtifactsRecording` doesn't do anything because line 117 of `remove_artifacts.py` becomes `traces[trig:trig,  :] = 0`, which doesn't slice anything.

### Changes
I added `+1` to line 117. I think this is the behavior a user would expect.