### PR TITLE
fix combinato and waveclus sorters

### DIFF
--- a/spikeinterface/sorters/combinato/combinato.py
+++ b/spikeinterface/sorters/combinato/combinato.py
@@ -8,6 +8,7 @@ from ..utils import ShellScript
 from spikeinterface.core import write_to_h5_dataset_format
 from ..basesorter import BaseSorter
 from spikeinterface.extractors import CombinatoSortingExtractor
+from spikeinterface.preprocessing import ScaleRecording
 
 try:
     import h5py
@@ -134,7 +135,7 @@ class CombinatoSorter(BaseSorter):
         vcFile_h5 = str(output_folder / ('recording.h5'))
         with h5py.File(vcFile_h5, mode='w') as f:
             f.create_dataset("sr", data=[recording.get_sampling_frequency()], dtype='float32')
-            write_to_h5_dataset_format(recording, dataset_path='/data', segment_index=0,
+            write_to_h5_dataset_format(ScaleRecording(recording), dataset_path='/data', segment_index=0,
                                        file_handle=f, time_axis=0, single_axis=True,
                                        chunk_memory=params['chunk_memory'])
 

--- a/spikeinterface/sorters/combinato/combinato.py
+++ b/spikeinterface/sorters/combinato/combinato.py
@@ -135,7 +135,7 @@ class CombinatoSorter(BaseSorter):
         vcFile_h5 = str(output_folder / ('recording.h5'))
         with h5py.File(vcFile_h5, mode='w') as f:
             f.create_dataset("sr", data=[recording.get_sampling_frequency()], dtype='float32')
-            write_to_h5_dataset_format(ScaleRecording(recording), dataset_path='/data', segment_index=0,
+            write_to_h5_dataset_format(ScaleRecording(recording, dtype="float32"), dataset_path='/data', segment_index=0,
                                        file_handle=f, time_axis=0, single_axis=True,
                                        chunk_memory=params['chunk_memory'])
 

--- a/spikeinterface/sorters/waveclus/waveclus.py
+++ b/spikeinterface/sorters/waveclus/waveclus.py
@@ -13,6 +13,7 @@ from ..utils import ShellScript
 from spikeinterface.core import write_to_h5_dataset_format
 from spikeinterface.extractors import WaveClusSortingExtractor
 from spikeinterface.core.channelslice import ChannelSliceRecording
+from spikeinterface.preprocessing import ScaleRecording
 
 PathType = Union[str, Path]
 
@@ -160,7 +161,7 @@ class WaveClusSorter(BaseSorter):
                 f.create_dataset(
                     "sr", data=[recording.get_sampling_frequency()], dtype='float32')
                 rec_sliced = ChannelSliceRecording(recording, channel_ids=[id])
-                write_to_h5_dataset_format(rec_sliced, dataset_path='/data', segment_index=0,
+                write_to_h5_dataset_format(ScaleRecording(rec_sliced), dataset_path='/data', segment_index=0,
                                            file_handle=f, time_axis=0, single_axis=True,
                                            chunk_memory=params['chunk_memory'])
 

--- a/spikeinterface/sorters/waveclus/waveclus.py
+++ b/spikeinterface/sorters/waveclus/waveclus.py
@@ -161,7 +161,7 @@ class WaveClusSorter(BaseSorter):
                 f.create_dataset(
                     "sr", data=[recording.get_sampling_frequency()], dtype='float32')
                 rec_sliced = ChannelSliceRecording(recording, channel_ids=[id])
-                write_to_h5_dataset_format(ScaleRecording(rec_sliced), dataset_path='/data', segment_index=0,
+                write_to_h5_dataset_format(ScaleRecording(rec_sliced, dtype="float32"), dataset_path='/data', segment_index=0,
                                            file_handle=f, time_axis=0, single_axis=True,
                                            chunk_memory=params['chunk_memory'])
 


### PR DESCRIPTION
Hi, the issue #892 showed me that combinato and waveclus sorters have an issue related to scales. Internally they use write_to_h5_dataset_format to handle the data input to the sorters but the trace is saved unscaled in the file. My fix uses ScaleRecording before calling write_to_h5_dataset_format .

Cheers 
Fer