### PR TITLE
Set MATLAB_SHELL to bash in kilosort shell cmd to work with Fish shell

### DIFF
--- a/spikeinterface/sorters/kilosortbase.py
+++ b/spikeinterface/sorters/kilosortbase.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from warnings import warn
 import json
 import shutil
 import sys
@@ -6,7 +7,7 @@ import sys
 import numpy as np
 import scipy.io
 
-from .utils import ShellScript
+from .utils import ShellScript, get_matlab_shell_name, get_bash_path
 from .basesorter import get_job_kwargs
 from spikeinterface.extractors import KiloSortSortingExtractor
 from spikeinterface.core import write_binary_recording
@@ -152,10 +153,19 @@ class KilosortBase:
                     matlab -nosplash -wait -r "{cls.sorter_name}_master('{output_folder}', '{sorter_path}')"
                 '''
             else:
+                if get_matlab_shell_name() == 'fish':
+                    # Avoid MATLAB's 'copyfile' function failing due to MATLAB using fish as a shell
+                    bash_path = get_bash_path()
+                    warn(f"Avoid Kilosort failing due to MATLAB using 'fish' as a shell: setting `MATLAB_SHELL` env variable to `{bash_path}`.")
+                    matlab_shell_str = f'''
+                    export MATLAB_SHELL="{bash_path}"
+                    echo "Set MATLAB shell to $MATLAB_SHELL"
+                    '''
+                else:
+                    matlab_shell_str = ""
                 shell_cmd = f'''
                     #!/bin/bash
-                    export MATLAB_SHELL='/usr/bin/bash'
-                    echo "Set Matlab shell to $MATLAB_SHELL"
+                    {matlab_shell_str}
                     cd "{output_folder}"
                     matlab -nosplash -nodisplay -r "{cls.sorter_name}_master('{output_folder}', '{sorter_path}')"
                 '''

--- a/spikeinterface/sorters/kilosortbase.py
+++ b/spikeinterface/sorters/kilosortbase.py
@@ -154,6 +154,8 @@ class KilosortBase:
             else:
                 shell_cmd = f'''
                     #!/bin/bash
+                    export MATLAB_SHELL='/usr/bin/bash'
+                    echo "Set Matlab shell to $MATLAB_SHELL"
                     cd "{output_folder}"
                     matlab -nosplash -nodisplay -r "{cls.sorter_name}_master('{output_folder}', '{sorter_path}')"
                 '''

--- a/spikeinterface/sorters/utils/__init__.py
+++ b/spikeinterface/sorters/utils/__init__.py
@@ -1,2 +1,2 @@
 from .shellscript import ShellScript
-from .misc import (SpikeSortingError, get_git_commit, has_nvidia)
+from .misc import (SpikeSortingError, get_git_commit, has_nvidia, get_matlab_shell_name, get_bash_path)

--- a/spikeinterface/sorters/utils/misc.py
+++ b/spikeinterface/sorters/utils/misc.py
@@ -1,10 +1,46 @@
-from subprocess import check_output
+from pathlib import Path
+from subprocess import check_output, CalledProcessError
 from typing import List, Union
 
 import numpy as np
 
 class SpikeSortingError(RuntimeError):
     """Raised whenever spike sorting fails"""
+
+
+def get_bash_path():
+    """Return path to existing bash install."""
+    try:
+        return check_output( ['which bash'], shell=True).decode().strip('\n')
+    except CalledProcessError as e:
+        raise Exception("Bash is not installed or accessible on your system.")
+
+
+def get_matlab_shell_name():
+    """Return name of shell program used by MATLAB.
+    
+    As per MATLAB docs:
+    'On UNIX, MATLAB uses a shell program to execute the given command. It
+    determines which shell program to use by checking environment variables on
+    your system. MATLAB first checks the MATLAB_SHELL variable, and if either
+    empty or not defined, then checks SHELL. If SHELL is also empty or not
+    defined, MATLAB uses /bin/sh'
+    """
+    try:
+        # Either of "", "bash", "zsh", "fish",...
+        # CalledProcessError if not defined
+        matlab_shell_name = check_output(['which $MATLAB_SHELL'], shell=True).decode().strip('\n').split('/')[-1]  
+        return matlab_shell_name
+    except CalledProcessError as e:
+        pass
+    try:
+        # Either of "", "bash", "zsh", "fish",...
+        # CalledProcessError if not defined
+        df_shell_name = check_output(['which $SHELL'], shell=True).decode().strip('\n').split('/')[-1]  
+        return df_shell_name
+    except CalledProcessError as e:
+        pass
+    return "sh"
 
 
 def get_git_commit(git_folder, shorten=True):


### PR DESCRIPTION
Hi,

This is required when running Kilosort if the user's default shell is Fish, otherwise matlab errors when calling `copyfile` during exporting to Phy.

Best