### PR TITLE
Do not use fancy indexing for >=2D array

### DIFF
--- a/spikeinterface/postprocessing/correlograms.py
+++ b/spikeinterface/postprocessing/correlograms.py
@@ -46,7 +46,7 @@ class CrossCorrelogramsCalculator(BaseWaveformExtractorExtension):
     def _specific_select_units(self, unit_ids, new_waveforms_folder):
         # filter metrics dataframe
         unit_indices = self.waveform_extractor.sorting.ids_to_indices(unit_ids)
-        new_ccgs = self.ccgs[unit_indices][unit_indices]
+        new_ccgs = self.ccgs[unit_indices][:, unit_indices]
         np.save(new_waveforms_folder / self.extension_name / 'ccgs.npy', new_ccgs)
         np.save(new_waveforms_folder / self.extension_name / 'bins.npy', self.bins)
         

--- a/spikeinterface/postprocessing/correlograms.py
+++ b/spikeinterface/postprocessing/correlograms.py
@@ -46,7 +46,7 @@ class CrossCorrelogramsCalculator(BaseWaveformExtractorExtension):
     def _specific_select_units(self, unit_ids, new_waveforms_folder):
         # filter metrics dataframe
         unit_indices = self.waveform_extractor.sorting.ids_to_indices(unit_ids)
-        new_ccgs = self.ccgs[np.array(unit_indices), np.array(unit_indices)]
+        new_ccgs = self.ccgs[unit_indices][unit_indices]
         np.save(new_waveforms_folder / self.extension_name / 'ccgs.npy', new_ccgs)
         np.save(new_waveforms_folder / self.extension_name / 'bins.npy', self.bins)
         

--- a/spikeinterface/postprocessing/isi.py
+++ b/spikeinterface/postprocessing/isi.py
@@ -44,7 +44,7 @@ class ISIHistogramsCalculator(BaseWaveformExtractorExtension):
     def _specific_select_units(self, unit_ids, new_waveforms_folder):
         # filter metrics dataframe
         unit_indices = self.waveform_extractor.sorting.ids_to_indices(unit_ids)
-        new_isi_hists = self.isi_histograms[np.array(unit_indices), :]
+        new_isi_hists = self.isi_histograms[unit_indices, :]
         np.save(new_waveforms_folder /
                 self.extension_name / 'isi_histograms.npy', new_isi_hists)
         np.save(new_waveforms_folder /

--- a/spikeinterface/postprocessing/template_similarity.py
+++ b/spikeinterface/postprocessing/template_similarity.py
@@ -34,7 +34,7 @@ class TemplateSimilarityCalculator(BaseWaveformExtractorExtension):
     def _specific_select_units(self, unit_ids, new_waveforms_folder):
         # filter metrics dataframe
         unit_indices = self.waveform_extractor.sorting.ids_to_indices(unit_ids)
-        new_similarity = self.similarity[unit_indices][unit_indices]
+        new_similarity = self.similarity[unit_indices][:, unit_indices]
         np.save(new_waveforms_folder / self.extension_name / 'similarity.npy',
                 new_similarity)
         

--- a/spikeinterface/postprocessing/template_similarity.py
+++ b/spikeinterface/postprocessing/template_similarity.py
@@ -34,8 +34,7 @@ class TemplateSimilarityCalculator(BaseWaveformExtractorExtension):
     def _specific_select_units(self, unit_ids, new_waveforms_folder):
         # filter metrics dataframe
         unit_indices = self.waveform_extractor.sorting.ids_to_indices(unit_ids)
-        new_similarity = self.similarity[np.array(
-            unit_indices), np.array(unit_indices)]
+        new_similarity = self.similarity[unit_indices][unit_indices]
         np.save(new_waveforms_folder / self.extension_name / 'similarity.npy',
                 new_similarity)
         

--- a/spikeinterface/postprocessing/unit_localization.py
+++ b/spikeinterface/postprocessing/unit_localization.py
@@ -46,7 +46,7 @@ class UnitLocationsCalculator(BaseWaveformExtractorExtension):
     def _specific_select_units(self, unit_ids, new_waveforms_folder):
         unit_inds = self.waveform_extractor.sorting.ids_to_indices(unit_ids)
 
-        new_unit_location = self.locaunit_locationstions[unit_inds]
+        new_unit_location = self.unit_locations[unit_inds]
         np.save(new_waveforms_folder / 'unit_locations.npy', new_unit_location)
 
     def run(self, **job_kwargs):

--- a/spikeinterface/widgets/crosscorrelograms.py
+++ b/spikeinterface/widgets/crosscorrelograms.py
@@ -45,7 +45,7 @@ class CrossCorrelogramsWidget(BaseWidget):
             correlograms = ccgs
         else:
             unit_indices = sorting.ids_to_indices(unit_ids)
-            correlograms = ccgs[unit_indices][unit_indices]
+            correlograms = ccgs[unit_indices][:, unit_indices]
 
         plot_data = dict(
             correlograms=correlograms,

--- a/spikeinterface/widgets/crosscorrelograms.py
+++ b/spikeinterface/widgets/crosscorrelograms.py
@@ -45,7 +45,7 @@ class CrossCorrelogramsWidget(BaseWidget):
             correlograms = ccgs
         else:
             unit_indices = sorting.ids_to_indices(unit_ids)
-            correlograms = ccgs[unit_indices, unit_indices, :]
+            correlograms = ccgs[unit_indices][unit_indices]
 
         plot_data = dict(
             correlograms=correlograms,


### PR DESCRIPTION
Using fancy indexing for >=2D data returns the actual values, not the slices.

Fixes mainly are for the `_specific_select_units` and for the crosscorrelogram widget