### PR TITLE
Zarr modification to work with cloud object directly

### DIFF
--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -716,9 +716,15 @@ class BaseExtractor:
                     if verbose:
                         print(f'Use cache_folder={zarr_path}')
         else:
-            zarr_path = Path(zarr_path)
-        assert not zarr_path.exists(), f'Path {zarr_path} already exists, choose another name'
-        zarr_root = zarr.open(str(zarr_path), "w")
+            if isinstance(zarr_path, str):
+                zarr_path = Path(zarr_path)
+                zarr_path_init = str(zarr_path)
+            else: # mapper
+                zarr_path_init = zarr_path
+
+        if isinstance(zarr_path, Path):
+            assert not zarr_path.exists(), f'Path {zarr_path} already exists, choose another name'
+        zarr_root = zarr.open(zarr_path_init, "w")
 
         if self.check_if_dumpable():
             zarr_root.attrs["provenance"] = check_json(self.to_dict())

--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -667,7 +667,8 @@ class BaseExtractor:
 
         return cached
 
-    def save_to_zarr(self, name=None, zarr_path=None, storage_options=None, verbose=True, **save_kwargs):
+    def save_to_zarr(self, name=None, zarr_path=None, storage_options=None, 
+                     channel_chunk_size=None, verbose=True, **save_kwargs):
         """
         Save extractor to zarr.
 
@@ -686,7 +687,9 @@ class BaseExtractor:
         storage_options: dict or None
             Storage options for zarr `store`. E.g., if "s3://" or "gcs://" they can provide authentication methods, etc.
             For cloud storage locations, this should not be None (in case of default values, use an empty dict)
-
+        channel_chunk_size: int or None
+            Channels per chunk. Default None (chunking in time only)
+        
         Returns
         -------
         cached: saved copy of the extractor.
@@ -729,6 +732,7 @@ class BaseExtractor:
         save_kwargs['zarr_root'] = zarr_root
         save_kwargs['zarr_path'] = zarr_path
         save_kwargs['storage_options'] = storage_options
+        save_kwargs['channel_chunk_size'] = channel_chunk_size
         cached = self._save(folder=None, verbose=verbose, **save_kwargs)
         cached_annotations = deepcopy(cached._annotations)
 

--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -550,13 +550,14 @@ class BaseExtractor:
 
     def save(self, **kwargs):
         """
-        Save a SpikeInterface object
+        Save a SpikeInterface object. 
 
         Parameters
         ----------
         kwargs: Keyword arguments for saving.
             * format: "memory", "zarr", or "binary" (for recording) / "memory" or "npz" for sorting.
-                In case format is not memory, the recording is saved to a folder
+                In case format is not memory, the recording is saved to a folder. See format specific functions for 
+                more info (`save_to_memory()`, `save_to_folder()`, `save_to_zarr()`)
             * folder: if provided, the folder path where the object is saved
             * name: if provided and folder is not given, the name of the folder in the global temporary
                     folder (use set_global_tmp_folder() to change this folder) where the object is saved.
@@ -666,7 +667,7 @@ class BaseExtractor:
 
         return cached
 
-    def save_to_zarr(self, name=None, zarr_path=None, verbose=True, **save_kwargs):
+    def save_to_zarr(self, name=None, zarr_path=None, storage_options=None, verbose=True, **save_kwargs):
         """
         Save extractor to zarr.
 
@@ -675,27 +676,16 @@ class BaseExtractor:
             * saving data into a zarr file 
             * dumping the original extractor for provenance in attributes
 
-        This replaces the use of the old CacheRecordingExtractor and CacheSortingExtractor.
-
-        There are 2 option for the 'folder' argument:
-            * explicit folder: `extractor.save(folder="/path-for-saving/")`
-            * explicit sub-folder, implicit base-folder : `extractor.save(name="extarctor_name")`
-            * generated: `extractor.save()`
-
-        The second option saves to subfolder "extarctor_name" in
-        "get_global_tmp_folder()". You can set the global tmp folder with:
-        "set_global_tmp_folder("path-to-global-folder")"
-
-        The folder must not exist. If it exists, remove it before.
-
         Parameters
         ----------
-        name: None str or Path
+        name: str or None
             Name of the subfolder in get_global_tmp_folder()
             If 'name' is given, 'folder' must be None.
-        folder: None str or Path
-            Name of the folder.
-            If 'folder' is given, 'name' must be None.
+        zarr_path: str, Path, or None
+            Name of the zarr folder (.zarr).
+        storage_options: dict or None
+            Storage options for zarr `store`. E.g., if "s3://" or "gcs://" they can provide authentication methods, etc.
+            For cloud storage locations, this should not be None (in case of default values, use an empty dict)
 
         Returns
         -------
@@ -709,22 +699,26 @@ class BaseExtractor:
                     string.ascii_uppercase + string.digits, k=8))
                 zarr_path = cache_folder / f"{name}.zarr"
                 if verbose:
-                    print(f'Use cache_folder={zarr_path}')
+                    print(f'Use zarr_path={zarr_path}')
             else:
                 zarr_path = cache_folder / f"{name}.zarr"
                 if not is_set_global_tmp_folder():
                     if verbose:
-                        print(f'Use cache_folder={zarr_path}')
+                        print(f'Use zarr_path={zarr_path}')
         else:
-            if isinstance(zarr_path, str):
-                zarr_path = Path(zarr_path)
-                zarr_path_init = str(zarr_path)
-            else: # mapper
+            if storage_options is None:
+                if isinstance(zarr_path, str):
+                    zarr_path_init = zarr_path
+                    zarr_path = Path(zarr_path)
+                else:
+                    zarr_path_init = str(zarr_path)
+            else:
                 zarr_path_init = zarr_path
 
         if isinstance(zarr_path, Path):
             assert not zarr_path.exists(), f'Path {zarr_path} already exists, choose another name'
-        zarr_root = zarr.open(zarr_path_init, "w")
+        
+        zarr_root = zarr.open(zarr_path_init, mode="w", storage_options=storage_options)
 
         if self.check_if_dumpable():
             zarr_root.attrs["provenance"] = check_json(self.to_dict())
@@ -734,6 +728,7 @@ class BaseExtractor:
         # save data (done the subclass)
         save_kwargs['zarr_root'] = zarr_root
         save_kwargs['zarr_path'] = zarr_path
+        save_kwargs['storage_options'] = storage_options
         cached = self._save(folder=None, verbose=verbose, **save_kwargs)
         cached_annotations = deepcopy(cached._annotations)
 

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -216,6 +216,7 @@ class BaseRecording(BaseExtractor):
             zarr_root = save_kwargs.get('zarr_root', None)
             zarr_path = save_kwargs.get('zarr_path', None)
             storage_options = save_kwargs.get('storage_options', None)
+            channel_chunk_size = save_kwargs.get('channel_chunk_size', None)
 
             zarr_root.attrs["sampling_frequency"] = float(self.get_sampling_frequency())
             zarr_root.attrs["num_segments"] = int(self.get_num_segments())
@@ -238,7 +239,8 @@ class BaseRecording(BaseExtractor):
             job_kwargs = {k: save_kwargs[k]
                           for k in job_keys if k in save_kwargs}
             write_traces_to_zarr(self, zarr_root=zarr_root, zarr_path=zarr_path, storage_options=storage_options,
-                                 dataset_paths=dataset_paths, dtype=dtype, compressor=compressor, filters=filters,
+                                 channel_chunk_size=channel_chunk_size, dataset_paths=dataset_paths, dtype=dtype, 
+                                 compressor=compressor, filters=filters,
                                  **job_kwargs)
 
             # save probe

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -215,6 +215,7 @@ class BaseRecording(BaseExtractor):
             
             zarr_root = save_kwargs.get('zarr_root', None)
             zarr_path = save_kwargs.get('zarr_path', None)
+            storage_options = save_kwargs.get('storage_options', None)
 
             zarr_root.attrs["sampling_frequency"] = float(self.get_sampling_frequency())
             zarr_root.attrs["num_segments"] = int(self.get_num_segments())
@@ -225,19 +226,20 @@ class BaseRecording(BaseExtractor):
             dtype = save_kwargs.get('dtype', None)
             if dtype is None:
                 dtype = self.get_dtype()
+            
             compressor = save_kwargs.get('compressor', None)
+            filters = save_kwargs.get('filters', None)
             
             if compressor is None:
                 compressor = get_default_zarr_compressor()
                 print(f"Using default zarr compressor: {compressor}. To use a different compressor, use the "
                       f"'compressor' argument")
             
-            filters = save_kwargs.get('filters', None)
-
             job_kwargs = {k: save_kwargs[k]
                           for k in job_keys if k in save_kwargs}
-            write_traces_to_zarr(self, zarr_root=zarr_root, zarr_path=zarr_path, dataset_paths=dataset_paths,
-                                 dtype=dtype, compressor=compressor, filters=filters, **job_kwargs)
+            write_traces_to_zarr(self, zarr_root=zarr_root, zarr_path=zarr_path, storage_options=storage_options,
+                                 dataset_paths=dataset_paths, dtype=dtype, compressor=compressor, filters=filters,
+                                 **job_kwargs)
 
             # save probe
             if self.get_property('contact_vector') is not None:
@@ -260,7 +262,7 @@ class BaseRecording(BaseExtractor):
                 zarr_root.create_dataset(name="t_starts", data=t_starts,
                                          compressor=None)
 
-            cached = ZarrRecordingExtractor(zarr_path)
+            cached = ZarrRecordingExtractor(zarr_path, storage_options)
 
         elif format == 'nwb':
             # TODO implement a format based on zarr

--- a/spikeinterface/core/core_tools.py
+++ b/spikeinterface/core/core_tools.py
@@ -593,7 +593,12 @@ def _init_zarr_worker(recording, zarr_path, dataset_paths, dtype):
         worker_ctx['recording'] = recording
 
     # reload root and datasets
-    root = zarr.open(str(zarr_path), mode="r+")
+    if isinstance(zarr_path, Path):
+        zarr_path_init = str(zarr_path)
+    else: # mapper
+        zarr_path_init = zarr_path
+
+    root = zarr.open(zarr_path_init, mode="r+")
     zarr_datasets = []
     for dset_name in dataset_paths:
         z = root[dset_name]

--- a/spikeinterface/core/core_tools.py
+++ b/spikeinterface/core/core_tools.py
@@ -519,7 +519,7 @@ def write_to_h5_dataset_format(recording, dataset_path, segment_index, save_path
 
 
 def write_traces_to_zarr(recording, zarr_root, zarr_path, storage_options, 
-                         dataset_paths, dtype=None,
+                         dataset_paths, channel_chunk_size=None, dtype=None,
                          compressor=None, filters=None, 
                          verbose=False, **job_kwargs):
     '''
@@ -541,6 +541,8 @@ def write_traces_to_zarr(recording, zarr_root, zarr_path, storage_options,
         Storage options for zarr `store`. E.g., if "s3://" or "gcs://" they can provide authentication methods, etc.
     dataset_paths: list
         List of paths to traces datasets in the zarr group
+    channel_chunk_size: int or None
+        Channels per chunk. Default None (chunking in time only)
     dtype: dtype
         Type of the saved data. Default float32.
     compressor: zarr compressor or None
@@ -570,7 +572,8 @@ def write_traces_to_zarr(recording, zarr_root, zarr_path, storage_options,
         dset_name = dataset_paths[segment_index]
         shape = (num_frames, num_channels)
         _ = zarr_root.create_dataset(name=dset_name, shape=shape,
-                                     chunks=(chunk_size, None), dtype=dtype,
+                                     chunks=(chunk_size, channel_chunk_size), 
+                                     dtype=dtype,
                                      filters=filters,
                                      compressor=compressor,)
                                 # synchronizer=zarr.ThreadSynchronizer())

--- a/spikeinterface/core/tests/test_baserecording.py
+++ b/spikeinterface/core/tests/test_baserecording.py
@@ -228,7 +228,7 @@ def test_BaseRecording():
                          compressor=compressor)
     check_recordings_equal(rec2, rec_zarr, return_scaled=False)
 
-    rec_zarr2 = rec2.save(format="zarr", zarr_path=cache_folder / "recording.zarr",
+    rec_zarr2 = rec2.save(format="zarr", zarr_path=cache_folder / "recording_channel_chunk.zarr",
                           compressor=compressor, channel_chunk_size=2)
     check_recordings_equal(rec2, rec_zarr2, return_scaled=False)
 

--- a/spikeinterface/core/tests/test_baserecording.py
+++ b/spikeinterface/core/tests/test_baserecording.py
@@ -228,6 +228,10 @@ def test_BaseRecording():
                          compressor=compressor)
     check_recordings_equal(rec2, rec_zarr, return_scaled=False)
 
+    rec_zarr2 = rec2.save(format="zarr", zarr_path=cache_folder / "recording.zarr",
+                          compressor=compressor, channel_chunk_size=2)
+    check_recordings_equal(rec2, rec_zarr2, return_scaled=False)
+
 
 
 if __name__ == '__main__':

--- a/spikeinterface/core/zarrrecordingextractor.py
+++ b/spikeinterface/core/zarrrecordingextractor.py
@@ -61,8 +61,6 @@ class ZarrRecordingExtractor(BaseRecording):
             root_path_kwarg = str(root_path.absolute())
         self._root = zarr.open(root_path_init, mode="r")
 
-        root_path = Path(root_path)
-        self._root = zarr.open(str(root_path), mode="r")
         sampling_frequency = self._root.attrs.get("sampling_frequency", None)
         num_segments = self._root.attrs.get("num_segments", None)
         assert "channel_ids" in self._root.keys(), "'channel_ids' dataset not found!"

--- a/spikeinterface/core/zarrrecordingextractor.py
+++ b/spikeinterface/core/zarrrecordingextractor.py
@@ -45,9 +45,9 @@ class ZarrRecordingExtractor(BaseRecording):
             if isinstance(root_path, str):
                 root_path_init = root_path
                 root_path = Path(root_path)
-                root_path_kwarg = str(root_path.absolute())
             else:
                 root_path_init = str(root_path)
+            root_path_kwarg = str(root_path.absolute())
         else:
             root_path_init = root_path
             root_path_kwarg = root_path_init

--- a/spikeinterface/core/zarrrecordingextractor.py
+++ b/spikeinterface/core/zarrrecordingextractor.py
@@ -50,6 +50,17 @@ class ZarrRecordingExtractor(BaseRecording):
 
     def __init__(self, root_path: Union[Path, str]):
         assert self.installed, self.installation_mesg
+        if isinstance(root_path, str):
+            root_path = Path(root_path)
+            
+        if not isinstance(root_path, Path):
+            root_path_init = root_path
+            root_path_kwarg = root_path
+        else:
+            root_path_init = str(root_path)
+            root_path_kwarg = str(root_path.absolute())
+        self._root = zarr.open(root_path_init, mode="r")
+
         root_path = Path(root_path)
         self._root = zarr.open(str(root_path), mode="r")
         sampling_frequency = self._root.attrs.get("sampling_frequency", None)
@@ -122,7 +133,7 @@ class ZarrRecordingExtractor(BaseRecording):
         cr = total_nbytes / total_nbytes_stored
         self.annotate(compression_ratio=cr, compression_ratio_segments=cr_by_segment)
         
-        self._kwargs = {'root_path': str(root_path.absolute())}
+        self._kwargs = {'root_path': root_path_kwarg}
 
 
 class ZarrRecordingSegment(BaseRecordingSegment):

--- a/spikeinterface/core/zarrrecordingextractor.py
+++ b/spikeinterface/core/zarrrecordingextractor.py
@@ -23,18 +23,8 @@ class ZarrRecordingExtractor(BaseRecording):
     ----------
     root_path: str or Path
         Path to the zarr root file
-    sampling_frequency: float
-        The sampling frequency
-    t_starts: None or list of float
-        Times in seconds of the first sample for each segment
-    channel_ids: list (optional)
-        A list of channel ids
-    gain_to_uV: float or array-like (optional)
-        The gain to apply to the traces
-    offset_to_uV: float or array-like
-        The offset to apply to the traces
-    is_filtered: bool or None
-        If True, the recording is assumed to be filtered. If None, is_filtered is not set.
+    storage_options: dict or None
+        Storage options for zarr `store`. E.g., if "s3://" or "gcs://" they can provide authentication methods, etc.
 
     Returns
     -------
@@ -48,18 +38,21 @@ class ZarrRecordingExtractor(BaseRecording):
     # error message when not installed
     installation_mesg = "To use the ZarrRecordingExtractor install zarr: \n\n pip install zarr\n\n"
 
-    def __init__(self, root_path: Union[Path, str]):
+    def __init__(self, root_path: Union[Path, str], storage_options=None):
         assert self.installed, self.installation_mesg
-        if isinstance(root_path, str):
-            root_path = Path(root_path)
-            
-        if not isinstance(root_path, Path):
-            root_path_init = root_path
-            root_path_kwarg = root_path
+        
+        if storage_options is None:
+            if isinstance(root_path, str):
+                root_path_init = root_path
+                root_path = Path(root_path)
+                root_path_kwarg = str(root_path.absolute())
+            else:
+                root_path_init = str(root_path)
         else:
-            root_path_init = str(root_path)
-            root_path_kwarg = str(root_path.absolute())
-        self._root = zarr.open(root_path_init, mode="r")
+            root_path_init = root_path
+            root_path_kwarg = root_path_init
+        
+        self._root = zarr.open(root_path_init, mode="r", storage_options=storage_options)
 
         sampling_frequency = self._root.attrs.get("sampling_frequency", None)
         num_segments = self._root.attrs.get("num_segments", None)
@@ -131,7 +124,8 @@ class ZarrRecordingExtractor(BaseRecording):
         cr = total_nbytes / total_nbytes_stored
         self.annotate(compression_ratio=cr, compression_ratio_segments=cr_by_segment)
         
-        self._kwargs = {'root_path': root_path_kwarg}
+        self._kwargs = {'root_path': root_path_kwarg,
+                        'storage_options': storage_options}
 
 
 class ZarrRecordingSegment(BaseRecordingSegment):

--- a/spikeinterface/toolkit/qualitymetrics/tests/test_quality_metric_calculator.py
+++ b/spikeinterface/toolkit/qualitymetrics/tests/test_quality_metric_calculator.py
@@ -23,13 +23,13 @@ def setup_module():
         if (cache_folder / folder_name).is_dir():
             shutil.rmtree(cache_folder / folder_name)
 
-    recording, sorting = toy_example(num_segments=2, num_units=10)
+    recording, sorting = toy_example(num_segments=2, num_units=10, duration=60)
     recording = recording.save(folder=cache_folder / 'toy_rec')
     sorting = sorting.save(folder=cache_folder / 'toy_sorting')
 
     we = WaveformExtractor.create(
         recording, sorting, cache_folder / 'toy_waveforms')
-    we.set_params(ms_before=3., ms_after=4., max_spikes_per_unit=500)
+    we.set_params(ms_before=3., ms_after=4., max_spikes_per_unit=None)
     we.run_extract_waveforms(n_jobs=1, chunk_size=30000)
 
 
@@ -76,7 +76,7 @@ def test_compute_quality_metrics_peak_sign():
 
     we_inv = WaveformExtractor.create(
         rec_inv, sort, cache_folder / 'toy_waveforms_inv')
-    we_inv.set_params(ms_before=3., ms_after=4., max_spikes_per_unit=500)
+    we_inv.set_params(ms_before=3., ms_after=4., max_spikes_per_unit=None)
     we_inv.run_extract_waveforms(n_jobs=1, chunk_size=30000)
     print(we_inv)
 


### PR DESCRIPTION
This PR allows the `zarr_path` to be any zarr-compatible `Store` object, including cloud storages (see https://zarr.readthedocs.io/en/stable/tutorial.html#distributed-cloud-storage)

Tested with Gcloud, more testing is required for other platforms.

