### PR TITLE
Extend NEO extractors

### DIFF
--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -31,6 +31,10 @@ class BaseExtractor:
     _main_properties = []
     _main_features = []
 
+    installed = True
+    installation_mesg = ""
+    is_writable = False
+
 
     def __init__(self, main_ids):
         # store init kwargs for nested serialisation

--- a/spikeinterface/core/baserecordingsnippets.py
+++ b/spikeinterface/core/baserecordingsnippets.py
@@ -16,6 +16,7 @@ class BaseRecordingSnippets(BaseExtractor):
     """
     Mixin that handles all probe and channel operations
     """
+    has_default_locations = False
 
     def __init__(self, sampling_frequency: float, channel_ids: List, dtype):
         BaseExtractor.__init__(self, channel_ids)

--- a/spikeinterface/core/binaryfolder.py
+++ b/spikeinterface/core/binaryfolder.py
@@ -25,6 +25,11 @@ class BinaryFolderRecording(BinaryRecordingExtractor):
     recording: BinaryFolderRecording
         The recording
     """
+    extractor_name = 'BinaryFolder'
+    has_default_locations = True
+    mode = 'folder'
+    name = "binaryfolder"
+
     def __init__(self,  folder_path):
         
         folder_path = Path(folder_path)

--- a/spikeinterface/core/binaryrecordingextractor.py
+++ b/spikeinterface/core/binaryrecordingextractor.py
@@ -44,12 +44,10 @@ class BinaryRecordingExtractor(BaseRecording):
     recording: BinaryRecordingExtractor
         The recording Extractor
     """
-    extractor_name = 'BinaryRecordingExtractor'
-    has_default_locations = False
-    installed = True  # check at class level if installed or not
+    extractor_name = 'BinaryRecording'
     is_writable = True
     mode = 'file'
-    installation_mesg = ""  # error message when not installed
+    name = "binary"
     
     def __init__(self, file_paths, sampling_frequency, num_chan, dtype, t_starts=None, channel_ids=None,
                  time_axis=0, file_offset=0, gain_to_uV=None, offset_to_uV=None,

--- a/spikeinterface/core/npyfoldersnippets.py
+++ b/spikeinterface/core/npyfoldersnippets.py
@@ -24,6 +24,9 @@ class NpyFolderSnippets(NpySnippetsExtractor):
     snippets: NpyFolderSnippets
         The snippets
     """
+    extractor_name = 'NpyFolderSnippets'
+    mode = 'folder'
+    name = "npyfolder"
 
     def __init__(self,  folder_path):
 

--- a/spikeinterface/core/npysnippetsextractor.py
+++ b/spikeinterface/core/npysnippetsextractor.py
@@ -14,11 +14,10 @@ class NpySnippetsExtractor(BaseSnippets):
     All spike are store in two columns maner index+labels
     """
 
-    extractor_name = 'NpySnippetsExtractor'
-    installed = True  # depend only on numpy
-    installation_mesg = "Always installed"
+    extractor_name = 'NpySnippets'
     is_writable = True
     mode = 'file'
+    name = "npy"
 
     def __init__(self, file_paths, sampling_frequency, channel_ids=None, nbefore=None,
                  gain_to_uV=None, offset_to_uV=None):

--- a/spikeinterface/core/npzsortingextractor.py
+++ b/spikeinterface/core/npzsortingextractor.py
@@ -15,10 +15,9 @@ class NpzSortingExtractor(BaseSorting):
     """
 
     extractor_name = 'NpzSortingExtractor'
-    installed = True  # depend only on numpy
-    installation_mesg = "Always installed"
     is_writable = True
     mode = 'file'
+    name = "npz"
 
     def __init__(self, file_path):
 

--- a/spikeinterface/core/numpyextractors.py
+++ b/spikeinterface/core/numpyextractors.py
@@ -21,7 +21,9 @@ class NumpyRecording(BaseRecording):
     channel_ids: list
         An optional list of channel_ids. If None, linear channels are assumed
     """
-    is_writable = False
+    extractor_name = 'Numpy'
+    mode = 'memory'
+    name = "numpy"
 
     def __init__(self, traces_list, sampling_frequency, t_starts=None, channel_ids=None):
         if isinstance(traces_list, list):
@@ -76,7 +78,7 @@ class NumpyRecordingSegment(BaseRecordingSegment):
 
 
 class NumpySorting(BaseSorting):
-    is_writable = False
+    name = "numpy"
 
     def __init__(self, sampling_frequency, unit_ids=[]):
         BaseSorting.__init__(self, sampling_frequency, unit_ids)
@@ -306,8 +308,6 @@ class NumpySnippets(BaseSnippets):
     channel_ids: list
         An optional list of channel_ids. If None, linear channels are assumed
     """
-
-    is_writable = False
 
     def __init__(self, snippets_list, spikesframes_list, sampling_frequency, nbefore=None, channel_ids=None):
         if isinstance(snippets_list, list):

--- a/spikeinterface/core/old_api_utils.py
+++ b/spikeinterface/core/old_api_utils.py
@@ -58,7 +58,6 @@ class NewToOldSorting:
       * unique segment
     """
     extractor_name = 'NewToOldSorting'
-    is_writable = False
 
     def __init__(self, sorting):
         assert sorting.get_num_segments() == 1

--- a/spikeinterface/core/zarrrecordingextractor.py
+++ b/spikeinterface/core/zarrrecordingextractor.py
@@ -31,12 +31,12 @@ class ZarrRecordingExtractor(BaseRecording):
     recording: ZarrRecordingExtractor
         The recording Extractor
     """
-    extractor_name = 'ZarrRecordingExtractor'
-    has_default_locations = False
+    extractor_name = 'ZarrRecording'
     installed = HAVE_ZARR  # check at class level if installed or not
     mode = 'file'
     # error message when not installed
     installation_mesg = "To use the ZarrRecordingExtractor install zarr: \n\n pip install zarr\n\n"
+    name = "zarr"
 
     def __init__(self, root_path: Union[Path, str], storage_options=None):
         assert self.installed, self.installation_mesg

--- a/spikeinterface/extractors/__init__.py
+++ b/spikeinterface/extractors/__init__.py
@@ -2,3 +2,4 @@ from .extractorlist import *
 
 from .toy_example import toy_example
 from .bids import read_bids
+from .neoextractors import get_neo_num_blocks, get_neo_streams

--- a/spikeinterface/extractors/alfsortingextractor.py
+++ b/spikeinterface/extractors/alfsortingextractor.py
@@ -30,8 +30,8 @@ class ALFSortingExtractor(BaseSorting):
 
     extractor_name = 'ALFSorting'
     installed = HAVE_PANDAS
-    is_writable = True
-    installation_mesg = "To use the SHYBRID extractors, install SHYBRID: \n\n pip install shybrid\n\n"
+    installation_mesg = "To use the ALF extractors, install pandas: \n\n pip install pandas\n\n"
+    name = "alf"
 
     def __init__(self, folder_path, sampling_frequency=30000):
 

--- a/spikeinterface/extractors/cbin_ibl.py
+++ b/spikeinterface/extractors/cbin_ibl.py
@@ -37,11 +37,10 @@ class CompressedBinaryIblExtractor(BaseRecording):
     """
     extractor_name = 'CompressedBinaryIbl'
     has_default_locations = True
-    has_unscaled = False
     installed = HAVE_MTSCOMP
-    is_writable = False
     mode = 'folder'
     installation_mesg = "To use the CompressedBinaryIblExtractor, install mtscomp: \n\n pip install mtscomp\n\n"
+    name = "cbin_ibl"
 
     def __init__(self, folder_path, load_sync_channel=False):
 

--- a/spikeinterface/extractors/combinatoextractors.py
+++ b/spikeinterface/extractors/combinatoextractors.py
@@ -35,10 +35,9 @@ class CombinatoSortingExtractor(BaseSorting):
     """
 
     extractor_name = 'CombinatoSortingExtractor'
-    installation_mesg = ""
     installed = HAVE_H5PY
-    is_writable = False
     installation_mesg = "To use the CombinatoSortingExtractor install h5py: \n\n pip install h5py\n\n"
+    name = "combinato"
 
     def __init__(self, folder_path, sampling_frequency=None, user='simple', det_sign='both', keep_good_only=True):
 

--- a/spikeinterface/extractors/extractorlist.py
+++ b/spikeinterface/extractors/extractorlist.py
@@ -5,33 +5,7 @@ from spikeinterface.core import (BaseRecording, BaseSorting, BinaryRecordingExtr
                                  NpzSortingExtractor, NumpyRecording, NumpySorting)
 
 # sorting/recording/event from neo
-from .neoextractors import (
-    MEArecRecordingExtractor, MEArecSortingExtractor, read_mearec,
-    SpikeGLXRecordingExtractor, read_spikeglx,
-    OpenEphysLegacyRecordingExtractor, OpenEphysBinaryRecordingExtractor, OpenEphysBinaryEventExtractor, 
-    read_openephys, read_openephys_event,
-    IntanRecordingExtractor, read_intan,
-    NeuroScopeRecordingExtractor, read_neuroscope_recording, 
-    NeuroScopeSortingExtractor, read_neuroscope_sorting,
-    read_neuroscope,
-    PlexonRecordingExtractor, read_plexon,
-    NeuralynxRecordingExtractor, read_neuralynx,
-    NeuralynxSortingExtractor, read_neuralynx_sorting,
-    BlackrockRecordingExtractor, read_blackrock,
-    BlackrockSortingExtractor, read_blackrock_sorting,
-    MCSRawRecordingExtractor, read_mcsraw,
-    Spike2RecordingExtractor, read_spike2,
-    CedRecordingExtractor, read_ced,
-    MaxwellRecordingExtractor, read_maxwell, MaxwellEventExtractor, read_maxwell_event,
-    NixRecordingExtractor, read_nix,
-    SpikeGadgetsRecordingExtractor, read_spikegadgets,
-    BiocamRecordingExtractor, read_biocam,
-    AxonaRecordingExtractor, read_axona,
-    TdtRecordingExtractor, read_tdt,
-    AlphaOmegaRecordingExtractor, read_alphaomega,
-    AlphaOmegaEventExtractor, read_alphaomega_event,
-    EDFRecordingExtractor, read_edf,
-)
+from .neoextractors import *
 
 # NWB sorting/recording/event
 from .nwbextractors import (NwbRecordingExtractor, NwbSortingExtractor,

--- a/spikeinterface/extractors/extractorlist.py
+++ b/spikeinterface/extractors/extractorlist.py
@@ -1,11 +1,16 @@
 from typing import Type
 
 # most important extractor are in spikeinterface.core
-from spikeinterface.core import (BaseRecording, BaseSorting, BinaryRecordingExtractor,
-                                 NpzSortingExtractor, NumpyRecording, NumpySorting)
+from spikeinterface.core import (BaseRecording, BaseSorting,
+                                 BinaryRecordingExtractor, NumpyRecording,
+                                 NpzSortingExtractor, NumpySorting,
+                                 NpySnippetsExtractor)
 
 # sorting/recording/event from neo
 from .neoextractors import *
+
+# non-NEO objects implemented in neo folder
+from .neoextractors import NeuroScopeSortingExtractor, MaxwellEventExtractor
 
 # NWB sorting/recording/event
 from .nwbextractors import (NwbRecordingExtractor, NwbSortingExtractor,
@@ -18,8 +23,7 @@ from .mcsh5extractors import MCSH5RecordingExtractor, read_mcsh5
 from .klustaextractors import KlustaSortingExtractor, read_klusta
 from .hdsortextractors import HDSortSortingExtractor, read_hdsort
 from .mclustextractors import MClustSortingExtractor, read_mclust
-from .waveclustextractors import WaveClusSortingExtractor, read_waveclust
-from .waveclussnippetstextractors import WaveClusSnippetsExtractor
+from .waveclustextractors import WaveClusSortingExtractor, read_waveclus
 from .yassextractors import YassSortingExtractor, read_yass
 from .combinatoextractors import CombinatoSortingExtractor, read_combinato
 from .tridesclousextractors import TridesclousSortingExtractor, read_tridesclous
@@ -31,6 +35,10 @@ from .phykilosortextractors import PhySortingExtractor, KiloSortSortingExtractor
 # sorting in relation with simulator
 from .shybridextractors import (SHYBRIDRecordingExtractor, SHYBRIDSortingExtractor,
                                 read_shybrid_recording, read_shybrid_sorting)
+
+# snippers
+from .waveclussnippetstextractors import WaveClusSnippetsExtractor, read_waveclus_snippets
+
 
 # misc
 from .alfsortingextractor import ALFSortingExtractor, read_alf_sorting
@@ -45,33 +53,11 @@ recording_extractor_full_list = [
     NumpyRecording,
     SHYBRIDRecordingExtractor,
     MdaRecordingExtractor,
-
-    # neo based
-    MEArecRecordingExtractor,
-    SpikeGLXRecordingExtractor,
-    OpenEphysLegacyRecordingExtractor,
-    OpenEphysBinaryRecordingExtractor,
-    IntanRecordingExtractor,
-    NeuroScopeRecordingExtractor,
-    PlexonRecordingExtractor,
-    NeuralynxRecordingExtractor,
-    BlackrockRecordingExtractor,
-    MCSRawRecordingExtractor,
-    Spike2RecordingExtractor,
-    CedRecordingExtractor,
-    MaxwellRecordingExtractor,
-    NixRecordingExtractor,
-    NwbRecordingExtractor,
-    SpikeGadgetsRecordingExtractor,
-    BiocamRecordingExtractor,
-    AxonaRecordingExtractor,
-    TdtRecordingExtractor,
-    AlphaOmegaRecordingExtractor,
-
     # others
     CompressedBinaryIblExtractor,
     MCSH5RecordingExtractor
 ]
+recording_extractor_full_list += neo_recording_extractors_list
 
 sorting_extractor_full_list = [
     NpzSortingExtractor,
@@ -95,16 +81,24 @@ sorting_extractor_full_list = [
     PhySortingExtractor,
     NwbSortingExtractor,
     NeuroScopeSortingExtractor,
-
-    # neo based
-    MEArecSortingExtractor
 ]
+sorting_extractor_full_list += neo_sorting_extractors_list
 
 event_extractor_full_list = [
-    OpenEphysBinaryEventExtractor,
-    MaxwellEventExtractor,
-    AlphaOmegaEventExtractor
+    MaxwellEventExtractor
 ]
+event_extractor_full_list += neo_event_extractors_list
+
+snippets_extractor_full_list = [
+    NpySnippetsExtractor,
+    WaveClusSnippetsExtractor
+]
+
+
+recording_extractor_full_dict = {recext.name: recext for recext in recording_extractor_full_list}
+sorting_extractor_full_dict = {recext.name: recext for recext in sorting_extractor_full_list}
+snippets_extractor_full_dict = {recext.name: recext for recext in snippets_extractor_full_list}
+
 
 
 def get_recording_extractor_from_name(name: str) -> Type[BaseRecording]:

--- a/spikeinterface/extractors/hdsortextractors.py
+++ b/spikeinterface/extractors/hdsortextractors.py
@@ -24,6 +24,8 @@ class HDSortSortingExtractor(MatlabHelper, BaseSorting):
         The loaded data.
     """
     extractor_name = "HDSortSortingExtractor"
+    mode = 'file'
+    name = "hdsort"
 
     def __init__(self, file_path, keep_good_only=True):
 

--- a/spikeinterface/extractors/herdingspikesextractors.py
+++ b/spikeinterface/extractors/herdingspikesextractors.py
@@ -30,9 +30,9 @@ class HerdingspikesSortingExtractor(BaseSorting):
 
     extractor_name = 'HS2Sorting'
     installed = HAVE_HS2SX  # check at class level if installed or not
-    is_writable = True
     mode = 'file'
     installation_mesg = "To use the HS2SortingExtractor install h5py: \n\n pip install h5py\n\n"  # error message when not installed
+    name = "herdingspikes"
 
     def __init__(self, file_path, load_unit_info=True):
         assert self.installed, self.installation_mesg

--- a/spikeinterface/extractors/klustaextractors.py
+++ b/spikeinterface/extractors/klustaextractors.py
@@ -44,8 +44,8 @@ class KlustaSortingExtractor(BaseSorting):
     extractor_name = 'KlustaSortingExtractor'
     installed = HAVE_H5PY  # check at class level if installed or not
     installation_mesg = "To use the KlustaSortingExtractor install h5py: \n\n pip install h5py\n\n"  # error message when not installed
-    is_writable = True
     mode = 'file_or_folder'
+    name = "klusta"
 
     default_cluster_groups = {0: 'Noise', 1: 'MUA', 2: 'Good', 3: 'Unsorted'}
 

--- a/spikeinterface/extractors/matlabhelpers.py
+++ b/spikeinterface/extractors/matlabhelpers.py
@@ -27,7 +27,6 @@ HAVE_MAT = HAVE_H5PY & HAVE_LOADMAT
 class MatlabHelper:
     extractor_name = "MATSortingExtractor"
     installed = HAVE_MAT  # check at class level if installed or not
-    is_writable = False
     mode = "file"
     installation_mesg = "To use the MATSortingExtractor install h5py and scipy: " \
                         "\n\n pip install h5py scipy\n\n"  # error message when not installed

--- a/spikeinterface/extractors/mclustextractors.py
+++ b/spikeinterface/extractors/mclustextractors.py
@@ -28,7 +28,7 @@ class MClustSortingExtractor(BaseSorting):
     """
 
     extractor_name = "MClustSortingExtractor"
-    installation_mesg = ""  # error message when not installed
+    name = "mclust"
 
     def __init__(self, folder_path, sampling_frequency, sampling_frequency_raw = None):
         end_header_str = '%%ENDHEADER'

--- a/spikeinterface/extractors/mcsh5extractors.py
+++ b/spikeinterface/extractors/mcsh5extractors.py
@@ -29,9 +29,9 @@ class MCSH5RecordingExtractor(BaseRecording):
     """
     extractor_name = 'MCSH5Recording'
     installed = HAVE_MCSH5  # check at class level if installed or not
-    is_writable = False
     mode = 'file'
     installation_mesg = "To use the MCSH5RecordingExtractor install h5py: \n\n pip install h5py\n\n"  # error message when not installed
+    name = "mcsh5"
 
     def __init__(self, file_path, stream_id=0):
         assert self.installed, self.installation_mesg

--- a/spikeinterface/extractors/mdaextractors.py
+++ b/spikeinterface/extractors/mdaextractors.py
@@ -35,11 +35,9 @@ class MdaRecordingExtractor(BaseRecording):
 
     extractor_name = 'MdaRecording'
     has_default_locations = True
-    has_unscaled = False
-    installed = True  # check at class level if installed or not
     is_writable = True
     mode = 'folder'
-    installation_mesg = ""  # error message when not installed
+    name = "mda"
 
     def __init__(self, folder_path, raw_fname='raw.mda', params_fname='params.json', geom_fname='geom.csv'):
         folder_path = Path(folder_path)
@@ -173,10 +171,9 @@ class MdaSortingExtractor(BaseSorting):
     """
 
     extractor_name = 'MdaSorting'
-    installed = True  # check at class level if installed or not
     is_writable = True
     mode = 'file'
-    installation_mesg = ""  # error message when not installed
+    name = "mda"
 
     def __init__(self, file_path, sampling_frequency):
         firings = readmda(str(file_path))

--- a/spikeinterface/extractors/neoextractors/__init__.py
+++ b/spikeinterface/extractors/neoextractors/__init__.py
@@ -1,56 +1,75 @@
 from .alphaomega import (AlphaOmegaRecordingExtractor, AlphaOmegaEventExtractor, 
-                         read_alphaomega, read_alphaomega_event,
-                         get_alphaomega_streams)
+                         read_alphaomega, read_alphaomega_event)
 from .axona import (AxonaRecordingExtractor, 
                     read_axona)
 from .biocam import (BiocamRecordingExtractor, 
-                     read_biocam,
-                     get_biocam_streams)
+                     read_biocam)
 from .blackrock import (BlackrockRecordingExtractor, BlackrockSortingExtractor,
-                        read_blackrock, read_blackrock_sorting,
-                        get_blackrock_streams)
+                        read_blackrock, read_blackrock_sorting)
 from .ced import (CedRecordingExtractor, 
-                  read_ced, 
-                  get_ced_streams)
+                  read_ced)
 from .edf import (EDFRecordingExtractor, 
-                  read_edf,
-                  get_edf_streams)
+                  read_edf)
 from .intan import (IntanRecordingExtractor, 
-                    read_intan, 
-                    get_intan_streams)
+                    read_intan)
 from .maxwell import (MaxwellRecordingExtractor, MaxwellEventExtractor, 
-                      read_maxwell, read_maxwell_event, 
-                      get_maxwell_streams)
+                      read_maxwell, read_maxwell_event)
 from .mearec import (MEArecRecordingExtractor, MEArecSortingExtractor,
                      read_mearec)
 from .mcsraw import (MCSRawRecordingExtractor, 
-                     read_mcsraw, 
-                     get_mcsraw_streams)
+                     read_mcsraw)
 from .neuralynx import (NeuralynxRecordingExtractor, NeuralynxSortingExtractor,
-                        read_neuralynx, read_neuralynx_sorting,
-                        get_neuralynx_streams)
+                        read_neuralynx, read_neuralynx_sorting)
 from .neuroscope import (NeuroScopeRecordingExtractor, NeuroScopeSortingExtractor,
-                         read_neuroscope_recording, read_neuroscope_sorting, read_neuroscope,
-                         get_neuroscope_streams)
+                         read_neuroscope_recording, read_neuroscope_sorting, read_neuroscope)
 from .nix import (NixRecordingExtractor, 
-                  read_nix,
-                  get_nix_streams, get_nix_num_blocks)
+                  read_nix)
 from .openephys import (OpenEphysLegacyRecordingExtractor,
                         OpenEphysBinaryRecordingExtractor, OpenEphysBinaryEventExtractor, 
-                        read_openephys, read_openephys_event,
-                        get_openephys_streams, get_openephys_num_blocks)
+                        read_openephys, read_openephys_event)
 from .plexon import (PlexonRecordingExtractor, 
-                     read_plexon, 
-                     get_plexon_streams)
+                     read_plexon)
 from .spike2 import (Spike2RecordingExtractor, 
-                     read_spike2,
-                     get_spike2_streams)
+                     read_spike2)
 from .spikegadgets import (SpikeGadgetsRecordingExtractor, 
-                           read_spikegadgets,
-                           get_spikegadgets_streams)
+                           read_spikegadgets)
 from .spikeglx import (SpikeGLXRecordingExtractor, 
-                       read_spikeglx, 
-                       get_spikeglx_streams)
+                       read_spikeglx)
 from .tdt import (TdtRecordingExtractor, 
-                  read_tdt,
-                  get_tdt_streams)
+                  read_tdt)
+
+from .neo_utils import get_neo_streams, get_neo_num_blocks
+
+neo_recording_extractors_list = [
+    AlphaOmegaRecordingExtractor,
+    AxonaRecordingExtractor,
+    BiocamRecordingExtractor,
+    BlackrockRecordingExtractor,
+    CedRecordingExtractor,
+    EDFRecordingExtractor,
+    IntanRecordingExtractor,
+    MaxwellRecordingExtractor,
+    MEArecRecordingExtractor,
+    MCSRawRecordingExtractor,
+    NeuralynxRecordingExtractor,
+    NeuroScopeRecordingExtractor,
+    NixRecordingExtractor,
+    OpenEphysBinaryRecordingExtractor,
+    OpenEphysLegacyRecordingExtractor,
+    PlexonRecordingExtractor,
+    Spike2RecordingExtractor,
+    SpikeGadgetsRecordingExtractor,
+    SpikeGLXRecordingExtractor,
+    TdtRecordingExtractor
+]
+
+neo_sorting_extractors_list = [
+    BlackrockSortingExtractor,
+    MEArecSortingExtractor,
+    NeuralynxSortingExtractor
+]
+
+neo_event_extractors_list = [
+    AlphaOmegaEventExtractor,
+    OpenEphysBinaryEventExtractor
+]

--- a/spikeinterface/extractors/neoextractors/__init__.py
+++ b/spikeinterface/extractors/neoextractors/__init__.py
@@ -1,24 +1,58 @@
-from .mearec import MEArecRecordingExtractor, MEArecSortingExtractor, read_mearec
-from .spikeglx import SpikeGLXRecordingExtractor, read_spikeglx
-from .openephys import (OpenEphysLegacyRecordingExtractor,
-                        OpenEphysBinaryRecordingExtractor, OpenEphysBinaryEventExtractor, read_openephys,
-                        read_openephys_event)
-from .intan import IntanRecordingExtractor, read_intan
+from .alphaomega import (AlphaOmegaRecordingExtractor, AlphaOmegaEventExtractor, 
+                         read_alphaomega, read_alphaomega_event,
+                         get_alphaomega_streams, get_alphaomega_num_blocks)
+from .axona import (AxonaRecordingExtractor, 
+                    read_axona,
+                    get_axona_streams, get_axona_num_blocks)
+from .biocam import (BiocamRecordingExtractor, 
+                     read_biocam,
+                     get_biocam_streams, get_biocam_num_blocks)
+from .blackrock import (BlackrockRecordingExtractor, BlackrockSortingExtractor,
+                        read_blackrock, read_blackrock_sorting,
+                        get_blackrock_streams, get_blackrock_num_blocks)
+from .ced import (CedRecordingExtractor, 
+                  read_ced, 
+                  get_ced_streams, get_ced_num_blocks)
+from .edf import (EDFRecordingExtractor, 
+                  read_edf,
+                  get_edf_streams, get_edf_num_blocks)
+from .intan import (IntanRecordingExtractor, 
+                    read_intan, 
+                    get_intan_streams, get_intan_num_blocks)
+from .maxwell import (MaxwellRecordingExtractor, MaxwellEventExtractor, 
+                      read_maxwell, read_maxwell_event, 
+                      get_maxwell_streams, get_maxwell_num_blocks)
+from .mearec import (MEArecRecordingExtractor, MEArecSortingExtractor,
+                     read_mearec, get_mearec_streams, 
+                     get_mearec_num_blocks)
+from .mscraw import (MCSRawRecordingExtractor, 
+                     read_mcsraw, 
+                     get_mcsraw_streams, get_mcsraw_num_blocks)
+from .neuralynx import (NeuralynxRecordingExtractor, NeuralynxSortingExtractor,
+                        read_neuralynx, read_neuralynx_sorting,
+                        get_neuralynx_streams, get_neuralynx_num_blocks)
 from .neuroscope import (NeuroScopeRecordingExtractor, NeuroScopeSortingExtractor,
-                         read_neuroscope_recording, read_neuroscope_sorting, read_neuroscope)
-from .plexon import PlexonRecordingExtractor, read_plexon
-from .neuralynx import NeuralynxRecordingExtractor, read_neuralynx
-from .neuralynx import NeuralynxSortingExtractor, read_neuralynx_sorting
-from .blackrock import BlackrockRecordingExtractor, read_blackrock
-from .blackrock import BlackrockSortingExtractor, read_blackrock_sorting
-from .mscraw import MCSRawRecordingExtractor, read_mcsraw
-from .spike2 import Spike2RecordingExtractor, read_spike2
-from .ced import CedRecordingExtractor, read_ced
-from .maxwell import MaxwellRecordingExtractor, read_maxwell, MaxwellEventExtractor, read_maxwell_event
-from .nix import NixRecordingExtractor, read_nix
-from .spikegadgets import SpikeGadgetsRecordingExtractor, read_spikegadgets
-from .biocam import BiocamRecordingExtractor, read_biocam
-from .axona import AxonaRecordingExtractor, read_axona
-from .tdt import TdtRecordingExtractor, read_tdt
-from .alphaomega import AlphaOmegaRecordingExtractor, read_alphaomega, AlphaOmegaEventExtractor, read_alphaomega_event
-from .edf import EDFRecordingExtractor, read_edf
+                         read_neuroscope_recording, read_neuroscope_sorting, read_neuroscope,
+                         get_neuroscope_streams, get_neuroscope_num_blocks)
+from .nix import (NixRecordingExtractor, 
+                  read_nix,
+                  get_nix_streams, get_nix_num_blocks)
+from .openephys import (OpenEphysLegacyRecordingExtractor,
+                        OpenEphysBinaryRecordingExtractor, OpenEphysBinaryEventExtractor, 
+                        read_openephys, read_openephys_event,
+                        get_openephys_streams, get_openephys_num_blocks)
+from .plexon import (PlexonRecordingExtractor, 
+                     read_plexon, 
+                     get_plexon_streams, get_plexon_num_blocks)
+from .spike2 import (Spike2RecordingExtractor, 
+                     read_spike2,
+                     get_spike2_streams, get_spike2_num_blocks)
+from .spikegadgets import (SpikeGadgetsRecordingExtractor, 
+                           read_spikegadgets,
+                           get_spikegadgets_streams, get_spikegadgets_num_blocks)
+from .spikeglx import (SpikeGLXRecordingExtractor, 
+                       read_spikeglx, 
+                       get_spikeglx_streams, get_spikeglx_num_blocks)
+from .tdt import (TdtRecordingExtractor, 
+                  read_tdt,
+                  get_tdt_streams, get_tdt_num_blocks)

--- a/spikeinterface/extractors/neoextractors/__init__.py
+++ b/spikeinterface/extractors/neoextractors/__init__.py
@@ -1,39 +1,37 @@
 from .alphaomega import (AlphaOmegaRecordingExtractor, AlphaOmegaEventExtractor, 
                          read_alphaomega, read_alphaomega_event,
-                         get_alphaomega_streams, get_alphaomega_num_blocks)
+                         get_alphaomega_streams)
 from .axona import (AxonaRecordingExtractor, 
-                    read_axona,
-                    get_axona_streams, get_axona_num_blocks)
+                    read_axona)
 from .biocam import (BiocamRecordingExtractor, 
                      read_biocam,
-                     get_biocam_streams, get_biocam_num_blocks)
+                     get_biocam_streams)
 from .blackrock import (BlackrockRecordingExtractor, BlackrockSortingExtractor,
                         read_blackrock, read_blackrock_sorting,
-                        get_blackrock_streams, get_blackrock_num_blocks)
+                        get_blackrock_streams)
 from .ced import (CedRecordingExtractor, 
                   read_ced, 
-                  get_ced_streams, get_ced_num_blocks)
+                  get_ced_streams)
 from .edf import (EDFRecordingExtractor, 
                   read_edf,
-                  get_edf_streams, get_edf_num_blocks)
+                  get_edf_streams)
 from .intan import (IntanRecordingExtractor, 
                     read_intan, 
-                    get_intan_streams, get_intan_num_blocks)
+                    get_intan_streams)
 from .maxwell import (MaxwellRecordingExtractor, MaxwellEventExtractor, 
                       read_maxwell, read_maxwell_event, 
-                      get_maxwell_streams, get_maxwell_num_blocks)
+                      get_maxwell_streams)
 from .mearec import (MEArecRecordingExtractor, MEArecSortingExtractor,
-                     read_mearec, get_mearec_streams, 
-                     get_mearec_num_blocks)
-from .mscraw import (MCSRawRecordingExtractor, 
+                     read_mearec)
+from .mcsraw import (MCSRawRecordingExtractor, 
                      read_mcsraw, 
-                     get_mcsraw_streams, get_mcsraw_num_blocks)
+                     get_mcsraw_streams)
 from .neuralynx import (NeuralynxRecordingExtractor, NeuralynxSortingExtractor,
                         read_neuralynx, read_neuralynx_sorting,
-                        get_neuralynx_streams, get_neuralynx_num_blocks)
+                        get_neuralynx_streams)
 from .neuroscope import (NeuroScopeRecordingExtractor, NeuroScopeSortingExtractor,
                          read_neuroscope_recording, read_neuroscope_sorting, read_neuroscope,
-                         get_neuroscope_streams, get_neuroscope_num_blocks)
+                         get_neuroscope_streams)
 from .nix import (NixRecordingExtractor, 
                   read_nix,
                   get_nix_streams, get_nix_num_blocks)
@@ -43,16 +41,16 @@ from .openephys import (OpenEphysLegacyRecordingExtractor,
                         get_openephys_streams, get_openephys_num_blocks)
 from .plexon import (PlexonRecordingExtractor, 
                      read_plexon, 
-                     get_plexon_streams, get_plexon_num_blocks)
+                     get_plexon_streams)
 from .spike2 import (Spike2RecordingExtractor, 
                      read_spike2,
-                     get_spike2_streams, get_spike2_num_blocks)
+                     get_spike2_streams)
 from .spikegadgets import (SpikeGadgetsRecordingExtractor, 
                            read_spikegadgets,
-                           get_spikegadgets_streams, get_spikegadgets_num_blocks)
+                           get_spikegadgets_streams)
 from .spikeglx import (SpikeGLXRecordingExtractor, 
                        read_spikeglx, 
-                       get_spikeglx_streams, get_spikeglx_num_blocks)
+                       get_spikeglx_streams)
 from .tdt import (TdtRecordingExtractor, 
                   read_tdt,
-                  get_tdt_streams, get_tdt_num_blocks)
+                  get_tdt_streams)

--- a/spikeinterface/extractors/neoextractors/alphaomega.py
+++ b/spikeinterface/extractors/neoextractors/alphaomega.py
@@ -1,6 +1,7 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseEventExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class AlphaOmegaRecordingExtractor(NeoBaseRecordingExtractor):
@@ -16,19 +17,28 @@ class AlphaOmegaRecordingExtractor(NeoBaseRecordingExtractor):
     lsx_files: list of strings or None, optional
         A list of listings files that refers to mpx files to load.
     stream_id: {'RAW', 'LFP', 'SPK', 'ACC', 'AI', 'UD'}, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = "folder"
     NeoRawIOClass = "AlphaOmegaRawIO"
 
-    def __init__(self, folder_path, lsx_files=None, stream_id="RAW",  all_annotations=False):
+    def __init__(self, folder_path, lsx_files=None, stream_id="RAW", 
+                 stream_name=None, block_index=None, all_annotations=False):
         neo_kwargs = {
             "dirname": str(folder_path),
             "lsx_files": lsx_files,
         }
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations,
+                                           **neo_kwargs)
         self._kwargs.update(dict(folder_path=str(folder_path), lsx_files=lsx_files))
 
 
@@ -47,3 +57,47 @@ class AlphaOmegaEventExtractor(NeoBaseEventExtractor):
 
 read_alphaomega = define_function_from_class(source_class=AlphaOmegaRecordingExtractor, name="read_alphaomega")
 read_alphaomega_event = define_function_from_class(source_class=AlphaOmegaEventExtractor, name="read_alphaomega_event")
+
+
+def get_alphaomega_streams(folder_path, lsx_files=None):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    folder_path : str
+        The folder path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = AlphaOmegaRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {
+            "dirname": str(folder_path),
+            "lsx_files": lsx_files,
+        }
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_alphaomega_num_blocks(folder_path, lsx_files=None):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    folder_path : str
+        The folder path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = AlphaOmegaRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {
+            "dirname": str(folder_path),
+            "lsx_files": lsx_files,
+        }
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/alphaomega.py
+++ b/spikeinterface/extractors/neoextractors/alphaomega.py
@@ -1,7 +1,6 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseEventExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class AlphaOmegaRecordingExtractor(NeoBaseRecordingExtractor):
@@ -25,18 +24,24 @@ class AlphaOmegaRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = "folder"
     NeoRawIOClass = "AlphaOmegaRawIO"
+    name = "alphaomega"
 
     def __init__(self, folder_path, lsx_files=None, stream_id="RAW", 
                  stream_name=None, all_annotations=False):
-        neo_kwargs = {
-            "dirname": str(folder_path),
-            "lsx_files": lsx_files,
-        }
+        neo_kwargs = self.map_to_neo_kwargs(folder_path, lsx_files)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
                                            all_annotations=all_annotations,
                                            **neo_kwargs)
         self._kwargs.update(dict(folder_path=str(folder_path), lsx_files=lsx_files))
+
+    @classmethod
+    def map_to_neo_kwargs(cls, folder_path, lsx_files=None):
+        neo_kwargs = {
+            "dirname": str(folder_path),
+            "lsx_files": lsx_files,
+        }
+        return neo_kwargs
 
 
 class AlphaOmegaEventExtractor(NeoBaseEventExtractor):
@@ -48,32 +53,14 @@ class AlphaOmegaEventExtractor(NeoBaseEventExtractor):
     handle_event_frame_directly = True
 
     def __init__(self, folder_path):
-        neo_kwargs = {"dirname": str(folder_path)}
+        neo_kwargs = self.map_to_neo_kwargs(folder_path)
         NeoBaseEventExtractor.__init__(self, **neo_kwargs)
+
+    @classmethod
+    def map_to_neo_kwargs(cls, folder_path):
+        neo_kwargs = {"dirname": str(folder_path)}
+        return neo_kwargs
 
 
 read_alphaomega = define_function_from_class(source_class=AlphaOmegaRecordingExtractor, name="read_alphaomega")
 read_alphaomega_event = define_function_from_class(source_class=AlphaOmegaEventExtractor, name="read_alphaomega_event")
-
-
-def get_alphaomega_streams(folder_path, lsx_files=None):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    folder_path : str
-        The folder path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = AlphaOmegaRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {
-            "dirname": str(folder_path),
-            "lsx_files": lsx_files,
-        }
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/alphaomega.py
+++ b/spikeinterface/extractors/neoextractors/alphaomega.py
@@ -20,8 +20,6 @@ class AlphaOmegaRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
@@ -29,14 +27,13 @@ class AlphaOmegaRecordingExtractor(NeoBaseRecordingExtractor):
     NeoRawIOClass = "AlphaOmegaRawIO"
 
     def __init__(self, folder_path, lsx_files=None, stream_id="RAW", 
-                 stream_name=None, block_index=None, all_annotations=False):
+                 stream_name=None, all_annotations=False):
         neo_kwargs = {
             "dirname": str(folder_path),
             "lsx_files": lsx_files,
         }
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
-                                           block_index=block_index,
                                            all_annotations=all_annotations,
                                            **neo_kwargs)
         self._kwargs.update(dict(folder_path=str(folder_path), lsx_files=lsx_files))
@@ -80,24 +77,3 @@ def get_alphaomega_streams(folder_path, lsx_files=None):
             "lsx_files": lsx_files,
         }
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_alphaomega_num_blocks(folder_path, lsx_files=None):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    folder_path : str
-        The folder path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = AlphaOmegaRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {
-            "dirname": str(folder_path),
-            "lsx_files": lsx_files,
-        }
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/axona.py
+++ b/spikeinterface/extractors/neoextractors/axona.py
@@ -1,7 +1,6 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class AxonaRecordingExtractor(NeoBaseRecordingExtractor):
@@ -12,21 +11,25 @@ class AxonaRecordingExtractor(NeoBaseRecordingExtractor):
 
     Parameters
     ----------
-    folder_path: str
-        The folder path to load the recordings from.
+    file_path: str
+        The file path to load the recordings from.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'folder'
     NeoRawIOClass = 'AxonaRawIO'
+    name = "axona"
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, 
-                 all_annotations=False):
-        neo_kwargs = {'filename': str(file_path)}
+    def __init__(self, file_path, all_annotations=False):
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(self,
                                            all_annotations=all_annotations,
                                            **neo_kwargs)
         self._kwargs.update({'file_path': file_path})
 
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
 
 read_axona = define_function_from_class(source_class=AxonaRecordingExtractor, name="read_axona")

--- a/spikeinterface/extractors/neoextractors/axona.py
+++ b/spikeinterface/extractors/neoextractors/axona.py
@@ -1,6 +1,7 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class AxonaRecordingExtractor(NeoBaseRecordingExtractor):
@@ -13,16 +14,66 @@ class AxonaRecordingExtractor(NeoBaseRecordingExtractor):
     ----------
     folder_path: str
         The folder path to load the recordings from.
+    stream_id: str, optional
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'folder'
     NeoRawIOClass = 'AxonaRawIO'
 
-    def __init__(self, file_path, all_annotations=False):
-        neo_kwargs = {'filename': file_path}
-        NeoBaseRecordingExtractor.__init__(self, all_annotations=all_annotations, **neo_kwargs)
+    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, 
+                 all_annotations=False):
+        neo_kwargs = {'filename': str(file_path)}
+        NeoBaseRecordingExtractor.__init__(self,
+                                           stream_id=stream_id,
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations,
+                                           **neo_kwargs)
         self._kwargs.update({'file_path': file_path})
 
 
 read_axona = define_function_from_class(source_class=AxonaRecordingExtractor, name="read_axona")
+
+
+def get_axona_streams(file_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = AxonaRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_axona_num_blocks(file_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = AxonaRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/axona.py
+++ b/spikeinterface/extractors/neoextractors/axona.py
@@ -14,12 +14,6 @@ class AxonaRecordingExtractor(NeoBaseRecordingExtractor):
     ----------
     folder_path: str
         The folder path to load the recordings from.
-    stream_id: str, optional
-        If there are several streams, specify the stream id you want to load.
-    stream_name: str, optional
-        If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
@@ -30,50 +24,9 @@ class AxonaRecordingExtractor(NeoBaseRecordingExtractor):
                  all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self,
-                                           stream_id=stream_id,
-                                           stream_name=stream_name,
-                                           block_index=block_index,
                                            all_annotations=all_annotations,
                                            **neo_kwargs)
         self._kwargs.update({'file_path': file_path})
 
 
 read_axona = define_function_from_class(source_class=AxonaRecordingExtractor, name="read_axona")
-
-
-def get_axona_streams(file_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = AxonaRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_streams(raw_class, **neo_kwargs)
-
-
-def get_axona_num_blocks(file_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = AxonaRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/biocam.py
+++ b/spikeinterface/extractors/neoextractors/biocam.py
@@ -3,7 +3,6 @@ import probeinterface as pi
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class BiocamRecordingExtractor(NeoBaseRecordingExtractor):
@@ -29,10 +28,12 @@ class BiocamRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'BiocamRawIO'
+    name = "biocam"
+    has_default_locations = True
 
     def __init__(self, file_path, mea_pitch=None, electrode_width=None, stream_id=None,
                  stream_name=None, block_index=None, all_annotations=False):
-        neo_kwargs = {'filename': str(file_path)}
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
                                            all_annotations=all_annotations,
@@ -51,25 +52,9 @@ class BiocamRecordingExtractor(NeoBaseRecordingExtractor):
 
         self._kwargs.update( {'file_path': str(file_path), 'mea_pitch':mea_pitch, 'electrode_width':electrode_width})
 
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
 
 read_biocam = define_function_from_class(source_class=BiocamRecordingExtractor, name="read_biocam")
-
-
-def get_biocam_streams(file_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = BiocamRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/biocam.py
+++ b/spikeinterface/extractors/neoextractors/biocam.py
@@ -24,8 +24,6 @@ class BiocamRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool  (default False)
         Load exhaustively all annotations from neo.
     """
@@ -37,7 +35,6 @@ class BiocamRecordingExtractor(NeoBaseRecordingExtractor):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
-                                           block_index=block_index,
                                            all_annotations=all_annotations,
                                            **neo_kwargs)
 
@@ -76,21 +73,3 @@ def get_biocam_streams(file_path):
     raw_class = BiocamRecordingExtractor.NeoRawIOClass
     neo_kwargs = {'filename': str(file_path)}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_biocam_num_blocks(file_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = BiocamRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/biocam.py
+++ b/spikeinterface/extractors/neoextractors/biocam.py
@@ -3,6 +3,7 @@ import probeinterface as pi
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class BiocamRecordingExtractor(NeoBaseRecordingExtractor):
@@ -20,16 +21,25 @@ class BiocamRecordingExtractor(NeoBaseRecordingExtractor):
     electrode_width: float, optional
         Width of the electrodes in um.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool  (default False)
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'BiocamRawIO'
 
-    def __init__(self, file_path, mea_pitch=None, electrode_width=None, stream_id=None,  all_annotations=False):
+    def __init__(self, file_path, mea_pitch=None, electrode_width=None, stream_id=None,
+                 stream_name=None, block_index=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations,
+                                           **neo_kwargs)
 
         # load probe from probeinterface
         probe_kwargs = {}
@@ -46,3 +56,41 @@ class BiocamRecordingExtractor(NeoBaseRecordingExtractor):
 
 
 read_biocam = define_function_from_class(source_class=BiocamRecordingExtractor, name="read_biocam")
+
+
+def get_biocam_streams(file_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = BiocamRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_biocam_num_blocks(file_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = BiocamRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/blackrock.py
+++ b/spikeinterface/extractors/neoextractors/blackrock.py
@@ -18,8 +18,6 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
@@ -30,7 +28,6 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
-                                           block_index=block_index,
                                            all_annotations=all_annotations,
                                            **neo_kwargs)
         self._kwargs.update({'file_path': str(file_path)})
@@ -80,21 +77,3 @@ def get_blackrock_streams(file_path):
     raw_class = BlackrockRecordingExtractor.NeoRawIOClass
     neo_kwargs = {'filename': str(file_path)}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_blackrock_num_blocks(file_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = BlackrockRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/blackrock.py
+++ b/spikeinterface/extractors/neoextractors/blackrock.py
@@ -1,6 +1,7 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
@@ -14,16 +15,24 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
     file_path: str
         The file path to load the recordings from.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'BlackrockRawIO'
 
-    def __init__(self, file_path, stream_id=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations,
+                                           **neo_kwargs)
         self._kwargs.update({'file_path': str(file_path)})
 
 
@@ -51,3 +60,41 @@ class BlackrockSortingExtractor(NeoBaseSortingExtractor):
 
 read_blackrock = define_function_from_class(source_class=BlackrockRecordingExtractor, name="read_blackrock")
 read_blackrock_sorting = define_function_from_class(source_class=BlackrockSortingExtractor, name="read_blackrock_sorting")
+
+
+def get_blackrock_streams(file_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = BlackrockRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_blackrock_num_blocks(file_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = BlackrockRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/blackrock.py
+++ b/spikeinterface/extractors/neoextractors/blackrock.py
@@ -1,7 +1,6 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
@@ -23,15 +22,20 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'BlackrockRawIO'
+    name = "blackrock"
 
     def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
-        neo_kwargs = {'filename': str(file_path)}
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
                                            all_annotations=all_annotations,
                                            **neo_kwargs)
         self._kwargs.update({'file_path': str(file_path)})
 
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
 
 class BlackrockSortingExtractor(NeoBaseSortingExtractor):
     """
@@ -49,31 +53,17 @@ class BlackrockSortingExtractor(NeoBaseSortingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'BlackrockRawIO'
+    name = "blackrock"
 
     def __init__(self, file_path, sampling_frequency=None):
-        neo_kwargs = {'filename': str(file_path)}
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseSortingExtractor.__init__(self, sampling_frequency=sampling_frequency, **neo_kwargs)
         self._kwargs.update({'file_path': str(file_path)})
 
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
+
 read_blackrock = define_function_from_class(source_class=BlackrockRecordingExtractor, name="read_blackrock")
 read_blackrock_sorting = define_function_from_class(source_class=BlackrockSortingExtractor, name="read_blackrock_sorting")
-
-
-def get_blackrock_streams(file_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = BlackrockRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/ced.py
+++ b/spikeinterface/extractors/neoextractors/ced.py
@@ -1,7 +1,6 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class CedRecordingExtractor(NeoBaseRecordingExtractor):
@@ -27,9 +26,10 @@ class CedRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'CedRawIO'
+    name = "ced"
 
     def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
-        neo_kwargs = {'filename': str(file_path)}
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
                                            all_annotations=all_annotations,
@@ -37,26 +37,9 @@ class CedRecordingExtractor(NeoBaseRecordingExtractor):
         self._kwargs.update(dict(file_path=str(file_path)))
         self.extra_requirements.append('sonpy')
 
-
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
 
 read_ced = define_function_from_class(source_class=CedRecordingExtractor, name="read_ced")
-
-
-def get_ced_streams(file_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = CedRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/ced.py
+++ b/spikeinterface/extractors/neoextractors/ced.py
@@ -28,11 +28,10 @@ class CedRecordingExtractor(NeoBaseRecordingExtractor):
     mode = 'file'
     NeoRawIOClass = 'CedRawIO'
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
-                                           block_index=block_index,
                                            all_annotations=all_annotations,
                                            **neo_kwargs)
         self._kwargs.update(dict(file_path=str(file_path)))
@@ -61,21 +60,3 @@ def get_ced_streams(file_path):
     raw_class = CedRecordingExtractor.NeoRawIOClass
     neo_kwargs = {'filename': str(file_path)}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_ced_num_blocks(file_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = CedRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/ced.py
+++ b/spikeinterface/extractors/neoextractors/ced.py
@@ -1,6 +1,7 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class CedRecordingExtractor(NeoBaseRecordingExtractor):
@@ -16,19 +17,65 @@ class CedRecordingExtractor(NeoBaseRecordingExtractor):
     file_path: str
         The file path to the smr or smrx file.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'CedRawIO'
 
-    def __init__(self, file_path, stream_id=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations,
+                                           **neo_kwargs)
         self._kwargs.update(dict(file_path=str(file_path)))
         self.extra_requirements.append('sonpy')
 
 
 
 read_ced = define_function_from_class(source_class=CedRecordingExtractor, name="read_ced")
+
+
+def get_ced_streams(file_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = CedRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_ced_num_blocks(file_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = CedRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/edf.py
+++ b/spikeinterface/extractors/neoextractors/edf.py
@@ -1,6 +1,7 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class EDFRecordingExtractor(NeoBaseRecordingExtractor):
@@ -14,19 +15,65 @@ class EDFRecordingExtractor(NeoBaseRecordingExtractor):
     file_path: str
         The file path to load the recordings from.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
-        For this neo reader stream are defined by their sampling frequency.
+        If there are several streams, specify the stream id you want to load.
+        For this neo reader streams are defined by their sampling frequency.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'EDFRawIO'
 
-    def __init__(self, file_path, stream_id=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations,
+                                           **neo_kwargs)
         self._kwargs.update({'file_path': str(file_path)})
         self.extra_requirements.append('pyedflib')
 
 
 read_edf = define_function_from_class(source_class=EDFRecordingExtractor, name="read_edf")
+
+
+def get_edf_streams(file_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = EDFRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_edf_num_blocks(file_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = EDFRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/edf.py
+++ b/spikeinterface/extractors/neoextractors/edf.py
@@ -1,7 +1,6 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class EDFRecordingExtractor(NeoBaseRecordingExtractor):
@@ -24,6 +23,7 @@ class EDFRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'EDFRawIO'
+    name = "edf"
 
     def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
@@ -34,25 +34,10 @@ class EDFRecordingExtractor(NeoBaseRecordingExtractor):
         self._kwargs.update({'file_path': str(file_path)})
         self.extra_requirements.append('pyedflib')
 
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
+
 
 read_edf = define_function_from_class(source_class=EDFRecordingExtractor, name="read_edf")
-
-
-def get_edf_streams(file_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = EDFRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/edf.py
+++ b/spikeinterface/extractors/neoextractors/edf.py
@@ -19,19 +19,16 @@ class EDFRecordingExtractor(NeoBaseRecordingExtractor):
         For this neo reader streams are defined by their sampling frequency.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'EDFRawIO'
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
-                                           block_index=block_index,
                                            all_annotations=all_annotations,
                                            **neo_kwargs)
         self._kwargs.update({'file_path': str(file_path)})
@@ -59,21 +56,3 @@ def get_edf_streams(file_path):
     raw_class = EDFRecordingExtractor.NeoRawIOClass
     neo_kwargs = {'filename': str(file_path)}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_edf_num_blocks(file_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = EDFRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/intan.py
+++ b/spikeinterface/extractors/neoextractors/intan.py
@@ -1,7 +1,6 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class IntanRecordingExtractor(NeoBaseRecordingExtractor):
@@ -23,9 +22,10 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'IntanRawIO'
+    name = "intan"
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
-        neo_kwargs = {'filename': str(file_path)}
+    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
                                            all_annotations=all_annotations,
@@ -33,25 +33,11 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
 
         self._kwargs.update(dict(file_path=str(file_path)))
 
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
+
+
 
 read_intan = define_function_from_class(source_class=IntanRecordingExtractor, name="read_intan")
-
-
-def get_intan_streams(file_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = IntanRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/intan.py
+++ b/spikeinterface/extractors/neoextractors/intan.py
@@ -1,6 +1,7 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class IntanRecordingExtractor(NeoBaseRecordingExtractor):
@@ -13,19 +14,65 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
     ----------
     file_path: str
         The file path to load the recordings from.
-    stream_id: str or None
-        If there are several streams, specify the one you want to load.
+    stream_id: str, optional
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'IntanRawIO'
 
-    def __init__(self, file_path, stream_id=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations,
+                                           **neo_kwargs)
 
         self._kwargs.update(dict(file_path=str(file_path)))
 
 
 read_intan = define_function_from_class(source_class=IntanRecordingExtractor, name="read_intan")
+
+
+def get_intan_streams(file_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = IntanRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_intan_num_blocks(file_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = IntanRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/intan.py
+++ b/spikeinterface/extractors/neoextractors/intan.py
@@ -18,8 +18,6 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
@@ -30,7 +28,6 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
-                                           block_index=block_index,
                                            all_annotations=all_annotations,
                                            **neo_kwargs)
 
@@ -58,21 +55,3 @@ def get_intan_streams(file_path):
     raw_class = IntanRecordingExtractor.NeoRawIOClass
     neo_kwargs = {'filename': str(file_path)}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_intan_num_blocks(file_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = IntanRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/maxwell.py
+++ b/spikeinterface/extractors/neoextractors/maxwell.py
@@ -26,12 +26,10 @@ class MaxwellRecordingExtractor(NeoBaseRecordingExtractor):
         need to specify stream_id='well000' or 'well0001', etc.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     rec_name: str, optional
-        When the file contains several blocks (aka recordings) you need to specify the one
+        When the file contains several recordings you need to specify the one
         you want to extract. (rec_name='rec0000').
     """
     mode = 'file'
@@ -140,21 +138,3 @@ def get_maxwell_streams(file_path, rec_name=None):
     raw_class = MaxwellRecordingExtractor.NeoRawIOClass
     neo_kwargs = {'filename': str(file_path), 'rec_name': rec_name}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_maxwell_num_blocks(file_path, rec_name=None):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = MaxwellRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path), 'rec_name': rec_name}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/maxwell.py
+++ b/spikeinterface/extractors/neoextractors/maxwell.py
@@ -6,6 +6,7 @@ from spikeinterface import BaseEvent, BaseEventSegment
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class MaxwellRecordingExtractor(NeoBaseRecordingExtractor):
@@ -20,9 +21,13 @@ class MaxwellRecordingExtractor(NeoBaseRecordingExtractor):
     file_path: str
         The file path to the maxwell h5 file.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
         For MaxTwo when there are several wells at the same time you
         need to specify stream_id='well000' or 'well0001', etc.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     rec_name: str, optional
@@ -32,9 +37,14 @@ class MaxwellRecordingExtractor(NeoBaseRecordingExtractor):
     mode = 'file'
     NeoRawIOClass = 'MaxwellRawIO'
 
-    def __init__(self, file_path, stream_id=None, all_annotations=False, rec_name=None):
+    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, 
+                 all_annotations=False, rec_name=None):
         neo_kwargs = {'filename': str(file_path), 'rec_name': rec_name}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=False, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations, 
+                                           **neo_kwargs)
 
         self.extra_requirements.append('h5py')
 
@@ -110,3 +120,41 @@ class MaxwellEventSegment(BaseEventSegment):
 
 read_maxwell = define_function_from_class(source_class=MaxwellRecordingExtractor, name="read_maxwell")
 read_maxwell_event = define_function_from_class(source_class=MaxwellEventExtractor, name="read_maxwell_event")
+
+
+def get_maxwell_streams(file_path, rec_name=None):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = MaxwellRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path), 'rec_name': rec_name}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_maxwell_num_blocks(file_path, rec_name=None):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = MaxwellRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path), 'rec_name': rec_name}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/mcsraw.py
+++ b/spikeinterface/extractors/neoextractors/mcsraw.py
@@ -1,7 +1,6 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class MCSRawRecordingExtractor(NeoBaseRecordingExtractor):
@@ -28,34 +27,19 @@ class MCSRawRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'RawMCSRawIO'
+    name = "mcsraw"
 
     def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
-        neo_kwargs = {'filename': str(file_path)}
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id,
                                            stream_name=stream_name,
                                            block_index=block_index,
                                            all_annotations=all_annotations, **neo_kwargs)
         self._kwargs.update(dict(file_path=str(file_path)))
 
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
 
 read_mcsraw = define_function_from_class(source_class=MCSRawRecordingExtractor, name="read_maxwell_event")
-
-
-def get_mcsraw_streams(file_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = MCSRawRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/mcsraw.py
+++ b/spikeinterface/extractors/neoextractors/mcsraw.py
@@ -59,21 +59,3 @@ def get_mcsraw_streams(file_path):
     raw_class = MCSRawRecordingExtractor.NeoRawIOClass
     neo_kwargs = {'filename': str(file_path)}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_mcsraw_num_blocks(file_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = MCSRawRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/mearec.py
+++ b/spikeinterface/extractors/neoextractors/mearec.py
@@ -1,7 +1,6 @@
 import probeinterface as pi
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class MEArecRecordingExtractor(NeoBaseRecordingExtractor):
@@ -19,9 +18,10 @@ class MEArecRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'MEArecRawIO'
+    name = "mearec"
 
     def __init__(self, file_path, all_annotations=False):
-        neo_kwargs = {'filename': str(file_path)}
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(self, 
                                            all_annotations=all_annotations,
                                            **neo_kwargs)
@@ -37,20 +37,31 @@ class MEArecRecordingExtractor(NeoBaseRecordingExtractor):
 
         self._kwargs.update({'file_path': str(file_path)})
 
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
+
 
 class MEArecSortingExtractor(NeoBaseSortingExtractor):
     mode = 'file'
     NeoRawIOClass = 'MEArecRawIO'
     handle_spike_frame_directly = False
+    name = "mearec"
 
     def __init__(self, file_path):
-        neo_kwargs = {'filename': str(file_path)}
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseSortingExtractor.__init__(self,
                                          sampling_frequency=None,  # auto guess is correct here
                                          use_natural_unit_ids=True,
                                          **neo_kwargs)
 
         self._kwargs = {'file_path': str(file_path)}
+
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
 
 
 def read_mearec(file_path):

--- a/spikeinterface/extractors/neoextractors/mearec.py
+++ b/spikeinterface/extractors/neoextractors/mearec.py
@@ -1,6 +1,7 @@
 import probeinterface as pi
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class MEArecRecordingExtractor(NeoBaseRecordingExtractor):
@@ -19,9 +20,14 @@ class MEArecRecordingExtractor(NeoBaseRecordingExtractor):
     mode = 'file'
     NeoRawIOClass = 'MEArecRawIO'
 
-    def __init__(self, file_path, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None,
+                 all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
-        NeoBaseRecordingExtractor.__init__(self, all_annotations=all_annotations, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(self, 
+                                           stream_id=stream_id,
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations, **neo_kwargs)
 
         self.extra_requirements.append('mearec')
 
@@ -68,3 +74,41 @@ def read_mearec(file_path):
     recording = MEArecRecordingExtractor(file_path)
     sorting = MEArecSortingExtractor(file_path)
     return recording, sorting
+
+
+def get_mearec_streams(file_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = MEArecRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_mearec_num_blocks(file_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = MEArecRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/mearec.py
+++ b/spikeinterface/extractors/neoextractors/mearec.py
@@ -20,14 +20,11 @@ class MEArecRecordingExtractor(NeoBaseRecordingExtractor):
     mode = 'file'
     NeoRawIOClass = 'MEArecRawIO'
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None,
-                 all_annotations=False):
+    def __init__(self, file_path, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, 
-                                           stream_id=stream_id,
-                                           stream_name=stream_name,
-                                           block_index=block_index,
-                                           all_annotations=all_annotations, **neo_kwargs)
+                                           all_annotations=all_annotations,
+                                           **neo_kwargs)
 
         self.extra_requirements.append('mearec')
 
@@ -74,41 +71,3 @@ def read_mearec(file_path):
     recording = MEArecRecordingExtractor(file_path)
     sorting = MEArecSortingExtractor(file_path)
     return recording, sorting
-
-
-def get_mearec_streams(file_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = MEArecRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_streams(raw_class, **neo_kwargs)
-
-
-def get_mearec_num_blocks(file_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = MEArecRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/mscraw.py
+++ b/spikeinterface/extractors/neoextractors/mscraw.py
@@ -1,6 +1,7 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class MCSRawRecordingExtractor(NeoBaseRecordingExtractor):
@@ -17,17 +18,62 @@ class MCSRawRecordingExtractor(NeoBaseRecordingExtractor):
     file_path: str
         The file path to load the recordings from.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'RawMCSRawIO'
 
-    def __init__(self, file_path, stream_id=None, all_annotations=False):
-        neo_kwargs = {'filename': file_path}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+        neo_kwargs = {'filename': str(file_path)}
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id,
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations, **neo_kwargs)
         self._kwargs.update(dict(file_path=str(file_path)))
 
 
 read_mcsraw = define_function_from_class(source_class=MCSRawRecordingExtractor, name="read_maxwell_event")
+
+
+def get_mcsraw_streams(file_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = MCSRawRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_mcsraw_num_blocks(file_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = MCSRawRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/neo_utils.py
+++ b/spikeinterface/extractors/neoextractors/neo_utils.py
@@ -1,24 +1,63 @@
-import neo
+from .neobaseextractor import NeoBaseRecordingExtractor
 
 
-def get_reader(raw_class, **neo_kwargs):
-    neoIOclass = eval('neo.rawio.' + raw_class)
-    neo_reader = neoIOclass(**neo_kwargs)
-    neo_reader.parse_header()
+def get_neo_streams(extractor_name, *args, **kwargs):
+    """Returns the NEO streams (stream names and stream ids) associated to a dataset.
+    For multi-stream datasets, the `stream_id` or `stream_name` arguments can be used 
+    to select which stream to read with the `read_**extractor_name**()` function.
+
+    Parameters
+    ----------
+    extractor_name : str
+        The extractor name (available through the se.recording_extractor_full_dict).
+    *args, **kwargs : arguments
+        Extractor specific arguments. You can check extractor specific arguments with:
+        `read_**extractor_name**?`
     
-    return neo_reader
+
+    Returns
+    -------
+    list
+        List of NEO stream names
+    list
+        List of NEO stream ids
+    """
+    neo_extractor = get_neo_extractor(extractor_name)
+    return neo_extractor.get_streams(*args, **kwargs)
 
 
-def get_streams(raw_class, **neo_kwargs):
-    neo_reader = get_reader(raw_class, **neo_kwargs)
+def get_neo_num_blocks(extractor_name, *args, **kwargs):
+    """Returns the number of NEO blocks. 
+    For multi-block datasets, the `block_index` argument can be used to select 
+    which bloack to read with the `read_**extractor_name**()` function.
     
-    stream_channels = neo_reader.header['signal_streams']
-    stream_names = list(stream_channels['name'])
-    stream_ids = list(stream_channels['id'])
+
+    Parameters
+    ----------
+    extractor_name : str
+        The extractor name (available through the se.recording_extractor_full_dict).
+    *args, **kwargs : arguments
+        Extractor specific arguments. You can check extractor specific arguments with:
+        `read_**extractor_name**?`
     
-    return stream_names, stream_ids
+    Returns
+    -------
+    int
+        Number of NEO blocks
+
+    Note
+    ----
+    Most datasets contain a single block.
+    """
+    neo_extractor = get_neo_extractor(extractor_name)
+    return neo_extractor.get_num_blocks(*args, **kwargs)
 
 
-def get_num_blocks(raw_class, **neo_kwargs):
-    neo_reader = get_reader(raw_class, **neo_kwargs)
-    return neo_reader.block_count()
+def get_neo_extractor(extractor_name):
+    from ..extractorlist import recording_extractor_full_dict
+
+    assert extractor_name in recording_extractor_full_dict, (f"{extractor_name} not an extractor name:"
+                                                             f"\n{list(recording_extractor_full_dict.keys())}")
+    neo_extractor = recording_extractor_full_dict[extractor_name]
+    assert issubclass(neo_extractor, NeoBaseRecordingExtractor), f"{extractor_name} is not a NEO recording extractor!"
+    return neo_extractor

--- a/spikeinterface/extractors/neoextractors/neo_utils.py
+++ b/spikeinterface/extractors/neoextractors/neo_utils.py
@@ -1,0 +1,24 @@
+import neo
+
+
+def get_reader(raw_class, **neo_kwargs):
+    neoIOclass = eval('neo.rawio.' + raw_class)
+    neo_reader = neoIOclass(**neo_kwargs)
+    neo_reader.parse_header()
+    
+    return neo_reader
+
+
+def get_streams(raw_class, **neo_kwargs):
+    neo_reader = get_reader(raw_class, **neo_kwargs)
+    
+    stream_channels = neo_reader.header['signal_streams']
+    stream_names = list(stream_channels['name'])
+    stream_ids = list(stream_channels['id'])
+    
+    return stream_names, stream_ids
+
+
+def get_num_blocks(raw_class, **neo_kwargs):
+    neo_reader = get_reader(raw_class, **neo_kwargs)
+    return neo_reader.block_count()

--- a/spikeinterface/extractors/neoextractors/neuralynx.py
+++ b/spikeinterface/extractors/neoextractors/neuralynx.py
@@ -1,7 +1,6 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class NeuralynxRecordingExtractor(NeoBaseRecordingExtractor):
@@ -23,14 +22,20 @@ class NeuralynxRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'folder'
     NeoRawIOClass = 'NeuralynxRawIO'
+    name = "neuralynx"
 
     def __init__(self, folder_path, stream_id=None, stream_name=None, all_annotations=False):
-        neo_kwargs = {'dirname': str(folder_path)}
+        neo_kwargs = self.map_to_neo_kwargs(folder_path)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
                                            all_annotations=all_annotations, 
                                            **neo_kwargs)
         self._kwargs.update(dict(folder_path=str(folder_path)))
+
+    @classmethod
+    def map_to_neo_kwargs(cls, folder_path):
+        neo_kwargs = {'dirname': str(folder_path)}
+        return neo_kwargs
 
 
 class NeuralynxSortingExtractor(NeoBaseSortingExtractor):
@@ -50,32 +55,18 @@ class NeuralynxSortingExtractor(NeoBaseSortingExtractor):
     mode = 'folder'
     NeoRawIOClass = 'NeuralynxRawIO'
     handle_spike_frame_directly = False
+    name = "neuralynx"
 
     def __init__(self, folder_path, sampling_frequency=None):
-        neo_kwargs = {'dirname': str(folder_path)}
+        neo_kwargs = self.map_to_neo_kwargs(folder_path)
         NeoBaseSortingExtractor.__init__(self, sampling_frequency=sampling_frequency, **neo_kwargs)
         self._kwargs.update(dict(folder_path=str(folder_path)))
 
+    @classmethod
+    def map_to_neo_kwargs(cls, folder_path):
+        neo_kwargs = {'dirname': str(folder_path)}
+        return neo_kwargs
+
+
 read_neuralynx = define_function_from_class(source_class=NeuralynxRecordingExtractor, name="read_neuralynx")
 read_neuralynx_sorting = define_function_from_class(source_class=NeoBaseSortingExtractor, name="read_neuralynx_sorting")
-
-
-
-def get_neuralynx_streams(folder_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    folder_path : str
-        The folder path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = NeuralynxRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'dirname': str(folder_path)}
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/neuralynx.py
+++ b/spikeinterface/extractors/neoextractors/neuralynx.py
@@ -18,19 +18,16 @@ class NeuralynxRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'folder'
     NeoRawIOClass = 'NeuralynxRawIO'
 
-    def __init__(self, folder_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+    def __init__(self, folder_path, stream_id=None, stream_name=None, all_annotations=False):
         neo_kwargs = {'dirname': str(folder_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
-                                           block_index=block_index,
                                            all_annotations=all_annotations, 
                                            **neo_kwargs)
         self._kwargs.update(dict(folder_path=str(folder_path)))
@@ -82,21 +79,3 @@ def get_neuralynx_streams(folder_path):
     raw_class = NeuralynxRecordingExtractor.NeoRawIOClass
     neo_kwargs = {'dirname': str(folder_path)}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_neuralynx_num_blocks(folder_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    folder_path : str
-        The folder path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = NeuralynxRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'dirname': str(folder_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/neuralynx.py
+++ b/spikeinterface/extractors/neoextractors/neuralynx.py
@@ -1,6 +1,7 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class NeuralynxRecordingExtractor(NeoBaseRecordingExtractor):
@@ -14,16 +15,24 @@ class NeuralynxRecordingExtractor(NeoBaseRecordingExtractor):
     folder_path: str
         The file path to load the recordings from.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'folder'
     NeoRawIOClass = 'NeuralynxRawIO'
 
-    def __init__(self, folder_path, stream_id=None, all_annotations=False):
-        neo_kwargs = {'dirname': folder_path}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+    def __init__(self, folder_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+        neo_kwargs = {'dirname': str(folder_path)}
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations, 
+                                           **neo_kwargs)
         self._kwargs.update(dict(folder_path=str(folder_path)))
 
 
@@ -46,9 +55,48 @@ class NeuralynxSortingExtractor(NeoBaseSortingExtractor):
     handle_spike_frame_directly = False
 
     def __init__(self, folder_path, sampling_frequency=None):
-        neo_kwargs = {'dirname': folder_path}
+        neo_kwargs = {'dirname': str(folder_path)}
         NeoBaseSortingExtractor.__init__(self, sampling_frequency=sampling_frequency, **neo_kwargs)
         self._kwargs.update(dict(folder_path=str(folder_path)))
 
 read_neuralynx = define_function_from_class(source_class=NeuralynxRecordingExtractor, name="read_neuralynx")
 read_neuralynx_sorting = define_function_from_class(source_class=NeoBaseSortingExtractor, name="read_neuralynx_sorting")
+
+
+
+def get_neuralynx_streams(folder_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    folder_path : str
+        The folder path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = NeuralynxRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'dirname': str(folder_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_neuralynx_num_blocks(folder_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    folder_path : str
+        The folder path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = NeuralynxRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'dirname': str(folder_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/neuroscope.py
+++ b/spikeinterface/extractors/neoextractors/neuroscope.py
@@ -35,19 +35,16 @@ class NeuroScopeRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'NeuroScopeRawIO'
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
-                                           block_index=block_index,
                                            all_annotations=all_annotations, 
                                            **neo_kwargs)
         self._kwargs.update(dict(file_path=str(file_path)))
@@ -336,21 +333,3 @@ def get_neuroscope_streams(file_path):
     raw_class = NeuroScopeRecordingExtractor.NeoRawIOClass
     neo_kwargs = {'filename': str(file_path)}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_neuroscope_num_blocks(file_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = NeuroScopeRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/neuroscope.py
+++ b/spikeinterface/extractors/neoextractors/neuroscope.py
@@ -8,7 +8,6 @@ from spikeinterface.core import (BaseSorting, BaseSortingSegment)
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 try:
     from lxml import etree as et
@@ -40,14 +39,20 @@ class NeuroScopeRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'NeuroScopeRawIO'
+    name = "neuroscope"
 
     def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
-        neo_kwargs = {'filename': str(file_path)}
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
                                            all_annotations=all_annotations, 
                                            **neo_kwargs)
         self._kwargs.update(dict(file_path=str(file_path)))
+
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
 
 
 class NeuroScopeSortingExtractor(BaseSorting):
@@ -91,6 +96,7 @@ class NeuroScopeSortingExtractor(BaseSorting):
     extractor_name = "NeuroscopeSortingExtractor"
     installed = HAVE_LXML
     installation_mesg = "Please install lxml to use this extractor!"
+    name = "neuroscope"
 
     def __init__(
         self,
@@ -313,23 +319,3 @@ def read_neuroscope(file_path, stream_id=None, keep_mua_units=False,
         outputs = outputs[0]
 
     return outputs
-
-
-def get_neuroscope_streams(file_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = NeuroScopeRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/neuroscope.py
+++ b/spikeinterface/extractors/neoextractors/neuroscope.py
@@ -8,6 +8,7 @@ from spikeinterface.core import (BaseSorting, BaseSortingSegment)
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 try:
     from lxml import etree as et
@@ -31,16 +32,24 @@ class NeuroScopeRecordingExtractor(NeoBaseRecordingExtractor):
     file_path: str
         The file path to load the recordings from.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'NeuroScopeRawIO'
 
-    def __init__(self, file_path, stream_id=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations, 
+                                           **neo_kwargs)
         self._kwargs.update(dict(file_path=str(file_path)))
 
 
@@ -307,3 +316,41 @@ def read_neuroscope(file_path, stream_id=None, keep_mua_units=False,
         outputs = outputs[0]
 
     return outputs
+
+
+def get_neuroscope_streams(file_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = NeuroScopeRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_neuroscope_num_blocks(file_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = NeuroScopeRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/nix.py
+++ b/spikeinterface/extractors/neoextractors/nix.py
@@ -1,7 +1,6 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class NixRecordingExtractor(NeoBaseRecordingExtractor):
@@ -25,9 +24,11 @@ class NixRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'NIXRawIO'
+    name = "nix"
+
 
     def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
-        neo_kwargs = {'filename': str(file_path)}
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
                                            block_index=block_index,
@@ -36,43 +37,10 @@ class NixRecordingExtractor(NeoBaseRecordingExtractor):
         self._kwargs.update(dict(file_path=str(file_path), stream_id=stream_id))
         self.extra_requirements.append('nixio')
 
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
+
 
 read_nix = define_function_from_class(source_class=NixRecordingExtractor, name="read_nix")
-
-
-def get_nix_streams(file_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = NixRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_streams(raw_class, **neo_kwargs)
-
-
-def get_nix_num_blocks(file_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = NixRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/nix.py
+++ b/spikeinterface/extractors/neoextractors/nix.py
@@ -1,12 +1,8 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
-try:
-    import nixio
-    HAVE_NIX = True
-except ModuleNotFoundError:
-    HAVE_NIX = False
 
 class NixRecordingExtractor(NeoBaseRecordingExtractor):
     """
@@ -19,18 +15,64 @@ class NixRecordingExtractor(NeoBaseRecordingExtractor):
     file_path: str
         The file path to load the recordings from.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'NIXRawIO'
 
-    def __init__(self, file_path, stream_id=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations, 
+                                           **neo_kwargs)
         self._kwargs.update(dict(file_path=str(file_path), stream_id=stream_id))
         self.extra_requirements.append('nixio')
 
 
 read_nix = define_function_from_class(source_class=NixRecordingExtractor, name="read_nix")
+
+
+def get_nix_streams(file_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = NixRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_nix_num_blocks(file_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = NixRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/plexon.py
+++ b/spikeinterface/extractors/neoextractors/plexon.py
@@ -1,6 +1,7 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class PlexonRecordingExtractor(NeoBaseRecordingExtractor):
@@ -14,17 +15,63 @@ class PlexonRecordingExtractor(NeoBaseRecordingExtractor):
     file_path: str
         The file path to load the recordings from.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'PlexonRawIO'
 
-    def __init__(self, file_path, stream_id=None, all_annotations=False):
-        neo_kwargs = {'filename': file_path}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+        neo_kwargs = {'filename': str(file_path)}
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations, 
+                                           **neo_kwargs)
         self._kwargs.update({'file_path': str(file_path)})
 
 
 read_plexon = define_function_from_class(source_class=PlexonRecordingExtractor, name="read_plexon")
+
+
+def get_plexon_streams(file_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = PlexonRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_plexon_num_blocks(file_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = PlexonRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/plexon.py
+++ b/spikeinterface/extractors/neoextractors/plexon.py
@@ -18,19 +18,16 @@ class PlexonRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'PlexonRawIO'
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
-                                           block_index=block_index,
                                            all_annotations=all_annotations, 
                                            **neo_kwargs)
         self._kwargs.update({'file_path': str(file_path)})
@@ -57,21 +54,3 @@ def get_plexon_streams(file_path):
     raw_class = PlexonRecordingExtractor.NeoRawIOClass
     neo_kwargs = {'filename': str(file_path)}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_plexon_num_blocks(file_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = PlexonRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/plexon.py
+++ b/spikeinterface/extractors/neoextractors/plexon.py
@@ -1,7 +1,6 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class PlexonRecordingExtractor(NeoBaseRecordingExtractor):
@@ -23,34 +22,20 @@ class PlexonRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'PlexonRawIO'
+    name = "plexon"
 
     def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
-        neo_kwargs = {'filename': str(file_path)}
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
                                            all_annotations=all_annotations, 
                                            **neo_kwargs)
         self._kwargs.update({'file_path': str(file_path)})
 
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
+
 
 read_plexon = define_function_from_class(source_class=PlexonRecordingExtractor, name="read_plexon")
-
-
-def get_plexon_streams(file_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = PlexonRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/spike2.py
+++ b/spikeinterface/extractors/neoextractors/spike2.py
@@ -1,6 +1,7 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class Spike2RecordingExtractor(NeoBaseRecordingExtractor):
@@ -15,19 +16,66 @@ class Spike2RecordingExtractor(NeoBaseRecordingExtractor):
     file_path: str
         The file path to load the recordings from.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'Spike2RawIO'
 
-    def __init__(self, file_path, stream_id=None, all_annotations=False):
-        neo_kwargs = {'filename': file_path}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+        neo_kwargs = {'filename': str(file_path)}
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations, 
+                                           **neo_kwargs)
         self._kwargs.update({'file_path': str(file_path)})
         self.extra_requirements.append('sonpy')
 
 
 
 read_spike2 = define_function_from_class(source_class=Spike2RecordingExtractor, name="read_spike2")
+
+
+
+def get_spike2_streams(file_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = Spike2RecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_spike2_num_blocks(file_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = Spike2RecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/spike2.py
+++ b/spikeinterface/extractors/neoextractors/spike2.py
@@ -1,7 +1,6 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class Spike2RecordingExtractor(NeoBaseRecordingExtractor):
@@ -24,9 +23,10 @@ class Spike2RecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'Spike2RawIO'
+    name = "spike2"
 
     def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
-        neo_kwargs = {'filename': str(file_path)}
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
                                            all_annotations=all_annotations, 
@@ -34,27 +34,10 @@ class Spike2RecordingExtractor(NeoBaseRecordingExtractor):
         self._kwargs.update({'file_path': str(file_path)})
         self.extra_requirements.append('sonpy')
 
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
 
 
 read_spike2 = define_function_from_class(source_class=Spike2RecordingExtractor, name="read_spike2")
-
-
-
-def get_spike2_streams(file_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = Spike2RecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/spike2.py
+++ b/spikeinterface/extractors/neoextractors/spike2.py
@@ -19,19 +19,16 @@ class Spike2RecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'Spike2RawIO'
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
-                                           block_index=block_index,
                                            all_annotations=all_annotations, 
                                            **neo_kwargs)
         self._kwargs.update({'file_path': str(file_path)})
@@ -61,21 +58,3 @@ def get_spike2_streams(file_path):
     raw_class = Spike2RecordingExtractor.NeoRawIOClass
     neo_kwargs = {'filename': str(file_path)}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_spike2_num_blocks(file_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = Spike2RecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/spikegadgets.py
+++ b/spikeinterface/extractors/neoextractors/spikegadgets.py
@@ -1,6 +1,7 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class SpikeGadgetsRecordingExtractor(NeoBaseRecordingExtractor):
@@ -14,17 +15,63 @@ class SpikeGadgetsRecordingExtractor(NeoBaseRecordingExtractor):
     file_path: str
         The file path to load the recordings from.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'
     NeoRawIOClass = 'SpikeGadgetsRawIO'
 
-    def __init__(self, file_path, stream_id=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
         neo_kwargs = {'filename': str(file_path)}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations, 
+                                           **neo_kwargs)
         self._kwargs.update(dict(file_path=str(file_path), stream_id=stream_id))
 
 
 read_spikegadgets = define_function_from_class(source_class=SpikeGadgetsRecordingExtractor, name="read_spikegadgets")
+
+
+def get_spikegadgets_streams(file_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = SpikeGadgetsRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_spikegadgets_num_blocks(file_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    file_path : str
+        The file path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = SpikeGadgetsRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'filename': str(file_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/spikegadgets.py
+++ b/spikeinterface/extractors/neoextractors/spikegadgets.py
@@ -1,7 +1,6 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class SpikeGadgetsRecordingExtractor(NeoBaseRecordingExtractor):
@@ -23,34 +22,20 @@ class SpikeGadgetsRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'file'
     NeoRawIOClass = 'SpikeGadgetsRawIO'
+    name = "spikegadgets"
 
     def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
-        neo_kwargs = {'filename': str(file_path)}
+        neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
                                            all_annotations=all_annotations, 
                                            **neo_kwargs)
         self._kwargs.update(dict(file_path=str(file_path), stream_id=stream_id))
 
+    @classmethod
+    def map_to_neo_kwargs(cls, file_path):
+        neo_kwargs = {'filename': str(file_path)}
+        return neo_kwargs
+
 
 read_spikegadgets = define_function_from_class(source_class=SpikeGadgetsRecordingExtractor, name="read_spikegadgets")
-
-
-def get_spikegadgets_streams(file_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = SpikeGadgetsRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/spikegadgets.py
+++ b/spikeinterface/extractors/neoextractors/spikegadgets.py
@@ -18,8 +18,6 @@ class SpikeGadgetsRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
@@ -30,7 +28,6 @@ class SpikeGadgetsRecordingExtractor(NeoBaseRecordingExtractor):
         neo_kwargs = {'filename': str(file_path)}
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
-                                           block_index=block_index,
                                            all_annotations=all_annotations, 
                                            **neo_kwargs)
         self._kwargs.update(dict(file_path=str(file_path), stream_id=stream_id))
@@ -57,21 +54,3 @@ def get_spikegadgets_streams(file_path):
     raw_class = SpikeGadgetsRecordingExtractor.NeoRawIOClass
     neo_kwargs = {'filename': str(file_path)}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_spikegadgets_num_blocks(file_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    file_path : str
-        The file path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = SpikeGadgetsRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'filename': str(file_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/spikeglx.py
+++ b/spikeinterface/extractors/neoextractors/spikeglx.py
@@ -9,6 +9,7 @@ from spikeinterface.core.core_tools import define_function_from_class
 from spikeinterface.extractors.neuropixels_utils import get_neuropixels_sample_shifts
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 HAS_NEO_10_2 = version.parse(neo.__version__) >= version.parse("0.10.2")
 
@@ -29,8 +30,12 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
     folder_path: str
         The folder path to load the recordings from.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
         For example, 'imec0.ap' 'nidq' or 'imec0.lf'.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
@@ -38,11 +43,15 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
     NeoRawIOClass = "SpikeGLXRawIO"
 
 
-    def __init__(self, folder_path, stream_id=None, all_annotations=False):
+    def __init__(self, folder_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
         neo_kwargs = {'dirname': str(folder_path)}
         if HAS_NEO_10_2:
             neo_kwargs['load_sync_channel'] = False
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations,
+                                           **neo_kwargs)
 
         # ~ # open the corresponding stream probe
         if HAS_NEO_10_2 and "nidq" not in self.stream_id:
@@ -76,3 +85,41 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
 
 
 read_spikeglx = define_function_from_class(source_class=SpikeGLXRecordingExtractor, name="read_spikeglx")
+
+
+def get_spikeglx_streams(folder_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    folder_path : str
+        The folder path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = SpikeGLXRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'dirname': str(folder_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_spikeglx_num_blocks(folder_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    folder_path : str
+        The folder path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = SpikeGLXRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'dirname': str(folder_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/spikeglx.py
+++ b/spikeinterface/extractors/neoextractors/spikeglx.py
@@ -9,7 +9,6 @@ from spikeinterface.core.core_tools import define_function_from_class
 from spikeinterface.extractors.neuropixels_utils import get_neuropixels_sample_shifts
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 HAS_NEO_10_2 = version.parse(neo.__version__) >= version.parse("0.10.2")
 
@@ -39,10 +38,12 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = "folder"
     NeoRawIOClass = "SpikeGLXRawIO"
+    name = "spikeglx"
+    has_default_locations = True
 
 
     def __init__(self, folder_path, stream_id=None, stream_name=None, all_annotations=False):
-        neo_kwargs = {'dirname': str(folder_path)}
+        neo_kwargs = self.map_to_neo_kwargs(folder_path)
         if HAS_NEO_10_2:
             neo_kwargs['load_sync_channel'] = False
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
@@ -80,25 +81,10 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
 
         self._kwargs.update(dict(folder_path=str(folder_path)))
 
+    @classmethod
+    def map_to_neo_kwargs(cls, folder_path):
+        neo_kwargs = {'dirname': str(folder_path)}
+        return neo_kwargs
+
 
 read_spikeglx = define_function_from_class(source_class=SpikeGLXRecordingExtractor, name="read_spikeglx")
-
-
-def get_spikeglx_streams(folder_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    folder_path : str
-        The folder path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = SpikeGLXRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'dirname': str(folder_path)}
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/spikeglx.py
+++ b/spikeinterface/extractors/neoextractors/spikeglx.py
@@ -34,8 +34,6 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
         For example, 'imec0.ap' 'nidq' or 'imec0.lf'.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
@@ -43,13 +41,12 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
     NeoRawIOClass = "SpikeGLXRawIO"
 
 
-    def __init__(self, folder_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+    def __init__(self, folder_path, stream_id=None, stream_name=None, all_annotations=False):
         neo_kwargs = {'dirname': str(folder_path)}
         if HAS_NEO_10_2:
             neo_kwargs['load_sync_channel'] = False
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
-                                           block_index=block_index,
                                            all_annotations=all_annotations,
                                            **neo_kwargs)
 
@@ -105,21 +102,3 @@ def get_spikeglx_streams(folder_path):
     raw_class = SpikeGLXRecordingExtractor.NeoRawIOClass
     neo_kwargs = {'dirname': str(folder_path)}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_spikeglx_num_blocks(folder_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    folder_path : str
-        The folder path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = SpikeGLXRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'dirname': str(folder_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/tdt.py
+++ b/spikeinterface/extractors/neoextractors/tdt.py
@@ -1,6 +1,7 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
+from .neo_utils import get_streams, get_num_blocks
 
 
 class TdtRecordingExtractor(NeoBaseRecordingExtractor):
@@ -14,17 +15,63 @@ class TdtRecordingExtractor(NeoBaseRecordingExtractor):
     folder_path: str
         The folder path to the tdt folder.
     stream_id: str, optional
-        If there are several streams, specify the one you want to load.
+        If there are several streams, specify the stream id you want to load.
+    stream_name: str, optional
+        If there are several streams, specify the stream name you want to load.
+    block_index: int, optional
+        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'folder'
     NeoRawIOClass = 'TdtRawIO'
 
-    def __init__(self, folder_path, stream_id=None, all_annotations=False):
-        neo_kwargs = {'dirname': folder_path}
-        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, all_annotations=all_annotations, **neo_kwargs)
+    def __init__(self, folder_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+        neo_kwargs = {'dirname': str(folder_path)}
+        NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
+                                           stream_name=stream_name,
+                                           block_index=block_index,
+                                           all_annotations=all_annotations, 
+                                           **neo_kwargs)
         self._kwargs.update(dict(folder_path=str(folder_path)))
 
 
 read_tdt = define_function_from_class(source_class=TdtRecordingExtractor, name="read_tdt")
+
+
+def get_tdt_streams(folder_path):
+    """Return available NEO streams
+
+    Parameters
+    ----------
+    folder_path : str
+        The folder path to load the recordings from.
+
+    Returns
+    -------
+    list
+        List of stream names
+    list
+        List of stream IDs
+    """
+    raw_class = TdtRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'dirname': str(folder_path)}
+    return get_streams(raw_class, **neo_kwargs)
+
+
+def get_tdt_num_blocks(folder_path):
+    """Return number of NEO blocks
+
+    Parameters
+    ----------
+    folder_path : str
+        The folder path to load the recordings from.
+
+    Returns
+    -------
+    int
+        Number of NEO blocks
+    """
+    raw_class = TdtRecordingExtractor.NeoRawIOClass
+    neo_kwargs = {'dirname': str(folder_path)}
+    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/tdt.py
+++ b/spikeinterface/extractors/neoextractors/tdt.py
@@ -18,8 +18,6 @@ class TdtRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    block_index: int, optional
-        If there are several blocks, specify the block index you want to load.
     all_annotations: bool, optional, default: False
         Load exhaustively all annotations from neo.
     """
@@ -57,21 +55,3 @@ def get_tdt_streams(folder_path):
     raw_class = TdtRecordingExtractor.NeoRawIOClass
     neo_kwargs = {'dirname': str(folder_path)}
     return get_streams(raw_class, **neo_kwargs)
-
-
-def get_tdt_num_blocks(folder_path):
-    """Return number of NEO blocks
-
-    Parameters
-    ----------
-    folder_path : str
-        The folder path to load the recordings from.
-
-    Returns
-    -------
-    int
-        Number of NEO blocks
-    """
-    raw_class = TdtRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'dirname': str(folder_path)}
-    return get_num_blocks(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/neoextractors/tdt.py
+++ b/spikeinterface/extractors/neoextractors/tdt.py
@@ -1,7 +1,6 @@
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
-from .neo_utils import get_streams, get_num_blocks
 
 
 class TdtRecordingExtractor(NeoBaseRecordingExtractor):
@@ -23,9 +22,10 @@ class TdtRecordingExtractor(NeoBaseRecordingExtractor):
     """
     mode = 'folder'
     NeoRawIOClass = 'TdtRawIO'
+    name = "tdt"
 
     def __init__(self, folder_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
-        neo_kwargs = {'dirname': str(folder_path)}
+        neo_kwargs = self.map_to_neo_kwargs(folder_path)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id, 
                                            stream_name=stream_name,
                                            block_index=block_index,
@@ -33,25 +33,9 @@ class TdtRecordingExtractor(NeoBaseRecordingExtractor):
                                            **neo_kwargs)
         self._kwargs.update(dict(folder_path=str(folder_path)))
 
+    @classmethod
+    def map_to_neo_kwargs(cls, folder_path):
+        neo_kwargs = {'dirname': str(folder_path)}
+        return neo_kwargs
 
 read_tdt = define_function_from_class(source_class=TdtRecordingExtractor, name="read_tdt")
-
-
-def get_tdt_streams(folder_path):
-    """Return available NEO streams
-
-    Parameters
-    ----------
-    folder_path : str
-        The folder path to load the recordings from.
-
-    Returns
-    -------
-    list
-        List of stream names
-    list
-        List of stream IDs
-    """
-    raw_class = TdtRecordingExtractor.NeoRawIOClass
-    neo_kwargs = {'dirname': str(folder_path)}
-    return get_streams(raw_class, **neo_kwargs)

--- a/spikeinterface/extractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors.py
@@ -89,7 +89,6 @@ class NwbRecordingExtractor(BaseRecording):
 
     extractor_name = 'NwbRecording'
     has_default_locations = True
-    has_unscaled = False
     installed = HAVE_NWB  # check at class level if installed or not
     is_writable = True
     mode = 'file'

--- a/spikeinterface/extractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors.py
@@ -94,6 +94,7 @@ class NwbRecordingExtractor(BaseRecording):
     is_writable = True
     mode = 'file'
     installation_mesg = "To use the Nwb extractors, install pynwb: \n\n pip install pynwb\n\n"
+    name = "nwb"
 
     def __init__(self, file_path: PathType, electrical_series_name: str = None, load_time_vector: bool = False,
                  samples_for_rate_estimation: int = 100000, driver=None):
@@ -298,9 +299,9 @@ class NwbSortingExtractor(BaseSorting):
     """
     extractor_name = 'NwbSorting'
     installed = HAVE_NWB  # check at class level if installed or not
-    is_writable = True
     mode = 'file'
     installation_mesg = "To use the Nwb extractors, install pynwb: \n\n pip install pynwb\n\n"
+    name = "nwb"
 
     def __init__(self, file_path: PathType, electrical_series_name: str = None, sampling_frequency: float = None,
                  samples_for_rate_estimation: int = 100000, driver=None):

--- a/spikeinterface/extractors/phykilosortextractors.py
+++ b/spikeinterface/extractors/phykilosortextractors.py
@@ -20,9 +20,9 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
     """
     extractor_name = 'BasePhyKilosortSorting'
     installed = False  # check at class level if installed or not
-    is_writable = False
     mode = 'folder'
     installation_mesg = "To use the PhySortingExtractor install pandas: \n\n pip install pandas\n\n"  # error message when not installed
+    name = "phykilosort"
 
     def __init__(self, folder_path, exclude_cluster_groups=None, keep_good_only=False):
         try:
@@ -173,7 +173,8 @@ class PhySortingExtractor(BasePhyKilosortSortingExtractor):
     extractor : PhySortingExtractor
         The loaded data.
     """
-    extractor_name = 'BasePhyKilosortSorting'
+    extractor_name = 'PhySorting'
+    name = "phy"
 
     def __init__(self, folder_path, exclude_cluster_groups=None):
         BasePhyKilosortSortingExtractor.__init__(self, folder_path, exclude_cluster_groups, keep_good_only=False)
@@ -201,6 +202,7 @@ class KiloSortSortingExtractor(BasePhyKilosortSortingExtractor):
         The loaded data.
     """
     extractor_name = 'KiloSortSorting'
+    name = "kilosort"
 
     def __init__(self, folder_path, keep_good_only=False):
         BasePhyKilosortSortingExtractor.__init__(self, folder_path, exclude_cluster_groups=None,

--- a/spikeinterface/extractors/shybridextractors.py
+++ b/spikeinterface/extractors/shybridextractors.py
@@ -33,12 +33,12 @@ class SHYBRIDRecordingExtractor(BinaryRecordingExtractor):
 
     extractor_name = 'SHYBRIDRecording'
     has_default_locations = True
-    has_unscaled = False
     installed = HAVE_SBEX  # check at class level if installed or not
     is_writable = True
     mode = 'folder'
     installation_mesg = "To use the SHYBRID extractors, install SHYBRID and pyyaml: " \
                         "\n\n pip install shybrid pyyaml\n\n"
+    name = "shybrid"
 
     def __init__(self, file_path):
         # load params file related to the given shybrid recording
@@ -148,6 +148,7 @@ class SHYBRIDSortingExtractor(BaseSorting):
     installed = HAVE_SBEX
     is_writable = True
     installation_mesg = "To use the SHYBRID extractors, install SHYBRID: \n\n pip install shybrid\n\n"
+    name = "shybrid"
 
     def __init__(self, file_path, sampling_frequency, delimiter=','):
         assert self.installed, self.installation_mesg

--- a/spikeinterface/extractors/spykingcircusextractors.py
+++ b/spikeinterface/extractors/spykingcircusextractors.py
@@ -28,9 +28,9 @@ class SpykingCircusSortingExtractor(BaseSorting):
 
     extractor_name = 'SpykingCircusSortingExtractor'
     installed = HAVE_H5PY  # check at class level if installed or not
-    is_writable = True
     mode = 'folder'
     installation_mesg = "To use the SpykingCircusSortingExtractor install h5py: \n\n pip install h5py\n\n"
+    name = "spykingcircus"
 
     def __init__(self, folder_path):
         assert HAVE_H5PY, self.installation_mesg

--- a/spikeinterface/extractors/tests/common_tests.py
+++ b/spikeinterface/extractors/tests/common_tests.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from spikeinterface import download_dataset, get_global_dataset_folder
 from spikeinterface.extractors.neoextractors.neobaseextractor import NeoBaseRecordingExtractor
+from spikeinterface.extractors import get_neo_streams, get_neo_num_blocks
 
 gin_repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
 local_folder = get_global_dataset_folder() / 'ephy_testing_data'
@@ -34,14 +35,14 @@ class RecordingCommonTestSuite(CommonTestSuite):
                 
             # test streams and blocks retrieval
             full_path = self.get_full_path(path)
-            stream_names, stream_ids = self.neo_funcs["streams"](full_path)
-            nblocks = self.neo_funcs["blocks"](full_path)
+            extractor_name = self.ExtractorClass.name
+            print(f"Extractor name {extractor_name}")
+            nblocks = get_neo_num_blocks(extractor_name, full_path)
+            stream_names, stream_ids = get_neo_streams(extractor_name, full_path)
             
-            print(f"Extractor name {self.ExtractorClass.__name__}")
             print(f"Num blocks: {nblocks}, Stream names: {stream_names}, Stream IDs: {stream_ids}")
 
             rec = self.ExtractorClass(full_path, **kwargs)
-            # print(rec)
 
             assert hasattr(rec, 'extra_requirements')
 

--- a/spikeinterface/extractors/tests/common_tests.py
+++ b/spikeinterface/extractors/tests/common_tests.py
@@ -31,8 +31,16 @@ class RecordingCommonTestSuite(CommonTestSuite):
             elif isinstance(entity, str):
                 path = entity
                 kwargs = {}
+                
+            # test streams and blocks retrieval
+            full_path = self.get_full_path(path)
+            stream_names, stream_ids = self.neo_funcs["streams"](full_path)
+            nblocks = self.neo_funcs["blocks"](full_path)
+            
+            print(f"Extractor name {self.ExtractorClass.__name__}")
+            print(f"Num blocks: {nblocks}, Stream names: {stream_names}, Stream IDs: {stream_ids}")
 
-            rec = self.ExtractorClass(self.get_full_path(path), **kwargs)
+            rec = self.ExtractorClass(full_path, **kwargs)
             # print(rec)
 
             assert hasattr(rec, 'extra_requirements')

--- a/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/spikeinterface/extractors/tests/test_neoextractors.py
@@ -9,17 +9,14 @@ from spikeinterface.extractors import *
 from spikeinterface.extractors.tests.common_tests import (RecordingCommonTestSuite,
                                                           SortingCommonTestSuite, EventCommonTestSuite)
 
-# local_folder = get_global_dataset_folder() / 'ephy_testing_data'
-from pathlib import Path
-local_folder = Path("/home/alessio/Documents/data/gin/ephy_testing_data")
+local_folder = get_global_dataset_folder() / 'ephy_testing_data'
 
 
 class MearecRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     ExtractorClass = MEArecRecordingExtractor
     downloads = ['mearec']
     entities = ['mearec/mearec_test_10s.h5']
-    neo_funcs = dict(streams=get_mearec_streams, blocks=get_mearec_num_blocks)
-
+    neo_funcs = dict()
 
 class MearecSortingTest(SortingCommonTestSuite, unittest.TestCase):
     ExtractorClass = MEArecSortingExtractor
@@ -35,8 +32,6 @@ class SpikeGLXRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('spikeglx/Noise4Sam_g0', {'stream_id': 'imec0.lf'}),
         ('spikeglx/Noise4Sam_g0', {'stream_id': 'nidq'}),
     ]
-    neo_funcs = dict(streams=get_spikeglx_streams,
-                     blocks=get_spikeglx_num_blocks)
 
 
 class OpenEphysBinaryRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -49,8 +44,6 @@ class OpenEphysBinaryRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('openephysbinary/v0.5.x_two_nodes', {'stream_id': '0'}),
         ('openephysbinary/v0.5.x_two_nodes', {'stream_id': '1'}),
     ]
-    neo_funcs = dict(streams=get_openephys_streams,
-                     blocks=get_openephys_num_blocks)
 
 
 class OpenEphysBinaryEventTest(EventCommonTestSuite, unittest.TestCase):
@@ -67,8 +60,6 @@ class OpenEphysLegacyRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         'openephys/OpenEphys_SampleData_1',
     ]
-    neo_funcs = dict(streams=get_openephys_streams,
-                     blocks=get_openephys_num_blocks)
 
 
 class IntanRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -83,7 +74,6 @@ class IntanRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('intan/intan_rhs_test_1.rhs', {'stream_id': '4'}),
         ('intan/intan_rhs_test_1.rhs', {'stream_id': '11'}),
     ]
-    neo_funcs = dict(streams=get_intan_streams, blocks=get_intan_num_blocks)
 
 
 class NeuroScopeRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -92,8 +82,6 @@ class NeuroScopeRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         'neuroscope/test1/test1.xml',
     ]
-    neo_funcs = dict(streams=get_neuroscope_streams,
-                     blocks=get_neuroscope_num_blocks)
 
 
 class NeuroScopeSortingTest(SortingCommonTestSuite, unittest.TestCase):
@@ -112,7 +100,6 @@ class PlexonRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         'plexon/File_plexon_3.plx',
     ]
-    neo_funcs = dict(streams=get_plexon_streams, blocks=get_plexon_num_blocks)
 
 
 class NeuralynxRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -126,8 +113,6 @@ class NeuralynxRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         'neuralynx/Cheetah_v5.6.3/original_data',
         'neuralynx/Cheetah_v5.7.4/original_data',
     ]
-    neo_funcs = dict(streams=get_neuralynx_streams,
-                     blocks=get_neuralynx_num_blocks)
 
 
 class NeuralynxSortingTest(SortingCommonTestSuite, unittest.TestCase):
@@ -147,8 +132,6 @@ class BlackrockRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('blackrock/blackrock_2_1/l101210-001.ns2', {'stream_id': '2'}),
         ('blackrock/blackrock_2_1/l101210-001.ns2', {'stream_id': '5'}),
     ]
-    neo_funcs = dict(streams=get_blackrock_streams,
-                     blocks=get_blackrock_num_blocks)
 
 
 class BlackrockSortingTest(SortingCommonTestSuite, unittest.TestCase):
@@ -166,7 +149,6 @@ class MCSRawRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         'rawmcs/raw_mcs_with_header_1.raw',
     ]
-    neo_funcs = dict(streams=get_mcsraw_streams, blocks=get_mcsraw_num_blocks)
 
 
 class TdTRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -175,7 +157,6 @@ class TdTRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         ('tdt/aep_05', {'stream_id': '1'})
     ]
-    neo_funcs = dict(streams=get_tdt_streams, blocks=get_tdt_num_blocks)
 
 
 class AxonaRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -184,7 +165,6 @@ class AxonaRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         'axona/axona_raw',
     ]
-    neo_funcs = dict(streams=get_axona_streams, blocks=get_axona_num_blocks)
 
 
 class KiloSortSortingTest(SortingCommonTestSuite, unittest.TestCase):
@@ -201,7 +181,6 @@ class Spike2RecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         ('spike2/130322-1LY.smr', {'stream_id': '1'}),
     ]
-    neo_funcs = dict(streams=get_spike2_streams, blocks=get_spike2_num_blocks)
 
 
 class CedRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -214,10 +193,6 @@ class CedRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('spike2/130322-1LY.smr', {'stream_id': '1'}),
         'spike2/m365_1sec.smrx',
     ]
-    neo_funcs = dict(streams=get_ced_streams, blocks=get_ced_num_blocks)
-
-    get_streams_fun = get_ced_streams
-    get_num_blocks_fun = get_ced_num_blocks
 
 
 class MaxwellRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -228,8 +203,6 @@ class MaxwellRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('maxwell/MaxTwo_data/Network/000028/data.raw.h5',
          {'stream_id': 'well000', 'rec_name': 'rec0000'})
     ]
-    neo_funcs = dict(streams=get_maxwell_streams,
-                     blocks=get_maxwell_num_blocks)
 
     def setUp(self):
         from neo.rawio.maxwellrawio import auto_install_maxwell_hdf5_compression_plugin
@@ -245,8 +218,6 @@ class SpikeGadgetsRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('spikegadgets/20210225_em8_minirec2_ac.rec', {'stream_id': 'trodes'}),
         'spikegadgets/W122_06_09_2019_1_fromSD.rec'
     ]
-    neo_funcs = dict(streams=get_spikegadgets_streams,
-                     blocks=get_spikegadgets_num_blocks)
 
 
 class BiocamRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -255,7 +226,6 @@ class BiocamRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         'biocam/biocam_hw3.0_fw1.6.brw'
     ]
-    neo_funcs = dict(streams=get_biocam_streams, blocks=get_biocam_num_blocks)
 
 
 class AlphaOmegaRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -264,8 +234,6 @@ class AlphaOmegaRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         "alphaomega/mpx_map_version4",
     ]
-    neo_funcs = dict(streams=get_alphaomega_streams,
-                     blocks=get_alphaomega_num_blocks)
 
 
 class AlphaOmegaEventTest(EventCommonTestSuite, unittest.TestCase):
@@ -280,14 +248,13 @@ class EDFRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     ExtractorClass = EDFRecordingExtractor
     downloads = ['edf']
     entities = ['edf/edf+C.edf']
-    neo_funcs = dict(streams=get_edf_streams, blocks=get_edf_num_blocks)
 
 
 if __name__ == '__main__':
     test = MearecRecordingTest()
     # test = MearecSortingTest()
     # test = SpikeGLXRecordingTest()
-    # test = OpenEphysBinaryRecordingTest()
+    test = OpenEphysBinaryRecordingTest()
     # test = OpenEphysLegacyRecordingTest()
     # test = OpenEphysBinaryEventTest()
     # test = ItanRecordingTest()
@@ -301,7 +268,7 @@ if __name__ == '__main__':
     # test = CedRecordingTest()
     # test = MaxwellRecordingTest()
     # test = SpikeGadgetsRecordingTest()
-    test = NeuroScopeSortingTest()
+    # test = NeuroScopeSortingTest()
 
     test.setUp()
     test.test_open()

--- a/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/spikeinterface/extractors/tests/test_neoextractors.py
@@ -301,6 +301,7 @@ if __name__ == '__main__':
     # test = CedRecordingTest()
     # test = MaxwellRecordingTest()
     # test = SpikeGadgetsRecordingTest()
+    test = NeuroScopeSortingTest()
 
     test.setUp()
     test.test_open()

--- a/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/spikeinterface/extractors/tests/test_neoextractors.py
@@ -9,13 +9,16 @@ from spikeinterface.extractors import *
 from spikeinterface.extractors.tests.common_tests import (RecordingCommonTestSuite,
                                                           SortingCommonTestSuite, EventCommonTestSuite)
 
-local_folder = get_global_dataset_folder() / 'ephy_testing_data'
+# local_folder = get_global_dataset_folder() / 'ephy_testing_data'
+from pathlib import Path
+local_folder = Path("/home/alessio/Documents/data/gin/ephy_testing_data")
 
 
 class MearecRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     ExtractorClass = MEArecRecordingExtractor
     downloads = ['mearec']
     entities = ['mearec/mearec_test_10s.h5']
+    neo_funcs = dict(streams=get_mearec_streams, blocks=get_mearec_num_blocks)
 
 
 class MearecSortingTest(SortingCommonTestSuite, unittest.TestCase):
@@ -32,6 +35,8 @@ class SpikeGLXRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('spikeglx/Noise4Sam_g0', {'stream_id': 'imec0.lf'}),
         ('spikeglx/Noise4Sam_g0', {'stream_id': 'nidq'}),
     ]
+    neo_funcs = dict(streams=get_spikeglx_streams,
+                     blocks=get_spikeglx_num_blocks)
 
 
 class OpenEphysBinaryRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -44,6 +49,8 @@ class OpenEphysBinaryRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('openephysbinary/v0.5.x_two_nodes', {'stream_id': '0'}),
         ('openephysbinary/v0.5.x_two_nodes', {'stream_id': '1'}),
     ]
+    neo_funcs = dict(streams=get_openephys_streams,
+                     blocks=get_openephys_num_blocks)
 
 
 class OpenEphysBinaryEventTest(EventCommonTestSuite, unittest.TestCase):
@@ -60,6 +67,8 @@ class OpenEphysLegacyRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         'openephys/OpenEphys_SampleData_1',
     ]
+    neo_funcs = dict(streams=get_openephys_streams,
+                     blocks=get_openephys_num_blocks)
 
 
 class IntanRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -74,6 +83,7 @@ class IntanRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('intan/intan_rhs_test_1.rhs', {'stream_id': '4'}),
         ('intan/intan_rhs_test_1.rhs', {'stream_id': '11'}),
     ]
+    neo_funcs = dict(streams=get_intan_streams, blocks=get_intan_num_blocks)
 
 
 class NeuroScopeRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -82,6 +92,8 @@ class NeuroScopeRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         'neuroscope/test1/test1.xml',
     ]
+    neo_funcs = dict(streams=get_neuroscope_streams,
+                     blocks=get_neuroscope_num_blocks)
 
 
 class NeuroScopeSortingTest(SortingCommonTestSuite, unittest.TestCase):
@@ -100,6 +112,7 @@ class PlexonRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         'plexon/File_plexon_3.plx',
     ]
+    neo_funcs = dict(streams=get_plexon_streams, blocks=get_plexon_num_blocks)
 
 
 class NeuralynxRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -113,6 +126,9 @@ class NeuralynxRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         'neuralynx/Cheetah_v5.6.3/original_data',
         'neuralynx/Cheetah_v5.7.4/original_data',
     ]
+    neo_funcs = dict(streams=get_neuralynx_streams,
+                     blocks=get_neuralynx_num_blocks)
+
 
 class NeuralynxSortingTest(SortingCommonTestSuite, unittest.TestCase):
     ExtractorClass = NeuralynxSortingExtractor
@@ -122,6 +138,7 @@ class NeuralynxSortingTest(SortingCommonTestSuite, unittest.TestCase):
         'neuralynx/Cheetah_v5.6.3/original_data',
     ]
 
+
 class BlackrockRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     ExtractorClass = BlackrockRecordingExtractor
     downloads = ['blackrock']
@@ -130,6 +147,10 @@ class BlackrockRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('blackrock/blackrock_2_1/l101210-001.ns2', {'stream_id': '2'}),
         ('blackrock/blackrock_2_1/l101210-001.ns2', {'stream_id': '5'}),
     ]
+    neo_funcs = dict(streams=get_blackrock_streams,
+                     blocks=get_blackrock_num_blocks)
+
+
 class BlackrockSortingTest(SortingCommonTestSuite, unittest.TestCase):
     ExtractorClass = BlackrockSortingExtractor
     downloads = ['blackrock']
@@ -137,8 +158,6 @@ class BlackrockSortingTest(SortingCommonTestSuite, unittest.TestCase):
         'blackrock/FileSpec2.3001.nev',
         "blackrock/blackrock_2_1/l101210-001.nev"
     ]
-    
-    
 
 
 class MCSRawRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -147,6 +166,7 @@ class MCSRawRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         'rawmcs/raw_mcs_with_header_1.raw',
     ]
+    neo_funcs = dict(streams=get_mcsraw_streams, blocks=get_mcsraw_num_blocks)
 
 
 class TdTRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -155,6 +175,7 @@ class TdTRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         ('tdt/aep_05', {'stream_id': '1'})
     ]
+    neo_funcs = dict(streams=get_tdt_streams, blocks=get_tdt_num_blocks)
 
 
 class AxonaRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -163,6 +184,7 @@ class AxonaRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         'axona/axona_raw',
     ]
+    neo_funcs = dict(streams=get_axona_streams, blocks=get_axona_num_blocks)
 
 
 class KiloSortSortingTest(SortingCommonTestSuite, unittest.TestCase):
@@ -179,6 +201,7 @@ class Spike2RecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         ('spike2/130322-1LY.smr', {'stream_id': '1'}),
     ]
+    neo_funcs = dict(streams=get_spike2_streams, blocks=get_spike2_num_blocks)
 
 
 class CedRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -191,6 +214,10 @@ class CedRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('spike2/130322-1LY.smr', {'stream_id': '1'}),
         'spike2/m365_1sec.smrx',
     ]
+    neo_funcs = dict(streams=get_ced_streams, blocks=get_ced_num_blocks)
+
+    get_streams_fun = get_ced_streams
+    get_num_blocks_fun = get_ced_num_blocks
 
 
 class MaxwellRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -198,8 +225,11 @@ class MaxwellRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     downloads = ['maxwell']
     entities = [
         'maxwell/MaxOne_data/Record/000011/data.raw.h5',
-        ('maxwell/MaxTwo_data/Network/000028/data.raw.h5', {'stream_id': 'well000', 'rec_name': 'rec0000'})
+        ('maxwell/MaxTwo_data/Network/000028/data.raw.h5',
+         {'stream_id': 'well000', 'rec_name': 'rec0000'})
     ]
+    neo_funcs = dict(streams=get_maxwell_streams,
+                     blocks=get_maxwell_num_blocks)
 
     def setUp(self):
         from neo.rawio.maxwellrawio import auto_install_maxwell_hdf5_compression_plugin
@@ -215,6 +245,8 @@ class SpikeGadgetsRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('spikegadgets/20210225_em8_minirec2_ac.rec', {'stream_id': 'trodes'}),
         'spikegadgets/W122_06_09_2019_1_fromSD.rec'
     ]
+    neo_funcs = dict(streams=get_spikegadgets_streams,
+                     blocks=get_spikegadgets_num_blocks)
 
 
 class BiocamRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -223,6 +255,7 @@ class BiocamRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         'biocam/biocam_hw3.0_fw1.6.brw'
     ]
+    neo_funcs = dict(streams=get_biocam_streams, blocks=get_biocam_num_blocks)
 
 
 class AlphaOmegaRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
@@ -231,6 +264,8 @@ class AlphaOmegaRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     entities = [
         "alphaomega/mpx_map_version4",
     ]
+    neo_funcs = dict(streams=get_alphaomega_streams,
+                     blocks=get_alphaomega_num_blocks)
 
 
 class AlphaOmegaEventTest(EventCommonTestSuite, unittest.TestCase):
@@ -240,15 +275,16 @@ class AlphaOmegaEventTest(EventCommonTestSuite, unittest.TestCase):
         "alphaomega/mpx_map_version4",
     ]
 
+
 class EDFRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     ExtractorClass = EDFRecordingExtractor
     downloads = ['edf']
     entities = ['edf/edf+C.edf']
+    neo_funcs = dict(streams=get_edf_streams, blocks=get_edf_num_blocks)
 
 
 if __name__ == '__main__':
-    pass
-    # test = MearecRecordingTest()
+    test = MearecRecordingTest()
     # test = MearecSortingTest()
     # test = SpikeGLXRecordingTest()
     # test = OpenEphysBinaryRecordingTest()
@@ -259,7 +295,7 @@ if __name__ == '__main__':
     # test = PlexonRecordingTest()
     # test = NeuralynxRecordingTest()
     # test = BlackrockRecordingTest()
-    test = MCSRawRecordingTest()
+    # test = MCSRawRecordingTest()
     # test = KiloSortSortingTest()
     # test = Spike2RecordingTest()
     # test = CedRecordingTest()

--- a/spikeinterface/extractors/tridesclousextractors.py
+++ b/spikeinterface/extractors/tridesclousextractors.py
@@ -28,9 +28,9 @@ class TridesclousSortingExtractor(BaseSorting):
 
     extractor_name = 'TridesclousSortingExtractor'
     installed = HAVE_TDC
-    is_writable = False
     mode = 'folder'
     installation_mesg = "To use the TridesclousSortingExtractor install tridesclous: \n\n pip install tridesclous\n\n"  # error message when not installed
+    name = "tridesclous"
 
     def __init__(self, folder_path, chan_grp=None):
         assert self.installed, self.installation_mesg

--- a/spikeinterface/extractors/waveclussnippetstextractors.py
+++ b/spikeinterface/extractors/waveclussnippetstextractors.py
@@ -9,7 +9,8 @@ from typing import List, Union
 
 class WaveClusSnippetsExtractor(MatlabHelper, BaseSnippets):
     extractor_name = "WaveClusSnippetsExtractor"
-    installation_mesg = ""  # error message when not installed
+    is_writable = True
+    name = "waveclus"
 
     def __init__(self, file_path):
         file_path = Path(file_path) if isinstance(file_path, str) else file_path
@@ -138,3 +139,6 @@ class WaveClustSnippetsSegment(BaseSnippetsSegment):
         if indices is None:
             return self._spikestimes
         return self._spikestimes[indices]
+
+read_waveclus_snippets = define_function_from_class(source_class=WaveClusSnippetsExtractor,
+                                                    name="read_waveclus_snippets")

--- a/spikeinterface/extractors/waveclustextractors.py
+++ b/spikeinterface/extractors/waveclustextractors.py
@@ -24,7 +24,7 @@ class WaveClusSortingExtractor(MatlabHelper, BaseSorting):
     """
 
     extractor_name = "WaveClusSortingExtractor"
-    installation_mesg = ""  # error message when not installed
+    name = "waveclus"
 
     def __init__(self, file_path, keep_good_only=True):
         MatlabHelper.__init__(self, file_path)
@@ -63,4 +63,4 @@ class WaveClustSortingSegment(BaseSortingSegment):
         return times
 
 
-read_waveclust = define_function_from_class(source_class=WaveClusSortingExtractor, name="read_waveclust")
+read_waveclus = define_function_from_class(source_class=WaveClusSortingExtractor, name="read_waveclus")

--- a/spikeinterface/extractors/yassextractors.py
+++ b/spikeinterface/extractors/yassextractors.py
@@ -29,10 +29,8 @@ class YassSortingExtractor(BaseSorting):
     extractor_name = 'YassExtractor'
     mode = 'folder'
     installed = HAVE_YAML  # check at class level if installed or not
-
-    has_default_locations = False
-    is_writable = False
     installation_mesg = "To use the Yass extractor, install pyyaml: \n\n pip install pyyaml\n\n"  # error message when not installed
+    name = "yass"
 
     def __init__(self, folder_path):
         assert HAVE_YAML, self.installation_mesg


### PR DESCRIPTION
This PR improves the NEO wrappers:

- allow to load multi-block recordings (`block_index` argument added)
- allow to select stream by `stream_name` or `stream_id`
- implemet `get_neo_streams(extractor_name)` and `get_neo_num_blocks(extractor_name)` to enable to better select and loop through blocks and streams
- add `name` class variable for all extractors
- make `extractor_full_dict` to associated names with classes