### PR TITLE
Fixes Multicomparison clean_graph and half-width

### DIFF
--- a/spikeinterface/comparison/basecomparison.py
+++ b/spikeinterface/comparison/basecomparison.py
@@ -147,22 +147,31 @@ class BaseMultiComparison(BaseComparison):
                         for e in edges:
                             edges_duplicates.append(e)
                             weights_duplicates.append(e[2]['weight'])
-                    # remove edges
-                    edges_to_remove = len(nodes_duplicate) - 1
-                    remove_idxs = np.argsort(weights_duplicates)[
-                        :edges_to_remove]
-                    for idx in remove_idxs:
-                        if self._verbose:
-                            print('Removed edge', edges_duplicates[idx])
+
+                    # remove extra edges
+                    n_edges_to_remove = len(nodes_duplicate) - 1
+                    remove_idxs = np.argsort(weights_duplicates)[:n_edges_to_remove]
+                    edges_to_remove = np.array(edges_duplicates, dtype=object)[remove_idxs]
+
+                    for edge_to_remove in edges_to_remove:
                         clean_graph.remove_edge(
-                            edges_duplicates[idx][0], edges_duplicates[idx][1])
+                            edge_to_remove[0], edge_to_remove[1])
                         sg.remove_edge(
-                            edges_duplicates[idx][0], edges_duplicates[idx][1])
-                        if edges_duplicates[idx][0] in nodes_duplicate:
-                            sg.remove_node(edges_duplicates[idx][0])
+                            edge_to_remove[0], edge_to_remove[1])
+                        if self._verbose:
+                            print(f"Removed edge: {edge_to_remove}")
+
+                    # remove extra nodes (as a second step to not affect edge removal)
+                    for edge_to_remove in edges_to_remove:
+                        if edge_to_remove[0] in nodes_duplicate:
+                            node_to_remove = edge_to_remove[0]
                         else:
-                            sg.remove_node(edges_duplicates[idx][1])
-                        removed_nodes += 1
+                            node_to_removed = edge_to_remove[1]
+                        if node_to_remove in sg.nodes:
+                            sg.remove_node(node_to_remove)
+                            print(f"Removed node: {node_to_remove}")
+                            removed_nodes += 1
+
         if self._verbose:
             print(f'Removed {removed_nodes} duplicate nodes')
         self.clean_graph = clean_graph

--- a/spikeinterface/extractors/extractorlist.py
+++ b/spikeinterface/extractors/extractorlist.py
@@ -29,6 +29,7 @@ from .nwbextractors import (NwbRecordingExtractor, NwbSortingExtractor,
                             read_nwb, read_nwb_recording, read_nwb_sorting)
                             
 from .cbin_ibl import CompressedBinaryIblExtractor, read_cbin_ibl
+from .mcsh5extractors import MCSH5RecordingExtractor, read_mcsh5
 
 # sorting extractors in relation with a sorter
 from .klustaextractors import KlustaSortingExtractor, read_klusta
@@ -82,6 +83,7 @@ recording_extractor_full_list = [
     
     # others
     CompressedBinaryIblExtractor,
+    MCSH5RecordingExtractor
 ]
 
 sorting_extractor_full_list = [

--- a/spikeinterface/extractors/mcsh5extractors.py
+++ b/spikeinterface/extractors/mcsh5extractors.py
@@ -1,0 +1,142 @@
+from spikeinterface import BaseRecording, BaseRecordingSegment
+import numpy as np
+from pathlib import Path
+
+try:
+    import h5py
+
+    HAVE_MCSH5 = True
+except ImportError:
+    HAVE_MCSH5 = False
+
+
+class MCSH5RecordingExtractor(BaseRecording):
+    """
+    Load a MCS H5 file as a recording extractor
+
+    Parameters
+    ----------
+    file_path : str or Path
+        The path to the MCS h5 file
+    stream_id : int, optional
+        The stream ID to load, by default 0
+        
+    Returns
+    -------
+    recording: MCSH5RecordingExtractor
+        The recording extractor for the MCS h5 file
+    """
+    extractor_name = 'MCSH5Recording'
+    installed = False  # check at class level if installed or not
+    is_writable = False
+    mode = 'file'
+    installation_mesg = "To use the MCSH5RecordingExtractor install h5py: \n\n pip install h5py\n\n"  # error message when not installed
+
+    def __init__(self, file_path, stream_id=0):
+        assert self.installed, self.installation_mesg
+        self._file_path = file_path
+
+        mcs_info = openMCSH5File(self._recording_file, stream_id)
+        self._rf = mcs_info["filehandle"]
+
+        BaseRecording.__init__(self, sampling_frequency=mcs_info["sampling_frequency"], channel_ids=mcs_info["channel_ids"],
+                               dtype=mcs_info["dtype"])
+        
+        recording_segment = MCSH5RecordingSegment(sampling_frequency=mcs_info["sampling_frequency"])
+        self.add_recording_segment(recording_segment)
+        
+        # set gain
+        self.set_channel_gains(mcs_info["gain"])
+        
+        # set other properties
+        self.set_property("electrode_labels", mcs_info["electrode_labels"])
+        
+        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'stream_id': stream_id}
+
+    def __del__(self):
+        self._rf.close()
+
+
+class MCSH5RecordingSegment(BaseRecordingSegment):
+    
+    def __init__(self, rf, stream_id, num_frames, sampling_frequency):
+        BaseRecordingSegment.__init__(self, sampling_frequency=sampling_frequency)
+        self._rf = rf
+        self._stream_id = stream_id
+        self._num_samples = int(num_frames)
+
+    def get_num_samples(self):
+        return self._num_samples
+    
+    def get_traces(self, 
+                   start_frame=None, 
+                   end_frame=None, 
+                   channel_indices=None):
+        stream = self._rf.require_group('/Data/Recording_0/AnalogStream/Stream_' + str(self._stream_id))
+
+        if isinstance(channel_indices, slice):
+            traces = stream.get('ChannelData')[channel_indices, start_frame:end_frame].T
+        else:
+            # channel_indices is np.ndarray
+            if np.array(channel_indices).size > 1 and np.any(np.diff(channel_indices) < 0):
+                # get around h5py constraint that it does not allow datasets
+                # to be indexed out of order
+                sorted_channel_indices = np.sort(channel_indices)
+                resorted_indices = np.array([list(sorted_channel_indices).index(ch) for ch in channel_indices])
+                recordings = stream.get('ChannelData')[sorted_channel_indices, start_frame:end_frame].T
+                traces = recordings[:, resorted_indices]
+            else:
+                traces = stream.get('ChannelData')[channel_indices, start_frame:end_frame].T
+
+        return traces
+
+
+def openMCSH5File(filename, stream_id):
+    """Open an MCS hdf5 file, read and return the recording info."""
+    rf = h5py.File(filename, 'r')
+
+    stream_name = 'Stream_' + str(stream_id)
+    analog_stream_names = list(rf.require_group('/Data/Recording_0/AnalogStream').keys())
+    assert stream_name in analog_stream_names, (f"Specified stream does not exist. "
+                                                f"Available streams: {analog_stream_names}")
+
+    stream = rf.require_group('/Data/Recording_0/AnalogStream/' + stream_name)
+    data = stream.get('ChannelData')
+    timestamps = np.array(stream.get('ChannelDataTimeStamps'))
+    info = np.array(stream.get('InfoChannel'))
+    dtype = data.dtype
+
+    Unit = info['Unit'][0]
+    Tick = info['Tick'][0] / 1e6
+    exponent = info['Exponent'][0]
+    convFact = info['ConversionFactor'][0]
+    gain = convFact.astype(float) * (10.0 ** exponent)
+
+    nRecCh, nFrames = data.shape
+    channel_ids = info['ChannelID']
+    assert len(np.unique(channel_ids)) == len(channel_ids), 'Duplicate MCS channel IDs found'
+    electrodeLabels = info['Label']
+
+    assert timestamps[0][0] < timestamps[0][2], 'Please check the validity of \'ChannelDataTimeStamps\' in the stream.'
+    TimeVals = np.arange(timestamps[0][0], timestamps[0][2] + 1, 1) * Tick
+
+    assert Unit == b'V', 'Unexpected units found, expected volts, found {}'.format(Unit.decode('UTF-8'))
+
+    timestep_avg = np.mean(TimeVals[1:] - TimeVals[0:-1])
+    timestep_min = np.min(TimeVals[1:] - TimeVals[0:-1])
+    timestep_max = np.min(TimeVals[1:] - TimeVals[0:-1])
+    assert all(np.abs(np.array(
+        (timestep_min, timestep_max)) - timestep_avg) / timestep_avg < 1e-6), 'Time steps vary by more than 1 ppm'
+    samplingRate = 1. / timestep_avg
+
+    mcs_info = {"filehandle": rf, "num_frames": nFrames, "sampling_rate": samplingRate, 
+                "num_channels": nRecCh, "electrode_labels": electrodeLabels, "gain": gain,
+                "dtype": dtype}
+
+    return mcs_info
+
+
+def read_mcsh5(*args, **kwargs):
+    return MCSH5RecordingExtractor(*args, **kwargs)
+
+read_mcsh5.__doc__ = MCSH5RecordingExtractor.__doc__

--- a/spikeinterface/extractors/mcsh5extractors.py
+++ b/spikeinterface/extractors/mcsh5extractors.py
@@ -65,6 +65,7 @@ class MCSH5RecordingSegment(BaseRecordingSegment):
         self._rf = rf
         self._stream_id = stream_id
         self._num_samples = int(num_frames)
+        self._stream = self._rf.require_group('/Data/Recording_0/AnalogStream/Stream_' + str(self._stream_id))
 
     def get_num_samples(self):
         return self._num_samples
@@ -73,10 +74,9 @@ class MCSH5RecordingSegment(BaseRecordingSegment):
                    start_frame=None, 
                    end_frame=None, 
                    channel_indices=None):
-        stream = self._rf.require_group('/Data/Recording_0/AnalogStream/Stream_' + str(self._stream_id))
 
         if isinstance(channel_indices, slice):
-            traces = stream.get('ChannelData')[channel_indices, start_frame:end_frame].T
+            traces = self._stream.get('ChannelData')[channel_indices, start_frame:end_frame].T
         else:
             # channel_indices is np.ndarray
             if np.array(channel_indices).size > 1 and np.any(np.diff(channel_indices) < 0):
@@ -84,10 +84,10 @@ class MCSH5RecordingSegment(BaseRecordingSegment):
                 # to be indexed out of order
                 sorted_channel_indices = np.sort(channel_indices)
                 resorted_indices = np.array([list(sorted_channel_indices).index(ch) for ch in channel_indices])
-                recordings = stream.get('ChannelData')[sorted_channel_indices, start_frame:end_frame].T
+                recordings = self._stream.get('ChannelData')[sorted_channel_indices, start_frame:end_frame].T
                 traces = recordings[:, resorted_indices]
             else:
-                traces = stream.get('ChannelData')[channel_indices, start_frame:end_frame].T
+                traces = self._stream.get('ChannelData')[channel_indices, start_frame:end_frame].T
 
         return traces
 

--- a/spikeinterface/toolkit/postprocessing/template_metrics.py
+++ b/spikeinterface/toolkit/postprocessing/template_metrics.py
@@ -183,7 +183,7 @@ def get_half_width(template, **kwargs):
         cross_post_pk = cpost_idx[-1] + 1 + trough_idx
 
         hw = (cross_post_pk - cross_pre_pk) / sampling_frequency
-        return hw
+    return hw
 
 
 def get_repolarization_slope(template, **kwargs):

--- a/spikeinterface/toolkit/qualitymetrics/misc_metrics.py
+++ b/spikeinterface/toolkit/qualitymetrics/misc_metrics.py
@@ -237,12 +237,17 @@ def compute_isi_violations(waveform_extractor, isi_threshold_ms=1.5, min_isi_ms=
             num_spikes += len(spike_train)
             num_violations += np.sum(isis < isi_threshold_samples)
         violation_time = 2 * num_spikes * (isi_threshold_s - min_isi_s)
-        total_rate = num_spikes / total_duration
-        violation_rate = num_violations / violation_time
-
-        isi_violations_ratio[unit_id] = violation_rate / total_rate
-        isi_violations_rate[unit_id] = num_violations / total_duration
-        isi_violations_count[unit_id] = num_violations
+        
+        if num_spikes > 0:
+            total_rate = num_spikes / total_duration
+            violation_rate = num_violations / violation_time
+            isi_violations_ratio[unit_id] = violation_rate / total_rate
+            isi_violations_rate[unit_id] = num_violations / total_duration
+            isi_violations_count[unit_id] = num_violations      
+        else:
+            isi_violations_ratio[unit_id] = np.nan
+            isi_violations_rate[unit_id] = np.nan
+            isi_violations_count[unit_id] = np.nan
 
     res = namedtuple('isi_violation',
                      ['isi_violations_ratio', 'isi_violations_rate', 'isi_violations_count'])

--- a/spikeinterface/version.py
+++ b/spikeinterface/version.py
@@ -1,1 +1,1 @@
-version = '0.95.0.dev0'
+version = '0.94.1.dev0'


### PR DESCRIPTION
- In multicomparison, remove duplicate nodes after removing all duplicate edges. If not, removing a node also removes all associated edges, and this triggers an error when attemtping to remove the duplicate edges (this happens when multiple edges from one node needs to be removed)
- small fix to template metrics computation: half-width should return `nan` instead of `None` when not computed