### PR TITLE
Catch errors in PC metrics

### DIFF
--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -340,6 +340,7 @@ class WaveformExtractor:
             The newly create waveform extractor with the selected units
         """
         sorting = self.sorting.select_units(unit_ids)
+        unit_indices = self.sorting.ids_to_indices(unit_ids)
 
         if self.folder is not None:
             assert new_folder is not None, "Please specify 'new_folder'"
@@ -364,6 +365,11 @@ class WaveformExtractor:
                     if f"waveforms_{unit}.npy" in wf_file.name or f'sampled_index_{unit}.npy' in wf_file.name:
                         shutil.copyfile(
                             wf_file, new_waveforms_folder / wf_file.name)
+
+            template_files = [f for f in self.folder.iterdir() if "template" in f.name and f.suffix == ".npy"]
+            for tmp_file in template_files:
+                templates_data_sliced = np.load(tmp_file)[unit_indices]
+                np.save(new_waveforms_folder / tmp_file.name, templates_data_sliced)
 
             for ext_name in self.get_available_extension_names():
                 ext = self.load_extension(ext_name)

--- a/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/spikeinterface/qualitymetrics/pca_metrics.py
@@ -657,8 +657,11 @@ def pca_metrics_one_unit(we_folder, metric_names, unit_id, neighbor_channel_ids,
 
     # metrics
     if 'isolation_distance' in metric_names or 'l_ratio' in metric_names:
-        isolation_distance, l_ratio = mahalanobis_metrics(
-            pcs_flat, labels, unit_id)
+        try:
+            isolation_distance, l_ratio = mahalanobis_metrics(pcs_flat, labels, unit_id)
+        except:
+            isolation_distance = np.nan
+            isolation_distance = np.nan
         if 'isolation_distance' in metric_names:
             pc_metrics['isolation_distance'] = isolation_distance
         if 'l_ratio' in metric_names:
@@ -668,25 +671,38 @@ def pca_metrics_one_unit(we_folder, metric_names, unit_id, neighbor_channel_ids,
         if len(unit_ids) == 1:
             d_prime = np.nan
         else:
-            d_prime = lda_metrics(pcs_flat, labels, unit_id)
+            try:
+                d_prime = lda_metrics(pcs_flat, labels, unit_id)
+            except:
+                d_prime = np.nan
         pc_metrics['d_prime'] = d_prime
 
     if 'nearest_neighbor' in metric_names:
-        nn_hit_rate, nn_miss_rate = nearest_neighbors_metrics(pcs_flat, labels, unit_id,
-                                                              max_spikes_for_nn, n_neighbors)
+        try:
+            nn_hit_rate, nn_miss_rate = nearest_neighbors_metrics(pcs_flat, labels, unit_id,
+                                                                  max_spikes_for_nn, n_neighbors)
+        except:
+            nn_hit_rate = np.nan
+            nn_miss_rate = np.nan
         pc_metrics['nn_hit_rate'] = nn_hit_rate
         pc_metrics['nn_miss_rate'] = nn_miss_rate
 
     if 'nn_isolation' in metric_names:
-        nn_isolation = nearest_neighbors_isolation(we, unit_id, max_spikes_for_nn,
-                                                   min_spikes_for_nn, n_neighbors,
-                                                   n_components, radius_um, seed)
+        try:
+            nn_isolation = nearest_neighbors_isolation(we, unit_id, max_spikes_for_nn,
+                                                       min_spikes_for_nn, n_neighbors,
+                                                       n_components, radius_um, seed)
+        except:
+            nn_isolation = np.nan
         pc_metrics['nn_isolation'] = nn_isolation
 
     if 'nn_noise_overlap' in metric_names:
-        nn_noise_overlap = nearest_neighbors_noise_overlap(we, unit_id, max_spikes_for_nn,
-                                                           min_spikes_for_nn, n_neighbors,
-                                                           n_components, radius_um, seed)
+        try:
+            nn_noise_overlap = nearest_neighbors_noise_overlap(we, unit_id, max_spikes_for_nn,
+                                                               min_spikes_for_nn, n_neighbors,
+                                                               n_components, radius_um, seed)
+        except:
+            nn_noise_overlap = np.nan
         pc_metrics['nn_noise_overlap'] = nn_noise_overlap
 
     return pc_metrics

--- a/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/spikeinterface/qualitymetrics/pca_metrics.py
@@ -661,7 +661,7 @@ def pca_metrics_one_unit(we_folder, metric_names, unit_id, neighbor_channel_ids,
             isolation_distance, l_ratio = mahalanobis_metrics(pcs_flat, labels, unit_id)
         except:
             isolation_distance = np.nan
-            isolation_distance = np.nan
+            l_ratio = np.nan
         if 'isolation_distance' in metric_names:
             pc_metrics['isolation_distance'] = isolation_distance
         if 'l_ratio' in metric_names:


### PR DESCRIPTION
If PC metrics computation fails for a unit, set the metric to NaN