### PR TITLE
Fix install dev si for singularity

### DIFF
--- a/spikeinterface/sorters/runsorter.py
+++ b/spikeinterface/sorters/runsorter.py
@@ -482,8 +482,7 @@ if __name__ == '__main__':
             # TODO later check output
             if install_si_from_source:
                 si_source = 'local machine'
-                res_output = container_client.run_command(f'cp -rf {si_dev_path_unix} /opt')
-                cmd = f'pip install /opt/spikeinterface[full]'
+                cmd = f'pip install {si_dev_path_unix}[full]'
             else:
                 si_source = 'remote repository'
                 cmd = 'pip install --upgrade --no-input git+https://github.com/SpikeInterface/spikeinterface.git#egg=spikeinterface[full]'


### PR DESCRIPTION
`/opt` is readonly when running on singularity, removing `cp` command and installing dev si directly from binded path

The bind is set to readonly, so it's safe not to copy