### PR TITLE
Check matplotlib backend when using ipywidgets

### DIFF
--- a/spikeinterface/widgets/ipywidgets/base_ipywidgets.py
+++ b/spikeinterface/widgets/ipywidgets/base_ipywidgets.py
@@ -22,4 +22,4 @@ class IpywidgetsPlotter(BackendPlotter):
     def __init__(self) -> None:
         super().__init__()
         mpl_backend = mpl.get_backend()
-        assert "ipympl" in mpl_backend, ("To use the 'ipywidgets' backend, you have to set %matplotlib widgets")
+        assert "ipympl" in mpl_backend, ("To use the 'ipywidgets' backend, you have to set %matplotlib widget")

--- a/spikeinterface/widgets/ipywidgets/base_ipywidgets.py
+++ b/spikeinterface/widgets/ipywidgets/base_ipywidgets.py
@@ -1,5 +1,6 @@
 from spikeinterface.widgets.base import BackendPlotter
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib import gridspec
 import numpy as np
@@ -18,4 +19,7 @@ class IpywidgetsPlotter(BackendPlotter):
         "display": True
     }
     
-    
+    def __init__(self) -> None:
+        super().__init__()
+        mpl_backend = mpl.get_backend()
+        assert "ipympl" in mpl_backend, ("To use the 'ipywidgets' backend, you have to set %matplotlib widgets")


### PR DESCRIPTION
If the `ipywidgets` backend is used, but `%matplotlib widget` is not set, raise an informative error