### PR TITLE
Fix labels and unit selection in widgets

### DIFF
--- a/spikeinterface/widgets/amplitudes.py
+++ b/spikeinterface/widgets/amplitudes.py
@@ -74,7 +74,7 @@ class AmplitudesWidget(BaseWidget):
             for unit, st in all_spiketrains.items():
                 amps = all_amplitudes[unit]
                 if len(st) > max_spikes_per_unit:
-                    random_idxs = np.random.permutation(len(st))[:max_spikes_per_unit]
+                    random_idxs = np.random.choice(len(st), size=max_spikes_per_unit, replace=False)
                     spiketrains_to_plot[unit] = st[random_idxs]
                     amplitudes_to_plot[unit] = amps[random_idxs]
                 else:

--- a/spikeinterface/widgets/amplitudes.py
+++ b/spikeinterface/widgets/amplitudes.py
@@ -1,8 +1,10 @@
+import numpy as np
+from warnings import warn
+
 from .base import BaseWidget
 from .utils import get_some_colors
 
 from ..core.waveform_extractor import WaveformExtractor
-from ..postprocessing import compute_spike_amplitudes
 
 
 class AmplitudesWidget(BaseWidget):
@@ -17,15 +19,25 @@ class AmplitudesWidget(BaseWidget):
         List of unit ids.
     segment_index: int
         The segment index (or None if mono-segment)
+    max_spikes_per_unit: int
+        Number of max spikes per unit to display. Use None for all spikes.
+        Default 500.
     hide_unit_selector : bool
-        For sortingview backend, if True the unit selector is not displayed
+        If True the unit selector is not displayed
+        (sortingview backend)
+    plot_histogram : bool
+        If True, an histogram of the amplitudes is plotted on the right axis 
+        (matplotlib backend)
+    bins : int
+        If plot_histogram is True, the number of bins for the amplitude histogram.
+        If None (default), this is automatically adjusted.
     """
     possible_backends = {}
 
     
     def __init__(self, waveform_extractor: WaveformExtractor, unit_ids=None, unit_colors=None,
-                 segment_index=None, hide_unit_selector=False, plot_histograms=False,
-                 bins=None, backend=None, **backend_kwargs):
+                 segment_index=None, max_spikes_per_unit=500, hide_unit_selector=False, 
+                 plot_histograms=False, bins=None, backend=None, **backend_kwargs):
         sorting = waveform_extractor.sorting
         self.check_extensions(waveform_extractor, "spike_amplitudes")
         sac = waveform_extractor.load_extension('spike_amplitudes')
@@ -39,7 +51,9 @@ class AmplitudesWidget(BaseWidget):
             unit_colors = get_some_colors(sorting.unit_ids)
 
         if sorting.get_num_segments() > 1:
-            assert segment_index is not None, "Specify segment index for multi-segment object"
+            if segment_index is None:
+                warn("More than one segment available! Using segment_index 0")
+                segment_index = 0
         else:
             segment_index = 0
         amplitudes_segment = amplitudes[segment_index]
@@ -51,16 +65,34 @@ class AmplitudesWidget(BaseWidget):
             times = sorting.get_unit_spike_train(unit_id, segment_index=segment_index)
             times = times / sorting.get_sampling_frequency()
             spiketrains_segment[unit_id] = times
-        
+
+        all_spiketrains = spiketrains_segment
+        all_amplitudes = amplitudes_segment
+        if max_spikes_per_unit is not None:
+            spiketrains_to_plot = dict()
+            amplitudes_to_plot = dict()
+            for unit, st in all_spiketrains.items():
+                amps = all_amplitudes[unit]
+                if len(st) > max_spikes_per_unit:
+                    random_idxs = np.random.permutation(len(st))[:max_spikes_per_unit]
+                    spiketrains_to_plot[unit] = st[random_idxs]
+                    amplitudes_to_plot[unit] = amps[random_idxs]
+                else:
+                    spiketrains_to_plot[unit] = st
+                    amplitudes_to_plot[unit] = amps
+        else:
+            spiketrains_to_plot = all_spiketrains
+            amplitudes_to_plot = all_amplitudes
+
         if plot_histograms and bins is None:
             bins = 100
 
         plot_data = dict(
             waveform_extractor=waveform_extractor,
-            amplitudes=amplitudes_segment,
+            amplitudes=amplitudes_to_plot,
             unit_ids=unit_ids,
             unit_colors=unit_colors,
-            spiketrains=spiketrains_segment,
+            spiketrains=spiketrains_to_plot,
             total_duration=total_duration,
             plot_histograms=plot_histograms,
             bins=bins,

--- a/spikeinterface/widgets/ipywidgets/amplitudes.py
+++ b/spikeinterface/widgets/ipywidgets/amplitudes.py
@@ -34,6 +34,7 @@ class AmplitudesPlotter(IpywidgetsPlotter):
                 fig = plt.figure(figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
                 plt.show()
 
+        data_plot['unit_ids'] = [data_plot['unit_ids'][0]]
         unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'], we.sorting.unit_ids,
                                                             ratios[0] * width_cm, height_cm)
 

--- a/spikeinterface/widgets/ipywidgets/spike_locations.py
+++ b/spikeinterface/widgets/ipywidgets/spike_locations.py
@@ -87,6 +87,7 @@ class PlotUpdater:
         data_plot["unit_ids"] = unit_ids
         data_plot["plot_all_units"] = True
         data_plot['plot_legend'] = True
+        data_plot['hide_axis'] = True
 
         backend_kwargs = {}
         backend_kwargs["ax"] = self.ax

--- a/spikeinterface/widgets/ipywidgets/spike_locations.py
+++ b/spikeinterface/widgets/ipywidgets/spike_locations.py
@@ -31,8 +31,11 @@ class SpikeLocationsPlotter(IpywidgetsPlotter):
         with plt.ioff():
             output = widgets.Output()
             with output:
-                fig, ax = plt.subplots(figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
+                fig, ax = plt.subplots(
+                    figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
                 plt.show()
+
+        data_plot['unit_ids'] = [data_plot['unit_ids'][0]]
 
         unit_widget, unit_controller = make_unit_controller(
             data_plot["unit_ids"],

--- a/spikeinterface/widgets/ipywidgets/spike_locations.py
+++ b/spikeinterface/widgets/ipywidgets/spike_locations.py
@@ -86,6 +86,7 @@ class PlotUpdater:
         data_plot = self.next_data_plot
         data_plot["unit_ids"] = unit_ids
         data_plot["plot_all_units"] = True
+        data_plot['plot_legend'] = True
 
         backend_kwargs = {}
         backend_kwargs["ax"] = self.ax

--- a/spikeinterface/widgets/ipywidgets/spike_locations.py
+++ b/spikeinterface/widgets/ipywidgets/spike_locations.py
@@ -35,7 +35,7 @@ class SpikeLocationsPlotter(IpywidgetsPlotter):
                     figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
                 plt.show()
 
-        data_plot['unit_ids'] = [data_plot['unit_ids'][0]]
+        data_plot['unit_ids'] = data_plot['unit_ids'][:1]
 
         unit_widget, unit_controller = make_unit_controller(
             data_plot["unit_ids"],

--- a/spikeinterface/widgets/ipywidgets/unit_locations.py
+++ b/spikeinterface/widgets/ipywidgets/unit_locations.py
@@ -36,8 +36,7 @@ class UnitLocationsPlotter(IpywidgetsPlotter):
 
         data_plot['unit_ids'] = data_plot['unit_ids'][:1]
         unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'],
-                                                            list(
-                                                                data_plot['unit_colors'].keys()),
+                                                            list(data_plot['unit_colors'].keys()),
                                                             ratios[0] * width_cm, height_cm)
 
         self.controller = unit_controller
@@ -82,6 +81,7 @@ class PlotUpdater:
         data_plot = self.next_data_plot
         data_plot['unit_ids'] = unit_ids
         data_plot['plot_all_units'] = True
+        data_plot['plot_legend'] = True
 
         backend_kwargs = {}
         backend_kwargs['ax'] = self.ax

--- a/spikeinterface/widgets/ipywidgets/unit_locations.py
+++ b/spikeinterface/widgets/ipywidgets/unit_locations.py
@@ -82,6 +82,7 @@ class PlotUpdater:
         data_plot['unit_ids'] = unit_ids
         data_plot['plot_all_units'] = True
         data_plot['plot_legend'] = True
+        data_plot['hide_axis'] = True
 
         backend_kwargs = {}
         backend_kwargs['ax'] = self.ax

--- a/spikeinterface/widgets/ipywidgets/unit_locations.py
+++ b/spikeinterface/widgets/ipywidgets/unit_locations.py
@@ -34,7 +34,7 @@ class UnitLocationsPlotter(IpywidgetsPlotter):
                     figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
                 plt.show()
 
-        data_plot['unit_ids'] = [data_plot['unit_ids'][0]]
+        data_plot['unit_ids'] = data_plot['unit_ids'][:1]
         unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'],
                                                             list(
                                                                 data_plot['unit_colors'].keys()),

--- a/spikeinterface/widgets/ipywidgets/unit_locations.py
+++ b/spikeinterface/widgets/ipywidgets/unit_locations.py
@@ -30,11 +30,14 @@ class UnitLocationsPlotter(IpywidgetsPlotter):
         with plt.ioff():
             output = widgets.Output()
             with output:
-                fig, ax = plt.subplots(figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
+                fig, ax = plt.subplots(
+                    figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
                 plt.show()
 
-        unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'], 
-                                                            list(data_plot['unit_colors'].keys()),
+        data_plot['unit_ids'] = [data_plot['unit_ids'][0]]
+        unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'],
+                                                            list(
+                                                                data_plot['unit_colors'].keys()),
                                                             ratios[0] * width_cm, height_cm)
 
         self.controller = unit_controller
@@ -56,7 +59,6 @@ class UnitLocationsPlotter(IpywidgetsPlotter):
 
         if backend_kwargs["display"]:
             display(self.widget)
-
 
 
 UnitLocationsPlotter.register(UnitLocationsWidget)

--- a/spikeinterface/widgets/ipywidgets/unit_waveforms.py
+++ b/spikeinterface/widgets/ipywidgets/unit_waveforms.py
@@ -38,6 +38,7 @@ class UnitWaveformPlotter(IpywidgetsPlotter):
                 fig_probe, ax_probe = plt.subplots(figsize=((ratios[2] * width_cm) * cm, height_cm * cm))
                 plt.show()
 
+        data_plot['unit_ids'] = [data_plot['unit_ids'][0]]
         unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'], we.sorting.unit_ids,
                                                             ratios[0] * width_cm, height_cm)
 

--- a/spikeinterface/widgets/ipywidgets/unit_waveforms.py
+++ b/spikeinterface/widgets/ipywidgets/unit_waveforms.py
@@ -38,7 +38,7 @@ class UnitWaveformPlotter(IpywidgetsPlotter):
                 fig_probe, ax_probe = plt.subplots(figsize=((ratios[2] * width_cm) * cm, height_cm * cm))
                 plt.show()
 
-        data_plot['unit_ids'] = [data_plot['unit_ids'][0]]
+        data_plot['unit_ids'] = data_plot['unit_ids'][:1]
         unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'], we.sorting.unit_ids,
                                                             ratios[0] * width_cm, height_cm)
 

--- a/spikeinterface/widgets/matplotlib/amplitudes.py
+++ b/spikeinterface/widgets/matplotlib/amplitudes.py
@@ -13,6 +13,7 @@ class AmplitudesPlotter(MplPlotter):
 
 
         if backend_kwargs["axes"] is not None:
+            axes = backend_kwargs["axes"]
             if dp.plot_histograms:
                 assert np.asarray(axes).size == 2
             else:

--- a/spikeinterface/widgets/matplotlib/spike_locations.py
+++ b/spikeinterface/widgets/matplotlib/spike_locations.py
@@ -52,17 +52,17 @@ class SpikeLocationsPlotter(MplPlotter):
         else:
             unit_ids = dp.unit_ids
             unit_colors = dp.unit_colors
-        labels = unit_ids
+        labels = dp.unit_ids
 
         for i, unit in enumerate(unit_ids):
             locs = spike_locations[unit]
             
             zorder = 5 if unit in dp.unit_ids else 3
             self.ax.scatter(locs["x"], locs["y"], s=2, alpha=0.3, color=unit_colors[unit],
-                            label=labels[i], zorder=zorder)
+                            zorder=zorder)
             
         handles = [Line2D([0], [0], ls="", marker='o', markersize=5, markeredgewidth=2, 
-                          color=unit_colors[unit]) for unit in unit_ids]
+                          color=unit_colors[unit]) for unit in dp.unit_ids]
             
         self.figure.legend(handles, labels, loc='upper center', bbox_to_anchor=(0.5, 1.),
                            ncol=5, fancybox=True, shadow=True)
@@ -80,7 +80,7 @@ class SpikeLocationsPlotter(MplPlotter):
         
         self.ax.set_xlim(ax_xlims)
         self.ax.set_ylim(ax_ylims)
-
+        self.ax.axis("off")
 
 
 SpikeLocationsPlotter.register(SpikeLocationsWidget)

--- a/spikeinterface/widgets/matplotlib/spike_locations.py
+++ b/spikeinterface/widgets/matplotlib/spike_locations.py
@@ -80,7 +80,8 @@ class SpikeLocationsPlotter(MplPlotter):
         
         self.ax.set_xlim(ax_xlims)
         self.ax.set_ylim(ax_ylims)
-        self.ax.axis("off")
+        if dp.hide_axis:
+            self.ax.axis("off")
 
 
 SpikeLocationsPlotter.register(SpikeLocationsWidget)

--- a/spikeinterface/widgets/matplotlib/unit_locations.py
+++ b/spikeinterface/widgets/matplotlib/unit_locations.py
@@ -69,7 +69,8 @@ class UnitLocationsPlotter(MplPlotter):
             
         self.figure.legend(handles, labels, loc='upper center', bbox_to_anchor=(0.5, 1.),
                            ncol=5, fancybox=True, shadow=True)
-        self.ax.axis("off")
+        if dp.hide_axis:
+            self.ax.axis("off")
 
 
 

--- a/spikeinterface/widgets/matplotlib/unit_locations.py
+++ b/spikeinterface/widgets/matplotlib/unit_locations.py
@@ -56,20 +56,20 @@ class UnitLocationsPlotter(MplPlotter):
         else:
             unit_ids = dp.unit_ids
             unit_colors = dp.unit_colors
-        labels = unit_ids
+        labels = dp.unit_ids
 
         patches = [Ellipse((unit_locations[unit]), color=unit_colors[unit], 
                            zorder=5 if unit in dp.unit_ids else 3, 
-                           alpha=0.9 if unit in dp.unit_ids else 0.5, label=labels[i],
+                           alpha=0.9 if unit in dp.unit_ids else 0.5,
                             **ellipse_kwargs) for i, unit in enumerate(unit_ids)]
         for p in patches:
             self.ax.add_patch(p)
-            
         handles = [Line2D([0], [0], ls="", marker='o', markersize=5, markeredgewidth=2, 
-                          color=unit_colors[unit]) for unit in unit_ids]
+                          color=unit_colors[unit]) for unit in dp.unit_ids]
             
         self.figure.legend(handles, labels, loc='upper center', bbox_to_anchor=(0.5, 1.),
                            ncol=5, fancybox=True, shadow=True)
+        self.ax.axis("off")
 
 
 

--- a/spikeinterface/widgets/spike_locations.py
+++ b/spikeinterface/widgets/spike_locations.py
@@ -32,6 +32,8 @@ class SpikeLocationsWidget(BaseWidget):
         are plotted in grey. Default True (matplotlib backend)
     plot_legend : bool
         If True, the legend is plotted. Default False (matplotlib backend)
+    hide_axis : bool
+        If True, the axis is set to off. Default False (matplotlib backend)
     """
 
     possible_backends = {}
@@ -47,6 +49,7 @@ class SpikeLocationsWidget(BaseWidget):
         hide_unit_selector=False,
         plot_all_units=True,
         plot_legend=False,
+        hide_axis=False,
         backend=None,
         **backend_kwargs
     ):
@@ -99,7 +102,8 @@ class SpikeLocationsWidget(BaseWidget):
             with_channel_ids=with_channel_ids,
             hide_unit_selector=hide_unit_selector,
             plot_all_units=plot_all_units,
-            plot_legend=False
+            plot_legend=plot_legend,
+            hide_axis=hide_axis
         )
 
         BaseWidget.__init__(self, plot_data, backend=backend, **backend_kwargs)

--- a/spikeinterface/widgets/spike_locations.py
+++ b/spikeinterface/widgets/spike_locations.py
@@ -27,6 +27,11 @@ class SpikeLocationsWidget(BaseWidget):
         If given, a dictionary with unit ids as keys and colors as values
     hide_unit_selector : bool
         For sortingview backend, if True the unit selector is not displayed
+    plot_all_units : bool
+        If True, all units are plotted. The unselected ones (not in unit_ids),
+        are plotted in grey. Default True (matplotlib backend)
+    plot_legend : bool
+        If True, the legend is plotted. Default False (matplotlib backend)
     """
 
     possible_backends = {}
@@ -41,6 +46,7 @@ class SpikeLocationsWidget(BaseWidget):
         unit_colors=None,
         hide_unit_selector=False,
         plot_all_units=True,
+        plot_legend=False,
         backend=None,
         **backend_kwargs
     ):
@@ -75,7 +81,8 @@ class SpikeLocationsWidget(BaseWidget):
             spike_locs = dict()
             for unit, locs_unit in all_spike_locs.items():
                 if len(locs_unit) > max_spikes_per_unit:
-                    spike_locs[unit] = locs_unit[np.random.permutation(len(locs_unit))[:max_spikes_per_unit]]
+                    random_idxs = np.random.choice(len(locs_unit), size=max_spikes_per_unit, replace=False)
+                    spike_locs[unit] = locs_unit[random_idxs]
                 else:
                     spike_locs[unit] = locs_unit
 
@@ -92,6 +99,7 @@ class SpikeLocationsWidget(BaseWidget):
             with_channel_ids=with_channel_ids,
             hide_unit_selector=hide_unit_selector,
             plot_all_units=plot_all_units,
+            plot_legend=False
         )
 
         BaseWidget.__init__(self, plot_data, backend=backend, **backend_kwargs)

--- a/spikeinterface/widgets/spike_locations.py
+++ b/spikeinterface/widgets/spike_locations.py
@@ -18,6 +18,9 @@ class SpikeLocationsWidget(BaseWidget):
         The object to compute/get spike locations from
     unit_ids: list
         List of unit ids.
+    max_spikes_per_unit: int
+        Number of max spikes per unit to display. Use None for all spikes.
+        Default 500.
     with_channel_ids: bool False default
         Add channel ids text on the probe
     unit_colors :  dict or None
@@ -33,6 +36,7 @@ class SpikeLocationsWidget(BaseWidget):
         waveform_extractor: WaveformExtractor,
         unit_ids=None,
         segment_index=None,
+        max_spikes_per_unit=500,
         with_channel_ids=False,
         unit_colors=None,
         hide_unit_selector=False,
@@ -64,10 +68,21 @@ class SpikeLocationsWidget(BaseWidget):
         if unit_ids is None:
             unit_ids = sorting.unit_ids
 
+        all_spike_locs = spike_locations[segment_index]
+        if max_spikes_per_unit is None:
+            spike_locs = all_spike_locs
+        else:
+            spike_locs = dict()
+            for unit, locs_unit in all_spike_locs.items():
+                if len(locs_unit) > max_spikes_per_unit:
+                    spike_locs[unit] = locs_unit[np.random.permutation(len(locs_unit))[:max_spikes_per_unit]]
+                else:
+                    spike_locs[unit] = locs_unit
+
         plot_data = dict(
             sorting=sorting,
             all_unit_ids=sorting.unit_ids,
-            spike_locations=spike_locations[segment_index],
+            spike_locations=spike_locs,
             segment_index=segment_index,
             unit_ids=unit_ids,
             channel_ids=channel_ids,

--- a/spikeinterface/widgets/template_similarity.py
+++ b/spikeinterface/widgets/template_similarity.py
@@ -15,8 +15,11 @@ class TemplateSimilarityWidget(BaseWidget):
     ----------
     waveform_extractor : WaveformExtractor
         The object to compute/get template similarity from
-    unit_ids: list
+    unit_ids : list
         List of unit ids.
+    display_diagonal_values : bool
+        If False, the diagonal is displayed as zeros.
+        If True, the similarity values (all 1s) are displayed. Default False
     cmap : Matplotlib colormap
         The matplotlib colormap. Default 'viridis'. (matplotlib backend)
     show_unit_ticks : bool
@@ -27,7 +30,7 @@ class TemplateSimilarityWidget(BaseWidget):
     possible_backends = {}
 
     def __init__(self, waveform_extractor: WaveformExtractor,
-                 unit_ids=None, cmap='viridis',
+                 unit_ids=None, cmap='viridis', display_diagonal_values=False,
                  show_unit_ticks=False, show_colorbar=True,
                  backend=None, **backend_kwargs):
         self.check_extensions(waveform_extractor, "similarity")
@@ -40,6 +43,9 @@ class TemplateSimilarityWidget(BaseWidget):
         else:
             unit_indices = sorting.ids_to_indices(unit_ids)
             similarity = similarity[unit_indices][:, unit_indices]
+
+        if not display_diagonal_values:
+            np.fill_diagonal(similarity, 0)
 
         plot_data = dict(
             similarity=similarity,

--- a/spikeinterface/widgets/unit_locations.py
+++ b/spikeinterface/widgets/unit_locations.py
@@ -30,13 +30,15 @@ class UnitLocationsWidget(BaseWidget):
         are plotted in grey. Default True (matplotlib backend)
     plot_legend : bool
         If True, the legend is plotted. Default False (matplotlib backend)
+    hide_axis : bool
+        If True, the axis is set to off. Default False (matplotlib backend)
     """
     possible_backends = {}
 
     def __init__(self, waveform_extractor: WaveformExtractor, 
                  unit_ids=None, with_channel_ids=False,
                  unit_colors=None, hide_unit_selector=False,
-                 plot_all_units=True, plot_legend=False,
+                 plot_all_units=True, plot_legend=False, hide_axis=False,
                  backend=None, **backend_kwargs):
         self.check_extensions(waveform_extractor, "unit_locations")
         ulc = waveform_extractor.load_extension("unit_locations")
@@ -66,7 +68,8 @@ class UnitLocationsWidget(BaseWidget):
             with_channel_ids=with_channel_ids,
             hide_unit_selector=hide_unit_selector,
             plot_all_units=plot_all_units,
-            plot_legend=plot_legend
+            plot_legend=plot_legend,
+            hide_axis=hide_axis
         )
 
         BaseWidget.__init__(self, plot_data, backend=backend, **backend_kwargs)

--- a/spikeinterface/widgets/unit_locations.py
+++ b/spikeinterface/widgets/unit_locations.py
@@ -23,13 +23,20 @@ class UnitLocationsWidget(BaseWidget):
     unit_colors :  dict or None
         If given, a dictionary with unit ids as keys and colors as values
     hide_unit_selector : bool
-        For sortingview backend, if True the unit selector is not displayed
+        If True, the unit selector is not displayed.
+        Default False (sortingview backend)
+    plot_all_units : bool
+        If True, all units are plotted. The unselected ones (not in unit_ids),
+        are plotted in grey. Default True (matplotlib backend)
+    plot_legend : bool
+        If True, the legend is plotted. Default False (matplotlib backend)
     """
     possible_backends = {}
 
     def __init__(self, waveform_extractor: WaveformExtractor, 
                  unit_ids=None, with_channel_ids=False,
-                 unit_colors=None, hide_unit_selector=False, plot_all_units=True,
+                 unit_colors=None, hide_unit_selector=False,
+                 plot_all_units=True, plot_legend=False,
                  backend=None, **backend_kwargs):
         self.check_extensions(waveform_extractor, "unit_locations")
         ulc = waveform_extractor.load_extension("unit_locations")
@@ -58,7 +65,8 @@ class UnitLocationsWidget(BaseWidget):
             probegroup_dict=probegroup.to_dict(),
             with_channel_ids=with_channel_ids,
             hide_unit_selector=hide_unit_selector,
-            plot_all_units=plot_all_units
+            plot_all_units=plot_all_units,
+            plot_legend=plot_legend
         )
 
         BaseWidget.__init__(self, plot_data, backend=backend, **backend_kwargs)


### PR DESCRIPTION
Previously, the `plot_unit_locations` and `plot_spike_locations` were plotting a legend with ALL units (in grey) and only selected units in color. This clealy doesn't scale up with number of units.

Now only selected units are displayed in the legend. In addition, for the `ipywidgets` backend, the first available unit is selected at initiation.

Finally, added `max_spikes_per_unit` argument in `plot_spike_locations()` and `plot_amplitudes` to keep the plots manageable with long recordings and many units
