### PR TITLE
Add extra_requirements attribute to extractors

### DIFF
--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -251,6 +251,8 @@ class BaseExtractor:
                 other.set_property(k, values[inds])
         # TODO: copy features also
 
+        other.extra_requirements.extend(self.extra_requirements)
+
     def to_dict(self, include_annotations=False, include_properties=False, include_features=False,
                 relative_to=None, folder_metadata=None):
         """

--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -54,6 +54,9 @@ class BaseExtractor:
 
         self.is_dumpable = True
 
+        # Extractor specific list of pip extra requirements
+        self.extra_requirements = []
+
     def get_num_segments(self):
         # This is implemented in BaseRecording or BaseSorting
         raise NotImplementedError

--- a/spikeinterface/extractors/__init__.py
+++ b/spikeinterface/extractors/__init__.py
@@ -1,4 +1,4 @@
 from .extractorlist import *
 
 from .toy_example import toy_example
-from .bids import read_bids_folder
+from .bids import read_bids

--- a/spikeinterface/extractors/alfsortingextractor.py
+++ b/spikeinterface/extractors/alfsortingextractor.py
@@ -82,6 +82,8 @@ class ALFSortingExtractor(BaseSorting):
         sorting_segment = ALFSortingSegment(spike_clusters, spike_times, sampling_frequency)
         self.add_sorting_segment(sorting_segment)
 
+        self.extra_requirements.append('pandas')
+
         # add properties
         for property_name, values in properties.items():
             self.set_property(property_name, values)

--- a/spikeinterface/extractors/bids.py
+++ b/spikeinterface/extractors/bids.py
@@ -34,6 +34,7 @@ def read_bids(folder_path):
         if file_path.suffix == '.nwb':
             rec, = read_nwb(file_path, load_recording=True, load_sorting=False, electrical_series_name=None)
             rec.annotate(bids_name=bids_name)
+            rec.extra_requirements.extend('pandas')
             probegroup = _read_probe_group(file_path.parent, bids_name, rec.channel_ids)
             rec = rec.set_probegroup(probegroup)
             recordings.append(rec)
@@ -45,6 +46,7 @@ def read_bids(folder_path):
 
             for stream_id in stream_ids:
                 rec = read_nix(file_path, stream_id=stream_id)
+                rec.extra_requirements.extend('pandas')
                 probegroup = _read_probe_group(file_path.parent, bids_name, rec.channel_ids)
                 rec = rec.set_probegroup(probegroup)
                 recordings.append(rec)

--- a/spikeinterface/extractors/bids.py
+++ b/spikeinterface/extractors/bids.py
@@ -11,7 +11,7 @@ from probeinterface import read_BIDS_probe
 import neo
 
 
-def read_bids_folder(folder_path):
+def read_bids(folder_path):
     """
     This read an entire BIDS folder and return a list of recording with
     there attached Probe.

--- a/spikeinterface/extractors/cbin_ibl.py
+++ b/spikeinterface/extractors/cbin_ibl.py
@@ -80,6 +80,8 @@ class CompressedBinaryIblExtractor(BaseRecording):
         recording_segment = CBinIblRecordingSegment(cbuffer, sampling_frequency, load_sync_channel)
         self.add_recording_segment(recording_segment)
 
+        self.extra_requirements.append('mtscomp')
+
         # set inplace meta data
         self.set_channel_gains(gains)
         self.set_channel_offsets(offsets)

--- a/spikeinterface/extractors/combinatoextractors.py
+++ b/spikeinterface/extractors/combinatoextractors.py
@@ -67,6 +67,8 @@ class CombinatoSortingExtractor(BaseSorting):
         self.set_property('artifact', np.array([metadata[u]['group_type'] == -1 for u in range(unit_counter)]))
         self._kwargs = {'folder_path': str(folder_path), 'user': user, 'det_sign': det_sign}
 
+        self.extra_requirements.append('h5py')
+
 
 class CombinatoSortingSegment(BaseSortingSegment):
     def __init__(self, spiketrains):

--- a/spikeinterface/extractors/herdingspikesextractors.py
+++ b/spikeinterface/extractors/herdingspikesextractors.py
@@ -41,6 +41,8 @@ class HerdingspikesSortingExtractor(BaseSorting):
         self.add_sorting_segment(HerdingspikesSortingSegment(unit_ids, spike_times, spike_ids))
         self._kwargs = {'file_path': str(Path(file_path).absolute()), 'load_unit_info': load_unit_info}
 
+        self.extra_requirements.append('h5py')
+
     def load_unit_info(self):
         # TODO
         """

--- a/spikeinterface/extractors/klustaextractors.py
+++ b/spikeinterface/extractors/klustaextractors.py
@@ -114,6 +114,7 @@ class KlustaSortingExtractor(BaseSorting):
 
         BaseSorting.__init__(self, sampling_frequency, unit_ids)
         self.is_dumpable = False
+        self.extra_requirements.append('h5py')
 
         self.add_sorting_segment(KlustSortingSegment(unit_ids, spiketrains))
 

--- a/spikeinterface/extractors/mcsh5extractors.py
+++ b/spikeinterface/extractors/mcsh5extractors.py
@@ -43,6 +43,8 @@ class MCSH5RecordingExtractor(BaseRecording):
 
         BaseRecording.__init__(self, sampling_frequency=mcs_info["sampling_frequency"], channel_ids=mcs_info["channel_ids"],
                                dtype=mcs_info["dtype"])
+
+        self.extra_requirements.append('h5py')
         
         recording_segment = MCSH5RecordingSegment(self._rf, stream_id, mcs_info["num_frames"], 
                                                   sampling_frequency=mcs_info["sampling_frequency"])

--- a/spikeinterface/extractors/neoextractors/ced.py
+++ b/spikeinterface/extractors/neoextractors/ced.py
@@ -24,6 +24,8 @@ class CedRecordingExtractor(NeoBaseRecordingExtractor):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, **neo_kwargs)
 
+        self.extra_requirements.append('sonpy')
+
         self._kwargs = dict(file_path=str(file_path), stream_id=stream_id)
 
 

--- a/spikeinterface/extractors/neoextractors/maxwell.py
+++ b/spikeinterface/extractors/neoextractors/maxwell.py
@@ -32,6 +32,8 @@ class MaxwellRecordingExtractor(NeoBaseRecordingExtractor):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, rec_name=rec_name, **neo_kwargs)
 
+        self.extra_requirements.append('h5py')
+
         # well_name is stream_id
         well_name = self.stream_id
         # rec_name auto set by neo

--- a/spikeinterface/extractors/neoextractors/mearec.py
+++ b/spikeinterface/extractors/neoextractors/mearec.py
@@ -22,6 +22,8 @@ class MEArecRecordingExtractor(NeoBaseRecordingExtractor):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, **neo_kwargs)
 
+        self.extra_requirements.append('mearec')
+
         probe = pi.read_mearec(file_path)
         self.set_probe(probe, in_place=True)
         self.annotate(is_filtered=True)

--- a/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -53,6 +53,7 @@ class NeoBaseRecordingExtractor(_NeoBaseExtractor, BaseRecording):
         sampling_frequency = self.neo_reader.get_signal_sampling_rate(stream_index=self.stream_index)
         dtype = signal_channels['dtype'][0]
         BaseRecording.__init__(self, sampling_frequency, chan_ids, dtype)
+        self.extra_requirements.append('neo')
 
         # find the gain to uV
         gains = signal_channels['gain']

--- a/spikeinterface/extractors/neoextractors/neuroscope.py
+++ b/spikeinterface/extractors/neoextractors/neuroscope.py
@@ -200,6 +200,8 @@ class NeuroScopeSortingExtractor(BaseSorting):
         self.add_sorting_segment(
             NeuroScopeSortingSegment(all_unit_ids, all_spiketrains))
 
+        self.extra_requirements.append('lxml')
+
         # set "group" property based on shank ids
         if len(all_unit_shank_ids) > 0:
             self.set_property("group", all_unit_shank_ids)

--- a/spikeinterface/extractors/neoextractors/nix.py
+++ b/spikeinterface/extractors/neoextractors/nix.py
@@ -2,6 +2,11 @@ from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
 
+try:
+    import nixio
+    HAVE_NIX = True
+except ModuleNotFoundError:
+    HAVE_NIX = False
 
 class NixRecordingExtractor(NeoBaseRecordingExtractor):
     """
@@ -21,6 +26,8 @@ class NixRecordingExtractor(NeoBaseRecordingExtractor):
     def __init__(self, file_path, stream_id=None):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, **neo_kwargs)
+
+        self.extra_requirements.append('nixio')
 
         self._kwargs = dict(file_path=str(file_path), stream_id=stream_id)
 

--- a/spikeinterface/extractors/neoextractors/spike2.py
+++ b/spikeinterface/extractors/neoextractors/spike2.py
@@ -23,6 +23,8 @@ class Spike2RecordingExtractor(NeoBaseRecordingExtractor):
         neo_kwargs = {'filename': file_path}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, **neo_kwargs)
 
+        self.extra_requirements.append('sonpy')
+
         self._kwargs = {'file_path': str(file_path), 'stream_id': stream_id}
 
 

--- a/spikeinterface/extractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors.py
@@ -160,6 +160,8 @@ class NwbRecordingExtractor(BaseRecording):
                                                 num_frames=num_frames, times_kwargs=times_kwargs)
         self.add_recording_segment(recording_segment)
 
+        self.extra_requirements.extend(['pandas', 'pynwb'])
+
         # If gains are not 1, set has_scaled to True
         if np.any(gains != 1):
             self.set_channel_gains(gains)

--- a/spikeinterface/extractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors.py
@@ -160,7 +160,7 @@ class NwbRecordingExtractor(BaseRecording):
                                                 num_frames=num_frames, times_kwargs=times_kwargs)
         self.add_recording_segment(recording_segment)
 
-        self.extra_requirements.extend(['pandas', 'pynwb'])
+        self.extra_requirements.extend(['pandas', 'pynwb', 'hdmf'])
 
         # If gains are not 1, set has_scaled to True
         if np.any(gains != 1):

--- a/spikeinterface/extractors/phykilosortextractors.py
+++ b/spikeinterface/extractors/phykilosortextractors.py
@@ -122,6 +122,7 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
             unit_ids = cluster_info["cluster_id"].values
 
         BaseSorting.__init__(self, sampling_frequency, unit_ids)
+        self.extra_requirements.append('pandas')
 
         del cluster_info["cluster_id"]
         for prop_name in cluster_info.columns:

--- a/spikeinterface/extractors/shybridextractors.py
+++ b/spikeinterface/extractors/shybridextractors.py
@@ -59,6 +59,7 @@ class SHYBRIDRecordingExtractor(BinaryRecordingExtractor):
         probegroup = read_prb(params['probe'])
         self.set_probegroup(probegroup, in_place=True)
         self._kwargs = {'file_path': str(Path(file_path).absolute())}
+        self.extra_requirements.append('hybridizer')
 
     @staticmethod
     def write_recording(recording, save_path, initial_sorting_fn, dtype='float32', verbose=True,
@@ -135,6 +136,7 @@ class SHYBRIDSortingExtractor(BaseSorting):
 
         self._kwargs = {'file_path': str(Path(file_path).absolute()), 'sampling_frequency': sampling_frequency,
                         'delimiter': delimiter}
+        self.extra_requirements.append('hybridizer')
 
     @staticmethod
     def write_sorting(sorting, save_path):

--- a/spikeinterface/extractors/shybridextractors.py
+++ b/spikeinterface/extractors/shybridextractors.py
@@ -59,7 +59,7 @@ class SHYBRIDRecordingExtractor(BinaryRecordingExtractor):
         probegroup = read_prb(params['probe'])
         self.set_probegroup(probegroup, in_place=True)
         self._kwargs = {'file_path': str(Path(file_path).absolute())}
-        self.extra_requirements.extend(['hybridizer', 'yaml'])
+        self.extra_requirements.extend(['hybridizer', 'pyyaml'])
 
     @staticmethod
     def write_recording(recording, save_path, initial_sorting_fn, dtype='float32', verbose=True,

--- a/spikeinterface/extractors/shybridextractors.py
+++ b/spikeinterface/extractors/shybridextractors.py
@@ -59,7 +59,7 @@ class SHYBRIDRecordingExtractor(BinaryRecordingExtractor):
         probegroup = read_prb(params['probe'])
         self.set_probegroup(probegroup, in_place=True)
         self._kwargs = {'file_path': str(Path(file_path).absolute())}
-        self.extra_requirements.append('hybridizer')
+        self.extra_requirements.extend(['hybridizer', 'yaml'])
 
     @staticmethod
     def write_recording(recording, save_path, initial_sorting_fn, dtype='float32', verbose=True,

--- a/spikeinterface/extractors/spykingcircusextractors.py
+++ b/spikeinterface/extractors/spykingcircusextractors.py
@@ -72,6 +72,7 @@ class SpykingCircusSortingExtractor(BaseSorting):
         self.add_sorting_segment(SpykingcircustSortingSegment(unit_ids, spiketrains))
 
         self._kwargs = {'folder_path': str(Path(folder_path).absolute())}
+        self.extra_requirements.append('h5py')
 
 
 class SpykingcircustSortingSegment(BaseSortingSegment):

--- a/spikeinterface/extractors/tests/common_tests.py
+++ b/spikeinterface/extractors/tests/common_tests.py
@@ -35,6 +35,8 @@ class RecordingCommonTestSuite(CommonTestSuite):
             rec = self.ExtractorClass(self.get_full_path(path), **kwargs)
             # print(rec)
 
+            assert hasattr(rec, 'extra_requirements')
+
             num_seg = rec.get_num_segments()
             num_chans = rec.get_num_channels()
             dtype = rec.get_dtype()

--- a/spikeinterface/extractors/tests/test_bids.py
+++ b/spikeinterface/extractors/tests/test_bids.py
@@ -17,7 +17,7 @@ def test_read_bids_folder():
     # ~ folder_path = '/home/samuel/Documents/BEP032-examples/ephys_nwb_petersen/sub-MS10/ses-PeterMS10170307154746concat/ephys/'
 
     folder_path = '/home/samuel/Documents/BEP032-examples/ephys_nix/sub-i/ses-140703/ephys/'
-    recordings = read_bids_folder(folder_path)
+    recordings = read_bids(folder_path)
     # ~ print(recordings)
 
     rec0 = recordings[0]

--- a/spikeinterface/extractors/tridesclousextractors.py
+++ b/spikeinterface/extractors/tridesclousextractors.py
@@ -17,7 +17,7 @@ class TridesclousSortingExtractor(BaseSorting):
     installation_mesg = "To use the TridesclousSortingExtractor install tridesclous: \n\n pip install tridesclous\n\n"  # error message when not installed
 
     def __init__(self, folder_path, chan_grp=None):
-        assert HAVE_TDC, self.installation_mesg
+        assert self.installed, self.installation_mesg
         tdc_folder = Path(folder_path)
 
         dataio = tdc.DataIO(str(tdc_folder))

--- a/spikeinterface/extractors/tridesclousextractors.py
+++ b/spikeinterface/extractors/tridesclousextractors.py
@@ -3,20 +3,20 @@ from pathlib import Path
 from spikeinterface.core import (BaseSorting, BaseSortingSegment)
 from spikeinterface.core.core_tools import define_function_from_class
 
+try:
+    import tridesclous as tdc
+    HAVE_TDC = True
+except ImportError:
+    HAVE_TDC = False
 
 class TridesclousSortingExtractor(BaseSorting):
     extractor_name = 'TridesclousSortingExtractor'
-    installed = False
+    installed = HAVE_TDC
     is_writable = False
     mode = 'folder'
     installation_mesg = "To use the TridesclousSortingExtractor install tridesclous: \n\n pip install tridesclous\n\n"  # error message when not installed
 
     def __init__(self, folder_path, chan_grp=None):
-        try:
-            import tridesclous as tdc
-            HAVE_TDC = True
-        except ImportError:
-            HAVE_TDC = False
         assert HAVE_TDC, self.installation_mesg
         tdc_folder = Path(folder_path)
 

--- a/spikeinterface/extractors/tridesclousextractors.py
+++ b/spikeinterface/extractors/tridesclousextractors.py
@@ -42,6 +42,7 @@ class TridesclousSortingExtractor(BaseSorting):
             self.add_sorting_segment(TridesclousSortingSegment(all_spikes))
 
         self._kwargs = {'folder_path': str(Path(folder_path).absolute()), 'chan_grp': chan_grp}
+        self.extra_requirements.append('tridesclous')
 
 
 class TridesclousSortingSegment(BaseSortingSegment):

--- a/spikeinterface/extractors/yassextractors.py
+++ b/spikeinterface/extractors/yassextractors.py
@@ -44,7 +44,7 @@ class YassSortingExtractor(BaseSorting):
         self.add_sorting_segment(YassSortingSegment(spiketrains))
 
         self._kwargs = {'folder_path': str(folder_path)}
-        self.extra_requirements.append('yaml')
+        self.extra_requirements.append('pyyaml')
 
 
 class YassSortingSegment(BaseSortingSegment):

--- a/spikeinterface/extractors/yassextractors.py
+++ b/spikeinterface/extractors/yassextractors.py
@@ -44,6 +44,7 @@ class YassSortingExtractor(BaseSorting):
         self.add_sorting_segment(YassSortingSegment(spiketrains))
 
         self._kwargs = {'folder_path': str(folder_path)}
+        self.extra_requirements.append('yaml')
 
 
 class YassSortingSegment(BaseSortingSegment):


### PR DESCRIPTION
This attribute is used by the `run_sorter_container` function to install missing requirements in the container.

This PR also harmonized the requirements handling for the tdc extractor and renames `read_bids_folder` to `read_bids` for consistent naming with other formats.