### PR TITLE
Make GPU usage for containers more flexible

### DIFF
--- a/spikeinterface/sorters/basesorter.py
+++ b/spikeinterface/sorters/basesorter.py
@@ -26,7 +26,7 @@ class BaseSorter:
     compiled_name = None
     SortingExtractor_Class = None  # convenience to get the extractor
     requires_locations = False
-    docker_requires_gpu = False
+    requires_gpu = None
     compatible_with_parallel = {'loky': True, 'multiprocessing': True, 'threading': True}
     _default_params = {}
     _params_description = {}
@@ -289,6 +289,10 @@ class BaseSorter:
         if retcode != 0:
             return False
         return True
+    
+    @classmethod
+    def use_gpu(cls, params):
+        return cls.requires_gpu
 
     #############################################
 

--- a/spikeinterface/sorters/ironclust/ironclust.py
+++ b/spikeinterface/sorters/ironclust/ironclust.py
@@ -34,7 +34,7 @@ class IronClustSorter(BaseSorter):
     ironclust_path: Union[str, None] = os.getenv('IRONCLUST_PATH', None)
 
     requires_locations = True
-    docker_requires_gpu = True
+    requires_gpu = 'nvidia'
 
     _default_params = {
         'detect_sign': -1,  # Use -1, 0, or 1, depending on the sign of the spikes in the recording
@@ -142,6 +142,13 @@ class IronClustSorter(BaseSorter):
                 version = d['version']
                 return version
         return 'unknown'
+    
+    @classmethod
+    def use_gpu(cls, params):
+        if params["fGpu"]:
+            return 'nvidia'
+        else:
+            return None
 
     @staticmethod
     def set_ironclust_path(ironclust_path: PathType):

--- a/spikeinterface/sorters/kilosort/kilosort.py
+++ b/spikeinterface/sorters/kilosort/kilosort.py
@@ -30,7 +30,7 @@ class KilosortSorter(KilosortBase, BaseSorter):
     compiled_name: str = 'ks_compiled'
     kilosort_path: Union[str, None] = os.getenv('KILOSORT_PATH', None)
     requires_locations = False
-    docker_requires_gpu = True
+    requires_gpu = None
 
     _default_params = {
         'detect_threshold': 6,
@@ -89,6 +89,13 @@ class KilosortSorter(KilosortBase, BaseSorter):
             return 'unknown'
         else:
             return 'git-' + commit
+        
+    @classmethod
+    def use_gpu(cls, params):
+        if params["useGPU"]:
+            return 'nvidia'
+        else:
+            return None
 
     @classmethod
     def set_kilosort_path(cls, kilosort_path: str):

--- a/spikeinterface/sorters/kilosort2/kilosort2.py
+++ b/spikeinterface/sorters/kilosort2/kilosort2.py
@@ -30,7 +30,6 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
     compiled_name: str = 'ks2_compiled'
     kilosort2_path: Union[str, None] = os.getenv('KILOSORT2_PATH', None)
     requires_locations = False
-    docker_requires_gpu = True
 
     _default_params = {
         'detect_threshold': 6,

--- a/spikeinterface/sorters/kilosort2_5/kilosort2_5.py
+++ b/spikeinterface/sorters/kilosort2_5/kilosort2_5.py
@@ -33,7 +33,6 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
     compiled_name: str = 'ks2_5_compiled'
     kilosort2_5_path: Union[str, None] = os.getenv('KILOSORT2_5_PATH', None)
     requires_locations = False
-    docker_requires_gpu = True
 
     _default_params = {
         'detect_threshold': 6,

--- a/spikeinterface/sorters/kilosort3/kilosort3.py
+++ b/spikeinterface/sorters/kilosort3/kilosort3.py
@@ -31,7 +31,6 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
     compiled_name: str = 'ks3_compiled'
     kilosort3_path: Union[str, None] = os.getenv('KILOSORT3_PATH', None)
     requires_locations = False
-    docker_requires_gpu = True
 
     _default_params = {
         'detect_threshold': 6,

--- a/spikeinterface/sorters/kilosortbase.py
+++ b/spikeinterface/sorters/kilosortbase.py
@@ -18,6 +18,7 @@ class KilosortBase:
       * _run_from_folder
       * _get_result_from_folder
     """
+    requires_gpu = 'nvidia'
 
     @staticmethod
     def _generate_channel_map_file(recording, output_folder):

--- a/spikeinterface/sorters/pykilosort/pykilosort.py
+++ b/spikeinterface/sorters/pykilosort/pykilosort.py
@@ -19,7 +19,7 @@ class PyKilosortSorter(BaseSorter):
 
     sorter_name = 'pykilosort'
     requires_locations = False
-    docker_requires_gpu = True
+    requires_gpu = 'nvidia'
     compatible_with_parallel = {'loky': True, 'multiprocessing': False, 'threading': False}
 
     _default_params = {

--- a/spikeinterface/sorters/utils/__init__.py
+++ b/spikeinterface/sorters/utils/__init__.py
@@ -1,2 +1,2 @@
 from .shellscript import ShellScript
-from .misc import (SpikeSortingError, get_git_commit)
+from .misc import (SpikeSortingError, get_git_commit, has_nvidia)

--- a/spikeinterface/sorters/utils/misc.py
+++ b/spikeinterface/sorters/utils/misc.py
@@ -20,3 +20,14 @@ def get_git_commit(git_folder, shorten=True):
     except:
         commit = None
     return commit
+
+
+def has_nvidia():
+    """
+    Checks if the machine has nvidia capability.
+    """
+    try:
+        check_output('nvidia-smi')
+        return True
+    except Exception:  # this command not being found can raise quite a few different errors depending on the configuration
+        return False

--- a/spikeinterface/sorters/yass/yass.py
+++ b/spikeinterface/sorters/yass/yass.py
@@ -17,7 +17,7 @@ class YassSorter(BaseSorter):
 
     sorter_name = 'yass'
     requires_locations = False
-    docker_requires_gpu = True
+    requires_gpu = 'nvidia'
 
     # #################################################
 


### PR DESCRIPTION
For some sorters (Ironclust, Kilosort1), GPU usage is optional.
This PR allows one to override the default GPU requirements using sorter parameters. Additionally, it checks if an nvidia gpu is available when needed (and if not it throws an interpretable error)