### PR TITLE
Add `EDFRecordingExtractor` 

### DIFF
--- a/requirements_extractors.txt
+++ b/requirements_extractors.txt
@@ -1,5 +1,6 @@
 MEArec>=1.7.1
 pynwb>=1.4
+pyedflib>=0.1.30
 # nixio>=1.5.0
 # shybrid>=0.4.2
 # pyyaml>=5.4.1  for shybrid

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -67,6 +67,9 @@ herdingspikes<=0.3.99
 ## mearec
 mearec
 
+## EDF 
+pyedflib
+
 ## container packages for local testing
 #docker
 #spython

--- a/spikeinterface/extractors/extractorlist.py
+++ b/spikeinterface/extractors/extractorlist.py
@@ -26,6 +26,7 @@ from .neoextractors import (
     TdtRecordingExtractor, read_tdt,
     AlphaOmegaRecordingExtractor, read_alphaomega,
     AlphaOmegaEventExtractor, read_alphaomega_event,
+    EDFRecordingExtractor, read_edf,
 )
 
 # NWB sorting/recording/event

--- a/spikeinterface/extractors/neoextractors/__init__.py
+++ b/spikeinterface/extractors/neoextractors/__init__.py
@@ -19,3 +19,4 @@ from .biocam import BiocamRecordingExtractor, read_biocam
 from .axona import AxonaRecordingExtractor, read_axona
 from .tdt import TdtRecordingExtractor, read_tdt
 from .alphaomega import AlphaOmegaRecordingExtractor, read_alphaomega, AlphaOmegaEventExtractor, read_alphaomega_event
+from .edf import EDFRecordingExtractor, read_edf

--- a/spikeinterface/extractors/neoextractors/edf.py
+++ b/spikeinterface/extractors/neoextractors/edf.py
@@ -1,0 +1,30 @@
+from spikeinterface.core.core_tools import define_function_from_class
+
+from .neobaseextractor import NeoBaseRecordingExtractor
+
+class EDFRecordingExtractor(NeoBaseRecordingExtractor):
+    """
+    Class for reading EDF (European data format) folder.
+
+    Based on :py:class:`neo.rawio.EDFRawIO`
+
+    Parameters
+    ----------
+    file_path: str
+        The file path to load the recordings from.
+    stream_id: str, optional
+        If there are several streams, specify the one you want to load.
+    all_annotations: bool, optional, default: False
+        Load exhaustively all annotations from neo.
+    """
+    mode = 'file'
+    NeoRawIOClass = 'EDFRawIO'
+
+    def __init__(self, file_path, stream_id=None, all_annotations=False):
+        neo_kwargs = {'filename': str(file_path)}
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+        self._kwargs.update({'file_path': str(file_path)})
+        self.extra_requirements.append('pyedflib')
+
+
+read_edf = define_function_from_class(source_class=EDFRecordingExtractor, name="read_edf")

--- a/spikeinterface/extractors/neoextractors/edf.py
+++ b/spikeinterface/extractors/neoextractors/edf.py
@@ -14,6 +14,7 @@ class EDFRecordingExtractor(NeoBaseRecordingExtractor):
         The file path to load the recordings from.
     stream_id: str, optional
         If there are several streams, specify the one you want to load.
+        For this neo reader stream are defined by their sampling frequency.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """

--- a/spikeinterface/extractors/tests/common_tests.py
+++ b/spikeinterface/extractors/tests/common_tests.py
@@ -66,11 +66,8 @@ class RecordingCommonTestSuite(CommonTestSuite):
                 trace_scaled = rec.get_traces(segment_index=segment_index, return_scaled=True, end_frame=2)
                 assert trace_scaled.dtype == 'float32'
             
-            if isinstance(rec, NeoBaseRecordingExtractor):
-                # for neo based also test annotations propagation
-                rec = self.ExtractorClass(local_folder / path, all_annotations=True, **kwargs)
-                
-    def test_annotations(self):
+                            
+    def test_neo_annotations(self):
         for entity in self.entities:
 
             if isinstance(entity, tuple):

--- a/spikeinterface/extractors/tests/common_tests.py
+++ b/spikeinterface/extractors/tests/common_tests.py
@@ -78,13 +78,10 @@ class RecordingCommonTestSuite(CommonTestSuite):
             elif isinstance(entity, str):
                 path = entity
                 kwargs = {}
-
-            rec = self.ExtractorClass(self.get_full_path(path), **kwargs)
-
+            
             if isinstance(rec, NeoBaseRecordingExtractor):
-                # for neo based also test annotations propagation
-                rec = self.ExtractorClass(local_folder / path, all_annotations=True, **kwargs)
-                
+                rec = self.ExtractorClass(self.get_full_path(path), all_annotations=True, **kwargs)
+
 class SortingCommonTestSuite(CommonTestSuite):
 
     def test_open(self):

--- a/spikeinterface/extractors/tests/common_tests.py
+++ b/spikeinterface/extractors/tests/common_tests.py
@@ -69,8 +69,22 @@ class RecordingCommonTestSuite(CommonTestSuite):
             if isinstance(rec, NeoBaseRecordingExtractor):
                 # for neo based also test annotations propagation
                 rec = self.ExtractorClass(local_folder / path, all_annotations=True, **kwargs)
+                
+    def test_annotations(self):
+        for entity in self.entities:
 
+            if isinstance(entity, tuple):
+                path, kwargs = entity
+            elif isinstance(entity, str):
+                path = entity
+                kwargs = {}
 
+            rec = self.ExtractorClass(self.get_full_path(path), **kwargs)
+
+            if isinstance(rec, NeoBaseRecordingExtractor):
+                # for neo based also test annotations propagation
+                rec = self.ExtractorClass(local_folder / path, all_annotations=True, **kwargs)
+                
 class SortingCommonTestSuite(CommonTestSuite):
 
     def test_open(self):

--- a/spikeinterface/extractors/tests/common_tests.py
+++ b/spikeinterface/extractors/tests/common_tests.py
@@ -78,8 +78,7 @@ class RecordingCommonTestSuite(CommonTestSuite):
             elif isinstance(entity, str):
                 path = entity
                 kwargs = {}
-            
-            if isinstance(rec, NeoBaseRecordingExtractor):
+            if hasattr(self.ExtractorClass , "NeoRawIOClass"):
                 rec = self.ExtractorClass(self.get_full_path(path), all_annotations=True, **kwargs)
 
 class SortingCommonTestSuite(CommonTestSuite):

--- a/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/spikeinterface/extractors/tests/test_neoextractors.py
@@ -224,6 +224,11 @@ class AlphaOmegaEventTest(EventCommonTestSuite, unittest.TestCase):
         "alphaomega/mpx_map_version4",
     ]
 
+class EDFRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
+    ExtractorClass = EDFRecordingExtractor
+    downloads = ['edf']
+    entities = ['edf/edf+C.edf']
+
 
 if __name__ == '__main__':
     pass


### PR DESCRIPTION
I am adding a recording extractor that reads the European Data Format:
https://www.edfplus.info/

This is based on neo so is a neo extractor:

https://github.com/NeuralEnsemble/python-neo/blob/f62bd73bff79d84d3f4cca653b37c86064205a4e/neo/rawio/edfrawio.py

I also added tests trying to follow the format set up in the `test_neoextractors` file. 

This is the first time that I add one extractor so let me know what else is missing or could be improved.

Related to:
https://github.com/catalystneuro/neuroconv/issues/44