### PR TITLE
Fix spikes_on_traces

### DIFF
--- a/spikeinterface/widgets/matplotlib/spikes_on_traces.py
+++ b/spikeinterface/widgets/matplotlib/spikes_on_traces.py
@@ -69,7 +69,8 @@ class SpikesOnTracesPlotter(MplPlotter):
                     vspacing = dp.timeseries["vspacing"]
                     traces = dp.timeseries["list_traces"][0]
                     waveform_idxs = spike_frames_to_plot[:, None] + np.arange(-we.nbefore, we.nafter) - frame_range[0]
-                    
+                    waveform_idxs = np.clip(waveform_idxs, 0, len(dp.timeseries['times'])-1)
+
                     times = dp.timeseries["times"][waveform_idxs]
                     # discontinuity
                     times[:, -1] = np.nan


### PR DESCRIPTION
The spikes_on_traces function is quite often leading to crashes, so here is a fix to prevent the problems with line display