### PR TITLE
Add guard into container py script

### DIFF
--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -372,18 +372,19 @@ import json
 from spikeinterface import load_extractor
 from spikeinterface.sorters import run_sorter_local
 
-# load recording in docker
-recording = load_extractor('{parent_folder_unix}/in_container_recording.json')
+if __name__ == '__main__':
+    # load recording in container
+    recording = load_extractor('{parent_folder_unix}/in_container_recording.json')
 
-# load params in docker
-with open('{parent_folder_unix}/in_container_params.json', encoding='utf8', mode='r') as f:
-    sorter_params = json.load(f)
+    # load params in container
+    with open('{parent_folder_unix}/in_container_params.json', encoding='utf8', mode='r') as f:
+        sorter_params = json.load(f)
 
-# run in docker
-output_folder = '{output_folder_unix}'
-run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
-            remove_existing_folder={remove_existing_folder}, delete_output_folder=False,
-            verbose={verbose}, raise_error={raise_error}, **sorter_params)
+    # run in container
+    output_folder = '{output_folder_unix}'
+    run_sorter_local('{sorter_name}', recording, output_folder=output_folder,
+                remove_existing_folder={remove_existing_folder}, delete_output_folder=False,
+                verbose={verbose}, raise_error={raise_error}, **sorter_params)
 """
     (parent_folder / 'in_container_sorter_script.py').write_text(py_script, encoding='utf8')
 

--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -373,6 +373,7 @@ from spikeinterface import load_extractor
 from spikeinterface.sorters import run_sorter_local
 
 if __name__ == '__main__':
+    # this __name__ protection help in some case with multiprocessing (for instance HS2)
     # load recording in container
     recording = load_extractor('{parent_folder_unix}/in_container_recording.json')
 


### PR DESCRIPTION
### Problem:
When running mountainsort4 in container, which uses multiprocessing, `RuntimeError` occours

### Solution
Adding guard clause to the `in_container_sorter_script.py` solves the problem

### Tested scenarios:
- run mountainsort4 (without container)
- run mountainsort4 with docker_image=True
- run mountainsort4 with singularity_image=True


### Full Traceback:

```
Error running mountainsort4
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/spikeinterface/sorters/basesorter.py", line 202, in run_from_folder
    SorterClass._run_from_folder(output_folder, sorter_params, verbose)
  File "/usr/local/lib/python3.8/site-packages/spikeinterface/sorters/mountainsort4/mountainsort4.py", line 116, in _run_from_folder
    old_api_sorting = mountainsort4.mountainsort4(
  File "/usr/local/lib/python3.8/site-packages/mountainsort4/mountainsort4.py", line 38, in mountainsort4
    MS4.sort()
  File "/usr/local/lib/python3.8/site-packages/mountainsort4/ms4alg.py", line 842, in sort
    dask.compute(*dask_list, num_workers=self._num_workers)
  File "/usr/local/lib/python3.8/site-packages/dask/base.py", line 600, in compute
    results = schedule(dsk, keys, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/dask/multiprocessing.py", line 232, in get
    result = get_async(
  File "/usr/local/lib/python3.8/site-packages/dask/local.py", line 496, in get_async
    fire_tasks(chunksize)
  File "/usr/local/lib/python3.8/site-packages/dask/local.py", line 491, in fire_tasks
    fut = submit(batch_execute_tasks, each_args)
  File "/usr/local/lib/python3.8/concurrent/futures/process.py", line 645, in submit
    self._start_queue_management_thread()
  File "/usr/local/lib/python3.8/concurrent/futures/process.py", line 584, in _start_queue_management_thread
    self._adjust_process_count()
  File "/usr/local/lib/python3.8/concurrent/futures/process.py", line 608, in _adjust_process_count
    p.start()
  File "/usr/local/lib/python3.8/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
  File "/usr/local/lib/python3.8/multiprocessing/context.py", line 284, in _Popen
    return Popen(process_obj)
  File "/usr/local/lib/python3.8/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)
  File "/usr/local/lib/python3.8/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/usr/local/lib/python3.8/multiprocessing/popen_spawn_posix.py", line 42, in _launch
    prep_data = spawn.get_preparation_data(process_obj._name)
  File "/usr/local/lib/python3.8/multiprocessing/spawn.py", line 154, in get_preparation_data
    _check_not_importing_main()
  File "/usr/local/lib/python3.8/multiprocessing/spawn.py", line 134, in _check_not_importing_main
    raise RuntimeError('''
RuntimeError: 
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.

Cleaning tmpdir:: /tmp/tmp29ci5hq0
Error running mountainsort4
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/spikeinterface/sorters/basesorter.py", line 202, in run_from_folder
    SorterClass._run_from_folder(output_folder, sorter_params, verbose)
  File "/usr/local/lib/python3.8/site-packages/spikeinterface/sorters/mountainsort4/mountainsort4.py", line 116, in _run_from_folder
    old_api_sorting = mountainsort4.mountainsort4(
  File "/usr/local/lib/python3.8/site-packages/mountainsort4/mountainsort4.py", line 38, in mountainsort4
    MS4.sort()
  File "/usr/local/lib/python3.8/site-packages/mountainsort4/ms4alg.py", line 842, in sort
    dask.compute(*dask_list, num_workers=self._num_workers)
  File "/usr/local/lib/python3.8/site-packages/dask/base.py", line 600, in compute
    results = schedule(dsk, keys, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/dask/multiprocessing.py", line 232, in get
    result = get_async(
  File "/usr/local/lib/python3.8/site-packages/dask/local.py", line 497, in get_async
    for key, res_info, failed in queue_get(queue).result():
  File "/usr/local/lib/python3.8/concurrent/futures/_base.py", line 437, in result
    return self.__get_result()
  File "/usr/local/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
concurrent.futures.process.BrokenProcessPool: A process in the process pool was terminated abruptly while the future was running or pending.
```