### PR TITLE
Add `packaging` as essential requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ neo>=0.10.2
 joblib
 tqdm
 probeinterface>=0.2.9
+packaging


### PR DESCRIPTION
When installing spikeinterface with minimal requirements `import spikeinterface` fails due to `packaging` not being available, but required by `core/base.py`.