### PR TITLE
Fix axes generation when num_axes is odd and figure is passed

### DIFF
--- a/spikeinterface/postprocessing/spike_locations.py
+++ b/spikeinterface/postprocessing/spike_locations.py
@@ -50,7 +50,7 @@ class SpikeLocationsCalculator(BaseWaveformExtractorExtension):
 
         spike_mask = np.in1d(self.spikes['unit_ind'], unit_inds)
         new_location = self.locations[spike_mask]
-        np.save(new_waveforms_folder / 'spike_locations.npy', new_location)
+        np.save(new_waveforms_folder / self.extension_name / 'spike_locations.npy', new_location)
         
     def run(self, **job_kwargs):
         """

--- a/spikeinterface/widgets/ipywidgets/unit_waveforms.py
+++ b/spikeinterface/widgets/ipywidgets/unit_waveforms.py
@@ -134,7 +134,8 @@ class PlotUpdater:
                 self.mpl_plotter.ax.axis("off")
         else:
             if hide_axis:
-                for ax in np.ravel(self.mpl_plotter.axes):
+                for i in range(len(unit_ids)):
+                    ax = self.mpl_plotter.axes.flatten()[i]
                     ax.axis("off")
 
         # update probe plot

--- a/spikeinterface/widgets/matplotlib/base_mpl.py
+++ b/spikeinterface/widgets/matplotlib/base_mpl.py
@@ -37,16 +37,12 @@ class MplPlotter(BackendPlotter):
                 assert ncols is not None
                 axes = []
                 nrows = int(np.ceil(num_axes / ncols))
-                axes = np.zeros((nrows, ncols), dtype=object)
-                for i in range(nrows * ncols):
+                axes = np.full((nrows, ncols), fill_value=None, dtype=object)
+                for i in range(num_axes):
                     ax = figure.add_subplot(nrows, ncols, i + 1)
                     r = i // ncols
                     c = i % ncols
                     axes[r, c] = ax
-                # remove extra axes
-                if ncols * nrows > num_axes:
-                    for extra_ax in axes.flatten()[num_axes:]:
-                        extra_ax.remove()
         elif ax is not None:
             assert figure is None and axes is None, 'figure/ax/axes : only one of then can be not None'
             figure = ax.get_figure()
@@ -81,8 +77,12 @@ class MplPlotter(BackendPlotter):
                     ax = None
                     # remove extra axes
                     if ncols * nrows > num_axes:
-                        for extra_ax in axes.flatten()[num_axes:]:
-                            extra_ax.remove()
+                        for i, extra_ax in enumerate(axes.flatten()):
+                            if i >= num_axes:
+                                extra_ax.remove()
+                                r = i // ncols
+                                c = i % ncols
+                                axes[r, c] = None
 
         self.figure = figure
         self.ax = ax

--- a/spikeinterface/widgets/matplotlib/base_mpl.py
+++ b/spikeinterface/widgets/matplotlib/base_mpl.py
@@ -38,11 +38,15 @@ class MplPlotter(BackendPlotter):
                 axes = []
                 nrows = int(np.ceil(num_axes / ncols))
                 axes = np.zeros((nrows, ncols), dtype=object)
-                for i in range(num_axes):
+                for i in range(nrows * ncols):
                     ax = figure.add_subplot(nrows, ncols, i + 1)
                     r = i // ncols
                     c = i % ncols
                     axes[r, c] = ax
+                # remove extra axes
+                if ncols * nrows > num_axes:
+                    for extra_ax in axes.flatten()[num_axes:]:
+                        extra_ax.remove()
         elif ax is not None:
             assert figure is None and axes is None, 'figure/ax/axes : only one of then can be not None'
             figure = ax.get_figure()


### PR DESCRIPTION
@samuelgarcia this fixes a bug that was caused by initializing the `axes` with `np.zeros`.

In case num_axes is odd, we still have to generate all `nrows * ncols` axes and then remove the excess ones (like it's done when not passing the figure). This bug was triggering an error because in other functions we assume (correctly) that all `axes` are mpl axes.

We should merge this and release 0.95.1 otherwise the `plot_unit_templates` and `plot_unit_waveforms` is broken.

Note that it worked when num_units is divisible by ncols.