### PR TITLE
Don't raise error for probe with unconnected channels

### DIFF
--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -228,6 +228,8 @@ class BaseExtractor:
 
         if ids is None:
             inds = slice(None)
+        elif len(ids) == 0:
+            inds = slice(0, 0)
         else:
             inds = self.ids_to_indices(ids)
 

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -402,7 +402,7 @@ class BaseRecording(BaseExtractor):
         order = np.argsort(inds)
         inds = inds[order]
         # check
-        if np.max(inds) >= self.get_num_channels():
+        if np.max(list(inds) + [0]) >= self.get_num_channels():
             raise ValueError('The given Probe have "device_channel_indices" that do not match channel count')
         new_channel_ids = self.get_channel_ids()[inds]
         arr = arr[order]

--- a/spikeinterface/core/tests/test_baserecording.py
+++ b/spikeinterface/core/tests/test_baserecording.py
@@ -173,7 +173,8 @@ def test_BaseRecording():
     probe.create_auto_shape()
 
     rec_empty_probe = rec.set_probe(probe, group_mode='by_shank')
-assert rec_empty_probe.channel_ids.size == 0
+    assert rec_empty_probe.channel_ids.size == 0
+    
     # test return_scale
     sampling_frequency = 30000
     traces = np.zeros((1000, 5), dtype='int16')

--- a/spikeinterface/core/tests/test_baserecording.py
+++ b/spikeinterface/core/tests/test_baserecording.py
@@ -173,7 +173,7 @@ def test_BaseRecording():
     probe.create_auto_shape()
 
     rec_empty_probe = rec.set_probe(probe, group_mode='by_shank')
-
+assert rec_empty_probe.channel_ids.size == 0
     # test return_scale
     sampling_frequency = 30000
     traces = np.zeros((1000, 5), dtype='int16')

--- a/spikeinterface/core/tests/test_baserecording.py
+++ b/spikeinterface/core/tests/test_baserecording.py
@@ -164,6 +164,16 @@ def test_BaseRecording():
     # plot_probe(probe2)
     # plt.show()
 
+    # set unconnected probe
+    probe = Probe(ndim=2)
+    positions = [[0., 0.], [0., 15.], [0, 30.]]
+    probe.set_contacts(positions=positions, shapes='circle',
+                       shape_params={'radius': 5})
+    probe.set_device_channel_indices([-1, -1, -1])
+    probe.create_auto_shape()
+
+    rec_empty_probe = rec.set_probe(probe, group_mode='by_shank')
+
     # test return_scale
     sampling_frequency = 30000
     traces = np.zeros((1000, 5), dtype='int16')


### PR DESCRIPTION
This PR adds a test case in which an unconnected probe is set for a recording.
Linking an unconnected probe is not a main use case, but might occur e.g. when looping across multiple recording streams and automatically generating probes for all of them.
Previously this case raised an error.