### PR TITLE
format-specific requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
 
+
 def open_requirements(fname):
     with open(fname, mode='r') as f:
         requires = f.read().split('\n')
@@ -13,6 +14,7 @@ extractors_requires = open_requirements('requirements_extractors.txt')
 extras_require = {
     "full": full_requires,
     "extractors": extractors_requires,
+    "ced": ["neo[ced]"],
 }
 
 d = {}


### PR DESCRIPTION
This is creating extra_requirements similar to how it is done in neo:

https://github.com/NeuralEnsemble/python-neo/blob/070eb47325839b8daf30299085f3b8f62eefc243/setup.py#L10-L20

This would allow downstream packages e.g. NeurConv to express the requirements for the CED interface as `spikeinterface[ced]`