### PR TITLE
Extend comparison to multi-segment sortings

### DIFF
--- a/spikeinterface/comparison/basecomparison.py
+++ b/spikeinterface/comparison/basecomparison.py
@@ -278,9 +278,11 @@ class MixinSpikeTrainComparison:
         self.delta_frames = None
         
     def set_frames_and_frequency(self, sorting_list):
-        if not np.all(sorting.get_num_segments() == 1 for sorting in sorting_list):
-            raise Exception(
-                'Comparison module work with sorting having num_segments=1')
+        sorting0 = sorting_list[0]
+        # check num segments
+        if not np.all(sorting.get_num_segments() == sorting0.get_num_segments()
+                      for sorting in sorting_list):
+            raise Exception('Sorting objects must have the same number of segments.')
 
         # take sampling frequency from sorting list and test that they are equivalent.
         sampling_freqs = np.array([sorting.get_sampling_frequency()

--- a/spikeinterface/comparison/collisioncomparison.py
+++ b/spikeinterface/comparison/collisioncomparison.py
@@ -20,6 +20,9 @@ class CollisionGTComparison(GroundTruthComparison):
         # Force compute labels
         kwargs['compute_labels'] = True
 
+        if gt_sorting.get_num_segments() > 1 or tested_sorting.get_num_segments() > 1:
+            raise NotImplementedError("Collision comparison is only available for mono-segment sorting objects")
+
         GroundTruthComparison.__init__(self, gt_sorting, tested_sorting, **kwargs)
 
         self.collision_lag = collision_lag

--- a/spikeinterface/comparison/correlogramcomparison.py
+++ b/spikeinterface/comparison/correlogramcomparison.py
@@ -20,6 +20,9 @@ class CorrelogramGTComparison(GroundTruthComparison):
         # Force compute labels
         kwargs['compute_labels'] = True
 
+        if gt_sorting.get_num_segments() > 1 or tested_sorting.get_num_segments() > 1:
+            raise NotImplementedError("Correlogram comparison is only available for mono-segment sorting objects")
+
         GroundTruthComparison.__init__(self, gt_sorting, tested_sorting, **kwargs)
 
         self.window_ms = window_ms

--- a/spikeinterface/comparison/multicomparisons.py
+++ b/spikeinterface/comparison/multicomparisons.py
@@ -60,6 +60,7 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
         self.set_frames_and_frequency(self.object_list)
         self._spiketrain_mode = spiketrain_mode
         self._spiketrains = None
+        self._num_segments = sorting_list[0].get_num_segments()
 
         if do_matching:
             self._compute_all()
@@ -84,36 +85,40 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
 
     def _populate_spiketrains(self):
         self._spiketrains = []
-        for (unit_id, sg) in zip(self._new_units, self.subgraphs):
-            sorter_unit_ids = self._new_units[unit_id]["unit_ids"]
-            edges = list(sg.edges(data=True))
-            # Append correct spike train
-            if len(sorter_unit_ids.keys()) == 1:
-                self._spiketrains.append(self.object_list[self.name_list.index(
-                    list(sorter_unit_ids.keys())[0])].get_unit_spike_train(list(sorter_unit_ids.values())[0]))
-            else:
-                max_edge = edges[int(np.argmax([d['weight']
-                                     for u, v, d in edges]))]
-                node1, node2, weight = max_edge
-                sorter1, unit1 = node1
-                sorter2, unit2 = node2
-                sp1 = self.object_list[self.name_list.index(
-                    sorter1)].get_unit_spike_train(unit1)
-                sp2 = self.object_list[self.name_list.index(
-                    sorter2)].get_unit_spike_train(unit2)
+        for seg_index in range(self._num_segments):
+            spike_trains_segment = dict()
+            for (unit_id, sg) in zip(self._new_units, self.subgraphs):
+                sorter_unit_ids = self._new_units[unit_id]["unit_ids"]
+                edges = list(sg.edges(data=True))
+                # Append correct spike train
+                if len(sorter_unit_ids.keys()) == 1:
+                    sorting = self.object_list[self.name_list.index(list(sorter_unit_ids.keys())[0])]
+                    unit_id = list(sorter_unit_ids.values())[0]
+                    spike_train = sorting.get_unit_spike_train(unit_id, seg_index)
+                else:
+                    max_edge = edges[int(np.argmax([d['weight']
+                                        for u, v, d in edges]))]
+                    node1, node2, weight = max_edge
+                    sorter1, unit1 = node1
+                    sorter2, unit2 = node2
 
-                if self._spiketrain_mode == 'union':
-                    lab1, lab2 = compare_spike_trains(sp1, sp2)
-                    # add FP to spike train 1 (FP are the only spikes outside the union)
-                    fp_idx2 = np.where(np.array(lab2) == 'FP')[0]
-                    sp_union = np.sort(np.concatenate((sp1, sp2[fp_idx2])))
-                    self._spiketrains.append(list(sp_union))
-                elif self._spiketrain_mode == 'intersection':
-                    lab1, lab2 = compare_spike_trains(sp1, sp2)
-                    # TP are the spikes in the intersection
-                    tp_idx1 = np.where(np.array(lab1) == 'TP')[0]
-                    sp_tp1 = list(np.array(sp1)[tp_idx1])
-                    self._spiketrains.append(sp_tp1)
+                    sorting1 = self.object_list[self.name_list.index(sorter1)]
+                    sorting2 = self.object_list[self.name_list.index(sorter2)]
+                    sp1 = sorting1.get_unit_spike_train(unit1, seg_index)
+                    sp2 = sorting2.get_unit_spike_train(unit2, seg_index)
+                    if self._spiketrain_mode == 'union':
+                        lab1, lab2 = compare_spike_trains(sp1, sp2)
+                        # add FP to spike train 1 (FP are the only spikes outside the union)
+                        fp_idx2 = np.where(np.array(lab2) == 'FP')[0]
+                        spike_train = np.sort(np.concatenate((sp1, sp2[fp_idx2])))
+                    elif self._spiketrain_mode == 'intersection':
+                        lab1, lab2 = compare_spike_trains(sp1, sp2)
+                        # TP are the spikes in the intersection
+                        tp_idx1 = np.where(np.array(lab1) == 'TP')[0]
+                        spike_train = np.array(sp1)[tp_idx1]
+                spike_trains_segment[unit_id] = spike_train
+            self._spiketrains.append(spike_trains_segment)
+
 
     def _do_agreement_matrix(self, minimum_agreement=1):
         sorted_name_list = sorted(self.name_list)
@@ -213,26 +218,26 @@ class AgreementSortingExtractor(BaseSorting):
             unit_ids = list(u for u in self._msc._new_units.keys()
                             if self._msc._new_units[u]['agreement_number'] >= min_agreement_count)
 
-        BaseSorting.__init__(
-            self, sampling_frequency=sampling_frequency, unit_ids=unit_ids)
+        BaseSorting.__init__(self, sampling_frequency=sampling_frequency, unit_ids=unit_ids)
+
         if len(unit_ids) > 0:
             for k in ('agreement_number', 'avg_agreement', 'unit_ids'):
                 values = [self._msc._new_units[unit_id][k]
                           for unit_id in unit_ids]
                 self.set_property(k, values, ids=unit_ids)
 
-        sorting_segment = AgreementSortingSegment(multisortingcomparison)
-        self.add_sorting_segment(sorting_segment)
+        for segment_index in range(multisortingcomparison._num_segments):
+            sorting_segment = AgreementSortingSegment(multisortingcomparison._spiketrains[segment_index])
+            self.add_sorting_segment(sorting_segment)
 
 
 class AgreementSortingSegment(BaseSortingSegment):
-    def __init__(self, multisortingcomparison):
+    def __init__(self, spiketrains_segment):
         BaseSortingSegment.__init__(self)
-        self._msc = multisortingcomparison
+        self.spiketrains = spiketrains_segment
 
     def get_unit_spike_train(self, unit_id, start_frame, end_frame):
-        ind = list(self._msc._new_units.keys()).index(unit_id)
-        spiketrain = np.array(self._msc._spiketrains[ind])
+        spiketrain = self.spiketrains[unit_id]
         if start_frame is not None:
             spiketrain = spiketrain[spiketrain >= start_frame]
         if end_frame is not None:

--- a/spikeinterface/comparison/paircomparisons.py
+++ b/spikeinterface/comparison/paircomparisons.py
@@ -21,6 +21,8 @@ class BasePairSorterComparison(BasePairComparison, MixinSpikeTrainComparison):
             sorting1_name = 'sorting1'
         if sorting2_name is None:
             sorting2_name = 'sorting2'
+        assert sorting1.get_num_segments() == sorting2.get_num_segments(), ("The two sortings must have the same "
+                                                                            "number of segments! ")
 
         BasePairComparison.__init__(self, object1=sorting1, object2=sorting2, 
                                     name1=sorting1_name, name2=sorting2_name,

--- a/spikeinterface/comparison/tests/test_comparisontools.py
+++ b/spikeinterface/comparison/tests/test_comparisontools.py
@@ -120,20 +120,20 @@ def test_do_score_labels():
                                       [101, 201, 301, ], [0, 0, 5])
     unit_map12 = {0: 0, 1: 5}
     labels_st1, labels_st2 = do_score_labels(sorting1, sorting2, delta_frames, unit_map12)
-    assert_array_equal(labels_st1[0], ['TP', 'TP', 'FN'])
-    assert_array_equal(labels_st1[1], ['TP', ])
-    assert_array_equal(labels_st2[0], ['TP', 'TP'])
-    assert_array_equal(labels_st2[5], ['TP', ])
+    assert_array_equal(labels_st1[0][0], ['TP', 'TP', 'FN'])
+    assert_array_equal(labels_st1[1][0], ['TP', ])
+    assert_array_equal(labels_st2[0][0], ['TP', 'TP'])
+    assert_array_equal(labels_st2[5][0], ['TP', ])
 
     # match when 2 units fire at same time
     sorting1, sorting2 = make_sorting([100, 100, 200, 200, 300], [0, 1, 0, 1, 0],
                                       [100, 100, 200, 200, 300], [0, 1, 0, 1, 0], )
     unit_map12 = {0: 0, 1: 1}
     labels_st1, labels_st2 = do_score_labels(sorting1, sorting2, delta_frames, unit_map12)
-    assert_array_equal(labels_st1[0], ['TP', 'TP', 'TP'])
-    assert_array_equal(labels_st1[1], ['TP', 'TP', ])
-    assert_array_equal(labels_st2[0], ['TP', 'TP', 'TP'])
-    assert_array_equal(labels_st2[1], ['TP', 'TP', ])
+    assert_array_equal(labels_st1[0][0], ['TP', 'TP', 'TP'])
+    assert_array_equal(labels_st1[1][0], ['TP', 'TP', ])
+    assert_array_equal(labels_st2[0][0], ['TP', 'TP', 'TP'])
+    assert_array_equal(labels_st2[1][0], ['TP', 'TP', ])
 
 
 def test_compare_spike_trains():

--- a/spikeinterface/comparison/tests/test_groundtruthcomparison.py
+++ b/spikeinterface/comparison/tests/test_groundtruthcomparison.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from spikeinterface.extractors import NumpySorting
+from spikeinterface.extractors import NumpySorting, toy_example
 from spikeinterface.comparison import compare_sorter_to_ground_truth
 
 
@@ -138,6 +138,7 @@ def test_get_performance():
     perf = sc.get_performance('pooled_with_average')
     assert perf['accuracy'] == 1.
     assert perf['miss_rate'] == 0.
+
 
 
 if __name__ == '__main__':

--- a/spikeinterface/comparison/tests/test_multisortingcomparison.py
+++ b/spikeinterface/comparison/tests/test_multisortingcomparison.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from spikeinterface.extractors import NumpySorting
+from spikeinterface.extractors import NumpySorting, toy_example
 from spikeinterface.comparison import compare_multiple_sorters, MultiSortingComparison
 
 
@@ -62,6 +62,26 @@ def test_compare_multiple_sorters():
     # sw.plot_multicomp_agreement(msc)
     # sw.plot_multicomp_agreement_by_sorter(msc)
     # plt.show()
+
+
+def test_compare_multi_segment():
+    num_segments = 3
+    _, sort = toy_example(num_segments=num_segments)
+
+    cmp_multi = compare_multiple_sorters([sort, sort, sort])
+
+    for k, cmp in cmp_multi.comparisons.items():
+        assert np.allclose(np.diag(cmp.agreement_scores), np.ones(len(sort.unit_ids)))
+
+    sort_agr = cmp_multi.get_agreement_sorting(minimum_agreement_count=num_segments)
+    assert len(sort_agr.unit_ids) == len(sort.unit_ids)
+    assert sort_agr.get_num_segments() == num_segments
+
+    # test that all spike trains from different segments can be retrieved
+    for unit in sort_agr.unit_ids:
+        for seg_index in range(num_segments):
+            st = sort_agr.get_unit_spike_train(unit, seg_index)
+            print(f"Segment {seg_index} unit {unit}: {st}")
 
 
 if __name__ == '__main__':

--- a/spikeinterface/comparison/tests/test_symmetricsortingcomparison.py
+++ b/spikeinterface/comparison/tests/test_symmetricsortingcomparison.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from spikeinterface.extractors import NumpySorting
+from spikeinterface.extractors import NumpySorting, toy_example
 from spikeinterface.comparison import compare_two_sorters
 
 
@@ -20,5 +20,14 @@ def test_compare_two_sorters():
     print(sc.agreement_scores)
 
 
+def test_compare_multi_segment():
+    _, sort = toy_example(num_segments=2)
+
+    cmp_multi = compare_two_sorters(sort, sort)
+
+    assert np.allclose(np.diag(cmp_multi.agreement_scores), np.ones(len(sort.unit_ids)))
+
+
 if __name__ == '__main__':
     test_compare_two_sorters()
+    test_compare_multi_segment()


### PR DESCRIPTION
This came up when running `remove_redundant_units` (which internally uses compare_two_sorters).

It just extends the logic of comparison to multi-segment objects, by looping through segments when needed