### PR TITLE
Add BinaryFolder + binary compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/cache_folder/**
+
 spikeinterface/core/tests/*.raw
 spikeinterface/core/tests/*.json
 spikeinterface/core/tests/*.pkl

--- a/spikeinterface/core/__init__.py
+++ b/spikeinterface/core/__init__.py
@@ -18,6 +18,8 @@ from .binaryrecordingextractor import BinaryRecordingExtractor, read_binary
 from .npzsortingextractor import NpzSortingExtractor, read_npz_sorting
 from .numpyextractors import NumpyRecording, NumpySorting, NumpyEvent
 from .zarrrecordingextractor import ZarrRecordingExtractor, read_zarr, get_default_zarr_compressor
+from .binaryfolder import BinaryFolderRecording, read_binary_folder
+
 
 # utility extractors (equivalent to OLD subrecording/subsorting)
 from .channelslicerecording import ChannelSliceRecording

--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -526,14 +526,22 @@ class BaseExtractor:
             # case from a folder after a calling extractor.save(...)
             folder = file_path
             file = None
+            
+            # the is spikeinterface<=0.94.0
+            # a folder came with 'cached.sjon'
             for dump_ext in ('json', 'pkl', 'pickle'):
                 f = folder / f'cached.{dump_ext}'
                 if f.is_file():
                     file = f
+            
+            # spikeinterface>=0.95.0
+            f = folder / f'si_folder.json'
+            if f.is_file():
+                file = f
+
             if file is None:
                 raise ValueError(f'This folder is not a cached folder {file_path}')
             extractor = BaseExtractor.load(file, base_folder=folder)
-
 
             return extractor
 
@@ -600,7 +608,7 @@ class BaseExtractor:
         return cached
 
     # TODO rename to saveto_binary_folder
-    def save_to_folder(self, name=None, folder=None, dump_ext='json', verbose=True, **save_kwargs):
+    def save_to_folder(self, name=None, folder=None,  verbose=True, **save_kwargs):
         """
         Save extractor to folder.
 
@@ -636,6 +644,7 @@ class BaseExtractor:
         -------
         cached: saved copy of the extractor.
         """
+        
         if folder is None:
             cache_folder = get_global_tmp_folder()
             if name is None:
@@ -654,7 +663,7 @@ class BaseExtractor:
         folder.mkdir(parents=True, exist_ok=False)
 
         # dump provenance
-        provenance_file = folder / f'provenance.{dump_ext}'
+        provenance_file = folder / f'provenance.json'
         if self.check_if_dumpable():
             self.dump(provenance_file)
         else:
@@ -662,17 +671,18 @@ class BaseExtractor:
                 json.dumps({'warning': 'the provenace is not dumpable!!!'}),
                 encoding='utf8'
             )
-
+        
+        self.save_metadata_to_folder(folder)
+        
         # save data (done the subclass)
         cached = self._save(folder=folder, verbose=verbose, **save_kwargs)
-
-        self.save_metadata_to_folder(folder)
 
         # copy properties/
         self.copy_metadata(cached)
 
         # dump
-        cached.dump(folder / f'cached.{dump_ext}', relative_to=folder, folder_metadata=folder)
+        # cached.dump(folder / f'cached.json', relative_to=folder, folder_metadata=folder)
+        cached.dump(folder / f'si_folder.json', relative_to=folder)
 
         return cached
 

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -693,13 +693,13 @@ class BaseRecording(BaseExtractor):
         -------
         is_binary_compatible: bool
         """
-        # have to changed in subclass is yes
+        # has to be changed in subclass if yes
         return False
         
     def get_binary_description(self):
         """
         When `rec.is_binary_compatible()` is True
-        This must return describing the binary format.
+        this returns a dictionary describing the binary format.
         """
         if not self.is_binary_compatible:
             raise NotImplementedError

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -20,7 +20,7 @@ class BaseRecording(BaseExtractor):
     _main_annotations = ['is_filtered']
     _main_properties = ['group', 'location', 'gain_to_uV', 'offset_to_uV']
     _main_features = []  # recording do not handle features
-
+    
     def __init__(self, sampling_frequency: float, channel_ids: List, dtype):
         BaseExtractor.__init__(self, channel_ids)
 
@@ -680,6 +680,59 @@ class BaseRecording(BaseExtractor):
         recording2d.set_probe(probe2d, in_place=True)
 
         return recording2d
+    
+    def is_binary_compatible(self):
+        """
+        Inform is this recording is "binary" compatible.
+        To be used before calling `rec.get_binary_description()`
+        
+        Returns
+        -------
+        is_binary_compatible: bool
+        """
+        # have to changed in subclass is yes
+        return False
+        
+    def get_binary_description(self):
+        """
+        When `rec.is_binary_compatible()` is True
+        This must return describing the binary format.
+        """
+        if not self.is_binary_compatible:
+            raise NotImplementedError
+    
+    def binary_compatible_with(self, dtype=None, time_axis=None, file_paths_lenght=None, 
+            file_offset=None, file_suffix=None):
+        """
+        Check is the recording is binary compatible with some constrain on
+          * dtype
+          * tim_axis
+          * len(file_paths)
+          * file_offset
+          * file_suffix
+        """
+        if not self.is_binary_compatible():
+            return False
+        
+        d = self.get_binary_description()
+        
+        if dtype is not None and dtype != d['dtype']:
+            return False
+        
+        if time_axis is not None and time_axis != d['time_axis']:
+            return False
+        
+        if file_paths_lenght is not None and file_paths_lenght != len(d['file_paths']):
+            return False
+        
+        if file_offset is not None and file_offset != d['file_offset']:
+            return False
+        
+        if file_suffix is not None and not all(Path(e).suffix == file_suffix):
+            return False
+
+        # good job you pass all crucible
+        return True
 
 
 class BaseRecordingSegment(BaseSegment):

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -192,8 +192,7 @@ class BaseRecording(BaseExtractor):
 
             job_kwargs = {k: save_kwargs[k] for k in job_keys if k in save_kwargs}
             write_binary_recording(self, file_paths=file_paths, dtype=dtype, **job_kwargs)
-            
-            
+
             from .binaryrecordingextractor import BinaryRecordingExtractor
             cached = BinaryRecordingExtractor(file_paths=file_paths, sampling_frequency=self.get_sampling_frequency(),
                                               num_chan=self.get_num_channels(), dtype=dtype,
@@ -201,7 +200,7 @@ class BaseRecording(BaseExtractor):
                                               file_offset=0, gain_to_uV=self.get_channel_gains(),
                                               offset_to_uV=self.get_channel_offsets())
             cached.dump(folder / 'binary.json', relative_to=folder)
-            
+
             from .binaryfolder import BinaryFolderRecording
             cached = BinaryFolderRecording(folder_path=folder)
 

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -184,7 +184,6 @@ class BaseRecording(BaseExtractor):
             t_starts = None
 
         if format == 'binary':
-            # TODO save properties as npz!!!!!
             folder = save_kwargs['folder']
             file_paths = [folder / f'traces_cached_seg{i}.raw' for i in range(self.get_num_segments())]
             dtype = save_kwargs.get('dtype', None)
@@ -193,13 +192,18 @@ class BaseRecording(BaseExtractor):
 
             job_kwargs = {k: save_kwargs[k] for k in job_keys if k in save_kwargs}
             write_binary_recording(self, file_paths=file_paths, dtype=dtype, **job_kwargs)
-
+            
+            
             from .binaryrecordingextractor import BinaryRecordingExtractor
             cached = BinaryRecordingExtractor(file_paths=file_paths, sampling_frequency=self.get_sampling_frequency(),
                                               num_chan=self.get_num_channels(), dtype=dtype,
                                               t_starts=t_starts, channel_ids=self.get_channel_ids(), time_axis=0,
                                               file_offset=0, gain_to_uV=self.get_channel_gains(),
                                               offset_to_uV=self.get_channel_offsets())
+            cached.dump(folder / 'binary.json', relative_to=folder)
+            
+            from .binaryfolder import BinaryFolderRecording
+            cached = BinaryFolderRecording(folder_path=folder)
 
         elif format == 'memory':
             job_kwargs = {k: save_kwargs[k] for k in job_keys if k in save_kwargs}

--- a/spikeinterface/core/basesorting.py
+++ b/spikeinterface/core/basesorting.py
@@ -119,10 +119,11 @@ class BaseSorting(BaseExtractor):
                 warnings.warn(
                     "The registered recording will not be persistent on disk, but only available in memory")
                 cached.register_recording(self._recording)
-        else:
+        elif format == 'memory':
             from .numpyextractors import NumpySorting
             cached = NumpySorting.from_extractor(self)
-            
+        else:
+            raise ValueError(f'format {format} not supported')            
         return cached
 
     def get_unit_property(self, unit_id, key):

--- a/spikeinterface/core/binaryfolder.py
+++ b/spikeinterface/core/binaryfolder.py
@@ -12,9 +12,9 @@ from .core_tools import define_function_from_class
 class BinaryFolderRecording(BinaryRecordingExtractor):
     """
     BinaryFolderRecording is an internal format used in spikeinterface.
-    It is a BinaryRecordingExtractor + metadata contain in a folder.
+    It is a BinaryRecordingExtractor + metadata contained in a folder.
     
-    It is create with any `rec.save(format='binary', folder='/myfolder')`
+    It is created with the function: `recording.save(format='binary', folder='/myfolder')`
     
     Parameters
     ----------

--- a/spikeinterface/core/binaryfolder.py
+++ b/spikeinterface/core/binaryfolder.py
@@ -29,7 +29,7 @@ class BinaryFolderRecording(BinaryRecordingExtractor):
         
         folder_path = Path(folder_path)
         
-        with open(folder_path / 'cached.json', 'r') as f:
+        with open(folder_path / 'binary.json', 'r') as f:
             d = json.load(f)
 
         if not d['class'].endswith('.BinaryRecordingExtractor'):

--- a/spikeinterface/core/binaryfolder.py
+++ b/spikeinterface/core/binaryfolder.py
@@ -33,13 +33,12 @@ class BinaryFolderRecording(BinaryRecordingExtractor):
             d = json.load(f)
 
         if not d['class'].endswith('.BinaryRecordingExtractor'):
-            raise ValueError('This folder is not a binary spikeinetrface folder')
-        
+            raise ValueError('This folder is not a binary spikeinterface folder')
+
         assert d['relative_paths']
 
         d = _make_paths_absolute(d, folder_path)
-        
-        
+
         BinaryRecordingExtractor.__init__(self, **d['kwargs'])
 
         folder_metadata = folder_path

--- a/spikeinterface/core/binaryfolder.py
+++ b/spikeinterface/core/binaryfolder.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+import json
+
+import numpy as np
+
+from .base import _make_paths_absolute
+from .binaryrecordingextractor import BinaryRecordingExtractor
+from .core_tools import define_function_from_class
+
+
+
+class BinaryFolderRecording(BinaryRecordingExtractor):
+    """
+    BinaryFolderRecording is an internal format used in spikeinterface.
+    It is a BinaryRecordingExtractor + metadata contain in a folder.
+    
+    It is create with any `rec.save(format='binary', folder='/myfolder')`
+    
+    Parameters
+    ----------
+    folder_path: str or Path
+    
+    Returns
+    -------
+    recording: BinaryFolderRecording
+        The recording
+    """
+    def __init__(self,  folder_path):
+        
+        folder_path = Path(folder_path)
+        
+        with open(folder_path / 'cached.json', 'r') as f:
+            d = json.load(f)
+
+        if not d['class'].endswith('.BinaryRecordingExtractor'):
+            raise ValueError('This folder is not a binary spikeinetrface folder')
+        
+        assert d['relative_paths']
+
+        d = _make_paths_absolute(d, folder_path)
+        
+        
+        BinaryRecordingExtractor.__init__(self, **d['kwargs'])
+
+        folder_metadata = folder_path
+        self.load_metadata_from_folder(folder_metadata)
+        
+        self._kwargs = dict(folder_path=str(folder_path))
+        self._bin_kwargs = d['kwargs']
+
+    def is_binary_compatible(self):
+        return True
+        
+    def get_binary_description(self):
+        d = dict(
+            file_paths=self._bin_kwargs['file_paths'],
+            dtype=np.dtype(self._bin_kwargs['dtype']),
+            num_channels=self._bin_kwargs['num_chan'],
+            time_axis=self._bin_kwargs['time_axis'],
+            file_offset=self._bin_kwargs['file_offset'],
+        )
+        return d
+
+
+read_binary_folder = define_function_from_class(source_class=BinaryFolderRecording, name="read_binary_folder")
+

--- a/spikeinterface/core/binaryrecordingextractor.py
+++ b/spikeinterface/core/binaryrecordingextractor.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 
 from .baserecording import BaseRecording, BaseRecordingSegment
-from .core_tools import read_binary_recording, write_binary_recording
+from .core_tools import read_binary_recording, write_binary_recording, define_function_from_class
 from .job_tools import _shared_job_kwargs_doc
 
 
@@ -50,7 +50,7 @@ class BinaryRecordingExtractor(BaseRecording):
     is_writable = True
     mode = 'file'
     installation_mesg = ""  # error message when not installed
-
+    
     def __init__(self, file_paths, sampling_frequency, num_chan, dtype, t_starts=None, channel_ids=None,
                  time_axis=0, file_offset=0, gain_to_uV=None, offset_to_uV=None,
                  is_filtered=None):
@@ -118,6 +118,19 @@ class BinaryRecordingExtractor(BaseRecording):
         """
         write_binary_recording(recording, file_paths=file_paths, dtype=dtype, **job_kwargs)
 
+    def is_binary_compatible(self):
+        return True
+        
+    def get_binary_description(self):
+        d = dict(
+            file_paths=self._kwargs['file_paths'],
+            dtype=np.dtype(self._kwargs['dtype']),
+            num_channels=self._kwargs['num_chan'],
+            time_axis=self._kwargs['time_axis'],
+            file_offset=self._kwargs['file_offset'],
+        )
+        return d
+
 
 BinaryRecordingExtractor.write_recording.__doc__ = BinaryRecordingExtractor.write_recording.__doc__.format(
     _shared_job_kwargs_doc)
@@ -156,10 +169,4 @@ class BinaryRecordingSegment(BaseRecordingSegment):
 # For backward compatibility (old good time)
 BinDatRecordingExtractor = BinaryRecordingExtractor
 
-
-def read_binary(*args, **kwargs):
-    recording = BinaryRecordingExtractor(*args, **kwargs)
-    return recording
-
-
-read_binary.__doc__ = BinaryRecordingExtractor.__doc__
+read_binary = define_function_from_class(source_class=BinaryRecordingExtractor, name="read_binary")

--- a/spikeinterface/core/npzsortingextractor.py
+++ b/spikeinterface/core/npzsortingextractor.py
@@ -3,6 +3,7 @@ from .basesorting import BaseSorting, BaseSortingSegment
 from pathlib import Path
 import numpy as np
 
+from .core_tools import define_function_from_class
 
 class NpzSortingExtractor(BaseSorting):
     """
@@ -88,7 +89,4 @@ class NpzSortingSegment(BaseSortingSegment):
         return spike_times.astype('int64')
 
 
-def read_npz_sorting(*args, **kwargs):
-    sorting = NpzSortingExtractor(*args, **kwargs)
-    return sorting
-read_npz_sorting.__doc__ = NpzSortingExtractor.__doc__
+read_npz_sorting = define_function_from_class(source_class=NpzSortingExtractor, name="read_npz_sorting")

--- a/spikeinterface/core/tests/test_basesorting.py
+++ b/spikeinterface/core/tests/test_basesorting.py
@@ -25,7 +25,7 @@ def test_BaseSorting():
     create_sorting_npz(num_seg, file_path)
 
     sorting = NpzSortingExtractor(file_path)
-    print(sorting)
+    # print(sorting)
 
     assert sorting.get_num_segments() == 2
     assert sorting.get_num_units() == 3

--- a/spikeinterface/core/tests/test_binaryfolder.py
+++ b/spikeinterface/core/tests/test_binaryfolder.py
@@ -1,0 +1,34 @@
+import pytest
+
+from pathlib import Path
+import shutil
+
+import numpy as np
+
+from spikeinterface.core import BinaryFolderRecording, read_binary_folder, load_extractor
+from spikeinterface.core.testing_tools import generate_recording
+
+
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "core"
+else:
+    cache_folder = Path("cache_folder") / "core"
+
+
+def test_BinaryFolderRecording():
+    
+    rec = generate_recording(num_channels=10, durations=[2., 2.])
+    folder = cache_folder / 'binary_folder_1'
+
+    if folder.is_dir():
+        shutil.rmtree(folder)
+    
+    saved_rec = rec.save(folder=folder)
+    print(saved_rec)
+    
+    loaded_rec = load_extractor(folder)
+    print(loaded_rec)
+
+
+if __name__ == '__main__':
+    test_BinaryFolderRecording()

--- a/spikeinterface/sorters/kilosortbase.py
+++ b/spikeinterface/sorters/kilosortbase.py
@@ -124,7 +124,7 @@ class KilosortBase:
             # local copy needed
             binary_file_path = output_folder / 'recording.dat'
             write_binary_recording(recording, file_paths=[binary_file_path],
-                                                     dtype='int16', verbose=False, **get_job_kwargs(params, verbose))
+                                   dtype='int16', verbose=False, **get_job_kwargs(params, verbose))
 
         cls._generate_ops_file(recording, params, output_folder, binary_file_path)
 

--- a/spikeinterface/sorters/kilosortbase.py
+++ b/spikeinterface/sorters/kilosortbase.py
@@ -8,7 +8,8 @@ import scipy.io
 
 from .utils import ShellScript
 from .basesorter import get_job_kwargs
-from spikeinterface.extractors import KiloSortSortingExtractor, BinaryRecordingExtractor
+from spikeinterface.extractors import KiloSortSortingExtractor
+from spikeinterface.core import write_binary_recording
 
 
 class KilosortBase:
@@ -113,16 +114,16 @@ class KilosortBase:
 
     @classmethod
     def _setup_recording(cls, recording, output_folder, params, verbose):
-
         cls._generate_channel_map_file(recording, output_folder)
         
-        if isinstance(recording, BinaryRecordingExtractor) and recording._kwargs['time_axis'] == 0 and \
-                recording._kwargs['dtype'] == np.dtype('int16') and len(recording._kwargs['file_paths']) == 1:
-            # in this specific case no copy is needed !!
-            binary_file_path = Path(recording._kwargs['file_paths'][0])
+        if recording.binary_compatible_with(dtype='int16', time_axis=0, file_paths_lenght=1):
+            # no copy
+            d = recording.get_binary_description()
+            binary_file_path = Path(d['file_paths'][0])
         else:
+            # local copy needed
             binary_file_path = output_folder / 'recording.dat'
-            BinaryRecordingExtractor.write_recording(recording, file_paths=binary_file_path,
+            write_binary_recording(recording, file_paths=[binary_file_path],
                                                      dtype='int16', verbose=False, **get_job_kwargs(params, verbose))
 
         cls._generate_ops_file(recording, params, output_folder, binary_file_path)

--- a/spikeinterface/sorters/klusta/klusta.py
+++ b/spikeinterface/sorters/klusta/klusta.py
@@ -98,7 +98,7 @@ class KlustaSorter(BaseSorter):
             raw_filename = output_folder / 'recording.dat'
             dtype = 'int16'
             write_binary_recording(recording, file_paths=[raw_filename], verbose=False, 
-                                                     **get_job_kwargs(params, verbose))
+                                   **get_job_kwargs(params, verbose))
 
         if p['detect_sign'] < 0:
             detect_sign = 'negative'

--- a/spikeinterface/sorters/klusta/klusta.py
+++ b/spikeinterface/sorters/klusta/klusta.py
@@ -8,7 +8,7 @@ from ..utils import ShellScript
 
 from probeinterface import write_prb
 
-from spikeinterface.core import BinaryRecordingExtractor
+from spikeinterface.core import write_binary_recording
 from spikeinterface.extractors import KlustaSortingExtractor
 
 try:
@@ -88,21 +88,16 @@ class KlustaSorter(BaseSorter):
         write_prb(prb_file, probegroup, radius=p['adjacency_radius'])
 
         # source file
-        # TODO fix .dat
-        if isinstance(recording, BinaryRecordingExtractor) and recording._kwargs['file_offset'] == 0:
-            # no need to copy
-            raw_filename = Path(recording._kwargs['file_paths'][0]).resolve()
-            if raw_filename.suffix != ".dat":
-                print("Binary file is not a .dat file. Making a copy!")
-                shutil.copy(raw_filename, output_folder / "recording.dat")
-                raw_filename = output_folder / "recording.dat"
-            raw_filename = str(raw_filename)
-            dtype = recording._kwargs['dtype']
+        if recording.binary_compatible_with(time_axis=0, file_offset=0, file_suffix='.dat'):
+            # no copy
+            d = recording.get_binary_description()
+            raw_filename = str(d['file_paths'][0])
+            dtype = str(d['dtype'])
         else:
             # save binary file (chunk by chunk) into a new file
             raw_filename = output_folder / 'recording.dat'
             dtype = 'int16'
-            BinaryRecordingExtractor.write_recording(recording, file_paths=[raw_filename], verbose=False, 
+            write_binary_recording(recording, file_paths=[raw_filename], verbose=False, 
                                                      **get_job_kwargs(params, verbose))
 
         if p['detect_sign'] < 0:

--- a/spikeinterface/sorters/tridesclous/tridesclous.py
+++ b/spikeinterface/sorters/tridesclous/tridesclous.py
@@ -102,7 +102,7 @@ class TridesclousSorter(BaseSorter):
             dtype = recording.get_dtype().str
             file_paths = [str(output_folder / f'raw_signals_{i}.raw') for i in range(num_seg)]
             write_binary_recording(recording, file_paths=file_paths,
-                                                     dtype=dtype, verbose=False, **get_job_kwargs(params, verbose))
+                                   dtype=dtype, verbose=False, **get_job_kwargs(params, verbose))
             file_offset = 0
 
         # initialize source and probe file

--- a/spikeinterface/sorters/tridesclous/tridesclous.py
+++ b/spikeinterface/sorters/tridesclous/tridesclous.py
@@ -91,7 +91,7 @@ class TridesclousSorter(BaseSorter):
             # no copy
             d = recording.get_binary_description()
             file_paths = d['file_paths']
-            dtype = d['dtype']
+            dtype = str(d['dtype'])
             num_chan = d['num_channels']
             file_offset = d['file_offset']
         else:

--- a/spikeinterface/sorters/tridesclous/tridesclous.py
+++ b/spikeinterface/sorters/tridesclous/tridesclous.py
@@ -9,7 +9,7 @@ from pprint import pprint
 from spikeinterface.extractors import TridesclousSortingExtractor
 
 from ..basesorter import BaseSorter, get_job_kwargs
-from spikeinterface.core import BinaryRecordingExtractor
+from spikeinterface.core import write_binary_recording
 
 from probeinterface import write_prb
 
@@ -87,14 +87,13 @@ class TridesclousSorter(BaseSorter):
         num_seg = recording.get_num_segments()
         sr = recording.get_sampling_frequency()
 
-        # source file
-        if isinstance(recording, BinaryRecordingExtractor) and recording._kwargs['time_axis'] == 0:
-            # no need to copy
-            kwargs = recording._kwargs
-            file_paths = kwargs['file_paths']
-            dtype = kwargs['dtype']
-            num_chan = kwargs['num_chan']
-            file_offset = kwargs['file_offset']
+        if recording.binary_compatible_with(time_axis=0):
+            # no copy
+            d = recording.get_binary_description()
+            file_paths = d['file_paths']
+            dtype = d['dtype']
+            num_chan = d['num_channels']
+            file_offset = d['file_offset']
         else:
             if verbose:
                 print('Local copy of recording')
@@ -102,7 +101,7 @@ class TridesclousSorter(BaseSorter):
             num_chan = recording.get_num_channels()
             dtype = recording.get_dtype().str
             file_paths = [str(output_folder / f'raw_signals_{i}.raw') for i in range(num_seg)]
-            BinaryRecordingExtractor.write_recording(recording, file_paths=file_paths,
+            write_binary_recording(recording, file_paths=file_paths,
                                                      dtype=dtype, verbose=False, **get_job_kwargs(params, verbose))
             file_offset = 0
 

--- a/spikeinterface/sorters/yass/yass.py
+++ b/spikeinterface/sorters/yass/yass.py
@@ -8,7 +8,7 @@ from ..utils import ShellScript
 
 from spikeinterface.core import load_extractor
 
-from spikeinterface.core import BinaryRecordingExtractor
+from spikeinterface.core import write_binary_recording
 from spikeinterface.extractors import YassSortingExtractor
 
 
@@ -159,8 +159,8 @@ class YassSorter(BaseSorter):
         input_file_path = os.path.join(output_folder, 'data.bin')
         dtype = 'int16'  # HARD CODE THIS FOR YASS
         input_file_path = output_folder / 'data.bin'
-        BinaryRecordingExtractor.write_recording(recording, file_paths=[input_file_path],
-                                                 dtype=dtype, verbose=False, **get_job_kwargs(params, verbose))
+        
+        write_binary_recording(recording, file_paths=[input_file_path], dtype=dtype, **get_job_kwargs(params, verbose))
 
         retrain = False
         if params['neural_nets_path'] is None:


### PR DESCRIPTION
This PR should remove a deep bug in spikeinterface core.
In some situation using dump to json could lost the propertis (and so the probe).

This should fix this.

It also add a better way to avoid copy for sorter when not needed.

