### PR TITLE
Fix run singularity with Bool value

### DIFF
--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -103,12 +103,17 @@ def run_sorter(
         with_output=with_output,
         **sorter_params,
     )
-
-    if docker_image or singularity_image:
+    if docker_image:
         return run_sorter_container(
-            container_image=docker_image if isinstance(docker_image, str) else singularity_image,
-            mode="docker" if docker_image else "singularity",
-            **common_kwargs,
+            container_image=docker_image if isinstance(docker_image, str) else None,
+            mode='docker',
+            **common_kwargs
+        )
+    if singularity_image:
+        return run_sorter_container(
+            container_image=singularity_image if isinstance(singularity_image, str) else None,
+            mode='singularity',
+            **common_kwargs
         )
 
     return run_sorter_local(**common_kwargs)


### PR DESCRIPTION
When trying to run singularity with Bool option, it's failing because `container_image` ends up to be `True` and this is preventing from mapping image name through `SORTER_DOCKER_MAP`

I tried this patch:
```python
    if docker_image or singularity_image:
        container_image = None
        if isinstance(docker_image, str):
            container_image = docker_image
        elif isinstance(singularity_image, str):
            container_image = singularity_image
        return run_sorter_container(
            container_image=container_image,
            mode="docker" if docker_image else "singularity",
            **common_kwargs,
        )
```

But it also fails if for some reason a user runs with `docker_image=True` and `singularity_image="<image-name>"`
So instead of adding one more check I decided to split call for `run_sorter_container`.
This way it's more clear that we're prioritizing docker and we don't have to check multiple combinations between True/False/str for docker_image and singularity_image