### PR TITLE
import datatlad only when running download_dataset()remove

### DIFF
--- a/spikeinterface/core/datasets.py
+++ b/spikeinterface/core/datasets.py
@@ -4,17 +4,12 @@ Some simple function to retrieve public datasets.
 
 from .default_folders import get_global_dataset_folder, is_set_global_dataset_folder
 
-try:
-    import datalad.api
-    from datalad.support.gitrepo import GitRepo
-    HAVE_DATALAD = True
-except:
-    HAVE_DATALAD = False
-
 
 def download_dataset(repo=None, remote_path=None, local_folder=None, update_if_exists=False,
                      unlock=False):
-    assert HAVE_DATALAD, 'You need to install datalad'
+    import datalad.api
+    from datalad.support.gitrepo import GitRepo
+
 
     if repo is None:
         #  print('Use gin NeuralEnsemble/ephy_testing_data')

--- a/spikeinterface/core/tests/test_datasets.py
+++ b/spikeinterface/core/tests/test_datasets.py
@@ -1,6 +1,11 @@
 import pytest
-from spikeinterface.core.datasets import HAVE_DATALAD
 from spikeinterface.core import download_dataset
+
+try:
+    import datalad
+    HAVE_DATALAD = True
+except:
+    HAVE_DATALAD = False
 
 
 @pytest.mark.skipif(not HAVE_DATALAD, reason='No datalad')


### PR DESCRIPTION
This remove the systematic import of datalad which can be annoying in notebook for some version because it trigger lot of errors.
datalad will be now imported on demand only.

Same as here : https://github.com/NeuralEnsemble/python-neo/pull/1132