### PR TITLE
Docker on windows

### DIFF
--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -13,7 +13,7 @@ from packaging.version import parse
 import numpy as np
 
 from .default_folders import get_global_tmp_folder, is_set_global_tmp_folder
-from .core_tools import check_json
+from .core_tools import check_json, is_dict_extractor
 from .job_tools import _shared_job_kwargs_doc
 
 
@@ -814,14 +814,14 @@ def _check_if_dumpable(d):
         return d['dumpable']
 
 
-def is_dict_extractor(d):
-    """
-    Check if a dict describe an extractor.
-    """
-    if not isinstance(d, dict):
-        return False
-    is_extractor = ('module' in d) and ('class' in d) and ('version' in d) and ('annotations' in d)
-    return is_extractor
+# def is_dict_extractor(d):
+#     """
+#     Check if a dict describe an extractor.
+#     """
+#     if not isinstance(d, dict):
+#         return False
+#     is_extractor = ('module' in d) and ('class' in d) and ('version' in d) and ('annotations' in d)
+#     return is_extractor
 
 
 def _load_extractor_from_dict(dic):

--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -814,16 +814,6 @@ def _check_if_dumpable(d):
         return d['dumpable']
 
 
-# def is_dict_extractor(d):
-#     """
-#     Check if a dict describe an extractor.
-#     """
-#     if not isinstance(d, dict):
-#         return False
-#     is_extractor = ('module' in d) and ('class' in d) and ('version' in d) and ('annotations' in d)
-#     return is_extractor
-
-
 def _load_extractor_from_dict(dic):
     cls = None
     class_name = None

--- a/spikeinterface/core/core_tools.py
+++ b/spikeinterface/core/core_tools.py
@@ -651,15 +651,31 @@ def is_dict_extractor(d):
 
 def recursive_path_modifier(d, func, target='path', copy=True):
     """
-    Generic function for recurssive modification of path.
-    A recording can be nested of several preprocessing step.
-    This explore the full tree in recurssive way.
+    Generic function for recursive modification of paths in an extractor dict.
+    A recording can be nested and this function explores the dictionary recursively
+    to find the parent file or folder paths.
 
-    Usefull for :
-      * relative/absolut path change
+    Useful for :
+      * relative/absolute path change
       * docker rebase path change
 
-    Modificatopn is inplace with a optional copy.
+    Modification is inplace with an optional copy.
+
+    Parameters
+    ----------
+    d : dict
+        Extractor dictionary
+    func : function
+        Function to apply to the path. It must take a path as input and return a path
+    target : str, optional
+        String to match to dictionary key, by default 'path'
+    copy : bool, optional
+        If True the original dictionary is deep copied, by default True
+
+    Returns
+    -------
+    dict
+        Modified dictionary
     """
     if copy:
         dc = deepcopy(d)

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -297,11 +297,14 @@ run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
         install_si_from_source = True
         # Making sure to get rid of last / or \
         si_dev_path = str(Path(si_dev_path).absolute().resolve())
-        si_dev_path_unix = path_to_unix(si_dev_path)
+        if platform.system() == 'Windows':
+            si_dev_path_unix = path_to_unix(si_dev_path)
+        else:
+            si_dev_path_unix = si_dev_path
         volumes[si_dev_path] = {'bind': si_dev_path_unix, 'mode': 'ro'}
     else:
         install_si_from_source = False
-
+        
     extra_kwargs = {}
     if SorterClass.docker_requires_gpu:
         extra_kwargs['requires_gpu'] = True

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -11,6 +11,7 @@ from spikeinterface.core.core_tools import check_json, recursive_path_modifier, 
 from .sorterlist import sorter_dict
 from .utils import SpikeSortingError
 
+
 _common_param_doc = """
     Parameters
     ----------
@@ -98,8 +99,6 @@ def run_sorter_local(sorter_name, recording, output_folder=None,
     return sorting
 
 
-
-
 def find_recording_folder(d):
     if "kwargs" in d.keys():
         # handle nested
@@ -147,25 +146,9 @@ def path_to_unix(path):
     return path_unix
 
 
-# def path_to_windows(path, prefix="C:"):
-#     path = Path(path)
-#     path_windows = Path(prefix + str(path))
-#     return path_windows
-
-
-# def get_windows_drive_path(path):
-#     path = str(path)
-#     assert ":" in path, "Cannot find windows drive path"
-#     return path[:path.find(":") + 1]
-
 def windows_extractor_dict_to_unix(d):
     d = recursive_path_modifier(d, path_to_unix, target='path', copy=True)
     return d
-
-# def unix_extractor_dict_to_windows(d):
-#     d = recursive_path_modifier(d, path_to_windows, target='path', copy=True)
-#     return d
-
 
 
 class ContainerClient:
@@ -263,7 +246,6 @@ def run_sorter_container(sorter_name, recording, mode, container_image, output_f
 
     if platform.system() == 'Windows':
         rec_dict = windows_extractor_dict_to_unix(rec_dict)
-        # windows_drive = get_windows_drive_path(parent_folder)
 
     # create 3 files for communication with container
     # recording dict inside
@@ -380,7 +362,7 @@ run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
         # this do not work with singularity:
         # cmd = f'chown {uid}:{uid} -R "{output_folder}"'
         # this approach is better
-        cmd = ['chown', f'{uid}:{uid}', '-R', '{output_folder}']
+        cmd = ['chown', f'{uid}:{uid}', '-R', f'{output_folder}']
         res_output = container_client.run_command(cmd)
     else:
         # not needed for Windows


### PR DESCRIPTION
Enable Docker mechanism for Windows machines.

The main idea is to modify the paths and the extractor dictionaries on the fly to switch between UNIX and Windows paths.

Tested with:
- `tridesclous-base:1.6.4-1`
- `spykingcircus-base:1.1.0`
- `ironclust-base:5.9.8`