### PR TITLE
defer to neo for extractor requirements

### DIFF
--- a/spikeinterface/extractors/neoextractors/ced.py
+++ b/spikeinterface/extractors/neoextractors/ced.py
@@ -27,7 +27,7 @@ class CedRecordingExtractor(NeoBaseRecordingExtractor):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
         self._kwargs.update(dict(file_path=str(file_path)))
-        self.extra_requirements.append('sonpy')
+        self.extra_requirements.append('neo[ced]')
 
 
 

--- a/spikeinterface/extractors/neoextractors/edf.py
+++ b/spikeinterface/extractors/neoextractors/edf.py
@@ -26,7 +26,7 @@ class EDFRecordingExtractor(NeoBaseRecordingExtractor):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
         self._kwargs.update({'file_path': str(file_path)})
-        self.extra_requirements.append('pyedflib')
+        self.extra_requirements.append('neo[edf]')
 
 
 read_edf = define_function_from_class(source_class=EDFRecordingExtractor, name="read_edf")

--- a/spikeinterface/extractors/neoextractors/nix.py
+++ b/spikeinterface/extractors/neoextractors/nix.py
@@ -30,7 +30,7 @@ class NixRecordingExtractor(NeoBaseRecordingExtractor):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
         self._kwargs.update(dict(file_path=str(file_path), stream_id=stream_id))
-        self.extra_requirements.append('nixio')
+        self.extra_requirements.append('neo[nixio]')
 
 
 read_nix = define_function_from_class(source_class=NixRecordingExtractor, name="read_nix")

--- a/spikeinterface/extractors/neoextractors/openephys.py
+++ b/spikeinterface/extractors/neoextractors/openephys.py
@@ -93,7 +93,6 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
             sample_shifts = get_neuropixels_sample_shifts(self.get_num_channels(), num_channels_per_adc)
             self.set_property("inter_sample_shift", sample_shifts)
 
-
         self._kwargs .update(dict(folder_path=str(folder_path)))
 
 


### PR DESCRIPTION
Defer to neo for format-specific requirements. Instead of specifying the ced requires sonpy, say it requires neo[ced] and let neo specify sonpy. The advantage of this is that you will always be up-to-date with the requirements of neo. If a library is added or removed for a format this will be automatically reflected in spikeinterface. I am also working with neo to make sure that it provides the appropriate hooks for this:

https://github.com/NeuralEnsemble/python-neo/pull/1154