### PR TITLE
Change typing of `channel_ids` in `BaseRecording.get_traces`

### DIFF
--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Iterable, List, Union
 from pathlib import Path
 
 import numpy as np
@@ -91,7 +91,7 @@ class BaseRecording(BaseExtractor):
                    segment_index: Union[int, None] = None,
                    start_frame: Union[int, None] = None,
                    end_frame: Union[int, None] = None,
-                   channel_ids: Union[List, None] = None,
+                   channel_ids: Union[Iterable, None] = None,
                    order: Union[str, None] = None,
                    return_scaled=False,
                    ):


### PR DESCRIPTION
Change from `List` to `Iterable`.

With possible incoming of `np.ndarray`, `List` is incompatible. On the other hand, `Iterable` is enough since it's only used as `ids` in the loop:

https://github.com/SpikeInterface/spikeinterface/blob/8143a0d057c93e4aa816f755189c159052a49df1/spikeinterface/core/base.py#L90