### PR TITLE
Various (small) improvements

### DIFF
--- a/spikeinterface/comparison/groundtruthstudy.py
+++ b/spikeinterface/comparison/groundtruthstudy.py
@@ -52,7 +52,7 @@ class GroundTruthStudy:
         setup_comparison_study(study_folder, gt_dict, **job_kwargs)
         return cls(study_folder)
 
-    def run_sorters(self, sorter_list, mode_if_folder_exists='keep', **kwargs):
+    def run_sorters(self, sorter_list, mode_if_folder_exists='keep', remove_sorter_folders=False, **kwargs):
 
         sorter_folders = self.study_folder / 'sorter_folders'
         recording_dict = get_recordings(self.study_folder)
@@ -62,6 +62,9 @@ class GroundTruthStudy:
 
         # results are copied so the heavy sorter_folders can be removed
         self.copy_sortings()
+
+        if remove_sorter_folders:
+            shutil.rmtree(self.study_folder / 'sorter_folders')
 
     def _check_rec_name(self, rec_name):
         if not self._is_scanned:

--- a/spikeinterface/sorters/kilosortbase.py
+++ b/spikeinterface/sorters/kilosortbase.py
@@ -17,9 +17,6 @@ class KilosortBase:
 
     @classmethod
     def _run_from_folder(cls, output_folder, params, verbose):
-
-        print('KilosortBase._run_from_folder', cls)
-
         if 'win' in sys.platform and sys.platform != 'darwin':
             disk_move = str(output_folder)[:2]
             shell_cmd = f'''

--- a/spikeinterface/toolkit/postprocessing/template_metrics.py
+++ b/spikeinterface/toolkit/postprocessing/template_metrics.py
@@ -25,7 +25,7 @@ def get_template_metric_names():
 
 
 def calculate_template_metrics(waveform_extractor, feature_names=None, peak_sign='neg',
-                               upsampling_factor=10, sparsity_dict=None, sparsity=None,
+                               upsampling_factor=10, sparsity=None,
                                **kwargs):
     """
     Compute template metrics including:
@@ -48,18 +48,10 @@ def calculate_template_metrics(waveform_extractor, feature_names=None, peak_sign
         "pos" | "neg", by default 'neg'
     upsampling_factor : int, optional
         Upsample factor, by default 10
-    sparsity_dict: dict or None
-        Default is sparsity_dict=None and template metric is computed on extremum channel only.
-        If given, the dictionary should contain a sparsity method (e.g. "best_channels") and optionally
-        arguments associated with the method (e.g. "num_channels" for "best_channels" method).
-        Other examples are:
-           * by radius: sparsity_dict=dict(method="radius", radius_um=100)
-           * by SNR threshold: sparsity_dict=dict(method="threshold", threshold=2)
-           * by property: sparsity_dict=dict(method="by_property", by_property="group")
-        For more info, see the toolkit.get_template_channel_sparsity() function.
     sparsity: dict or None
-        In alternative to 'sparsity_dict', the 'sparsity' can be a dictionary with unit_id as key
-        and channel id(s) as values (either a scalar or an array).
+        Default is sparsity=None and template metric is computed on extremum channel only.
+        If given, the dictionary should contain a unit ids as keys and a channel id or a list of channel ids as values.
+        For more generating a sparsity dict, see the toolkit.get_template_channel_sparsity() function.
     **kwargs: keyword arguments for get_recovery_slope function:
         * window_ms: window in ms after the positiv peak to compute slope
 
@@ -67,8 +59,8 @@ def calculate_template_metrics(waveform_extractor, feature_names=None, peak_sign
     -------
     tempalte_metrics : pd.DataFrame
         Dataframe with the computed template metrics.
-        If 'sparsity_dict' is None, the index is the unit_id.
-        If 'sparsity_dict' is given, the index is a multi-index (unit_id, channel_id)
+        If 'sparsity' is None, the index is the unit_id.
+        If 'sparsity' is given, the index is a multi-index (unit_id, channel_id)
     """
     unit_ids = waveform_extractor.sorting.unit_ids
     sampling_frequency = waveform_extractor.recording.get_sampling_frequency()
@@ -76,18 +68,14 @@ def calculate_template_metrics(waveform_extractor, feature_names=None, peak_sign
     if feature_names is None:
         feature_names = list(_metric_name_to_func.keys())
 
-    if sparsity_dict is None and sparsity is None:
+    if sparsity is None:
         extremum_channels_ids = get_template_extremum_channel(waveform_extractor, peak_sign=peak_sign,
                                                               outputs='id')
 
         template_metrics = pd.DataFrame(
             index=unit_ids, columns=feature_names)
     else:
-        if sparsity is None:
-            extremum_channels_ids = get_template_channel_sparsity(
-                waveform_extractor, **sparsity_dict)
-        else:
-            extremum_channels_ids = sparsity
+        extremum_channels_ids = sparsity
         unit_ids = []
         channel_ids = []
         for unit_id, sparse_channels in extremum_channels_ids.items():
@@ -107,7 +95,7 @@ def calculate_template_metrics(waveform_extractor, feature_names=None, peak_sign
         template = template_all_chans[:, chan_ind]
 
         for i, template_single in enumerate(template.T):
-            if sparsity_dict is None and sparsity is None:
+            if sparsity is None:
                 index = unit_id
             else:
                 index = (unit_id, chan_ids[i])

--- a/spikeinterface/toolkit/postprocessing/tests/test_template_metrics.py
+++ b/spikeinterface/toolkit/postprocessing/tests/test_template_metrics.py
@@ -7,7 +7,7 @@ import pytest
 from spikeinterface import extract_waveforms, WaveformExtractor
 from spikeinterface.extractors import toy_example
 
-from spikeinterface.toolkit.postprocessing import calculate_template_metrics
+from spikeinterface.toolkit.postprocessing import calculate_template_metrics, get_template_channel_sparsity
 
 if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "toolkit"
@@ -37,9 +37,9 @@ def test_calculate_template_metrics():
     features_up = calculate_template_metrics(we, upsampling_factor=2)
     print(features_up)
 
+    sparsity = get_template_channel_sparsity(we, method="radius", radius_um=20)
     features_sparse = calculate_template_metrics(we, upsampling_factor=2,
-                                                 sparsity_dict=dict(method="radius",
-                                                                    radius_um=20))
+                                                 sparsity=sparsity)
     print(features_sparse)
 
 

--- a/spikeinterface/toolkit/utils.py
+++ b/spikeinterface/toolkit/utils.py
@@ -57,6 +57,7 @@ def get_channel_distances(recording):
     channel_distances = scipy.spatial.distance.cdist(locations, locations, metric='euclidean')
     return channel_distances
 
+
 def get_closest_channels(recording, channel_ids=None, num_channels=None):
     """Get closest channels + distances
 
@@ -92,6 +93,7 @@ def get_closest_channels(recording, channel_ids=None, num_channels=None):
         dists.append(distances[order][1:num_channels + 1])
 
     return np.array(closest_channels_inds), np.array(dists)
+
 
 def get_noise_levels(recording, return_scaled=True, **random_chunk_kwargs):
     """


### PR DESCRIPTION
- Add `seed` for sampling waveforms in waveform extractor (useful when comparing different pre-processing)
- Remove print in Kilosort run
- Add `sparsity` option in template metrics, where one can directly specify a dictionary with a list of `channel_ids` for each `unit_id`
- Add option to `remove_sorters_folder` in `GTStudy`