### PR TITLE
Add `array_to_image` function to `widgets.utils`

### DIFF
--- a/spikeinterface/widgets/__init__.py
+++ b/spikeinterface/widgets/__init__.py
@@ -1,4 +1,4 @@
-from .utils import get_unit_colors
+from .utils import get_unit_colors, array_to_image
 
 # basics
 from .timeseries import plot_timeseries, TimeseriesWidget

--- a/spikeinterface/widgets/utils.py
+++ b/spikeinterface/widgets/utils.py
@@ -1,4 +1,6 @@
 import matplotlib.pyplot as plt
+from scipy.ndimage import zoom
+
 import numpy as np
 
 import random
@@ -66,9 +68,6 @@ def array_to_image(data,
     output_image : 3D numpy array
     
     """
-
-    from scipy.ndimage import zoom
-    import matplotlib.pyplot as plt
 
     num_timepoints = data.shape[0]
     num_channels = data.shape[1]

--- a/spikeinterface/widgets/utils.py
+++ b/spikeinterface/widgets/utils.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+import numpy as np
 
 import random
 
@@ -36,3 +37,64 @@ def get_unit_colors(sorting, map_name='gist_ncar', format='RGBA', shuffle=False)
     
 
     return dict_colors
+
+
+def array_to_image(data, 
+                   colormap='RdGy',
+                   color_range=200, 
+                   spatial_zoom=(0.75,1.25),
+                   num_timepoints_per_row=30000,
+                   row_spacing=0.25):
+    
+    """
+    Converts a 2D numpy array (width x height) to a 
+    3D image array (width x height x RGB color).
+
+    Useful for visualizing data before/after preprocessing
+    
+    Params
+    =======
+    data : 2D numpy array
+    colormap : str identifier for a Matplotlib colormap
+    color_range : maximum range
+    spatial_zoom : tuple specifying width & height scaling
+    num_timepoints_per_row : max number of samples before wrapping
+    row_spacing : ratio of row spacing to overall channel height
+    
+    Returns
+    ========
+    output_image : 3D numpy array
+    
+    """
+
+    from scipy.ndimage import zoom
+    import matplotlib.pyplot as plt
+
+    num_timepoints = data.shape[0]
+    num_channels = data.shape[1]
+    num_channels_after_scaling = int(num_channels * spatial_zoom[1])
+    spacing = int(num_channels * spatial_zoom[1] * row_spacing)
+    
+    num_timepoints_after_scaling = int(num_timepoints * spatial_zoom[0])
+    num_timepoints_per_row_after_scaling = int(np.min([num_timepoints_per_row, num_timepoints]) * spatial_zoom[0])
+    
+    cmap = plt.get_cmap(colormap)
+    zoomed_data = zoom(data, spatial_zoom)
+    scaled_data = (zoomed_data + color_range)/(color_range*2) # rescale between 0 and 1
+    scaled_data[scaled_data < 0] = 0 # remove outliers
+    scaled_data[scaled_data > 1] = 1 # remove outliers
+    a = np.flip((cmap(scaled_data.T)[:,:,:3]*255).astype(np.uint8), axis=0) # colorize and convert to uint8
+    
+    num_rows = int(np.ceil(num_timepoints / num_timepoints_per_row))
+    
+    output_image = np.ones(
+        (num_rows * (num_channels_after_scaling + spacing) - spacing, 
+         num_timepoints_per_row_after_scaling, 3), dtype=np.uint8
+        ) * 255
+    
+    for ir in range(num_rows):
+        i1 = ir * num_timepoints_per_row_after_scaling
+        i2 = min(i1 + num_timepoints_per_row_after_scaling, num_timepoints_after_scaling)
+        output_image[ir * (num_channels_after_scaling + spacing):ir * (num_channels_after_scaling + spacing) + num_channels_after_scaling, :i2-i1, :] = a[:, i1:i2, :]
+
+    return output_image


### PR DESCRIPTION
This commit adds a new plotting utility function that can be used to convert a very large 2D array (e.g. seconds to minutes of raw data) into an RGB image array.

In the short term, this is needed to run the [SpikeInterface example](https://github.com/scratchrealm/figurl-tiled-image/blob/main/examples/spikeinterface_example.py) in the `figurl-tiled-image` repository.

In the longer term, this can be used to implement an alternative backend to `plot_timeseries` which creates a multi-layer tiled image on `figurl`.