### PR TITLE
Hide diagonal in similarity plot

### DIFF
--- a/spikeinterface/widgets/template_similarity.py
+++ b/spikeinterface/widgets/template_similarity.py
@@ -15,8 +15,11 @@ class TemplateSimilarityWidget(BaseWidget):
     ----------
     waveform_extractor : WaveformExtractor
         The object to compute/get template similarity from
-    unit_ids: list
+    unit_ids : list
         List of unit ids.
+    display_diagonal_values : bool
+        If False, the diagonal is displayed as zeros.
+        If True, the similarity values (all 1s) are displayed. Default False
     cmap : Matplotlib colormap
         The matplotlib colormap. Default 'viridis'. (matplotlib backend)
     show_unit_ticks : bool
@@ -27,7 +30,7 @@ class TemplateSimilarityWidget(BaseWidget):
     possible_backends = {}
 
     def __init__(self, waveform_extractor: WaveformExtractor,
-                 unit_ids=None, cmap='viridis',
+                 unit_ids=None, cmap='viridis', display_diagonal_values=False,
                  show_unit_ticks=False, show_colorbar=True,
                  backend=None, **backend_kwargs):
         self.check_extensions(waveform_extractor, "similarity")
@@ -40,6 +43,9 @@ class TemplateSimilarityWidget(BaseWidget):
         else:
             unit_indices = sorting.ids_to_indices(unit_ids)
             similarity = similarity[unit_indices][:, unit_indices]
+
+        if not display_diagonal_values:
+            np.fill_diagonal(similarity, 0)
 
         plot_data = dict(
             similarity=similarity,


### PR DESCRIPTION
- Adds the `display_diagonal_values` (default `False`) to zero out values on diagonal of similarity plot (which are all ones...)