### PR TITLE
Correct time units for `BlackrockSortingExtractor`

### DIFF
--- a/spikeinterface/extractors/neoextractors/blackrock.py
+++ b/spikeinterface/extractors/neoextractors/blackrock.py
@@ -38,9 +38,11 @@ class BlackrockSortingExtractor(NeoBaseSortingExtractor):
     file_path: str
         The file path to load the recordings from.
     sampling_frequency: float, None by default.
-        The sampling frequency for the spiking channels. When the signal data is available (.ncs) those files will be 
-        used to extract the frequency. Otherwise, the sampling frequency needs to be specified for this extractor.
+        The sampling frequency for the sorting extractor. When the signal data is available (.ncs) those files will be 
+        used to extract the frequency automatically. Otherwise, the sampling frequency needs to be specified for 
+        this extractor to be initialized.
     """
+    
     mode = 'file'
     NeoRawIOClass = 'BlackrockRawIO'
     handle_spike_frame_directly = False

--- a/spikeinterface/extractors/neoextractors/blackrock.py
+++ b/spikeinterface/extractors/neoextractors/blackrock.py
@@ -43,6 +43,8 @@ class BlackrockSortingExtractor(NeoBaseSortingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'BlackrockRawIO'
+    handle_spike_frame_directly = False
+
 
     def __init__(self, file_path, sampling_frequency=None):
         neo_kwargs = {'filename': str(file_path)}

--- a/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -239,7 +239,7 @@ class NeoSortingSegment(BaseSortingSegment):
             # When handle_spike_frame_directly=True, the extractors handles timestamps as frames
             spike_frames = spike_timestamps
         else:
-            # Conver timestamps to seconds
+            # Convert timestamps to seconds
             spike_times = self.neo_reader.rescale_spike_timestamp(spike_timestamps, dtype='float64')
             # Re-center to zero for each segment and multiply by frequency to convert seconds to frames
             spike_frames = ((spike_times - self._t_start) * self._sampling_frequency).astype('int64')

--- a/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -177,14 +177,14 @@ class NeoBaseSortingExtractor(_NeoBaseExtractor, BaseSorting):
 
     def _auto_guess_sampling_frequency(self):
         """
-        When the signal channels are available the sampling rate is set the one with the higher frequency.
+        When the signal channels are available the sampling rate is set that of the channel with the higher frequency.
         
-        Because neo handle spike in times (s or ms) but spikeinterface in frames related to signals spikeinterface 
+        Because neo handle spike in times (s or ms) but spikeinterface in frames related to signals, spikeinterface 
         need the sampling frequency. 
         
-        Internally many format do have have the spike time stamps at the same speed as the signal but at a higher
-        clocks speed. Here in spikeinterface we need spike index to be at the same speed that signal it do not make 
-        sense to have spikes at 50kHz sample when the signal is 10kHz. Neo handle this but not spikeinterface.
+        Internally many format do have the spike timestamps at the same speed as the signal but at a higher
+        clocks speed. Here in spikeinterface we need spike index to be at the same speed that signal, therefore it does
+        not make sense to have spikes at 50kHz when the signal is 10kHz. Neo handle this but not spikeinterface.
 
         In neo spikes can have diffrents sampling rate than signals so conversion from signals frames to times is
         format dependent.

--- a/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -177,28 +177,25 @@ class NeoBaseSortingExtractor(_NeoBaseExtractor, BaseSorting):
 
     def _auto_guess_sampling_frequency(self):
         """
-        Because neo handle spike in times (s or ms) but spikeinterface in frames related to signals.
-        spikeinterface need so the sampling frequency.
-        Getting the sampling rate in for psike is quite tricky because in neo
-        spike are handle in s or ms
-        internally many format do have have the spike time stamps
-        at the same speed as the signal but at a higher clocks speed.
-        here in spikeinterface we need spike index to be at the same speed
-        that signal it do not make sens to have spikes at 50kHz sample
-        when the sig is 10kHz.
-        neo handle this but not spieinterface
+        When the signal channels are available the sampling rate is set the one with the higher frequency.
+        
+        Because neo handle spike in times (s or ms) but spikeinterface in frames related to signals spikeinterface 
+        need the sampling frequency. 
+        
+        Internally many format do have have the spike time stamps at the same speed as the signal but at a higher
+        clocks speed. Here in spikeinterface we need spike index to be at the same speed that signal it do not make 
+        sense to have spikes at 50kHz sample when the signal is 10kHz. Neo handle this but not spikeinterface.
 
-        In neo spikes can have diffrents sampling rate than signals so conversion from
-        signals frames to times is format dependent
+        In neo spikes can have diffrents sampling rate than signals so conversion from signals frames to times is
+        format dependent.
         """
 
         # here the generic case
         #  all channels are in the same neo group so
         sig_channels = self.neo_reader.header['signal_channels']
-        assert sig_channels.size > 0, 'sampling_frequqency is not given and it is hard to guess it'
+        assert sig_channels.size > 0, 'sampling_frequency could not be inferred from the signals, set it manually'
         sampling_frequency = np.max(sig_channels['sampling_rate'])
 
-        #  print('_auto_guess_sampling_frequency', sampling_frequency)
         return sampling_frequency
 
 
@@ -229,12 +226,12 @@ class NeoSortingSegment(BaseSortingSegment):
                                                                 seg_index=self.segment_index,
                                                                 spike_channel_index=unit_index)
         if self._t_start is None:
-            # because handle_spike_frame_directly=True
+            # When handle_spike_frame_directly=True, the extractors handles timestamps as frames
             spike_frames = spike_timestamps
         else:
-            # convert to second second
+            # Conver timestamps to seconds
             spike_times = self.neo_reader.rescale_spike_timestamp(spike_timestamps, dtype='float64')
-            # convert to sample related to recording signals
+            # Re-center to zero for each segment and multiply by frequency to convert seconds to frames
             spike_frames = ((spike_times - self._t_start) * self._sampling_frequency).astype('int64')
 
         # clip


### PR DESCRIPTION
In #856 I forgot to scale the timestamps of the spikes correctly. This small PR fixes that by scaling the timestamps of neo (which are usually in seconds) to frames.

I also did some small fixes to some of the docstrings in `neobaseextractor`.