### PR TITLE
Added SpikeLocationsCalculator as WaveformExtension

### DIFF
--- a/spikeinterface/toolkit/postprocessing/__init__.py
+++ b/spikeinterface/toolkit/postprocessing/__init__.py
@@ -21,6 +21,8 @@ from .principal_component import (
 
 from .spike_amplitudes import compute_spike_amplitudes, SpikeAmplitudesCalculator
 
+from .spike_locations import compute_spike_locations, SpikeLocationsCalculator
+
 from .correlograms import compute_correlograms
 
 from .unit_localization import localize_units, compute_center_of_mass

--- a/spikeinterface/toolkit/postprocessing/spike_amplitudes.py
+++ b/spikeinterface/toolkit/postprocessing/spike_amplitudes.py
@@ -164,9 +164,9 @@ WaveformExtractor.register_extension(SpikeAmplitudesCalculator)
 
 
 def compute_spike_amplitudes(waveform_extractor, load_if_exists=False, 
-    peak_sign='neg', return_scaled=True,
-    outputs='concatenated',
-    **job_kwargs):
+                             peak_sign='neg', return_scaled=True,
+                             outputs='concatenated',
+                             **job_kwargs):
 
     folder = waveform_extractor.folder
     ext_folder = folder / SpikeAmplitudesCalculator.extension_name

--- a/spikeinterface/toolkit/postprocessing/spike_locations.py
+++ b/spikeinterface/toolkit/postprocessing/spike_locations.py
@@ -167,13 +167,13 @@ def compute_spike_locations(waveform_extractor, load_if_exists=False,
     ext_folder = folder / SpikeLocationsCalculator.extension_name
 
     if load_if_exists and ext_folder.is_dir():
-        sac = SpikeLocationsCalculator.load_from_folder(folder)
+        slc = SpikeLocationsCalculator.load_from_folder(folder)
     else:
-        sac = SpikeLocationsCalculator(waveform_extractor)
-        sac.set_params(ms_before=ms_before, ms_after=ms_after, method=method, method_kwargs=method_kwargs)
-        sac.compute_locations(**job_kwargs)
+        slc = SpikeLocationsCalculator(waveform_extractor)
+        slc.set_params(ms_before=ms_before, ms_after=ms_after, method=method, method_kwargs=method_kwargs)
+        slc.compute_locations(**job_kwargs)
     
-    locs = sac.get_locations(outputs=outputs)
+    locs = slc.get_locations(outputs=outputs)
     return locs
 
 

--- a/spikeinterface/toolkit/postprocessing/spike_locations.py
+++ b/spikeinterface/toolkit/postprocessing/spike_locations.py
@@ -63,21 +63,11 @@ class SpikeLocationsCalculator(BaseWaveformExtractorExtension):
         return params        
         
     def _specific_load_from_folder(self):
-        #~ recording = self.waveform_extractor.recording
-        #~ sorting = self.waveform_extractor.sorting
         we = self.waveform_extractor
-        #~ all_spikes = sorting.get_all_spike_trains(outputs='unit_index')
-        #~ self._all_spikes = all_spikes
 
         extremum_channel_inds = get_template_extremum_channel(we, outputs="index")
         self.spikes = we.sorting.to_spike_vector(extremum_channel_inds=extremum_channel_inds)
         self.locations =np.load( self.extension_folder / 'spike_locations.npy')
-
-        #~ self._locations = []
-        #~ for segment_index in range(recording.get_num_segments()):
-            #~ file_locs = self.extension_folder / f'locations_segment_{segment_index}.npy'
-            #~ locs_seg = np.load(file_locs)
-            #~ self._locations.append(locs_seg)
 
     def _reset(self):
         self.locations = None
@@ -90,16 +80,6 @@ class SpikeLocationsCalculator(BaseWaveformExtractorExtension):
         new_location = self.locations[spike_mask]
         np.save(new_waveforms_folder / 'spike_locations.npy', new_location)
         
-        # load filter and save amplitude files
-        #~ for seg_index in range(self.waveform_extractor.recording.get_num_segments()):
-            #~ loc_file_name = f"locations_segment_{seg_index}.npy"
-            #~ locs = np.load(self.extension_folder / loc_file_name)
-            #~ _, all_labels = self.waveform_extractor.sorting.get_all_spike_trains()[seg_index]
-            #~ filtered_idxs = np.in1d(all_labels, np.array(unit_ids)).nonzero()
-            #~ np.save(new_waveforms_folder / self.extension_name /
-                    #~ loc_file_name, locs[filtered_idxs])
-    
-        
     def compute_locations(self, **job_kwargs):
         """
         This function first transforms the sorting object into a `peaks` numpy array and then
@@ -109,38 +89,9 @@ class SpikeLocationsCalculator(BaseWaveformExtractorExtension):
         from spikeinterface.sortingcomponents.peak_localization import localize_peaks
         
         we = self.waveform_extractor
-        #~ recording = we.recording
-        #~ sorting = we.sorting
-
-        #~ all_spikes = sorting.get_all_spike_trains(outputs='unit_index')
-        #~ self._all_spikes = all_spikes
         
         extremum_channel_inds = get_template_extremum_channel(we, outputs="index")
         self.spikes = we.sorting.to_spike_vector(extremum_channel_inds=extremum_channel_inds)
-        
-        
-        #~ extremum_channel_inds = get_template_extremum_channel(we, outputs="index")
-        #~ sorting_peaks = we.sorting.to_spike_vector()
-        #~ unit_inds = sorting_peaks['unit_ind']
-        #~ channel_inds = [extremum_channel_inds[u_id] for u_id in we.sorting.unit_ids[unit_inds]] 
-        #~ sorting_peaks['unit_ind'] = channel_inds
-        #~ dtype_names = list(sorting_peaks.dtype.names)
-        #~ unit_ind_index = dtype_names.index("unit_ind")
-        #~ dtype_names[unit_ind_index] = "channel_ind"
-        #~ sorting_peaks.dtype.names = tuple(dtype_names)
-        
-        #~ localization_params = {**self._params, **job_kwargs}
-        
-        
-        #~ self._locations = []
-        #~ for segment_index in range(recording.get_num_segments()):
-            #~ mask = sorting_peaks["segment_ind"] == segment_index
-            #~ locs_seg = locs[mask]
-            #~ self._locations.append(locs)
-            
-            #~ # save to folder
-            #~ file_locs = self.extension_folder / f'locations_segment_{segment_index}.npy'
-            #~ np.save(file_locs, locs_seg)
         
         self.locations = localize_peaks(we.recording, self.spikes, **self._params, **job_kwargs)
         np.save(self.extension_folder / 'spike_locations.npy', self.locations)
@@ -166,10 +117,6 @@ class SpikeLocationsCalculator(BaseWaveformExtractorExtension):
                 for unit_ind, unit_id in enumerate(sorting.unit_ids):
                     mask = spikes['unit_ind'] == unit_ind
                     locations_by_unit[segment_index][unit_id] = locations[mask]
-                    #~ spike_times, spike_labels = self._all_spikes[segment_index]
-                    #~ mask = spike_labels == unit_index
-                    #~ amps = self._locations[segment_index][mask]
-                    #~ locations_by_unit[segment_index][unit_id] = amps
             return locations_by_unit
 
 

--- a/spikeinterface/toolkit/postprocessing/spike_locations.py
+++ b/spikeinterface/toolkit/postprocessing/spike_locations.py
@@ -1,7 +1,6 @@
 import numpy as np
-import shutil
 
-from spikeinterface.core.job_tools import ChunkRecordingExecutor, _shared_job_kwargs_doc, ensure_n_jobs
+from spikeinterface.core.job_tools import _shared_job_kwargs_doc
 
 from spikeinterface.core.waveform_extractor import WaveformExtractor, BaseWaveformExtractorExtension
 
@@ -14,8 +13,8 @@ class SpikeLocationsCalculator(BaseWaveformExtractorExtension):
     Localize spikes in 2D or 3D depending the method.
 
     When a probe is 2D then:
-       * X is axis 0 of the probe
-       * Y is axis 1 of the probe
+       * X is axis 0 of the probe (width)
+       * Y is axis 1 of the probe (depth)
        * Z is orthogonal to the plane of the probe
 
     Parameters
@@ -50,11 +49,11 @@ class SpikeLocationsCalculator(BaseWaveformExtractorExtension):
     
     def __init__(self, waveform_extractor):
         BaseWaveformExtractorExtension.__init__(self, waveform_extractor)
+        
+        self.locations = None
+        self.spikes = None
 
-        self._locations = None
-        self._all_spikes = None
-
-    def _set_params(self, ms_before=1, ms_after=1, method='center_of_mass',
+    def _set_params(self, ms_before=1., ms_after=1.5, method='center_of_mass',
                     method_kwargs={}):
 
         params = dict(ms_before=ms_before,
@@ -64,30 +63,41 @@ class SpikeLocationsCalculator(BaseWaveformExtractorExtension):
         return params        
         
     def _specific_load_from_folder(self):
-        recording = self.waveform_extractor.recording
-        sorting = self.waveform_extractor.sorting
+        #~ recording = self.waveform_extractor.recording
+        #~ sorting = self.waveform_extractor.sorting
+        we = self.waveform_extractor
+        #~ all_spikes = sorting.get_all_spike_trains(outputs='unit_index')
+        #~ self._all_spikes = all_spikes
 
-        all_spikes = sorting.get_all_spike_trains(outputs='unit_index')
-        self._all_spikes = all_spikes
+        extremum_channel_inds = get_template_extremum_channel(we, outputs="index")
+        self.spikes = we.sorting.to_spike_vector(extremum_channel_inds=extremum_channel_inds)
+        self.locations =np.load( self.extension_folder / 'spike_locations.npy')
 
-        self._locations = []
-        for segment_index in range(recording.get_num_segments()):
-            file_locs = self.extension_folder / f'locations_segment_{segment_index}.npy'
-            locs_seg = np.load(file_locs)
-            self._locations.append(locs_seg)
+        #~ self._locations = []
+        #~ for segment_index in range(recording.get_num_segments()):
+            #~ file_locs = self.extension_folder / f'locations_segment_{segment_index}.npy'
+            #~ locs_seg = np.load(file_locs)
+            #~ self._locations.append(locs_seg)
 
     def _reset(self):
-        self._locations = None
+        self.locations = None
     
     def _specific_select_units(self, unit_ids, new_waveforms_folder):
+        old_unit_ids = self.waveform_extractor.sorting.unit_ids
+        unit_inds = np.flatnonzero(np.in1d(old_unit_ids, unit_ids))
+
+        spike_mask = np.in1d(self.spikes['unit_ind'], unit_inds)
+        new_location = self.locations[spike_mask]
+        np.save(new_waveforms_folder / 'spike_locations.npy', new_location)
+        
         # load filter and save amplitude files
-        for seg_index in range(self.waveform_extractor.recording.get_num_segments()):
-            loc_file_name = f"locations_segment_{seg_index}.npy"
-            locs = np.load(self.extension_folder / loc_file_name)
-            _, all_labels = self.waveform_extractor.sorting.get_all_spike_trains()[seg_index]
-            filtered_idxs = np.in1d(all_labels, np.array(unit_ids)).nonzero()
-            np.save(new_waveforms_folder / self.extension_name /
-                    loc_file_name, locs[filtered_idxs])
+        #~ for seg_index in range(self.waveform_extractor.recording.get_num_segments()):
+            #~ loc_file_name = f"locations_segment_{seg_index}.npy"
+            #~ locs = np.load(self.extension_folder / loc_file_name)
+            #~ _, all_labels = self.waveform_extractor.sorting.get_all_spike_trains()[seg_index]
+            #~ filtered_idxs = np.in1d(all_labels, np.array(unit_ids)).nonzero()
+            #~ np.save(new_waveforms_folder / self.extension_name /
+                    #~ loc_file_name, locs[filtered_idxs])
     
         
     def compute_locations(self, **job_kwargs):
@@ -99,36 +109,42 @@ class SpikeLocationsCalculator(BaseWaveformExtractorExtension):
         from spikeinterface.sortingcomponents.peak_localization import localize_peaks
         
         we = self.waveform_extractor
-        recording = we.recording
-        sorting = we.sorting
+        #~ recording = we.recording
+        #~ sorting = we.sorting
 
-        all_spikes = sorting.get_all_spike_trains(outputs='unit_index')
-        self._all_spikes = all_spikes
+        #~ all_spikes = sorting.get_all_spike_trains(outputs='unit_index')
+        #~ self._all_spikes = all_spikes
         
         extremum_channel_inds = get_template_extremum_channel(we, outputs="index")
-        sorting_peaks = we.sorting.to_spike_vector()
-        unit_inds = sorting_peaks['unit_ind']
-        channel_inds = [extremum_channel_inds[u_id] for u_id in we.sorting.unit_ids[unit_inds]] 
-        sorting_peaks['unit_ind'] = channel_inds
-        dtype_names = list(sorting_peaks.dtype.names)
-        unit_ind_index = dtype_names.index("unit_ind")
-        dtype_names[unit_ind_index] = "channel_ind"
-        sorting_peaks.dtype.names = tuple(dtype_names)
+        self.spikes = we.sorting.to_spike_vector(extremum_channel_inds=extremum_channel_inds)
         
-        localization_params = {**self._params, **job_kwargs}
         
-        locs = localize_peaks(recording, sorting_peaks, 
-                              **localization_params)
-
-        self._locations = []
-        for segment_index in range(recording.get_num_segments()):
-            mask = sorting_peaks["segment_ind"] == segment_index
-            locs_seg = locs[mask]
-            self._locations.append(locs)
+        #~ extremum_channel_inds = get_template_extremum_channel(we, outputs="index")
+        #~ sorting_peaks = we.sorting.to_spike_vector()
+        #~ unit_inds = sorting_peaks['unit_ind']
+        #~ channel_inds = [extremum_channel_inds[u_id] for u_id in we.sorting.unit_ids[unit_inds]] 
+        #~ sorting_peaks['unit_ind'] = channel_inds
+        #~ dtype_names = list(sorting_peaks.dtype.names)
+        #~ unit_ind_index = dtype_names.index("unit_ind")
+        #~ dtype_names[unit_ind_index] = "channel_ind"
+        #~ sorting_peaks.dtype.names = tuple(dtype_names)
+        
+        #~ localization_params = {**self._params, **job_kwargs}
+        
+        
+        #~ self._locations = []
+        #~ for segment_index in range(recording.get_num_segments()):
+            #~ mask = sorting_peaks["segment_ind"] == segment_index
+            #~ locs_seg = locs[mask]
+            #~ self._locations.append(locs)
             
-            # save to folder
-            file_locs = self.extension_folder / f'locations_segment_{segment_index}.npy'
-            np.save(file_locs, locs_seg)
+            #~ # save to folder
+            #~ file_locs = self.extension_folder / f'locations_segment_{segment_index}.npy'
+            #~ np.save(file_locs, locs_seg)
+        
+        self.locations = localize_peaks(we.recording, self.spikes, **self._params, **job_kwargs)
+        np.save(self.extension_folder / 'spike_locations.npy', self.locations)
+
     
     def get_locations(self, outputs='concatenated'):
         we = self.waveform_extractor
@@ -136,17 +152,24 @@ class SpikeLocationsCalculator(BaseWaveformExtractorExtension):
         sorting = we.sorting
 
         if outputs == 'concatenated':
-            return self._locations
+            return self.locations
 
         elif outputs == 'by_unit':
             locations_by_unit = []
             for segment_index in range(recording.get_num_segments()):
+                i0 =np.searchsorted(self.spikes['segment_ind'], segment_index, side="left")
+                i1 =np.searchsorted(self.spikes['segment_ind'], segment_index, side="right")
+                spikes = self.spikes[i0: i1]
+                locations = self.locations[i0: i1]
+                
                 locations_by_unit.append({})
-                for unit_index, unit_id in enumerate(sorting.unit_ids):
-                    spike_times, spike_labels = self._all_spikes[segment_index]
-                    mask = spike_labels == unit_index
-                    amps = self._locations[segment_index][mask]
-                    locations_by_unit[segment_index][unit_id] = amps
+                for unit_ind, unit_id in enumerate(sorting.unit_ids):
+                    mask = spikes['unit_ind'] == unit_ind
+                    locations_by_unit[segment_index][unit_id] = locations[mask]
+                    #~ spike_times, spike_labels = self._all_spikes[segment_index]
+                    #~ mask = spike_labels == unit_index
+                    #~ amps = self._locations[segment_index][mask]
+                    #~ locations_by_unit[segment_index][unit_id] = amps
             return locations_by_unit
 
 
@@ -156,7 +179,7 @@ WaveformExtractor.register_extension(SpikeLocationsCalculator)
 
 
 def compute_spike_locations(waveform_extractor, load_if_exists=False, 
-                            ms_before=1, ms_after=1, 
+                            ms_before=1., ms_after=1.5, 
                             method='center_of_mass',
                             method_kwargs={},
                             outputs='concatenated',

--- a/spikeinterface/toolkit/postprocessing/spike_locations.py
+++ b/spikeinterface/toolkit/postprocessing/spike_locations.py
@@ -1,0 +1,180 @@
+import numpy as np
+import shutil
+
+from spikeinterface.core.job_tools import ChunkRecordingExecutor, _shared_job_kwargs_doc, ensure_n_jobs
+
+from spikeinterface.core.waveform_extractor import WaveformExtractor, BaseWaveformExtractorExtension
+
+from .template_tools import (get_template_extremum_channel,
+                             get_template_extremum_channel_peak_shift)
+
+
+class SpikeLocationsCalculator(BaseWaveformExtractorExtension):
+    """
+    Localize spikes in 2D or 3D depending the method.
+
+    When a probe is 2D then:
+       * X is axis 0 of the probe
+       * Y is axis 1 of the probe
+       * Z is orthogonal to the plane of the probe
+
+    Parameters
+    ----------
+    waveform_extractor: WaveformExtractor
+        The waveform extractor object
+    ms_before: float
+        The left window, before a peak, in milliseconds.
+    ms_after: float
+        The right window, after a peak, in milliseconds.
+    method: 'center_of_mass' or 'monopolar_triangulation'
+        Method to use.
+    method_kwargs: dict of kwargs method
+        Keyword arguments for the chosen method:
+            'center_of_mass':
+                * local_radius_um: float
+                    For channel sparsity.
+            'monopolar_triangulation':
+                * local_radius_um: float
+                    For channel sparsity.
+                * max_distance_um: float, default: 1000
+                    Boundary for distance estimation.
+    {}
+
+    Returns
+    -------
+    spike_locations: np.array
+        The spike locations.
+            - If 'concatenated' all locations for all spikes and all units are concatenated
+    """    
+    extension_name = 'spike_locations'
+    
+    def __init__(self, waveform_extractor):
+        BaseWaveformExtractorExtension.__init__(self, waveform_extractor)
+
+        self._locations = None
+        self._all_spikes = None
+
+    def _set_params(self, ms_before=1, ms_after=1, method='center_of_mass',
+                    method_kwargs={}):
+
+        params = dict(ms_before=ms_before,
+                      ms_after=ms_after,
+                      method=method,
+                      method_kwargs=method_kwargs)
+        return params        
+        
+    def _specific_load_from_folder(self):
+        recording = self.waveform_extractor.recording
+        sorting = self.waveform_extractor.sorting
+
+        all_spikes = sorting.get_all_spike_trains(outputs='unit_index')
+        self._all_spikes = all_spikes
+
+        self._locations = []
+        for segment_index in range(recording.get_num_segments()):
+            file_locs = self.extension_folder / f'locations_segment_{segment_index}.npy'
+            locs_seg = np.load(file_locs)
+            self._locations.append(locs_seg)
+
+    def _reset(self):
+        self._locations = None
+    
+    def _specific_select_units(self, unit_ids, new_waveforms_folder):
+        # load filter and save amplitude files
+        for seg_index in range(self.waveform_extractor.recording.get_num_segments()):
+            loc_file_name = f"locations_segment_{seg_index}.npy"
+            locs = np.load(self.extension_folder / loc_file_name)
+            _, all_labels = self.waveform_extractor.sorting.get_all_spike_trains()[seg_index]
+            filtered_idxs = np.in1d(all_labels, np.array(unit_ids)).nonzero()
+            np.save(new_waveforms_folder / self.extension_name /
+                    loc_file_name, locs[filtered_idxs])
+    
+        
+    def compute_locations(self, **job_kwargs):
+        """
+        This function first transforms the sorting object into a `peaks` numpy array and then
+        uses the`sortingcomponents.peak_localization.localize_peaks()` function to triangulate
+        spike locations.
+        """
+        from spikeinterface.sortingcomponents.peak_localization import localize_peaks
+        
+        we = self.waveform_extractor
+        recording = we.recording
+        sorting = we.sorting
+
+        all_spikes = sorting.get_all_spike_trains(outputs='unit_index')
+        self._all_spikes = all_spikes
+        
+        extremum_channel_inds = get_template_extremum_channel(we, outputs="index")
+        sorting_peaks = we.sorting.to_spike_vector()
+        unit_inds = sorting_peaks['unit_ind']
+        channel_inds = [extremum_channel_inds[u_id] for u_id in we.sorting.unit_ids[unit_inds]] 
+        sorting_peaks['unit_ind'] = channel_inds
+        dtype_names = list(sorting_peaks.dtype.names)
+        unit_ind_index = dtype_names.index("unit_ind")
+        dtype_names[unit_ind_index] = "channel_ind"
+        sorting_peaks.dtype.names = tuple(dtype_names)
+        
+        localization_params = {**self._params, **job_kwargs}
+        
+        locs = localize_peaks(recording, sorting_peaks, 
+                              **localization_params)
+
+        self._locations = []
+        for segment_index in range(recording.get_num_segments()):
+            mask = sorting_peaks["segment_ind"] == segment_index
+            locs_seg = locs[mask]
+            self._locations.append(locs)
+            
+            # save to folder
+            file_locs = self.extension_folder / f'locations_segment_{segment_index}.npy'
+            np.save(file_locs, locs_seg)
+    
+    def get_locations(self, outputs='concatenated'):
+        we = self.waveform_extractor
+        recording = we.recording
+        sorting = we.sorting
+
+        if outputs == 'concatenated':
+            return self._locations
+
+        elif outputs == 'by_unit':
+            locations_by_unit = []
+            for segment_index in range(recording.get_num_segments()):
+                locations_by_unit.append({})
+                for unit_index, unit_id in enumerate(sorting.unit_ids):
+                    spike_times, spike_labels = self._all_spikes[segment_index]
+                    mask = spike_labels == unit_index
+                    amps = self._locations[segment_index][mask]
+                    locations_by_unit[segment_index][unit_id] = amps
+            return locations_by_unit
+
+
+SpikeLocationsCalculator.__doc__.format(_shared_job_kwargs_doc)
+
+WaveformExtractor.register_extension(SpikeLocationsCalculator)
+
+
+def compute_spike_locations(waveform_extractor, load_if_exists=False, 
+                            ms_before=1, ms_after=1, 
+                            method='center_of_mass',
+                            method_kwargs={},
+                            outputs='concatenated',
+                            **job_kwargs):
+
+
+    folder = waveform_extractor.folder
+    ext_folder = folder / SpikeLocationsCalculator.extension_name
+
+    if load_if_exists and ext_folder.is_dir():
+        sac = SpikeLocationsCalculator.load_from_folder(folder)
+    else:
+        sac = SpikeLocationsCalculator(waveform_extractor)
+        sac.set_params(ms_before=ms_before, ms_after=ms_after, method=method, method_kwargs=method_kwargs)
+        sac.compute_locations(**job_kwargs)
+    
+    locs = sac.get_locations(outputs=outputs)
+    return locs
+
+
+compute_spike_locations.__doc__ = SpikeLocationsCalculator.__doc__

--- a/spikeinterface/toolkit/postprocessing/tests/test_spike_amplitudes.py
+++ b/spikeinterface/toolkit/postprocessing/tests/test_spike_amplitudes.py
@@ -22,7 +22,7 @@ def test_compute_spike_amplitudes():
     recording = se.MEArecRecordingExtractor(local_path)
     sorting = se.MEArecSortingExtractor(local_path)
 
-    folder = cache_folder / 'mearec_waveforms'
+    folder = cache_folder / 'mearec_waveforms_amps'
 
     we = extract_waveforms(recording, sorting, folder,
                            ms_before=1., ms_after=2., max_spikes_per_unit=500,
@@ -38,7 +38,7 @@ def test_compute_spike_amplitudes():
     recording.set_channel_gains(gain)
     recording.set_channel_offsets(0)
 
-    folder = cache_folder / 'mearec_waveforms_scaled'
+    folder = cache_folder / 'mearec_waveforms_amps_scaled'
 
     we_scaled = extract_waveforms(recording, sorting, folder,
                                   ms_before=1., ms_after=2., max_spikes_per_unit=500,
@@ -70,7 +70,7 @@ def test_compute_spike_amplitudes_parallel():
     recording = se.MEArecRecordingExtractor(local_path)
     sorting = se.MEArecSortingExtractor(local_path)
 
-    folder = cache_folder / 'mearec_waveforms_all'
+    folder = cache_folder / 'mearec_waveforms_all_amps'
 
     we = extract_waveforms(recording, sorting, folder,
                            ms_before=1., ms_after=2., max_spikes_per_unit=None,
@@ -87,12 +87,12 @@ def test_compute_spike_amplitudes_parallel():
 
 
 def test_select_units():
-    we = WaveformExtractor.load_from_folder(cache_folder / 'mearec_waveforms')
+    we = WaveformExtractor.load_from_folder(cache_folder / 'mearec_waveforms_amps')
     amps = compute_spike_amplitudes(we, load_if_exists=True)
 
     keep_units = we.sorting.get_unit_ids()[::2]
     we_filt = we.select_units(
-        keep_units, cache_folder / 'mearec_waveforms_filt')
+        keep_units, cache_folder / 'mearec_waveforms_filt_amps')
     assert "spike_amplitudes" in we_filt.get_available_extension_names()
 
 

--- a/spikeinterface/toolkit/postprocessing/tests/test_spike_locations.py
+++ b/spikeinterface/toolkit/postprocessing/tests/test_spike_locations.py
@@ -22,7 +22,7 @@ def test_compute_spike_locations():
     recording = se.MEArecRecordingExtractor(local_path)
     sorting = se.MEArecSortingExtractor(local_path)
 
-    folder = cache_folder / 'mearec_waveforms'
+    folder = cache_folder / 'mearec_waveforms_locs'
 
     we = extract_waveforms(recording, sorting, folder,
                            ms_before=1., ms_after=2., max_spikes_per_unit=500,
@@ -58,7 +58,7 @@ def test_compute_spike_locations_parallel():
     recording = se.MEArecRecordingExtractor(local_path)
     sorting = se.MEArecSortingExtractor(local_path)
 
-    folder = cache_folder / 'mearec_waveforms_all'
+    folder = cache_folder / 'mearec_waveforms_all_locs'
 
     we = extract_waveforms(recording, sorting, folder,
                            ms_before=1., ms_after=2., max_spikes_per_unit=None,
@@ -74,12 +74,13 @@ def test_compute_spike_locations_parallel():
 
 
 def test_select_units():
-    we = WaveformExtractor.load_from_folder(cache_folder / 'mearec_waveforms')
+    we = WaveformExtractor.load_from_folder(
+        cache_folder / 'mearec_waveforms_locs')
     locs = compute_spike_locations(we, load_if_exists=True)
 
     keep_units = we.sorting.get_unit_ids()[::2]
     we_filt = we.select_units(
-        keep_units, cache_folder / 'mearec_waveforms_filt')
+        keep_units, cache_folder / 'mearec_waveforms_filt_locs')
     assert "spike_locations" in we_filt.get_available_extension_names()
 
 

--- a/spikeinterface/toolkit/postprocessing/tests/test_spike_locations.py
+++ b/spikeinterface/toolkit/postprocessing/tests/test_spike_locations.py
@@ -1,0 +1,88 @@
+import pytest
+import numpy as np
+from pathlib import Path
+import shutil
+
+from spikeinterface import download_dataset, extract_waveforms, WaveformExtractor
+import spikeinterface.extractors as se
+from spikeinterface.toolkit import compute_spike_locations, SpikeLocationsCalculator
+
+
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "toolkit"
+else:
+    cache_folder = Path("cache_folder") / "toolkit"
+
+
+def test_compute_spike_locations():
+    repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
+    remote_path = 'mearec/mearec_test_10s.h5'
+    local_path = download_dataset(
+        repo=repo, remote_path=remote_path, local_folder=None)
+    recording = se.MEArecRecordingExtractor(local_path)
+    sorting = se.MEArecSortingExtractor(local_path)
+
+    folder = cache_folder / 'mearec_waveforms'
+
+    we = extract_waveforms(recording, sorting, folder,
+                           ms_before=1., ms_after=2., max_spikes_per_unit=500,
+                           n_jobs=1, chunk_size=30000, load_if_exists=False,
+                           overwrite=True)
+
+    # test all options
+    locs_com = compute_spike_locations(
+        we, method="center_of_mass", chunk_size=10000, n_jobs=1)
+    locs_com = compute_spike_locations(
+        we, method="center_of_mass", outputs='by_unit', chunk_size=10000, n_jobs=1)
+    locs_mono = compute_spike_locations(
+        we, method="monopolar_triangulation", chunk_size=10000, n_jobs=1)
+    locs_mono = compute_spike_locations(
+        we, method="monopolar_triangulation", outputs='by_unit', chunk_size=10000, n_jobs=1)
+    
+
+    # reload as an extension from we
+    assert SpikeLocationsCalculator in we.get_available_extensions()
+    assert we.is_extension('spike_locations')
+    slc = we.load_extension('spike_locations')
+    assert isinstance(slc, SpikeLocationsCalculator)
+    assert slc._locations is not None
+    slc = SpikeLocationsCalculator.load_from_folder(folder)
+    assert slc._locations is not None
+
+
+def test_compute_spike_locations_parallel():
+    repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
+    remote_path = 'mearec/mearec_test_10s.h5'
+    local_path = download_dataset(
+        repo=repo, remote_path=remote_path, local_folder=None)
+    recording = se.MEArecRecordingExtractor(local_path)
+    sorting = se.MEArecSortingExtractor(local_path)
+
+    folder = cache_folder / 'mearec_waveforms_all'
+
+    we = extract_waveforms(recording, sorting, folder,
+                           ms_before=1., ms_after=2., max_spikes_per_unit=None,
+                           n_jobs=1, chunk_size=30000, load_if_exists=True)
+
+    locs_mono = compute_spike_locations(
+        we, method="monopolar_triangulation", chunk_size=10000, n_jobs=1)
+    locs_mono = compute_spike_locations(
+        we, method="monopolar_triangulation", chunk_size=10000, n_jobs=2)
+    
+    assert np.array_equal(locs_mono[0], locs_mono[0])
+    # shutil.rmtree(folder)
+
+
+def test_select_units():
+    we = WaveformExtractor.load_from_folder(cache_folder / 'mearec_waveforms')
+    locs = compute_spike_locations(we, load_if_exists=True)
+
+    keep_units = we.sorting.get_unit_ids()[::2]
+    we_filt = we.select_units(
+        keep_units, cache_folder / 'mearec_waveforms_filt')
+    assert "spike_locations" in we_filt.get_available_extension_names()
+
+
+if __name__ == '__main__':
+    test_compute_spike_locations()
+    test_compute_spike_locations_parallel()

--- a/spikeinterface/toolkit/postprocessing/tests/test_spike_locations.py
+++ b/spikeinterface/toolkit/postprocessing/tests/test_spike_locations.py
@@ -45,9 +45,9 @@ def test_compute_spike_locations():
     assert we.is_extension('spike_locations')
     slc = we.load_extension('spike_locations')
     assert isinstance(slc, SpikeLocationsCalculator)
-    assert slc._locations is not None
+    assert slc.locations is not None
     slc = SpikeLocationsCalculator.load_from_folder(folder)
-    assert slc._locations is not None
+    assert slc.locations is not None
 
 
 def test_compute_spike_locations_parallel():

--- a/spikeinterface/toolkit/postprocessing/unit_localization.py
+++ b/spikeinterface/toolkit/postprocessing/unit_localization.py
@@ -102,8 +102,7 @@ def estimate_distance_error_with_log(vec, wf_ptp, local_contact_locations, maxpt
 
 
 def compute_monopolar_triangulation(waveform_extractor, optimizer='least_square', radius_um=50, max_distance_um=1000,
-        
-        return_alpha=False):
+                                    return_alpha=False):
     '''
     Localize unit with monopolar triangulation.
     This method is from Julien Boussard, Erdem Varol and Charlie Windolf
@@ -128,7 +127,7 @@ def compute_monopolar_triangulation(waveform_extractor, optimizer='least_square'
     method: str  ('least_square', 'minimize_with_log_penality')
        2 variants of the method
     radius_um: float
-        For channel sparsiry
+        For channel sparsity
     max_distance_um: float
         to make bounddary in x, y, z and also for alpha
     return_alpha: bool default False


### PR DESCRIPTION
Adds a function/class to compute spike locations from waveform extractor (similar to amplitude calculator).

Internally, it uses the `localiza_peaks` form sorting components.