### PR TITLE
fix the kwargs bug in neo case

### DIFF
--- a/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -26,9 +26,9 @@ class NeoBaseRecordingExtractor(_NeoBaseExtractor, BaseRecording):
 
         _NeoBaseExtractor.__init__(self, **neo_kwargs)
 
-        self._kwargs = dict(all_annotations=all_annotations)
+        kwargs = dict(all_annotations=all_annotations)
         if stream_id is not None:
-            self._kwargs['stream_id'] = stream_id
+            kwargs['stream_id'] = stream_id
 
         stream_channels = self.neo_reader.header['signal_streams']
         stream_ids = stream_channels['id']
@@ -100,7 +100,8 @@ class NeoBaseRecordingExtractor(_NeoBaseExtractor, BaseRecording):
         for segment_index in range(nseg):
             rec_segment = NeoRecordingSegment(self.neo_reader, segment_index, self.stream_index)
             self.add_recording_segment(rec_segment)
-
+        
+        self._kwargs.update(kwargs)
 
 class NeoRecordingSegment(BaseRecordingSegment):
     def __init__(self, neo_reader, segment_index, stream_index):


### PR DESCRIPTION
@alejoe91 : we were very tired.
The bug of kwargs was still here becasue `BaseRecording.init` was called after !!!!!
Go back to your solution.