### PR TITLE
Fix plot_unit/spike_locations legend

### DIFF
--- a/spikeinterface/comparison/basecomparison.py
+++ b/spikeinterface/comparison/basecomparison.py
@@ -278,9 +278,11 @@ class MixinSpikeTrainComparison:
         self.delta_frames = None
         
     def set_frames_and_frequency(self, sorting_list):
-        if not np.all(sorting.get_num_segments() == 1 for sorting in sorting_list):
-            raise Exception(
-                'Comparison module work with sorting having num_segments=1')
+        sorting0 = sorting_list[0]
+        # check num segments
+        if not np.all(sorting.get_num_segments() == sorting0.get_num_segments()
+                      for sorting in sorting_list):
+            raise Exception('Sorting objects must have the same number of segments.')
 
         # take sampling frequency from sorting list and test that they are equivalent.
         sampling_freqs = np.array([sorting.get_sampling_frequency()

--- a/spikeinterface/comparison/collisioncomparison.py
+++ b/spikeinterface/comparison/collisioncomparison.py
@@ -20,6 +20,9 @@ class CollisionGTComparison(GroundTruthComparison):
         # Force compute labels
         kwargs['compute_labels'] = True
 
+        if gt_sorting.get_num_segments() > 1 or tested_sorting.get_num_segments() > 1:
+            raise NotImplementedError("Collision comparison is only available for mono-segment sorting objects")
+
         GroundTruthComparison.__init__(self, gt_sorting, tested_sorting, **kwargs)
 
         self.collision_lag = collision_lag

--- a/spikeinterface/comparison/correlogramcomparison.py
+++ b/spikeinterface/comparison/correlogramcomparison.py
@@ -20,6 +20,9 @@ class CorrelogramGTComparison(GroundTruthComparison):
         # Force compute labels
         kwargs['compute_labels'] = True
 
+        if gt_sorting.get_num_segments() > 1 or tested_sorting.get_num_segments() > 1:
+            raise NotImplementedError("Correlogram comparison is only available for mono-segment sorting objects")
+
         GroundTruthComparison.__init__(self, gt_sorting, tested_sorting, **kwargs)
 
         self.window_ms = window_ms

--- a/spikeinterface/comparison/multicomparisons.py
+++ b/spikeinterface/comparison/multicomparisons.py
@@ -60,6 +60,7 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
         self.set_frames_and_frequency(self.object_list)
         self._spiketrain_mode = spiketrain_mode
         self._spiketrains = None
+        self._num_segments = sorting_list[0].get_num_segments()
 
         if do_matching:
             self._compute_all()
@@ -84,36 +85,40 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
 
     def _populate_spiketrains(self):
         self._spiketrains = []
-        for (unit_id, sg) in zip(self._new_units, self.subgraphs):
-            sorter_unit_ids = self._new_units[unit_id]["unit_ids"]
-            edges = list(sg.edges(data=True))
-            # Append correct spike train
-            if len(sorter_unit_ids.keys()) == 1:
-                self._spiketrains.append(self.object_list[self.name_list.index(
-                    list(sorter_unit_ids.keys())[0])].get_unit_spike_train(list(sorter_unit_ids.values())[0]))
-            else:
-                max_edge = edges[int(np.argmax([d['weight']
-                                     for u, v, d in edges]))]
-                node1, node2, weight = max_edge
-                sorter1, unit1 = node1
-                sorter2, unit2 = node2
-                sp1 = self.object_list[self.name_list.index(
-                    sorter1)].get_unit_spike_train(unit1)
-                sp2 = self.object_list[self.name_list.index(
-                    sorter2)].get_unit_spike_train(unit2)
+        for seg_index in range(self._num_segments):
+            spike_trains_segment = dict()
+            for (unit_id, sg) in zip(self._new_units, self.subgraphs):
+                sorter_unit_ids = self._new_units[unit_id]["unit_ids"]
+                edges = list(sg.edges(data=True))
+                # Append correct spike train
+                if len(sorter_unit_ids.keys()) == 1:
+                    sorting = self.object_list[self.name_list.index(list(sorter_unit_ids.keys())[0])]
+                    unit_id = list(sorter_unit_ids.values())[0]
+                    spike_train = sorting.get_unit_spike_train(unit_id, seg_index)
+                else:
+                    max_edge = edges[int(np.argmax([d['weight']
+                                        for u, v, d in edges]))]
+                    node1, node2, weight = max_edge
+                    sorter1, unit1 = node1
+                    sorter2, unit2 = node2
 
-                if self._spiketrain_mode == 'union':
-                    lab1, lab2 = compare_spike_trains(sp1, sp2)
-                    # add FP to spike train 1 (FP are the only spikes outside the union)
-                    fp_idx2 = np.where(np.array(lab2) == 'FP')[0]
-                    sp_union = np.sort(np.concatenate((sp1, sp2[fp_idx2])))
-                    self._spiketrains.append(list(sp_union))
-                elif self._spiketrain_mode == 'intersection':
-                    lab1, lab2 = compare_spike_trains(sp1, sp2)
-                    # TP are the spikes in the intersection
-                    tp_idx1 = np.where(np.array(lab1) == 'TP')[0]
-                    sp_tp1 = list(np.array(sp1)[tp_idx1])
-                    self._spiketrains.append(sp_tp1)
+                    sorting1 = self.object_list[self.name_list.index(sorter1)]
+                    sorting2 = self.object_list[self.name_list.index(sorter2)]
+                    sp1 = sorting1.get_unit_spike_train(unit1, seg_index)
+                    sp2 = sorting2.get_unit_spike_train(unit2, seg_index)
+                    if self._spiketrain_mode == 'union':
+                        lab1, lab2 = compare_spike_trains(sp1, sp2)
+                        # add FP to spike train 1 (FP are the only spikes outside the union)
+                        fp_idx2 = np.where(np.array(lab2) == 'FP')[0]
+                        spike_train = np.sort(np.concatenate((sp1, sp2[fp_idx2])))
+                    elif self._spiketrain_mode == 'intersection':
+                        lab1, lab2 = compare_spike_trains(sp1, sp2)
+                        # TP are the spikes in the intersection
+                        tp_idx1 = np.where(np.array(lab1) == 'TP')[0]
+                        spike_train = np.array(sp1)[tp_idx1]
+                spike_trains_segment[unit_id] = spike_train
+            self._spiketrains.append(spike_trains_segment)
+
 
     def _do_agreement_matrix(self, minimum_agreement=1):
         sorted_name_list = sorted(self.name_list)
@@ -213,26 +218,26 @@ class AgreementSortingExtractor(BaseSorting):
             unit_ids = list(u for u in self._msc._new_units.keys()
                             if self._msc._new_units[u]['agreement_number'] >= min_agreement_count)
 
-        BaseSorting.__init__(
-            self, sampling_frequency=sampling_frequency, unit_ids=unit_ids)
+        BaseSorting.__init__(self, sampling_frequency=sampling_frequency, unit_ids=unit_ids)
+
         if len(unit_ids) > 0:
             for k in ('agreement_number', 'avg_agreement', 'unit_ids'):
                 values = [self._msc._new_units[unit_id][k]
                           for unit_id in unit_ids]
                 self.set_property(k, values, ids=unit_ids)
 
-        sorting_segment = AgreementSortingSegment(multisortingcomparison)
-        self.add_sorting_segment(sorting_segment)
+        for segment_index in range(multisortingcomparison._num_segments):
+            sorting_segment = AgreementSortingSegment(multisortingcomparison._spiketrains[segment_index])
+            self.add_sorting_segment(sorting_segment)
 
 
 class AgreementSortingSegment(BaseSortingSegment):
-    def __init__(self, multisortingcomparison):
+    def __init__(self, spiketrains_segment):
         BaseSortingSegment.__init__(self)
-        self._msc = multisortingcomparison
+        self.spiketrains = spiketrains_segment
 
     def get_unit_spike_train(self, unit_id, start_frame, end_frame):
-        ind = list(self._msc._new_units.keys()).index(unit_id)
-        spiketrain = np.array(self._msc._spiketrains[ind])
+        spiketrain = self.spiketrains[unit_id]
         if start_frame is not None:
             spiketrain = spiketrain[spiketrain >= start_frame]
         if end_frame is not None:

--- a/spikeinterface/comparison/paircomparisons.py
+++ b/spikeinterface/comparison/paircomparisons.py
@@ -21,6 +21,8 @@ class BasePairSorterComparison(BasePairComparison, MixinSpikeTrainComparison):
             sorting1_name = 'sorting1'
         if sorting2_name is None:
             sorting2_name = 'sorting2'
+        assert sorting1.get_num_segments() == sorting2.get_num_segments(), ("The two sortings must have the same "
+                                                                            "number of segments! ")
 
         BasePairComparison.__init__(self, object1=sorting1, object2=sorting2, 
                                     name1=sorting1_name, name2=sorting2_name,

--- a/spikeinterface/comparison/tests/test_comparisontools.py
+++ b/spikeinterface/comparison/tests/test_comparisontools.py
@@ -120,20 +120,20 @@ def test_do_score_labels():
                                       [101, 201, 301, ], [0, 0, 5])
     unit_map12 = {0: 0, 1: 5}
     labels_st1, labels_st2 = do_score_labels(sorting1, sorting2, delta_frames, unit_map12)
-    assert_array_equal(labels_st1[0], ['TP', 'TP', 'FN'])
-    assert_array_equal(labels_st1[1], ['TP', ])
-    assert_array_equal(labels_st2[0], ['TP', 'TP'])
-    assert_array_equal(labels_st2[5], ['TP', ])
+    assert_array_equal(labels_st1[0][0], ['TP', 'TP', 'FN'])
+    assert_array_equal(labels_st1[1][0], ['TP', ])
+    assert_array_equal(labels_st2[0][0], ['TP', 'TP'])
+    assert_array_equal(labels_st2[5][0], ['TP', ])
 
     # match when 2 units fire at same time
     sorting1, sorting2 = make_sorting([100, 100, 200, 200, 300], [0, 1, 0, 1, 0],
                                       [100, 100, 200, 200, 300], [0, 1, 0, 1, 0], )
     unit_map12 = {0: 0, 1: 1}
     labels_st1, labels_st2 = do_score_labels(sorting1, sorting2, delta_frames, unit_map12)
-    assert_array_equal(labels_st1[0], ['TP', 'TP', 'TP'])
-    assert_array_equal(labels_st1[1], ['TP', 'TP', ])
-    assert_array_equal(labels_st2[0], ['TP', 'TP', 'TP'])
-    assert_array_equal(labels_st2[1], ['TP', 'TP', ])
+    assert_array_equal(labels_st1[0][0], ['TP', 'TP', 'TP'])
+    assert_array_equal(labels_st1[1][0], ['TP', 'TP', ])
+    assert_array_equal(labels_st2[0][0], ['TP', 'TP', 'TP'])
+    assert_array_equal(labels_st2[1][0], ['TP', 'TP', ])
 
 
 def test_compare_spike_trains():

--- a/spikeinterface/comparison/tests/test_groundtruthcomparison.py
+++ b/spikeinterface/comparison/tests/test_groundtruthcomparison.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from spikeinterface.extractors import NumpySorting
+from spikeinterface.extractors import NumpySorting, toy_example
 from spikeinterface.comparison import compare_sorter_to_ground_truth
 
 
@@ -138,6 +138,7 @@ def test_get_performance():
     perf = sc.get_performance('pooled_with_average')
     assert perf['accuracy'] == 1.
     assert perf['miss_rate'] == 0.
+
 
 
 if __name__ == '__main__':

--- a/spikeinterface/comparison/tests/test_multisortingcomparison.py
+++ b/spikeinterface/comparison/tests/test_multisortingcomparison.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from spikeinterface.extractors import NumpySorting
+from spikeinterface.extractors import NumpySorting, toy_example
 from spikeinterface.comparison import compare_multiple_sorters, MultiSortingComparison
 
 
@@ -62,6 +62,26 @@ def test_compare_multiple_sorters():
     # sw.plot_multicomp_agreement(msc)
     # sw.plot_multicomp_agreement_by_sorter(msc)
     # plt.show()
+
+
+def test_compare_multi_segment():
+    num_segments = 3
+    _, sort = toy_example(num_segments=num_segments)
+
+    cmp_multi = compare_multiple_sorters([sort, sort, sort])
+
+    for k, cmp in cmp_multi.comparisons.items():
+        assert np.allclose(np.diag(cmp.agreement_scores), np.ones(len(sort.unit_ids)))
+
+    sort_agr = cmp_multi.get_agreement_sorting(minimum_agreement_count=num_segments)
+    assert len(sort_agr.unit_ids) == len(sort.unit_ids)
+    assert sort_agr.get_num_segments() == num_segments
+
+    # test that all spike trains from different segments can be retrieved
+    for unit in sort_agr.unit_ids:
+        for seg_index in range(num_segments):
+            st = sort_agr.get_unit_spike_train(unit, seg_index)
+            print(f"Segment {seg_index} unit {unit}: {st}")
 
 
 if __name__ == '__main__':

--- a/spikeinterface/comparison/tests/test_symmetricsortingcomparison.py
+++ b/spikeinterface/comparison/tests/test_symmetricsortingcomparison.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from spikeinterface.extractors import NumpySorting
+from spikeinterface.extractors import NumpySorting, toy_example
 from spikeinterface.comparison import compare_two_sorters
 
 
@@ -20,5 +20,14 @@ def test_compare_two_sorters():
     print(sc.agreement_scores)
 
 
+def test_compare_multi_segment():
+    _, sort = toy_example(num_segments=2)
+
+    cmp_multi = compare_two_sorters(sort, sort)
+
+    assert np.allclose(np.diag(cmp_multi.agreement_scores), np.ones(len(sort.unit_ids)))
+
+
 if __name__ == '__main__':
     test_compare_two_sorters()
+    test_compare_multi_segment()

--- a/spikeinterface/core/__init__.py
+++ b/spikeinterface/core/__init__.py
@@ -48,6 +48,9 @@ from .segmentutils import (
     SplitSegmentSorting,
 )
 
+# dummy objects
+from .dummy import dummy_recording, dummy_sorting
+
 # default folder
 from .default_folders import (set_global_tmp_folder, get_global_tmp_folder,
                               is_set_global_tmp_folder, reset_global_tmp_folder,

--- a/spikeinterface/core/core_tools.py
+++ b/spikeinterface/core/core_tools.py
@@ -115,29 +115,15 @@ def check_json(d):
                         v_arr = v_arr.astype('int32')
                     if v_arr.dtype == np.dtype('float64'):
                         v_arr = v_arr.astype('float32')
-                    if len(v_arr.shape) == 1:
-                        if 'int' in str(v_arr.dtype):
-                            v_arr = [int(v_el) for v_el in v_arr]
-                            dc[k] = v_arr
-                        elif 'float' in str(v_arr.dtype):
-                            v_arr = [float(v_el) for v_el in v_arr]
-                            dc[k] = v_arr
-                        elif isinstance(v_arr[0], str):
-                            v_arr = [str(v_el) for v_el in v_arr]
-                            dc[k] = v_arr
+
+                    if v_arr.dtype.kind in ("u", "i", "f", "b", "S", "U"):
+                        if len(v_arr.shape) < 4:
+                            dc[k] = v_arr.tolist()
                         else:
-                            print(f'Skipping field {k}: only 1D arrays of int, float, or str types can be serialized')
-                    elif len(v_arr.shape) == 2:
-                        if 'int' in str(v_arr.dtype):
-                            v_arr = [[int(v_el) for v_el in v_row] for v_row in v_arr]
-                            dc[k] = v_arr
-                        elif 'float' in str(v_arr.dtype):
-                            v_arr = [[float(v_el) for v_el in v_row] for v_row in v_arr]
-                            dc[k] = v_arr
-                        else:
-                            print(f'Skipping field {k}: only 2D arrays of int or float type can be serialized')
+                            print(f"Skipping field {k}: only 1/2/3d arraysc can be serialized")
                     else:
-                        print(f"Skipping field {k}: only 1D and 2D arrays can be serialized")
+                        print(f"Dtype {v_arr.dtype} can't be serialized. Skipping!")
+                        del dc[k]
             else:
                 dc[k] = list(v)
     return dc

--- a/spikeinterface/core/dummy.py
+++ b/spikeinterface/core/dummy.py
@@ -1,0 +1,116 @@
+from probeinterface import ProbeGroup
+
+from .baserecording import BaseRecording, BaseRecordingSegment
+from .basesorting import BaseSorting, BaseSortingSegment
+from .core_tools import define_function_from_class
+
+
+class DummyRecording(BaseRecording):
+    """
+    Dummy recording class that enables to retrieve Recording metadata
+    with the same interface as a BaseRecording object.
+
+    The get_traces() method is not available.
+
+    Parameters
+    ----------
+    recording: BaseRecording
+        The recording to make "dummy"
+
+    Returns
+    -------
+    BaseRecording
+        The dummy recording object
+
+    """
+
+    def __init__(self, recording=None, channel_ids=None, num_segments=None,
+                 sampling_frequency=None, dtype=None, probegroup=None):
+
+        if recording is not None:
+            channel_ids = recording.channel_ids
+            sampling_frequency = recording.get_sampling_frequency()
+            num_segments = recording.get_num_segments()
+            dtype = recording.get_dtype()
+            probegroup = recording.get_probegroup()
+        else:
+            assert channel_ids is not None
+            assert sampling_frequency is not None
+            assert num_segments is not None
+            assert dtype is not None
+
+        BaseRecording.__init__(self, sampling_frequency, channel_ids, dtype)
+
+        for segment_index in range(num_segments):
+            segment = DummyRecordingSegment(
+                sampling_frequency=sampling_frequency)
+            self.add_recording_segment(segment)
+
+        if probegroup is not None:
+            if isinstance(probegroup, dict):
+                probegroup = ProbeGroup.from_dict(probegroup)
+            self.set_probegroup(probegroup, in_place=True)
+
+        self._kwargs = dict(
+            channel_ids=channel_ids, sampling_frequency=sampling_frequency,
+            num_segments=num_segments, dtype=str(dtype),
+            probegroup=probegroup.to_dict() if probegroup is not None else None
+        )
+
+
+class DummyRecordingSegment(BaseRecordingSegment):
+
+    def get_num_samples(self) -> int:
+        return 0
+
+
+dummy_recording = define_function_from_class(DummyRecording, "dummy_recording")
+
+
+class DummySorting(BaseSorting):
+    """
+    Dummy sorting class that enables to retrieve Sorting metadata
+    with the same interface as a BaseSorting object.
+
+    The get_unit_spike_train() method is not available.
+
+    Parameters
+    ----------
+    sorting: BaseSorting
+        The sorting to make "dummy"
+
+    Returns
+    -------
+    BaseSorting
+        The dummy sorting object  
+    """
+
+    def __init__(self, sorting=None, unit_ids=None, num_segments=None,
+                 sampling_frequency=None):
+
+        if sorting is not None:
+            unit_ids = sorting.unit_ids
+            sampling_frequency = sorting.get_sampling_frequency()
+            num_segments = sorting.get_num_segments()
+        else:
+            assert unit_ids is not None
+            assert sampling_frequency is not None
+            assert num_segments is not None
+
+        BaseSorting.__init__(self, sampling_frequency, unit_ids)
+
+        for segment_index in range(num_segments):
+            segment = DummySortingSegment()
+            self.add_sorting_segment(segment)
+
+        self._kwargs = dict(
+            unit_ids=unit_ids, sampling_frequency=sampling_frequency,
+            num_segments=num_segments
+        )
+
+
+class DummySortingSegment(BaseSortingSegment):
+    pass
+
+
+dummy_sorting = define_function_from_class(DummySorting, "dummy_sorting")

--- a/spikeinterface/core/npzsortingextractor.py
+++ b/spikeinterface/core/npzsortingextractor.py
@@ -22,6 +22,7 @@ class NpzSortingExtractor(BaseSorting):
     def __init__(self, file_path):
 
         self.npz_filename = file_path
+        parent_folder = Path(file_path).parent
 
         npz = np.load(file_path)
         num_segment = int(npz['num_segment'][0])
@@ -35,6 +36,9 @@ class NpzSortingExtractor(BaseSorting):
             spike_labels = npz[f'spike_labels_seg{seg_index}']
             sorting_segment = NpzSortingSegment(spike_indexes, spike_labels)
             self.add_sorting_segment(sorting_segment)
+
+        if (parent_folder / "properties").is_dir():
+            self.load_metadata_from_folder(parent_folder)
 
         self._kwargs = {'file_path': str(Path(file_path).absolute())}
 

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -2,9 +2,11 @@ import pytest
 from pathlib import Path
 import shutil
 import numpy as np
+import platform
 
 from spikeinterface.core.testing_tools import generate_recording, generate_sorting
 from spikeinterface import WaveformExtractor, extract_waveforms
+from spikeinterface.core.dummy import DummyRecording, DummySorting
 
 
 if hasattr(pytest, "global_test_folder"):
@@ -247,8 +249,63 @@ def test_portability():
         assert np.allclose(wf, wf_loaded)
 
 
+def test_dummy_objects():
+    durations = [30, 40]
+    sampling_frequency = 30000.
+
+    # 2 segments
+    num_channels = 2
+    recording = generate_recording(num_channels=num_channels, durations=durations,
+                                   sampling_frequency=sampling_frequency)
+    recording.annotate(is_filtered=True)
+    num_units = 15
+    sorting = generate_sorting(
+        num_units=num_units, sampling_frequency=sampling_frequency, durations=durations)
+
+    # recording and sorting are not dumpable
+    wf_folder = cache_folder / "wf_dummy1"
+
+    # save with relative paths
+    we = extract_waveforms(recording, sorting, wf_folder,
+                           use_relative_path=True)
+
+    # move all to a separate folder
+    we_loaded = WaveformExtractor.load_from_folder(wf_folder)
+
+    assert we_loaded.recording is not None
+    assert we_loaded.sorting is not None
+    print(we_loaded.recording, we_loaded.sorting)
+    assert isinstance(we_loaded.recording, DummyRecording)
+    assert isinstance(we_loaded.sorting, DummySorting)
+
+    # now save and delete saved file
+    recording = recording.save(folder=cache_folder / "recording_dummy")
+    sorting = sorting.save(folder=cache_folder / "sorting_dummy")
+
+    # recording and sorting are not dumpable
+    wf_folder = cache_folder / "wf_dummy2"
+
+    # save with relative paths
+    we = extract_waveforms(recording, sorting, wf_folder,
+                           use_relative_path=True)
+
+    if platform.system() != "Windows":
+        shutil.rmtree(cache_folder / "recording_dummy")
+        shutil.rmtree(cache_folder / "sorting_dummy")
+
+        # move all to a separate folder
+        we_loaded = WaveformExtractor.load_from_folder(wf_folder)
+
+        assert we_loaded.recording is not None
+        assert we_loaded.sorting is not None
+        print(we_loaded.recording, we_loaded.sorting)
+        assert isinstance(we_loaded.recording, DummyRecording)
+        assert isinstance(we_loaded.sorting, DummySorting)
+
+
 if __name__ == '__main__':
     test_WaveformExtractor()
     test_extract_waveforms()
     test_sparsity()
     test_portability()
+    test_dummy_objects()

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import shutil
 import json
+from warnings import warn
 
 import numpy as np
 
@@ -8,9 +9,12 @@ from .base import load_extractor
 
 from .core_tools import check_json
 from .job_tools import _shared_job_kwargs_doc
+from .dummy import dummy_recording, dummy_sorting, DummyRecording
+
 from spikeinterface.core.waveform_tools import extract_waveforms_to_buffers
 
 _possible_template_modes = ('average', 'std', 'median')
+
 
 class WaveformExtractor:
     """
@@ -20,11 +24,11 @@ class WaveformExtractor:
     Parameters
     ----------
     recording: Recording
-        The recording object
+        The recording object (or None)
     sorting: Sorting
-        The sorting object
+        The sorting object (or None)
     folder: Path
-        The folder where waveforms are cached
+        The folder where waveforms are cached (or None for memory mode)
 
     Returns
     -------
@@ -51,14 +55,20 @@ class WaveformExtractor:
     """
     extensions = []
     def __init__(self, recording, sorting, folder=None):
-        assert recording.get_num_segments() == sorting.get_num_segments(), \
-            "The recording and sorting objects must have the same number of segments!"
-        np.testing.assert_almost_equal(recording.get_sampling_frequency(),
-                                       sorting.get_sampling_frequency(), decimal=2)
+        if recording is not None and sorting is not None:
+            assert sorting is not None
+            assert recording.get_num_segments() == sorting.get_num_segments(), \
+                "The recording and sorting objects must have the same number of segments!"
+            np.testing.assert_almost_equal(recording.get_sampling_frequency(),
+                                           sorting.get_sampling_frequency(), decimal=2)
 
-        if not recording.is_filtered():
-            raise Exception('The recording is not filtered, you must filter it using `bandpass_filter()`.'
-                            'If the recording is already filtered, you can also do `recording.annotate(is_filtered=True)')
+            if not isinstance(recording, DummyRecording):
+                if not recording.is_filtered():
+                    raise Exception('The recording is not filtered, you must filter it using `bandpass_filter()`.'
+                                    'If the recording is already filtered, you can also do '
+                                    '`recording.annotate(is_filtered=True)')
+        else:
+            warn("Recording and Sorting objects will not be available for additional computations!")
 
         self.recording = recording
         self.sorting = sorting
@@ -93,10 +103,23 @@ class WaveformExtractor:
     def load_from_folder(cls, folder):
         folder = Path(folder)
         assert folder.is_dir(), f'This folder does not exists {folder}'
-        recording = load_extractor(folder / 'recording.json',
-                                   base_folder=folder)
-        sorting = load_extractor(folder / 'sorting.json',
-                                 base_folder=folder)
+        try:
+            recording = load_extractor(folder / 'recording.json',
+                                       base_folder=folder)
+        except Exception as e:
+            if (folder / 'recording_dummy.json').is_file():
+                recording = load_extractor(folder / 'recording_dummy.json')
+            else:
+                recording = None
+        try:
+            sorting = load_extractor(folder / 'sorting.json',
+                                     base_folder=folder)
+        except Exception as e:
+            if (folder / 'sorting_dummy.json').is_file():
+                sorting = load_extractor(folder / 'sorting_dummy.json')
+            else:
+                sorting = None
+
         we = cls(recording, sorting, folder)
 
         for mode in _possible_template_modes:
@@ -129,6 +152,12 @@ class WaveformExtractor:
                 recording.dump(folder / 'recording.json', relative_to=relative_to)
             if sorting.is_dumpable:
                 sorting.dump(folder / 'sorting.json', relative_to=relative_to)
+            # dump dummy objects
+            recording_dummy = dummy_recording(recording)
+            sorting_dummy = dummy_sorting(sorting)
+
+            recording_dummy.dump(folder / 'recording_dummy.json')
+            sorting_dummy.dump(folder / 'sorting_dummy.json')
 
         return cls(recording, sorting, folder)
 
@@ -353,6 +382,9 @@ class WaveformExtractor:
                             new_folder / "params.json")
             shutil.copyfile(self.folder / "recording.json",
                             new_folder / "recording.json")
+            if (self.folder / "recording_dummy.json").is_file():
+                shutil.copyfile(self.folder / "recording_dummy.json",
+                                new_folder / "recording_dummy.json")
 
             if use_relative_path:
                 relative_to = new_folder
@@ -360,6 +392,8 @@ class WaveformExtractor:
                 relative_to = None
 
             sorting.dump(new_folder / 'sorting.json', relative_to=relative_to)
+            sorting_dummy = dummy_sorting(sorting)
+            sorting_dummy.dump(new_folder / 'sorting_dummy.json')
 
             # create and populate waveforms folder
             new_waveforms_folder = new_folder / "waveforms"

--- a/spikeinterface/postprocessing/spike_amplitudes.py
+++ b/spikeinterface/postprocessing/spike_amplitudes.py
@@ -216,7 +216,6 @@ def _spike_amplitudes_chunk(segment_index, start_frame, end_frame, worker_ctx):
     peak_shifts = worker_ctx['peak_shifts']
     
     seg_size = recording.get_num_samples(segment_index=segment_index)
-    unit_ids = worker_ctx['sorting'].unit_ids
 
     spike_times, spike_labels = all_spikes[segment_index]
     d = np.diff(spike_times)
@@ -225,8 +224,8 @@ def _spike_amplitudes_chunk(segment_index, start_frame, end_frame, worker_ctx):
     i0 = np.searchsorted(spike_times, start_frame)
     i1 = np.searchsorted(spike_times, end_frame)
     
-    n_spike = i1 - i0
-    amplitudes = np.zeros(n_spike, dtype=recording.get_dtype())
+    n_spikes = i1 - i0
+    amplitudes = np.zeros(n_spikes, dtype=recording.get_dtype())
     
     if i0 != i1:
         # some spike in the chunk
@@ -236,7 +235,7 @@ def _spike_amplitudes_chunk(segment_index, start_frame, end_frame, worker_ctx):
         sample_inds = spike_times[i0:i1].copy()
         labels = spike_labels[i0:i1]
         
-        # apply shifts  per spike
+        # apply shifts per spike
         sample_inds += peak_shifts[labels]
         
         # get channels per spike
@@ -244,14 +243,15 @@ def _spike_amplitudes_chunk(segment_index, start_frame, end_frame, worker_ctx):
         
         # prevent border accident due to shift
         sample_inds[sample_inds < 0] = 0
-        sample_inds[sample_inds >= seg_size] = seg_size
+        sample_inds[sample_inds >= seg_size] = seg_size - 1
         
         first = np.min(sample_inds)
         last = np.max(sample_inds)
         sample_inds -= first
         
         # load trace in memory
-        traces = recording.get_traces(start_frame=first, end_frame=last+1, segment_index=segment_index,
+        traces = recording.get_traces(start_frame=first, end_frame=last+1, 
+                                      segment_index=segment_index,
                                       return_scaled=return_scaled)
         
         # and get amplitudes

--- a/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -7,7 +7,8 @@ import numpy as np
 from spikeinterface import extract_waveforms, WaveformExtractor
 from spikeinterface.extractors import toy_example
 
-from spikeinterface.postprocessing import WaveformPrincipalComponent, compute_principal_components
+from spikeinterface.postprocessing import (WaveformPrincipalComponent, compute_principal_components,
+                                           get_template_channel_sparsity)
 
 
 if hasattr(pytest, "global_test_folder"):
@@ -186,6 +187,73 @@ def test_pca_models_and_project_new():
     assert new_proj.shape == (100, n_components)
 
 
+def test_sparse_principal_components():
+    we = WaveformExtractor.load_from_folder(cache_folder / 'toy_waveforms_2seg')
+    unit_ids = we.sorting.unit_ids
+    num_channels = we.recording.get_num_channels()
+    pc = WaveformPrincipalComponent(we)
+
+    sparsity_radius = get_template_channel_sparsity(we, method="radius",
+                                                    radius_um=50)
+    sparsity_best = get_template_channel_sparsity(we, method="best_channels",
+                                                  num_channels=2)
+    sparsities = [sparsity_radius, sparsity_best]
+    print(sparsities)
+
+    for mode in ('by_channel_local', 'by_channel_global'):
+        for sparsity in sparsities:
+            pc.set_params(n_components=5, mode=mode, sparsity=sparsity)
+            print(pc)
+            pc.run()
+            for i, unit_id in enumerate(unit_ids):
+                proj = pc.get_projections(unit_id)
+                # print(comp.shape)
+                assert proj.shape[1:] == (5, 4)
+
+            # import matplotlib.pyplot as plt
+            # plt.ion()
+            # cmap = plt.get_cmap('jet', len(unit_ids))
+            # fig, axs = plt.subplots(nrows=len(unit_ids), ncols=num_channels)
+            # for i, unit_id in enumerate(unit_ids):
+            #     comp = pc.get_projections(unit_id)
+            #     print(comp.shape)
+            #     for chan_ind in range(num_channels):
+            #         ax = axs[i, chan_ind]
+            #         ax.scatter(comp[:, 0, chan_ind], comp[:, 1, chan_ind], color=cmap(i))
+            #         ax.set_title(f"{mode}-{sparsity[unit_id]}")
+            #         if i == 0:
+            #             ax.set_xlabel(f"Ch{chan_ind}")
+            # plt.show()
+
+    for mode in ('concatenated',):
+        # concatenated is only compatible with "best"
+        pc.set_params(n_components=5, mode=mode, sparsity=sparsity_best)
+        print(pc)
+        pc.run()
+        for i, unit_id in enumerate(unit_ids):
+            proj = pc.get_projections(unit_id)
+            assert proj.shape[1] == 5
+            # print(comp.shape)
+
+    all_labels, all_components = pc.get_all_projections()
+
+    # relod as an extension from we
+    assert WaveformPrincipalComponent in we.get_available_extensions()
+    assert we.is_extension('principal_components')
+    pc = we.load_extension('principal_components')
+    assert isinstance(pc, WaveformPrincipalComponent)
+    pc = WaveformPrincipalComponent.load_from_folder(
+        cache_folder / 'toy_waveforms_2seg')
+
+    # import matplotlib.pyplot as plt
+    # cmap = plt.get_cmap('jet', len(unit_ids))
+    # fig, ax = plt.subplots()
+    # for i, unit_id in enumerate(unit_ids):
+    # comp = pca.get_components(unit_id)
+    # print(comp.shape)
+    # ax.scatter(comp[:, 0], comp[:, 1], color=cmap(i))
+    # plt.show()
+
 def test_select_units():
     we = WaveformExtractor.load_from_folder(
         cache_folder / 'toy_waveforms_1seg')
@@ -201,4 +269,5 @@ if __name__ == '__main__':
     setup_module()
     #~ test_WaveformPrincipalComponent()
     #~ test_compute_principal_components_for_all_spikes()
-    test_pca_models_and_project_new()
+    # test_pca_models_and_project_new()
+    test_sparse_principal_components()

--- a/spikeinterface/preprocessing/common_reference.py
+++ b/spikeinterface/preprocessing/common_reference.py
@@ -33,8 +33,6 @@ class CommonReferenceRecording(BasePreprocessor):
         int is expected.
     local_radius: tuple(int, int)
         Use in the local CAR implementation as the selecting annulus (exclude radius, include radius)
-    dtype: str
-        dtype of the returned traces. If None, dtype is maintained
     verbose: bool
         If True, output is verbose
 

--- a/spikeinterface/widgets/amplitudes.py
+++ b/spikeinterface/widgets/amplitudes.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from .base import BaseWidget
 from .utils import get_some_colors
 
@@ -17,15 +19,25 @@ class AmplitudesWidget(BaseWidget):
         List of unit ids.
     segment_index: int
         The segment index (or None if mono-segment)
+    max_spikes_per_unit: int
+        Number of max spikes per unit to display. Use None for all spikes.
+        Default 500.
     hide_unit_selector : bool
-        For sortingview backend, if True the unit selector is not displayed
+        If True the unit selector is not displayed
+        (sortingview backend)
+    plot_histogram : bool
+        If True, an histogram of the amplitudes is plotted on the right axis 
+        (matplotlib backend)
+    bins : int
+        If plot_histogram is True, the number of bins for the amplitude histogram.
+        If None (default), this is automatically adjusted.
     """
     possible_backends = {}
 
     
     def __init__(self, waveform_extractor: WaveformExtractor, unit_ids=None, unit_colors=None,
-                 segment_index=None, hide_unit_selector=False, plot_histograms=False,
-                 bins=None, backend=None, **backend_kwargs):
+                 segment_index=None, max_spikes_per_unit=500, hide_unit_selector=False, 
+                 plot_histograms=False, bins=None, backend=None, **backend_kwargs):
         sorting = waveform_extractor.sorting
         self.check_extensions(waveform_extractor, "spike_amplitudes")
         sac = waveform_extractor.load_extension('spike_amplitudes')
@@ -51,16 +63,34 @@ class AmplitudesWidget(BaseWidget):
             times = sorting.get_unit_spike_train(unit_id, segment_index=segment_index)
             times = times / sorting.get_sampling_frequency()
             spiketrains_segment[unit_id] = times
-        
+
+        all_spiketrains = spiketrains_segment
+        all_amplitudes = amplitudes_segment
+        if max_spikes_per_unit is not None:
+            spiketrains_to_plot = dict()
+            amplitudes_to_plot = dict()
+            for unit, st in all_spiketrains.items():
+                amps = all_amplitudes[unit]
+                if len(st) > max_spikes_per_unit:
+                    random_idxs = np.random.permutation(len(st))[:max_spikes_per_unit]
+                    spiketrains_to_plot[unit] = st[random_idxs]
+                    amplitudes_to_plot[unit] = amps[random_idxs]
+                else:
+                    spiketrains_to_plot[unit] = st
+                    amplitudes_to_plot[unit] = amps
+        else:
+            spiketrains_to_plot = all_spiketrains
+            amplitudes_to_plot = all_amplitudes
+
         if plot_histograms and bins is None:
             bins = 100
 
         plot_data = dict(
             waveform_extractor=waveform_extractor,
-            amplitudes=amplitudes_segment,
+            amplitudes=amplitudes_to_plot,
             unit_ids=unit_ids,
             unit_colors=unit_colors,
-            spiketrains=spiketrains_segment,
+            spiketrains=spiketrains_to_plot,
             total_duration=total_duration,
             plot_histograms=plot_histograms,
             bins=bins,

--- a/spikeinterface/widgets/amplitudes.py
+++ b/spikeinterface/widgets/amplitudes.py
@@ -1,10 +1,10 @@
 import numpy as np
+from warnings import warn
 
 from .base import BaseWidget
 from .utils import get_some_colors
 
 from ..core.waveform_extractor import WaveformExtractor
-from ..postprocessing import compute_spike_amplitudes
 
 
 class AmplitudesWidget(BaseWidget):
@@ -51,7 +51,9 @@ class AmplitudesWidget(BaseWidget):
             unit_colors = get_some_colors(sorting.unit_ids)
 
         if sorting.get_num_segments() > 1:
-            assert segment_index is not None, "Specify segment index for multi-segment object"
+            if segment_index is None:
+                warn("More than one segment available! Using segment_index 0")
+                segment_index = 0
         else:
             segment_index = 0
         amplitudes_segment = amplitudes[segment_index]

--- a/spikeinterface/widgets/ipywidgets/amplitudes.py
+++ b/spikeinterface/widgets/ipywidgets/amplitudes.py
@@ -34,6 +34,7 @@ class AmplitudesPlotter(IpywidgetsPlotter):
                 fig = plt.figure(figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
                 plt.show()
 
+        data_plot['unit_ids'] = [data_plot['unit_ids'][0]]
         unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'], we.sorting.unit_ids,
                                                             ratios[0] * width_cm, height_cm)
 

--- a/spikeinterface/widgets/ipywidgets/spike_locations.py
+++ b/spikeinterface/widgets/ipywidgets/spike_locations.py
@@ -31,8 +31,11 @@ class SpikeLocationsPlotter(IpywidgetsPlotter):
         with plt.ioff():
             output = widgets.Output()
             with output:
-                fig, ax = plt.subplots(figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
+                fig, ax = plt.subplots(
+                    figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
                 plt.show()
+
+        data_plot['unit_ids'] = [data_plot['unit_ids'][0]]
 
         unit_widget, unit_controller = make_unit_controller(
             data_plot["unit_ids"],

--- a/spikeinterface/widgets/ipywidgets/unit_locations.py
+++ b/spikeinterface/widgets/ipywidgets/unit_locations.py
@@ -30,11 +30,14 @@ class UnitLocationsPlotter(IpywidgetsPlotter):
         with plt.ioff():
             output = widgets.Output()
             with output:
-                fig, ax = plt.subplots(figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
+                fig, ax = plt.subplots(
+                    figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
                 plt.show()
 
-        unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'], 
-                                                            list(data_plot['unit_colors'].keys()),
+        data_plot['unit_ids'] = [data_plot['unit_ids'][0]]
+        unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'],
+                                                            list(
+                                                                data_plot['unit_colors'].keys()),
                                                             ratios[0] * width_cm, height_cm)
 
         self.controller = unit_controller
@@ -56,7 +59,6 @@ class UnitLocationsPlotter(IpywidgetsPlotter):
 
         if backend_kwargs["display"]:
             display(self.widget)
-
 
 
 UnitLocationsPlotter.register(UnitLocationsWidget)

--- a/spikeinterface/widgets/ipywidgets/unit_waveforms.py
+++ b/spikeinterface/widgets/ipywidgets/unit_waveforms.py
@@ -38,6 +38,7 @@ class UnitWaveformPlotter(IpywidgetsPlotter):
                 fig_probe, ax_probe = plt.subplots(figsize=((ratios[2] * width_cm) * cm, height_cm * cm))
                 plt.show()
 
+        data_plot['unit_ids'] = [data_plot['unit_ids'][0]]
         unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'], we.sorting.unit_ids,
                                                             ratios[0] * width_cm, height_cm)
 

--- a/spikeinterface/widgets/matplotlib/amplitudes.py
+++ b/spikeinterface/widgets/matplotlib/amplitudes.py
@@ -13,6 +13,7 @@ class AmplitudesPlotter(MplPlotter):
 
 
         if backend_kwargs["axes"] is not None:
+            axes = backend_kwargs["axes"]
             if dp.plot_histograms:
                 assert np.asarray(axes).size == 2
             else:

--- a/spikeinterface/widgets/matplotlib/spike_locations.py
+++ b/spikeinterface/widgets/matplotlib/spike_locations.py
@@ -52,17 +52,17 @@ class SpikeLocationsPlotter(MplPlotter):
         else:
             unit_ids = dp.unit_ids
             unit_colors = dp.unit_colors
-        labels = unit_ids
+        labels = dp.unit_ids
 
         for i, unit in enumerate(unit_ids):
             locs = spike_locations[unit]
             
             zorder = 5 if unit in dp.unit_ids else 3
             self.ax.scatter(locs["x"], locs["y"], s=2, alpha=0.3, color=unit_colors[unit],
-                            label=labels[i], zorder=zorder)
+                            zorder=zorder)
             
         handles = [Line2D([0], [0], ls="", marker='o', markersize=5, markeredgewidth=2, 
-                          color=unit_colors[unit]) for unit in unit_ids]
+                          color=unit_colors[unit]) for unit in dp.unit_ids]
             
         self.figure.legend(handles, labels, loc='upper center', bbox_to_anchor=(0.5, 1.),
                            ncol=5, fancybox=True, shadow=True)
@@ -80,7 +80,7 @@ class SpikeLocationsPlotter(MplPlotter):
         
         self.ax.set_xlim(ax_xlims)
         self.ax.set_ylim(ax_ylims)
-
+        self.ax.axis("off")
 
 
 SpikeLocationsPlotter.register(SpikeLocationsWidget)

--- a/spikeinterface/widgets/matplotlib/unit_locations.py
+++ b/spikeinterface/widgets/matplotlib/unit_locations.py
@@ -56,20 +56,20 @@ class UnitLocationsPlotter(MplPlotter):
         else:
             unit_ids = dp.unit_ids
             unit_colors = dp.unit_colors
-        labels = unit_ids
+        labels = dp.unit_ids
 
         patches = [Ellipse((unit_locations[unit]), color=unit_colors[unit], 
                            zorder=5 if unit in dp.unit_ids else 3, 
-                           alpha=0.9 if unit in dp.unit_ids else 0.5, label=labels[i],
+                           alpha=0.9 if unit in dp.unit_ids else 0.5,
                             **ellipse_kwargs) for i, unit in enumerate(unit_ids)]
         for p in patches:
             self.ax.add_patch(p)
-            
         handles = [Line2D([0], [0], ls="", marker='o', markersize=5, markeredgewidth=2, 
-                          color=unit_colors[unit]) for unit in unit_ids]
+                          color=unit_colors[unit]) for unit in dp.unit_ids]
             
         self.figure.legend(handles, labels, loc='upper center', bbox_to_anchor=(0.5, 1.),
                            ncol=5, fancybox=True, shadow=True)
+        self.ax.axis("off")
 
 
 

--- a/spikeinterface/widgets/spike_locations.py
+++ b/spikeinterface/widgets/spike_locations.py
@@ -18,6 +18,9 @@ class SpikeLocationsWidget(BaseWidget):
         The object to compute/get spike locations from
     unit_ids: list
         List of unit ids.
+    max_spikes_per_unit: int
+        Number of max spikes per unit to display. Use None for all spikes.
+        Default 500.
     with_channel_ids: bool False default
         Add channel ids text on the probe
     unit_colors :  dict or None
@@ -33,6 +36,7 @@ class SpikeLocationsWidget(BaseWidget):
         waveform_extractor: WaveformExtractor,
         unit_ids=None,
         segment_index=None,
+        max_spikes_per_unit=500,
         with_channel_ids=False,
         unit_colors=None,
         hide_unit_selector=False,
@@ -64,10 +68,21 @@ class SpikeLocationsWidget(BaseWidget):
         if unit_ids is None:
             unit_ids = sorting.unit_ids
 
+        all_spike_locs = spike_locations[segment_index]
+        if max_spikes_per_unit is None:
+            spike_locs = all_spike_locs
+        else:
+            spike_locs = dict()
+            for unit, locs_unit in all_spike_locs.items():
+                if len(locs_unit) > max_spikes_per_unit:
+                    spike_locs[unit] = locs_unit[np.random.permutation(len(locs_unit))[:max_spikes_per_unit]]
+                else:
+                    spike_locs[unit] = locs_unit
+
         plot_data = dict(
             sorting=sorting,
             all_unit_ids=sorting.unit_ids,
-            spike_locations=spike_locations[segment_index],
+            spike_locations=spike_locs,
             segment_index=segment_index,
             unit_ids=unit_ids,
             channel_ids=channel_ids,

--- a/spikeinterface/widgets/template_similarity.py
+++ b/spikeinterface/widgets/template_similarity.py
@@ -15,8 +15,11 @@ class TemplateSimilarityWidget(BaseWidget):
     ----------
     waveform_extractor : WaveformExtractor
         The object to compute/get template similarity from
-    unit_ids: list
+    unit_ids : list
         List of unit ids.
+    display_diagonal_values : bool
+        If False, the diagonal is displayed as zeros.
+        If True, the similarity values (all 1s) are displayed. Default False
     cmap : Matplotlib colormap
         The matplotlib colormap. Default 'viridis'. (matplotlib backend)
     show_unit_ticks : bool
@@ -27,7 +30,7 @@ class TemplateSimilarityWidget(BaseWidget):
     possible_backends = {}
 
     def __init__(self, waveform_extractor: WaveformExtractor,
-                 unit_ids=None, cmap='viridis',
+                 unit_ids=None, cmap='viridis', display_diagonal_values=False,
                  show_unit_ticks=False, show_colorbar=True,
                  backend=None, **backend_kwargs):
         self.check_extensions(waveform_extractor, "similarity")
@@ -40,6 +43,9 @@ class TemplateSimilarityWidget(BaseWidget):
         else:
             unit_indices = sorting.ids_to_indices(unit_ids)
             similarity = similarity[unit_indices][:, unit_indices]
+
+        if not display_diagonal_values:
+            np.fill_diagonal(similarity, 0)
 
         plot_data = dict(
             similarity=similarity,


### PR DESCRIPTION
Previously, the `plot_unit_locations` and `plot_spike_locations` were plotting a legend with ALL units (in grey) and only selected units in color. This clealy doesn't scale up with number of units.

Now only selected units are displayed in the legend. In addition, for the `ipywidgets` backend, the first available unit is selected at initiation.

Finally, added `max_spikes_per_unit` argument in `plot_spike_locations()` and `plot_amplitudes` to keep the plots manageable with long recordings and many units
