### PR TITLE
Removing the DeprecationWarning on neo import

### DIFF
--- a/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -4,7 +4,9 @@ from typing import Union, List
 
 import numpy as np
 
+warnings.filterwarnings("ignore")
 import neo
+warnings.filterwarnings("default")
 
 from spikeinterface.core import (BaseRecording, BaseSorting, BaseEvent,
                                  BaseRecordingSegment, BaseSortingSegment, BaseEventSegment)


### PR DESCRIPTION
Everytime I import `spikeinterface.extractors`, I get this warning:

```
/users/nsr/wyngaard/dev/miniconda3/envs/MEArec/lib/python3.8/site-packages/neo/io/nixio.py:57: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  MIN_NIX_VER = Version("1.5.0")
/users/nsr/wyngaard/dev/miniconda3/envs/MEArec/lib/python3.8/site-packages/neo/io/neomatlabio.py:30: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  if version.LooseVersion(scipy.version.version) < '0.12.0':
/users/nsr/wyngaard/dev/miniconda3/envs/MEArec/lib/python3.8/site-packages/setuptools/_distutils/version.py:351: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  other = LooseVersion(other)
```

This commit removes this specific DeprecationWarning.