### PR TITLE
In case recordings are already filtered

### DIFF
--- a/spikeinterface/sortingcomponents/benchmark/benchmark_clustering.py
+++ b/spikeinterface/sortingcomponents/benchmark/benchmark_clustering.py
@@ -29,7 +29,10 @@ class BenchmarkClustering:
 
         self.verbose = verbose
         self.recording, self.gt_sorting = read_mearec(mearec_file)
-        self.recording_f = bandpass_filter(self.recording, dtype='float32')
+        if not self.recording.is_filtered():
+            self.recording_f = bandpass_filter(self.recording,  dtype='float32')
+        else:
+            self.recording_f = self.recording
         self.recording_f = common_reference(self.recording_f)
         self.sampling_rate = self.recording_f.get_sampling_frequency()
         self.job_kwargs = job_kwargs

--- a/spikeinterface/sortingcomponents/benchmark/benchmark_matching.py
+++ b/spikeinterface/sortingcomponents/benchmark/benchmark_matching.py
@@ -22,7 +22,10 @@ class BenchmarkMatching:
         self.method = method
         self.method_kwargs = method_kwargs
         self.recording, self.gt_sorting = read_mearec(mearec_file)
-        self.recording_f = bandpass_filter(self.recording, dtype='float32')
+        if not self.recording.is_filtered():
+            self.recording_f = bandpass_filter(self.recording,  dtype='float32')
+        else:
+            self.recording_f = self.recording
         self.recording_f = common_reference(self.recording_f)
         self.sampling_rate = self.recording_f.get_sampling_frequency()
         self.job_kwargs = job_kwargs

--- a/spikeinterface/sortingcomponents/benchmark/benchmark_peak_selection.py
+++ b/spikeinterface/sortingcomponents/benchmark/benchmark_peak_selection.py
@@ -25,7 +25,10 @@ class BenchmarkPeakSelection:
         self.verbose = verbose
         self.recording, self.gt_sorting = read_mearec(mearec_file)
         self.job_kwargs = job_kwargs
-        self.recording_f = bandpass_filter(self.recording, dtype='float32')
+        if not self.recording.is_filtered():
+            self.recording_f = bandpass_filter(self.recording,  dtype='float32')
+        else:
+            self.recording_f = self.recording
         self.recording_f = common_reference(self.recording_f)
         self.sampling_rate = self.recording_f.get_sampling_frequency()
 

--- a/spikeinterface/sortingcomponents/clustering/clustering_tools.py
+++ b/spikeinterface/sortingcomponents/clustering/clustering_tools.py
@@ -355,7 +355,7 @@ def auto_clean_clustering(wfs_arrays, sparsity_mask, labels, peak_labels, nbefor
             
             equal, shift = check_equal_template_with_distribution_overlap(wfs0, wfs1,
                             num_shift=auto_merge_num_shift, quantile_limit=auto_merge_quantile_limit, 
-                            return_shift=True, debug=False)
+                            return_shift=True)
             
             if equal:
                 auto_merge_list.append((l0, l1, shift))


### PR DESCRIPTION
Handle the fact that MEArec recordings could be filtered. However, something is weird here, because I am supposed to generate recordings that are explicitly unfiltered (given the MEArec syntax). So either this flag is not considered, either SI always assumes MEArec recordings are filtered. I don't know