### PR TITLE
Move `_preferred_mp_context` inside `DeepInterpolatedRecording. __init__ `

### DIFF
--- a/spikeinterface/preprocessing/deepinterpolation/deepinterpolation.py
+++ b/spikeinterface/preprocessing/deepinterpolation/deepinterpolation.py
@@ -205,7 +205,6 @@ def define_input_generator_class(use_gpu, disable_tf_logger=True):
 
 class DeepInterpolatedRecording(BasePreprocessor):
     name = 'deepinterpolate'
-    preferred_mp_context = "spawn"
 
     def __init__(self, recording: BaseRecording, model_path: str,
                  pre_frames: int = 30, post_frames: int = 30, pre_post_omission: int = 1,
@@ -286,6 +285,7 @@ class DeepInterpolatedRecording(BasePreprocessor):
                                                                  disable_tf_logger)
             self.add_recording_segment(recording_segment)
 
+        self._preferred_mp_context = "spawn"
         self._kwargs = dict(recording=recording.to_dict(), model_path=model_path,
                             pre_frames=pre_frames, post_frames=post_frames, pre_post_omission=pre_post_omission,
                             batch_size=batch_size, **random_chunk_kwargs)


### PR DESCRIPTION
For parallel saving to work for `DeepInterpolatedRecording` by default, its preferred mp context should be set to `spawn`. Right now `_mp_preferred_context="spawn"` is defined outside of `DeepInterpolatedRecording.__init__`. This doesn't work because `DeepInterpolatedRecording` subclasses `BasePreprocessor` and calls `BasePreprocessor.__init__(self, recording)` inside its `__init__` to get properties like `sampling_frequency` and `channel_ids`. As a result, it inherits `_mp_preferred_context` from `BasePreprocessor` as well, which is by default `None` (defined all the way back in `BaseExtractor`). So even if you define `_mp_preferred_context='spawn'` outside of `__init__` of `DeepInterpolatedRecording`, you end up re-defining it when it is instantiated. 

This PR sets `self._mp_preferred_context = 'spawn'` inside `__init__` of `DeepInterpolatedRecording` after calling `BasePreprocessor.__init__(self, recording)` so that parallel processing (e.g. saving) works.