### PR TITLE
Add `cast_unsigned` option in get_traces() 

### DIFF
--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -95,7 +95,39 @@ class BaseRecording(BaseExtractor):
                    channel_ids: Union[Iterable, None] = None,
                    order: Union[str, None] = None,
                    return_scaled=False,
+                   cast_unsigned=True
                    ):
+        """Returns traces from recording.
+
+        Parameters
+        ----------
+        segment_index : Union[int, None], optional
+            The segment index to get traces from. If recording is multi-segment, it is required, by default None
+        start_frame : Union[int, None], optional
+            The start frame. If None, 0 is used, by default None
+        end_frame : Union[int, None], optional
+            The end frame. If None, the number of samples in the segment is used, by default None
+        channel_ids : Union[Iterable, None], optional
+            The channel ids. If None, all channels are used, by default None
+        order : Union[str, None], optional
+            The order of the traces ("C" | "F"). If None, traces are returned as they are, by default None
+        return_scaled : bool, optional
+            If True and the recording has scaling (gain_to_uV and offset_to_uV properties),
+            traces are scaled to uV, by default False
+        cast_unsigned : bool, optional
+            If True and the traces are unsigned, they are cast to integer and centered 
+            (an offset of (2**nbits) is subtracted), by default True
+
+        Returns
+        -------
+        np.array
+            The traces (num_samples, num_channels)
+
+        Raises
+        ------
+        ValueError
+            If return_scaled is True, but recording does not have scaled traces
+        """
         segment_index = self._check_segment_index(segment_index)
         channel_indices = self.ids_to_indices(channel_ids, prefer_slice=True)
         rs = self._recording_segments[segment_index]
@@ -103,6 +135,15 @@ class BaseRecording(BaseExtractor):
         if order is not None:
             assert order in ["C", "F"]
             traces = np.asanyarray(traces, order=order)
+
+        if cast_unsigned:
+            dtype = traces.dtype
+            # if dtype is unsigned, return centered signed signal
+            if dtype.kind == "u":
+                nbits = dtype.itemsize * 8
+                traces = traces.astype('float32') - 2 ** (nbits - 1)
+                traces = traces.astype(f"int{dtype.itemsize * 8}")
+
         if return_scaled:
             if hasattr(self, "NeoRawIOClass"):
                 if self.has_non_standard_units:

--- a/spikeinterface/core/binaryrecordingextractor.py
+++ b/spikeinterface/core/binaryrecordingextractor.py
@@ -157,12 +157,6 @@ class BinaryRecordingSegment(BaseRecordingSegment):
         traces = self._timeseries[start_frame:end_frame]
         if channel_indices is not None:
             traces = traces[:, channel_indices]
-
-        if self._timeseries.dtype.str.startswith('uint'):
-            exp_idx = self._dtype.find('int') + 3
-            exp = int(self._dtype[exp_idx:])
-            traces = traces.astype('float32') - 2 ** (exp - 1)
-
         return traces
 
 

--- a/spikeinterface/core/core_tools.py
+++ b/spikeinterface/core/core_tools.py
@@ -182,7 +182,7 @@ def read_binary_recording(file, num_chan, dtype, time_axis=0, offset=0):
 
 
 # used by write_binary_recording + ChunkRecordingExecutor
-def _init_binary_worker(recording, rec_memmaps_dict, dtype):
+def _init_binary_worker(recording, rec_memmaps_dict, dtype, cast_unsigned):
     # create a local dict per worker
     worker_ctx = {}
     if isinstance(recording, dict):
@@ -191,19 +191,13 @@ def _init_binary_worker(recording, rec_memmaps_dict, dtype):
     else:
         worker_ctx['recording'] = recording
 
-    recording_dtype = np.dtype(worker_ctx['recording'].get_dtype())
-
     rec_memmaps = []
     for d in rec_memmaps_dict:
         rec_memmaps.append(np.memmap(**d))
 
     worker_ctx['rec_memmaps'] = rec_memmaps
     worker_ctx['dtype'] = np.dtype(dtype)
-
-    if worker_ctx['dtype'] != recording_dtype and recording_dtype.kind == "u":
-        worker_ctx['cast_unsigned'] = True
-    else:
-        worker_ctx['cast_unsigned'] = False
+    worker_ctx['cast_unsigned'] = cast_unsigned
 
     return worker_ctx
 
@@ -224,7 +218,7 @@ def _write_binary_chunk(segment_index, start_frame, end_frame, worker_ctx):
 
 
 def write_binary_recording(recording, file_paths=None, dtype=None, add_file_extension=True,
-                           verbose=False, byte_offset=0, **job_kwargs):
+                           verbose=False, byte_offset=0, auto_cast_uint=True, **job_kwargs):
     '''
     Save the trace of a recording extractor in several binary .dat format.
 
@@ -246,6 +240,8 @@ def write_binary_recording(recording, file_paths=None, dtype=None, add_file_exte
         If True, output is verbose (when chunks are used)
     byte_offset: int
         Offset in bytes (default 0) to for the binary file (e.g. to write a header)
+    auto_cast_uint: bool
+        If True (default), unsigned integers are automatically cast to int if the specified dtype is signed
     {}
     '''
     assert file_paths is not None, "Provide 'file_path'"
@@ -258,6 +254,10 @@ def write_binary_recording(recording, file_paths=None, dtype=None, add_file_exte
 
     if dtype is None:
         dtype = recording.get_dtype()
+    if auto_cast_uint:
+        cast_unsigned = determine_cast_unsigned(recording, dtype)
+    else:
+        cast_unsigned = False
 
     # create memmap files
     rec_memmaps = []
@@ -276,9 +276,9 @@ def write_binary_recording(recording, file_paths=None, dtype=None, add_file_exte
     init_func = _init_binary_worker
     n_jobs = ensure_n_jobs(recording, n_jobs=job_kwargs.get('n_jobs', 1))
     if n_jobs == 1:
-        init_args = (recording, rec_memmaps_dict, dtype)
+        init_args = (recording, rec_memmaps_dict, dtype, cast_unsigned)
     else:
-        init_args = (recording.to_dict(), rec_memmaps_dict, dtype)
+        init_args = (recording.to_dict(), rec_memmaps_dict, dtype, cast_unsigned)
     executor = ChunkRecordingExecutor(recording, func, init_func, init_args, verbose=verbose,
                                       job_name='write_binary_recording', **job_kwargs)
     executor.run()
@@ -332,7 +332,7 @@ def write_binary_recording_file_handle(recording, file_handle=None,
 
 
 # used by write_memory_recording
-def _init_memory_worker(recording, arrays, shm_names, shapes, dtype):
+def _init_memory_worker(recording, arrays, shm_names, shapes, dtype, cast_unsigned):
     # create a local dict per worker
     worker_ctx = {}
     if isinstance(recording, dict):
@@ -341,7 +341,6 @@ def _init_memory_worker(recording, arrays, shm_names, shapes, dtype):
     else:
         worker_ctx['recording'] = recording
 
-    recording_dtype = np.dtype(worker_ctx['recording'].get_dtype())
     worker_ctx['dtype'] = np.dtype(dtype)
 
     if arrays is None:
@@ -357,11 +356,7 @@ def _init_memory_worker(recording, arrays, shm_names, shapes, dtype):
             arrays.append(arr)
 
     worker_ctx['arrays'] = arrays
-
-    if worker_ctx['dtype'] != recording_dtype and recording_dtype.kind == "u":
-        worker_ctx['cast_unsigned'] = True
-    else:
-        worker_ctx['cast_unsigned'] = False
+    worker_ctx['cast_unsigned'] = cast_unsigned
 
     return worker_ctx
 
@@ -398,7 +393,7 @@ def make_shared_array(shape, dtype):
     return arr, shm
 
 
-def write_memory_recording(recording, dtype=None, verbose=False, **job_kwargs):
+def write_memory_recording(recording, dtype=None, verbose=False, auto_cast_uint=True, **job_kwargs):
     """
     Save the traces into numpy arrays (memory).
     try to use the SharedMemory introduce in py3.8 if n_jobs > 1
@@ -411,6 +406,8 @@ def write_memory_recording(recording, dtype=None, verbose=False, **job_kwargs):
         Type of the saved data. Default float32.
     verbose: bool
         If True, output is verbose (when chunks are used)
+    auto_cast_uint: bool
+        If True (default), unsigned integers are automatically cast to int if the specified dtype is signed
     {}
 
     Returns
@@ -423,6 +420,10 @@ def write_memory_recording(recording, dtype=None, verbose=False, **job_kwargs):
 
     if dtype is None:
         dtype = recording.get_dtype()
+    if auto_cast_uint:
+        cast_unsigned = determine_cast_unsigned(recording, dtype)
+    else:
+        cast_unsigned = False
 
     # create sharedmmep
     arrays = []
@@ -444,9 +445,9 @@ def write_memory_recording(recording, dtype=None, verbose=False, **job_kwargs):
     func = _write_memory_chunk
     init_func = _init_memory_worker
     if n_jobs > 1:
-        init_args = (recording.to_dict(), None, shm_names, shapes, dtype)
+        init_args = (recording.to_dict(), None, shm_names, shapes, dtype, cast_unsigned)
     else:
-        init_args = (recording, arrays, None, None, dtype)
+        init_args = (recording, arrays, None, None, dtype, cast_unsigned)
 
     executor = ChunkRecordingExecutor(recording, func, init_func, init_args, verbose=verbose,
                                       job_name='write_memory_recording', **job_kwargs)
@@ -460,7 +461,7 @@ write_memory_recording.__doc__ = write_memory_recording.__doc__.format(_shared_j
 
 def write_to_h5_dataset_format(recording, dataset_path, segment_index, save_path=None, file_handle=None,
                                time_axis=0, single_axis=False, dtype=None, chunk_size=None, chunk_memory='500M',
-                               verbose=False):
+                               verbose=False, auto_cast_uint=True):
     """
     Save the traces of a recording extractor in an h5 dataset.
 
@@ -491,6 +492,8 @@ def write_to_h5_dataset_format(recording, dataset_path, segment_index, save_path
         Chunk size in bytes must endswith 'k', 'M' or 'G' (default '500M')
     verbose: bool
         If True, output is verbose (when chunks are used)
+    auto_cast_uint: bool
+        If True (default), unsigned integers are automatically cast to int if the specified dtype is signed
     """
     import h5py
     # ~ assert HAVE_H5, "To write to h5 you need to install h5py: pip install h5py"
@@ -514,6 +517,10 @@ def write_to_h5_dataset_format(recording, dataset_path, segment_index, save_path
         dtype_file = recording.get_dtype()
     else:
         dtype_file = dtype
+    if auto_cast_uint:
+        cast_unsigned = determine_cast_unsigned(recording, dtype)
+    else:
+        cast_unsigned = False
 
     if single_axis:
         shape = (num_frames,)
@@ -528,7 +535,7 @@ def write_to_h5_dataset_format(recording, dataset_path, segment_index, save_path
     chunk_size = ensure_chunk_size(recording, chunk_size=chunk_size, chunk_memory=chunk_memory, n_jobs=1)
 
     if chunk_size is None:
-        traces = recording.get_traces()
+        traces = recording.get_traces(cast_unsigned=cast_unsigned)
         if dtype is not None:
             traces = traces.astype(dtype_file)
         if time_axis == 1:
@@ -550,7 +557,8 @@ def write_to_h5_dataset_format(recording, dataset_path, segment_index, save_path
         for i in chunks:
             traces = recording.get_traces(segment_index=segment_index,
                                           start_frame=i * chunk_size,
-                                          end_frame=min((i + 1) * chunk_size, num_frames))
+                                          end_frame=min((i + 1) * chunk_size, num_frames),
+                                          cast_unsigned=cast_unsigned)
             chunk_frames = traces.shape[0]
             if dtype is not None:
                 traces = traces.astype(dtype_file)
@@ -572,13 +580,11 @@ def write_to_h5_dataset_format(recording, dataset_path, segment_index, save_path
 def write_traces_to_zarr(recording, zarr_root, zarr_path, storage_options, 
                          dataset_paths, channel_chunk_size=None, dtype=None,
                          compressor=None, filters=None, 
-                         verbose=False, **job_kwargs):
+                         verbose=False, auto_cast_uint=True, 
+                         **job_kwargs):
     '''
     Save the trace of a recording extractor in several zarr format.
 
-    Note :
-        time_axis is always 0 (contrary to previous version.
-        to get time_axis=1 (which is a bad idea) use `write_binary_recording_file_handle()`
 
     Parameters
     ----------
@@ -602,6 +608,8 @@ def write_traces_to_zarr(recording, zarr_root, zarr_path, storage_options,
         List of zarr filters
     verbose: bool
         If True, output is verbose (when chunks are used)
+    auto_cast_uint: bool
+        If True (default), unsigned integers are automatically cast to int if the specified dtype is signed
     {}
     '''
     assert dataset_paths is not None, "Provide 'file_path'"
@@ -612,6 +620,10 @@ def write_traces_to_zarr(recording, zarr_root, zarr_path, storage_options,
 
     if dtype is None:
         dtype = recording.get_dtype()
+    if auto_cast_uint:
+        cast_unsigned = determine_cast_unsigned(recording, dtype)
+    else:
+        cast_unsigned = False
 
     chunk_size = ensure_chunk_size(recording, **job_kwargs)
     n_jobs = ensure_n_jobs(recording, n_jobs=job_kwargs.get('n_jobs', 1))
@@ -633,16 +645,16 @@ def write_traces_to_zarr(recording, zarr_root, zarr_path, storage_options,
     func = _write_zarr_chunk
     init_func = _init_zarr_worker
     if n_jobs == 1:
-        init_args = (recording, zarr_path, storage_options, dataset_paths, dtype)
+        init_args = (recording, zarr_path, storage_options, dataset_paths, dtype, cast_unsigned)
     else:
-        init_args = (recording.to_dict(), zarr_path, storage_options, dataset_paths, dtype)
+        init_args = (recording.to_dict(), zarr_path, storage_options, dataset_paths, dtype, cast_unsigned)
     executor = ChunkRecordingExecutor(recording, func, init_func, init_args, verbose=verbose,
                                       job_name='write_zarr_recording', **job_kwargs)
     executor.run()
 
 
 # used by write_zarr_recording + ChunkRecordingExecutor
-def _init_zarr_worker(recording, zarr_path, storage_options, dataset_paths, dtype):
+def _init_zarr_worker(recording, zarr_path, storage_options, dataset_paths, dtype, cast_unsigned):
     import zarr
 
     # create a local dict per worker
@@ -652,8 +664,6 @@ def _init_zarr_worker(recording, zarr_path, storage_options, dataset_paths, dtyp
         worker_ctx['recording'] = load_extractor(recording)
     else:
         worker_ctx['recording'] = recording
-
-    recording_dtype = np.dtype(worker_ctx['recording'].get_dtype())
 
     # reload root and datasets
     if storage_options is None:
@@ -672,11 +682,7 @@ def _init_zarr_worker(recording, zarr_path, storage_options, dataset_paths, dtyp
         zarr_datasets.append(z)
     worker_ctx['zarr_datasets'] = zarr_datasets
     worker_ctx['dtype'] = np.dtype(dtype)
-
-    if worker_ctx['dtype'] != recording_dtype and recording_dtype.kind == "u":
-        worker_ctx['cast_unsigned'] = True
-    else:
-        worker_ctx['cast_unsigned'] = False
+    worker_ctx['cast_unsigned'] = cast_unsigned
 
     return worker_ctx
 
@@ -695,6 +701,15 @@ def _write_zarr_chunk(segment_index, start_frame, end_frame, worker_ctx):
     traces = traces.astype(dtype)
     zarr_dataset[start_frame:end_frame, :] = traces
 
+
+def determine_cast_unsigned(recording, dtype):
+    recording_dtype = np.dtype(recording.get_dtype())
+
+    if np.dtype(dtype) != recording_dtype and recording_dtype.kind == "u" and np.dtype(dtype).kind == "i":
+        cast_unsigned = True
+    else:
+        cast_unsigned = False
+    return cast_unsigned
 
 
 def is_dict_extractor(d):

--- a/spikeinterface/core/tests/test_core_tools.py
+++ b/spikeinterface/core/tests/test_core_tools.py
@@ -42,6 +42,7 @@ def test_write_binary_recording():
                            dtype=None, verbose=False, n_jobs=2, total_memory='200k', progress_bar=True)
 
 
+
 def test_write_memory_recording():
     # 2 segments
     recording = generate_recording(num_channels=2, durations=[10.325, 3.5])

--- a/spikeinterface/core/zarrrecordingextractor.py
+++ b/spikeinterface/core/zarrrecordingextractor.py
@@ -149,12 +149,6 @@ class ZarrRecordingSegment(BaseRecordingSegment):
         traces = self._timeseries[start_frame:end_frame]
         if channel_indices is not None:
             traces = traces[:, channel_indices]
-
-        if self._timeseries.dtype.str.startswith('uint'):
-            exp_idx = self._dtype.find('int') + 3
-            exp = int(self._dtype[exp_idx:])
-            traces = traces.astype('float32') - 2 ** (exp - 1)
-
         return traces
 
 


### PR DESCRIPTION
The casting from unsigned to signed was scattered in the code base and not handled well in all situations (see https://github.com/SpikeInterface/spikeinterface/issues/657).

My proposal is:
- adding a `cast_unsigned` (False by default) as an additional arg to the `BaseRecording.get_traces()` that automatically does the centering and casting
- the write functions (to binary, to zarr, to memory) check the dtype:
   * if None and recording dtype is unsigned --> write unsigned
   * if dtype specified is int and recording is unsigned --> cast unsigned first and then cast to new dtype

This will fix https://github.com/SpikeInterface/spikeinterface/issues/657 because the intan recording is unsigned, and Kilosort writes to binary in `int16`, so this will trigger the `cast_unsigned=True` option in the write function.

@samuelgarcia @johnmbarrett let me know what you think!