### PR TITLE
Implement dummy objects for WaveformExtractor

### DIFF
--- a/spikeinterface/core/__init__.py
+++ b/spikeinterface/core/__init__.py
@@ -48,6 +48,9 @@ from .segmentutils import (
     SplitSegmentSorting,
 )
 
+# dummy objects
+from .dummy import dummy_recording, dummy_sorting
+
 # default folder
 from .default_folders import (set_global_tmp_folder, get_global_tmp_folder,
                               is_set_global_tmp_folder, reset_global_tmp_folder,

--- a/spikeinterface/core/core_tools.py
+++ b/spikeinterface/core/core_tools.py
@@ -115,29 +115,15 @@ def check_json(d):
                         v_arr = v_arr.astype('int32')
                     if v_arr.dtype == np.dtype('float64'):
                         v_arr = v_arr.astype('float32')
-                    if len(v_arr.shape) == 1:
-                        if 'int' in str(v_arr.dtype):
-                            v_arr = [int(v_el) for v_el in v_arr]
-                            dc[k] = v_arr
-                        elif 'float' in str(v_arr.dtype):
-                            v_arr = [float(v_el) for v_el in v_arr]
-                            dc[k] = v_arr
-                        elif isinstance(v_arr[0], str):
-                            v_arr = [str(v_el) for v_el in v_arr]
-                            dc[k] = v_arr
+
+                    if v_arr.dtype.kind in ("u", "i", "f", "b", "S", "U"):
+                        if len(v_arr.shape) < 4:
+                            dc[k] = v_arr.tolist()
                         else:
-                            print(f'Skipping field {k}: only 1D arrays of int, float, or str types can be serialized')
-                    elif len(v_arr.shape) == 2:
-                        if 'int' in str(v_arr.dtype):
-                            v_arr = [[int(v_el) for v_el in v_row] for v_row in v_arr]
-                            dc[k] = v_arr
-                        elif 'float' in str(v_arr.dtype):
-                            v_arr = [[float(v_el) for v_el in v_row] for v_row in v_arr]
-                            dc[k] = v_arr
-                        else:
-                            print(f'Skipping field {k}: only 2D arrays of int or float type can be serialized')
+                            print(f"Skipping field {k}: only 1/2/3d arraysc can be serialized")
                     else:
-                        print(f"Skipping field {k}: only 1D and 2D arrays can be serialized")
+                        print(f"Dtype {v_arr.dtype} can't be serialized. Skipping!")
+                        del dc[k]
             else:
                 dc[k] = list(v)
     return dc

--- a/spikeinterface/core/dummy.py
+++ b/spikeinterface/core/dummy.py
@@ -1,0 +1,116 @@
+from probeinterface import ProbeGroup
+
+from .baserecording import BaseRecording, BaseRecordingSegment
+from .basesorting import BaseSorting, BaseSortingSegment
+from .core_tools import define_function_from_class
+
+
+class DummyRecording(BaseRecording):
+    """
+    Dummy recording class that enables to retrieve Recording metadata
+    with the same interface as a BaseRecording object.
+
+    The get_traces() method is not available.
+
+    Parameters
+    ----------
+    recording: BaseRecording
+        The recording to make "dummy"
+
+    Returns
+    -------
+    BaseRecording
+        The dummy recording object
+
+    """
+
+    def __init__(self, recording=None, channel_ids=None, num_segments=None,
+                 sampling_frequency=None, dtype=None, probegroup=None):
+
+        if recording is not None:
+            channel_ids = recording.channel_ids
+            sampling_frequency = recording.get_sampling_frequency()
+            num_segments = recording.get_num_segments()
+            dtype = recording.get_dtype()
+            probegroup = recording.get_probegroup()
+        else:
+            assert channel_ids is not None
+            assert sampling_frequency is not None
+            assert num_segments is not None
+            assert dtype is not None
+
+        BaseRecording.__init__(self, sampling_frequency, channel_ids, dtype)
+
+        for segment_index in range(num_segments):
+            segment = DummyRecordingSegment(
+                sampling_frequency=sampling_frequency)
+            self.add_recording_segment(segment)
+
+        if probegroup is not None:
+            if isinstance(probegroup, dict):
+                probegroup = ProbeGroup.from_dict(probegroup)
+            self.set_probegroup(probegroup, in_place=True)
+
+        self._kwargs = dict(
+            channel_ids=channel_ids, sampling_frequency=sampling_frequency,
+            num_segments=num_segments, dtype=str(dtype),
+            probegroup=probegroup.to_dict() if probegroup is not None else None
+        )
+
+
+class DummyRecordingSegment(BaseRecordingSegment):
+
+    def get_num_samples(self) -> int:
+        return 0
+
+
+dummy_recording = define_function_from_class(DummyRecording, "dummy_recording")
+
+
+class DummySorting(BaseSorting):
+    """
+    Dummy sorting class that enables to retrieve Sorting metadata
+    with the same interface as a BaseSorting object.
+
+    The get_unit_spike_train() method is not available.
+
+    Parameters
+    ----------
+    sorting: BaseSorting
+        The sorting to make "dummy"
+
+    Returns
+    -------
+    BaseSorting
+        The dummy sorting object  
+    """
+
+    def __init__(self, sorting=None, unit_ids=None, num_segments=None,
+                 sampling_frequency=None):
+
+        if sorting is not None:
+            unit_ids = sorting.unit_ids
+            sampling_frequency = sorting.get_sampling_frequency()
+            num_segments = sorting.get_num_segments()
+        else:
+            assert unit_ids is not None
+            assert sampling_frequency is not None
+            assert num_segments is not None
+
+        BaseSorting.__init__(self, sampling_frequency, unit_ids)
+
+        for segment_index in range(num_segments):
+            segment = DummySortingSegment()
+            self.add_sorting_segment(segment)
+
+        self._kwargs = dict(
+            unit_ids=unit_ids, sampling_frequency=sampling_frequency,
+            num_segments=num_segments
+        )
+
+
+class DummySortingSegment(BaseSortingSegment):
+    pass
+
+
+dummy_sorting = define_function_from_class(DummySorting, "dummy_sorting")

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -2,6 +2,7 @@ import pytest
 from pathlib import Path
 import shutil
 import numpy as np
+import platform
 
 from spikeinterface.core.testing_tools import generate_recording, generate_sorting
 from spikeinterface import WaveformExtractor, extract_waveforms
@@ -288,17 +289,18 @@ def test_dummy_objects():
     we = extract_waveforms(recording, sorting, wf_folder,
                            use_relative_path=True)
 
-    (cache_folder / "recording_dummy").rename(cache_folder / "recording_dummy2")
-    (cache_folder / "sorting_dummy").rename(cache_folder / "sorting_dummy2")
+    if platform.system() != "Windows":
+        shutil.rmtree(cache_folder / "recording_dummy")
+        shutil.rmtree(cache_folder / "sorting_dummy")
 
-    # move all to a separate folder
-    we_loaded = WaveformExtractor.load_from_folder(wf_folder)
+        # move all to a separate folder
+        we_loaded = WaveformExtractor.load_from_folder(wf_folder)
 
-    assert we_loaded.recording is not None
-    assert we_loaded.sorting is not None
-    print(we_loaded.recording, we_loaded.sorting)
-    assert isinstance(we_loaded.recording, DummyRecording)
-    assert isinstance(we_loaded.sorting, DummySorting)
+        assert we_loaded.recording is not None
+        assert we_loaded.sorting is not None
+        print(we_loaded.recording, we_loaded.sorting)
+        assert isinstance(we_loaded.recording, DummyRecording)
+        assert isinstance(we_loaded.sorting, DummySorting)
 
 
 if __name__ == '__main__':

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from spikeinterface.core.testing_tools import generate_recording, generate_sorting
 from spikeinterface import WaveformExtractor, extract_waveforms
+from spikeinterface.core.dummy import DummyRecording, DummySorting
 
 
 if hasattr(pytest, "global_test_folder"):
@@ -247,8 +248,62 @@ def test_portability():
         assert np.allclose(wf, wf_loaded)
 
 
+def test_dummy_objects():
+    durations = [30, 40]
+    sampling_frequency = 30000.
+
+    # 2 segments
+    num_channels = 2
+    recording = generate_recording(num_channels=num_channels, durations=durations,
+                                   sampling_frequency=sampling_frequency)
+    recording.annotate(is_filtered=True)
+    num_units = 15
+    sorting = generate_sorting(
+        num_units=num_units, sampling_frequency=sampling_frequency, durations=durations)
+
+    # recording and sorting are not dumpable
+    wf_folder = cache_folder / "wf_dummy1"
+
+    # save with relative paths
+    we = extract_waveforms(recording, sorting, wf_folder,
+                           use_relative_path=True)
+
+    # move all to a separate folder
+    we_loaded = WaveformExtractor.load_from_folder(wf_folder)
+
+    assert we_loaded.recording is not None
+    assert we_loaded.sorting is not None
+    print(we_loaded.recording, we_loaded.sorting)
+    assert isinstance(we_loaded.recording, DummyRecording)
+    assert isinstance(we_loaded.sorting, DummySorting)
+
+    # now save and delete saved file
+    recording = recording.save(folder=cache_folder / "recording_dummy")
+    sorting = sorting.save(folder=cache_folder / "sorting_dummy")
+
+    # recording and sorting are not dumpable
+    wf_folder = cache_folder / "wf_dummy2"
+
+    # save with relative paths
+    we = extract_waveforms(recording, sorting, wf_folder,
+                           use_relative_path=True)
+
+    shutil.rmtree(cache_folder / "recording_dummy")
+    shutil.rmtree(cache_folder / "sorting_dummy")
+
+    # move all to a separate folder
+    we_loaded = WaveformExtractor.load_from_folder(wf_folder)
+
+    assert we_loaded.recording is not None
+    assert we_loaded.sorting is not None
+    print(we_loaded.recording, we_loaded.sorting)
+    assert isinstance(we_loaded.recording, DummyRecording)
+    assert isinstance(we_loaded.sorting, DummySorting)
+
+
 if __name__ == '__main__':
-    test_WaveformExtractor()
-    test_extract_waveforms()
-    test_sparsity()
-    test_portability()
+    # test_WaveformExtractor()
+    # test_extract_waveforms()
+    # test_sparsity()
+    # test_portability()
+    test_dummy_objects()

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -288,8 +288,8 @@ def test_dummy_objects():
     we = extract_waveforms(recording, sorting, wf_folder,
                            use_relative_path=True)
 
-    shutil.rmtree(cache_folder / "recording_dummy")
-    shutil.rmtree(cache_folder / "sorting_dummy")
+    (cache_folder / "recording_dummy").rename(cache_folder / "recording_dummy2")
+    (cache_folder / "sorting_dummy").rename(cache_folder / "sorting_dummy2")
 
     # move all to a separate folder
     we_loaded = WaveformExtractor.load_from_folder(wf_folder)
@@ -302,8 +302,8 @@ def test_dummy_objects():
 
 
 if __name__ == '__main__':
-    # test_WaveformExtractor()
-    # test_extract_waveforms()
-    # test_sparsity()
-    # test_portability()
+    test_WaveformExtractor()
+    test_extract_waveforms()
+    test_sparsity()
+    test_portability()
     test_dummy_objects()

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -9,7 +9,7 @@ from .base import load_extractor
 
 from .core_tools import check_json
 from .job_tools import _shared_job_kwargs_doc
-from .dummy import dummy_recording, dummy_sorting
+from .dummy import dummy_recording, dummy_sorting, DummyRecording
 
 from spikeinterface.core.waveform_tools import extract_waveforms_to_buffers
 
@@ -62,9 +62,11 @@ class WaveformExtractor:
             np.testing.assert_almost_equal(recording.get_sampling_frequency(),
                                            sorting.get_sampling_frequency(), decimal=2)
 
-            if not recording.is_filtered():
-                raise Exception('The recording is not filtered, you must filter it using `bandpass_filter()`.'
-                                'If the recording is already filtered, you can also do `recording.annotate(is_filtered=True)')
+            if not isinstance(recording, DummyRecording):
+                if not recording.is_filtered():
+                    raise Exception('The recording is not filtered, you must filter it using `bandpass_filter()`.'
+                                    'If the recording is already filtered, you can also do '
+                                    '`recording.annotate(is_filtered=True)')
         else:
             warn("Recording and Sorting objects will not be available for additional computations!")
 


### PR DESCRIPTION
- implements `DummyRecording` and `DummySorting`
- these objects keep all the metadata needed for most operations. The only unavailable operations are retreiving traces and spike strains
- allow to load a WaveformExtractor without access to original data