### PR TITLE
move extra_requirements to class attribute

### DIFF
--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -30,6 +30,7 @@ class BaseExtractor:
     _main_annotations = []
     _main_properties = []
     _main_features = []
+    extra_requirements = []
 
 
     def __init__(self, main_ids):
@@ -53,9 +54,6 @@ class BaseExtractor:
         self._features = {}
 
         self.is_dumpable = True
-
-        # extractor specific list of pip extra requirements
-        self.extra_requirements = []
         
         # preferred context for multiprocessing
         self._preferred_mp_context = None

--- a/spikeinterface/extractors/neoextractors/edf.py
+++ b/spikeinterface/extractors/neoextractors/edf.py
@@ -21,12 +21,12 @@ class EDFRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'EDFRawIO'
+    extra_requirements = NeoBaseRecordingExtractor.extra_requirements + ["pyedflib"]
 
     def __init__(self, file_path, stream_id=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
         self._kwargs.update({'file_path': str(file_path)})
-        self.extra_requirements.append('pyedflib')
 
 
 read_edf = define_function_from_class(source_class=EDFRecordingExtractor, name="read_edf")

--- a/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -26,6 +26,8 @@ class _NeoBaseExtractor:
 
 class NeoBaseRecordingExtractor(_NeoBaseExtractor, BaseRecording):
 
+    extra_requirements = BaseRecording.extra_requirements + ['neo']
+
     def __init__(self, stream_id=None, all_annotations=False, **neo_kwargs):
 
         _NeoBaseExtractor.__init__(self, **neo_kwargs)
@@ -59,7 +61,6 @@ class NeoBaseRecordingExtractor(_NeoBaseExtractor, BaseRecording):
         sampling_frequency = self.neo_reader.get_signal_sampling_rate(stream_index=self.stream_index)
         dtype = signal_channels['dtype'][0]
         BaseRecording.__init__(self, sampling_frequency, chan_ids, dtype)
-        self.extra_requirements.append('neo')
 
         # find the gain to uV
         gains = signal_channels['gain']

--- a/spikeinterface/extractors/neoextractors/openephys.py
+++ b/spikeinterface/extractors/neoextractors/openephys.py
@@ -93,8 +93,7 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
             sample_shifts = get_neuropixels_sample_shifts(self.get_num_channels(), num_channels_per_adc)
             self.set_property("inter_sample_shift", sample_shifts)
 
-
-        self._kwargs .update(dict(folder_path=str(folder_path)))
+        self._kwargs.update(dict(folder_path=str(folder_path)))
 
 
 class OpenEphysBinaryEventExtractor(NeoBaseEventExtractor):


### PR DESCRIPTION
I think extra_requirements would go better as a class attribute so it is available before an instance of the class is defined.