### PR TITLE
Implement sparse PCA

### DIFF
--- a/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -7,7 +7,8 @@ import numpy as np
 from spikeinterface import extract_waveforms, WaveformExtractor
 from spikeinterface.extractors import toy_example
 
-from spikeinterface.postprocessing import WaveformPrincipalComponent, compute_principal_components
+from spikeinterface.postprocessing import (WaveformPrincipalComponent, compute_principal_components,
+                                           get_template_channel_sparsity)
 
 
 if hasattr(pytest, "global_test_folder"):
@@ -186,6 +187,73 @@ def test_pca_models_and_project_new():
     assert new_proj.shape == (100, n_components)
 
 
+def test_sparse_principal_components():
+    we = WaveformExtractor.load_from_folder(cache_folder / 'toy_waveforms_2seg')
+    unit_ids = we.sorting.unit_ids
+    num_channels = we.recording.get_num_channels()
+    pc = WaveformPrincipalComponent(we)
+
+    sparsity_radius = get_template_channel_sparsity(we, method="radius",
+                                                    radius_um=50)
+    sparsity_best = get_template_channel_sparsity(we, method="best_channels",
+                                                  num_channels=2)
+    sparsities = [sparsity_radius, sparsity_best]
+    print(sparsities)
+
+    for mode in ('by_channel_local', 'by_channel_global'):
+        for sparsity in sparsities:
+            pc.set_params(n_components=5, mode=mode, sparsity=sparsity)
+            print(pc)
+            pc.run()
+            for i, unit_id in enumerate(unit_ids):
+                proj = pc.get_projections(unit_id)
+                # print(comp.shape)
+                assert proj.shape[1:] == (5, 4)
+
+            # import matplotlib.pyplot as plt
+            # plt.ion()
+            # cmap = plt.get_cmap('jet', len(unit_ids))
+            # fig, axs = plt.subplots(nrows=len(unit_ids), ncols=num_channels)
+            # for i, unit_id in enumerate(unit_ids):
+            #     comp = pc.get_projections(unit_id)
+            #     print(comp.shape)
+            #     for chan_ind in range(num_channels):
+            #         ax = axs[i, chan_ind]
+            #         ax.scatter(comp[:, 0, chan_ind], comp[:, 1, chan_ind], color=cmap(i))
+            #         ax.set_title(f"{mode}-{sparsity[unit_id]}")
+            #         if i == 0:
+            #             ax.set_xlabel(f"Ch{chan_ind}")
+            # plt.show()
+
+    for mode in ('concatenated',):
+        # concatenated is only compatible with "best"
+        pc.set_params(n_components=5, mode=mode, sparsity=sparsity_best)
+        print(pc)
+        pc.run()
+        for i, unit_id in enumerate(unit_ids):
+            proj = pc.get_projections(unit_id)
+            assert proj.shape[1] == 5
+            # print(comp.shape)
+
+    all_labels, all_components = pc.get_all_projections()
+
+    # relod as an extension from we
+    assert WaveformPrincipalComponent in we.get_available_extensions()
+    assert we.is_extension('principal_components')
+    pc = we.load_extension('principal_components')
+    assert isinstance(pc, WaveformPrincipalComponent)
+    pc = WaveformPrincipalComponent.load_from_folder(
+        cache_folder / 'toy_waveforms_2seg')
+
+    # import matplotlib.pyplot as plt
+    # cmap = plt.get_cmap('jet', len(unit_ids))
+    # fig, ax = plt.subplots()
+    # for i, unit_id in enumerate(unit_ids):
+    # comp = pca.get_components(unit_id)
+    # print(comp.shape)
+    # ax.scatter(comp[:, 0], comp[:, 1], color=cmap(i))
+    # plt.show()
+
 def test_select_units():
     we = WaveformExtractor.load_from_folder(
         cache_folder / 'toy_waveforms_1seg')
@@ -201,4 +269,5 @@ if __name__ == '__main__':
     setup_module()
     #~ test_WaveformPrincipalComponent()
     #~ test_compute_principal_components_for_all_spikes()
-    test_pca_models_and_project_new()
+    # test_pca_models_and_project_new()
+    test_sparse_principal_components()


### PR DESCRIPTION
### Implementation of sparse PCA:

For `by_channel_local` and `by_channel_local` modes:
- restrict waveform fit and projection to channels in sparsity for each unit id
- sparsity doesn't need to have the same number of channels for each unit

For `concatenated` mode:
- in this case we check that the number of channels on the sparsity of each unit is the same (due to concatenation).

### Benchmark on simulated Neuropixels 384 - 30 min - 200 units (4 jobs):

- No sparsity: > 30 min

- Sparsity (radius - 200um): < 3 min
- 
![image](https://user-images.githubusercontent.com/17097257/192901712-7e23daa5-2e37-40c7-b4a7-cf86b33d50d0.png)
