### PR TITLE
Compute features from peaks

### DIFF
--- a/spikeinterface/sortingcomponents/features_from_peaks.py
+++ b/spikeinterface/sortingcomponents/features_from_peaks.py
@@ -1,0 +1,269 @@
+"""Sorting components: peak waveform features."""
+import numpy as np
+
+from spikeinterface.core.job_tools import ChunkRecordingExecutor, _shared_job_kwargs_doc
+from ..toolkit import get_chunk_with_margin
+from spikeinterface.toolkit import get_channel_distances
+
+
+def compute_features_from_peaks(
+    recording,
+    peaks,
+    feature_list=["amplitude", "ptp"],
+    feature_params = {"amplitude" : {"ms_before" : 0.2, "ms_after" : 0.2, "peak_sign" : "neg"},
+                      "ptp" : {"ms_before" : 1, "ms_after" : 1},
+                      "com" : {"ms_before" : 1, "ms_after" : 1, "local_radius_um" : 50},
+                      "dist_com_vs_max_ptp_channel" : {"ms_before" : 1, "ms_after" : 1, "local_radius_um" : 50},
+                      "dist_com_vs_max_std_channel" : {"ms_before" : 1, "ms_after" : 1, "local_radius_um" : 50},
+                      "energy" : {"ms_before" : 1, "ms_after" : 1, "local_radius_um" : 50}
+                      },
+    **job_kwargs,
+):
+    """Extract features on the fly from the recording given a list of peaks. 
+
+    Parameters
+    ----------
+    recording: RecordingExtractor
+        The recording extractor object.
+    peaks: array
+        Peaks array, as returned by detect_peaks() in "compact_numpy" way.
+    feature_list: List
+        List of features to be computed. Can be chosen between:
+            - amplitude (params: ms_before, ms_after, peak_sign)
+            - ptp (params: ms_before, ms_after)
+            - com (params: ms_before, ms_after, local_radius_um)
+            - dist_com_vs_max_p2p_channel (params: ms_before, ms_after)
+            - dist_com_vs_max_std_channel (params: ms_before, ms_after)
+
+    {}
+
+    Returns
+    -------
+    waveform_features: ndarray (NxCxF)
+        Array with waveform features for each spike.
+    """
+    has_com = False
+    for feature in feature_list:
+        assert feature in feature_params.keys(), "feature is not known..."
+        if feature == 'com':
+            has_com = True
+        if feature in ['dist_com_vs_max_std_channel', 'dist_com_vs_max_ptp_channel']:
+            assert has_com, "some features requires CoM to be computed first"
+
+
+    nbefore_max = 0
+    nafter_max = 0
+
+    for feature in feature_list:
+        if "ms_before" in feature_params[feature]:
+            ms_before = feature_params[feature]['ms_before']
+            nbefore = int(ms_before * recording.get_sampling_frequency() / 1000.0)
+            feature_params[feature]['nbefore'] = nbefore
+        if "ms_after" in feature_params[feature]:
+            ms_after = feature_params[feature]['ms_after']
+            nafter = int(ms_after * recording.get_sampling_frequency() / 1000.0)
+            feature_params[feature]['nafter'] = nafter
+
+        if nbefore > nbefore_max:
+            nbefore_max = nbefore
+
+        if nafter > nafter_max:
+            nafter_max = nafter
+
+        if "local_radius_um" in feature_params[feature]:
+            num_chans = recording.get_num_channels()
+            sparsity_mask = np.zeros((peaks.size, num_chans), dtype='bool')
+            chan_locs = recording.get_channel_locations()
+            unit_inds = range(num_chans)
+            chan_distances = get_channel_distances(recording)
+            #spikes['unit_ind'] = np.argmin(np.linalg.norm(chan_locs - locations[:, np.newaxis, :], axis=2), 1) 
+
+            for main_chan in unit_inds:
+                closest_chans, = np.nonzero(chan_distances[main_chan, :] <= feature_params[feature]['local_radius_um'])
+                sparsity_mask[main_chan, closest_chans] = True
+            feature_params[feature]['sparsity_mask'] = sparsity_mask
+            feature_params['chan_locs'] = chan_locs
+
+        if feature == "com":
+            feature_params['nb_com_dims'] = len(recording.get_channel_locations().shape)
+
+    # margin at border for get_trace
+    margin = max(nbefore_max, nafter_max)
+
+    # and run
+    func = _compute_features_from_peaks_chunk  # _localize_peaks_chunk
+    init_func = _init_worker_compute_features_from_peaks
+    init_args = (
+        recording.to_dict(),
+        peaks,
+        margin,
+        feature_list,
+        feature_params
+    )
+    processor = ChunkRecordingExecutor(
+        recording,
+        func,
+        init_func,
+        init_args,
+        handle_returns=True,
+        job_name="compute waveform features",
+        **job_kwargs,
+    )
+    peak_waveform_features = processor.run()
+    peak_waveform_features = np.concatenate(peak_waveform_features)
+
+    return peak_waveform_features
+
+
+compute_features_from_peaks.__doc__ = (
+    compute_features_from_peaks.__doc__.format(_shared_job_kwargs_doc)
+)
+
+
+def _init_worker_compute_features_from_peaks(
+    recording,
+    peaks,
+    margin,
+    feature_list,
+    feature_params
+):
+    """Initialize worker for localizing peaks."""
+
+    if isinstance(recording, dict):
+        from spikeinterface.core import load_extractor
+
+        recording = load_extractor(recording)
+
+    # create a local dict per worker
+    worker_ctx = {}
+    worker_ctx["recording"] = recording
+    worker_ctx["peaks"] = peaks
+    worker_ctx["margin"] = margin
+    worker_ctx["feature_list"] = feature_list
+    worker_ctx["feature_params"] = feature_params
+    return worker_ctx
+
+
+def _compute_features_from_peaks_chunk(segment_index, start_frame, end_frame, worker_ctx):
+    """Localize peaks in a chunk of data."""
+
+    # recover variables of the worker
+    recording = worker_ctx["recording"]
+    peaks = worker_ctx["peaks"]
+    margin = worker_ctx["margin"]
+    feature_list = worker_ctx["feature_list"]
+    feature_params = worker_ctx["feature_params"]
+
+    # load trace in memory
+    recording_segment = recording._recording_segments[segment_index]
+    traces, left_margin, right_margin = get_chunk_with_margin(
+        recording_segment, start_frame, end_frame, None, margin, add_zeros=True
+    )
+
+    # get local peaks (sgment + start_frame/end_frame)
+    i0 = np.searchsorted(peaks["segment_ind"], segment_index)
+    i1 = np.searchsorted(peaks["segment_ind"], segment_index + 1)
+    peak_in_segment = peaks[i0:i1]
+    i0 = np.searchsorted(peak_in_segment["sample_ind"], start_frame)
+    i1 = np.searchsorted(peak_in_segment["sample_ind"], end_frame)
+    local_peaks = peak_in_segment[i0:i1]
+
+    # make sample index local to traces
+    local_peaks = local_peaks.copy()
+    local_peaks["sample_ind"] -= start_frame - left_margin
+
+    peak_waveform_features = compute_features(
+        traces,
+        local_peaks,
+        feature_list,
+        feature_params
+    )
+
+    return peak_waveform_features
+
+
+def compute_features(
+    traces, local_peak, feature_list, feature_params
+):
+    """Localize peaks using the center of mass method."""
+
+    if 'com' in feature_list:
+        feature_size = len(feature_list) + (feature_params['nb_com_dims'] - 1)
+        com_start = feature_list.index('com')
+    else:
+        feature_size = len(feature_list)
+
+    peak_waveform_features = np.zeros(
+        (local_peak.size, feature_size), dtype=np.float32
+    )
+
+    feature_idx = 0
+
+    for feature in feature_list:
+
+        nbefore = feature_params[feature]['nbefore']
+        nafter = feature_params[feature]['nafter']
+
+        wf = traces[local_peak['sample_ind'][:, None] + np.arange(-nbefore, nafter), :]
+
+        if feature == 'amplitude':
+            if feature_params['peak_sign'] == 'neg':
+                features = np.min(wf, axis=(1, 2))
+            elif feature_params['peak_sign'] == 'pos':
+                features = np.max(wf, axis=(1, 2))
+            elif feature_params['peak_sign'] == 'both':
+                features = np.max(np.abs(wf), axis=(1, 2))
+
+        elif feature == 'ptp':
+            all_ptps = np.ptp(wf, axis=1)
+            features = np.max(all_ptps, axis=1)
+
+        elif feature == 'energy':
+            features = np.zeros(local_peak.size, dtype=np.float32)
+            for main_chan in range(traces.shape[1]):
+                idx = np.where(local_peak['channel_ind'] == main_chan)[0]
+                nb_channels = np.sum(feature_params[feature]['sparsity_mask'][main_chan])
+                features[idx] = np.linalg.norm(wf[idx] * feature_params[feature]['sparsity_mask'][main_chan], axis=(1, 2))/np.sqrt(nb_channels)
+
+        elif feature == 'com':
+            features = np.zeros((local_peak.size, feature_params['nb_com_dims']), dtype=np.float32)
+            for main_chan in range(traces.shape[1]):
+                idx = np.where(local_peak['channel_ind'] == main_chan)[0]
+                chan_inds, = np.nonzero(feature_params[feature]['sparsity_mask'][main_chan])
+                local_contact_locations = feature_params['chan_locs'][chan_inds, :]
+
+                wf_ptp = (wf[idx][:, :, chan_inds]).ptp(axis=1)
+                features[idx] = np.dot(wf_ptp, local_contact_locations)/(np.sum(wf_ptp, axis=1)[:,np.newaxis])
+
+        elif feature == 'dist_com_vs_max_ptp_channel':
+            features = np.zeros(local_peak.size, dtype=np.float32)
+            for main_chan in range(traces.shape[1]):
+                idx = np.where(local_peak['channel_ind'] == main_chan)[0]
+                chan_inds, = np.nonzero(feature_params[feature]['sparsity_mask'][main_chan])
+                local_contact_locations = feature_params['chan_locs'][chan_inds, :]
+
+                wf_ptp = (wf[idx][:, :, chan_inds]).ptp(axis=1)
+                max_ptp_channels = np.argmax(wf_ptp, axis=1)
+                coms = peak_waveform_features[idx, com_start:com_start+feature_params['nb_com_dims']]
+                features[idx] = np.linalg.norm(local_contact_locations[max_ptp_channels] - coms, axis=1)
+
+        elif feature == 'dist_com_vs_max_std_channel':
+            features = np.zeros(local_peak.size, dtype=np.float32)
+            for main_chan in range(traces.shape[1]):
+                idx = np.where(local_peak['channel_ind'] == main_chan)[0]
+                chan_inds, = np.nonzero(feature_params[feature]['sparsity_mask'][main_chan])
+                local_contact_locations = feature_params['chan_locs'][chan_inds, :]
+
+                wf_std = (wf[idx][:, :, chan_inds]).std(axis=1)
+                max_std_channels = np.argmax(wf_std, axis=1)
+                coms = peak_waveform_features[idx, com_start:com_start+feature_params['nb_com_dims']]
+                features[idx] = np.linalg.norm(local_contact_locations[max_std_channels] - coms, axis=1)
+
+        if feature != 'com':
+            peak_waveform_features[:, feature_idx] = features
+            feature_idx += 1
+        else:
+            peak_waveform_features[:, feature_idx:feature_idx+feature_params['nb_com_dims']] = features
+            feature_idx += feature_params['nb_com_dims']
+
+    return peak_waveform_features

--- a/spikeinterface/sortingcomponents/peak_localization.py
+++ b/spikeinterface/sortingcomponents/peak_localization.py
@@ -181,18 +181,17 @@ def localize_peaks_center_of_mass(traces, local_peak, contact_locations, neighbo
 
     peak_locations = np.zeros(local_peak.size, dtype=dtype_localize_by_method['center_of_mass'])
 
-    for i, peak in enumerate(local_peak):
-        chan_mask = neighbours_mask[peak['channel_ind'], :]
-        chan_inds, = np.nonzero(chan_mask)
+    wf = traces[local_peak['sample_ind'][:, None]+np.arange(-nbefore, nafter)]
 
+    for main_chan in range(traces.shape[1]):
+        idx = np.where(local_peak['channel_ind'] == main_chan)[0]
+        chan_inds, = np.nonzero(neighbours_mask[main_chan])
         local_contact_locations = contact_locations[chan_inds, :]
 
-        wf = traces[peak['sample_ind']-nbefore:peak['sample_ind']+nafter, :][:, chan_inds]
-        wf_ptp = wf.ptp(axis=0)
-        com = np.sum(wf_ptp[:, np.newaxis] * local_contact_locations, axis=0) / np.sum(wf_ptp)
-
-        peak_locations['x'][i] = com[0]
-        peak_locations['y'][i] = com[1]
+        wf_ptp = (wf[idx][:, :, chan_inds]).ptp(axis=1)
+        coms = np.dot(wf_ptp, local_contact_locations)/(np.sum(wf_ptp, axis=1)[:,np.newaxis])
+        peak_locations['x'][idx] = coms[:, 0]
+        peak_locations['y'][idx] = coms[:, 1]
 
     return peak_locations
 

--- a/spikeinterface/sortingcomponents/peak_waveform_features.py
+++ b/spikeinterface/sortingcomponents/peak_waveform_features.py
@@ -1,6 +1,4 @@
 """Sorting components: peak waveform features."""
-
-from lib2to3.pgen2.token import AMPER
 import numpy as np
 
 from spikeinterface.core.job_tools import ChunkRecordingExecutor, _shared_job_kwargs_doc

--- a/spikeinterface/sortingcomponents/tests/test_features_from_peaks.py
+++ b/spikeinterface/sortingcomponents/tests/test_features_from_peaks.py
@@ -1,0 +1,34 @@
+import pytest
+import numpy as np
+
+from spikeinterface import download_dataset, BaseSorting
+from spikeinterface.extractors import MEArecRecordingExtractor
+
+from spikeinterface.sortingcomponents.features_from_peaks import compute_features_from_peaks
+
+from spikeinterface.toolkit import get_noise_levels
+
+from spikeinterface.sortingcomponents.peak_detection import detect_peaks
+
+
+def test_features_from_peaks():
+
+    repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
+    remote_path = 'mearec/mearec_test_10s.h5'
+    local_path = download_dataset(
+        repo=repo, remote_path=remote_path, local_folder=None)
+    recording = MEArecRecordingExtractor(local_path)
+
+    noise_levels = get_noise_levels(recording, return_scaled=False)
+
+    peaks = detect_peaks(recording, method='by_channel',
+                         peak_sign='neg', detect_threshold=5, n_shifts=2,
+                         chunk_size=10000, verbose=1, progress_bar=False, noise_levels=noise_levels)
+
+    # locally_exclusive
+    features = compute_features_from_peaks(recording, peaks, ['ptp', 'energy', 'com', 'dist_com_vs_max_ptp_channel', 'dist_com_vs_max_std_channel'])
+
+    print(features)
+
+if __name__ == '__main__':
+    test_features_from_peaks()


### PR DESCRIPTION
I found that the file made by Cole during the Hackhaton should clearly be enhanced, allowing for an easier addition of features computed on the fly from the peaks. So here is a proposal, that could still be improved. In fact, once peaks are detected, one can, one the fly compute various metrics such as CoM, ptp, distances, ... These features could be useful for clustering algorithms, and if we can avoid extracting snippets of waveforms and saving them, this is a hugh plus 1. 
@samuelgarcia while I understand the philosophy of the shared_memory option for buffer extraction, this is not scaling for Neuropixel data. One can hardly store in memory all the snippets, even if sparsified. And we want to avoid memmap arrays. So if one can compute everything on the fly, sharing the load over several cores thanks to your ChunkRecordingExtractor, then so be it. Let's discuss that more in depth when you have time. 
In such a compute_features_from_peaks function, one could also (should) add denoising options if needed

In addition, in this PR, I implemented a fully vectorized version of CoM, faster