### PR TITLE
Autoload of sample shifts for open-ephys NPIX and better naming

### DIFF
--- a/spikeinterface/extractors/neoextractors/openephys.py
+++ b/spikeinterface/extractors/neoextractors/openephys.py
@@ -85,7 +85,7 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
         probe = pi.read_openephys(folder_path, raise_error=False)
         if probe is not None:
             self.set_probe(probe, in_place=True)
-            probe_name = probe.annotations("probe_name")
+            probe_name = probe.annotations["probe_name"]
             # load num_channels_per_adc depending on probe type
             if "2.0" in probe_name:
                 num_channels_per_adc = 16

--- a/spikeinterface/extractors/neoextractors/openephys.py
+++ b/spikeinterface/extractors/neoextractors/openephys.py
@@ -20,6 +20,8 @@ from .neobaseextractor import (NeoBaseRecordingExtractor,
                                NeoBaseSortingExtractor,
                                NeoBaseEventExtractor)
 
+from spikeinterface.extractors.neuropixels_utils import get_neuropixels_sample_shifts
+
 
 class OpenEphysLegacyRecordingExtractor(NeoBaseRecordingExtractor):
     """
@@ -83,6 +85,15 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
         probe = pi.read_openephys(folder_path, raise_error=False)
         if probe is not None:
             self.set_probe(probe, in_place=True)
+            probe_name = probe.annotations("probe_name")
+            # load num_channels_per_adc depending on probe type
+            if "2.0" in probe_name:
+                num_channels_per_adc = 16
+            else:
+                num_channels_per_adc = 12
+            sample_shifts = get_neuropixels_sample_shifts(self.get_num_channels(), num_channels_per_adc)
+            self.set_property("inter_sample_shift", sample_shifts)    
+        
             
         self._kwargs .update(dict(folder_path=str(folder_path)))
 

--- a/spikeinterface/extractors/neoextractors/spikeglx.py
+++ b/spikeinterface/extractors/neoextractors/spikeglx.py
@@ -66,15 +66,15 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
                 self.set_probe(probe, in_place=True)
             self.set_probe(probe, in_place=True)
             
-            # load sample shifts
+            # load num_channels_per_adc depending on probe type
             imDatPrb_type = probe.annotations["imDatPrb_type"]
 
             if imDatPrb_type == 2:
-                num_adcs = 16
+                num_channels_per_adc = 16
             else:
-                num_adcs = 12
+                num_channels_per_adc = 12
 
-            sample_shifts = get_neuropixels_sample_shifts(self.get_num_channels(), num_adcs)
+            sample_shifts = get_neuropixels_sample_shifts(self.get_num_channels(), num_channels_per_adc)
             self.set_property("inter_sample_shift", sample_shifts)
 
         self._kwargs.update(dict(folder_path=str(folder_path)))

--- a/spikeinterface/extractors/neuropixels_utils.py
+++ b/spikeinterface/extractors/neuropixels_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-def get_neuropixels_sample_shifts(num_channels = 384, num_adcs = 12):
+def get_neuropixels_sample_shifts(num_channels=384, num_channels_per_adc=12):
 
     """
     Calculates the relative sampling phase of each channel that results 
@@ -17,7 +17,7 @@ def get_neuropixels_sample_shifts(num_channels = 384, num_adcs = 12):
     num_channels : The total number of channels in a recording. 
         All currently available Neuropixels variants have 384 channels.
 
-    num_adcs : The total number of ADCs on the probe
+    num_channels_per_adc : The total number of ADCs on the probe
         Neuropixels 1.0 probes have 12 ADCs
         Neuropixels 2.0 probes have 16 ADCs
 
@@ -28,17 +28,18 @@ def get_neuropixels_sample_shifts(num_channels = 384, num_adcs = 12):
    
     """
 
-    adc_indices = np.floor(np.arange(num_channels) / (num_adcs * 2)) * 2 + np.mod(np.arange(num_channels), 2)
+    adc_indices = np.floor(np.arange(num_channels) / 
+                           (num_channels_per_adc * 2)) * 2 + np.mod(np.arange(num_channels), 2)
 
     sample_shifts = np.zeros_like(adc_indices)
 
     for a in adc_indices:
-        sample_shifts[adc_indices == a] = np.arange(num_adcs) / num_adcs
+        sample_shifts[adc_indices == a] = np.arange(num_channels_per_adc) / num_channels_per_adc
 
     return sample_shifts
 
 
-def get_neuropixels_channel_groups(num_channels = 384, num_adcs = 12):
+def get_neuropixels_channel_groups(num_channels=384, num_adcs=12):
     
     """
     Returns groups of simultaneously sampled channels on a Neuropixels probe.
@@ -79,12 +80,12 @@ def get_neuropixels_channel_groups(num_channels = 384, num_adcs = 12):
 
     groups = []
 
-    for i in range(num_adcs):
+    for i in range(num_channels_per_adc):
         
         groups.append(
             list(
-                np.sort(np.concatenate([np.arange(i*2, num_channels, num_adcs*2),
-                                        np.arange(i*2+1, num_channels, num_adcs*2)]))
+                np.sort(np.concatenate([np.arange(i*2, num_channels, num_channels_per_adc*2),
+                                        np.arange(i*2+1, num_channels, num_channels_per_adc*2)]))
             )
         )
         

--- a/spikeinterface/extractors/neuropixels_utils.py
+++ b/spikeinterface/extractors/neuropixels_utils.py
@@ -17,7 +17,7 @@ def get_neuropixels_sample_shifts(num_channels=384, num_channels_per_adc=12):
     num_channels : The total number of channels in a recording. 
         All currently available Neuropixels variants have 384 channels.
 
-    num_channels_per_adc : The total number of ADCs on the probe
+    num_channels_per_adc : The number channels per ADCs on the probe
         Neuropixels 1.0 probes have 12 ADCs
         Neuropixels 2.0 probes have 16 ADCs
 


### PR DESCRIPTION
`num_adcs` --> `num_channels_per_adc`