### PR TITLE
Fix bug in correlograms

### DIFF
--- a/spikeinterface/toolkit/postprocessing/correlograms.py
+++ b/spikeinterface/toolkit/postprocessing/correlograms.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 
 
@@ -113,10 +114,10 @@ if HAVE_NUMBA:
                 if diff >= max_time:
                     start_j += 1
                     continue
-                if diff <= -max_time:
+                if diff < -max_time:
                     break
 
-                bin = int(diff / bin_size) - (0 if diff >= 0 else 1)
+                bin = math.floor(diff / bin_size)
                 cross_corr[n_bins//2 + bin] += 1
 
         return (cross_corr, bins)


### PR DESCRIPTION
Fixed a bug where there wouldn't be an equal amount of spikes in each bin with numba code.

![bug_correlograms](https://user-images.githubusercontent.com/3465310/176190678-9208ff30-3ecd-4ac1-9d4f-b4d370a53171.png)

This is the cross-correlograms between two completely random spike trains (with no refractory period).
As you can see, there is a difference between the `numpy` and `numba` methods, and both are incorrect (the cross-corr should be complelety flat).

I corrected the `numba` version, but we still need to correct the `numpy` one.
@samuelgarcia Do you have an idea on how to correct it?

What I did is to have all of the bins be included for the lower value, and excluded for the higher one.