### PR TITLE
Missing values for dtype object should be None

### DIFF
--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -174,7 +174,7 @@ class BaseExtractor:
             it specifies the how the missing values should be filled, by default None.
             The missing_value has to be specified for types int and unsigned int.
         """
-        default_missing_values = {"f": np.nan, "S": "", "U": ""}
+        default_missing_values = {"f": np.nan, "O": None, "S": "", "U": ""}
         
         if values is None:
             if key in self._properties:


### PR DESCRIPTION
In the case where the value is of dtype `object`, the default missing value should be `None`. Especially since the user cannot tell the function that he wants `None` to be the default value, as `missing_value=None` means that the missing value is inferred from the dtype.