### PR TITLE
Waveform extractor no recording

### DIFF
--- a/spikeinterface/comparison/multicomparisons.py
+++ b/spikeinterface/comparison/multicomparisons.py
@@ -300,7 +300,7 @@ class MultiTemplateComparison(BaseMultiComparison, MixinTemplateComparison):
     def _populate_nodes(self):
         for i, we in enumerate(self.object_list):
             session_name = self.name_list[i]
-            for unit_id in we.sorting.get_unit_ids():
+            for unit_id in we.get_unit_ids():
                 node = session_name, unit_id
                 self.graph.add_node(node)
 

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -235,12 +235,10 @@ def test_portability():
     assert we_loaded.recording is not None
     assert we_loaded.sorting is not None
 
-    assert np.allclose(
-        we.recording.get_channel_ids(), we_loaded.recording.get_channel_ids())
-    assert np.allclose(
-        we.sorting.get_unit_ids(), we_loaded.sorting.get_unit_ids())
+    assert np.allclose(we.channel_ids, we_loaded.recording.channel_ids)
+    assert np.allclose(we.unit_ids(), we_loaded.unit_ids)
 
-    for unit in we.sorting.get_unit_ids():
+    for unit in we.unit_ids:
         wf = we.get_waveforms(unit_id=unit)
         wf_loaded = we_loaded.get_waveforms(unit_id=unit)
 

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -153,6 +153,37 @@ class WaveformExtractor:
         assert all(extension_class.extension_name != ext.extension_name for ext in cls.extensions), \
             'Extension name already exists'
         cls.extensions.append(extension_class)
+    
+    # map some method from recording and sorting
+    @property
+    def channel_ids(self):
+        return self.recording.channel_ids
+    
+    @property
+    def sampling_frequency(self):
+        return self.recording.get_sampling_frequency()
+    
+    def get_num_channels(self):
+        return self.recording.get_num_channels()
+
+    def get_num_segments(self):
+        return self.recording.get_num_segments()
+        # return self.sorting.get_num_segments()
+
+    def get_probegroup(self):
+        return self.recording.get_probegroup()
+    
+    def get_probe(self):
+        return self.recording.get_probe()
+    
+    def get_channel_locations(self):
+        return self.recording.get_channel_locations()
+
+    @property
+    def unit_ids(self):
+        return self.sorting.unit_ids
+    
+
 
     def get_extension_class(self, extension_name):
         """

--- a/spikeinterface/postprocessing/principal_component.py
+++ b/spikeinterface/postprocessing/principal_component.py
@@ -325,7 +325,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         we = self.waveform_extractor
         p = self._params
 
-        unit_ids = we.sorting.unit_ids
+        unit_ids = we.unit_ids
         channel_ids = we.channel_ids
 
         # there is one PCA per channel for independent fit per channel
@@ -392,7 +392,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         we = self.waveform_extractor
         p = self._params
 
-        unit_ids = we.sorting.unit_ids
+        unit_ids = we.unit_ids
         channel_ids = we.channel_ids
 
         pca_model = self._fit_by_channel_local(sparsity, n_jobs, progress_bar)
@@ -428,7 +428,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         we = self.waveform_extractor
         p = self._params
 
-        unit_ids = we.sorting.unit_ids
+        unit_ids = we.unit_ids
         channel_ids = we.channel_ids
 
         # there is one unique PCA accross channels
@@ -464,7 +464,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         we = self.waveform_extractor
         p = self._params
 
-        unit_ids = we.sorting.unit_ids
+        unit_ids = we.unit_ids
         channel_ids = we.channel_ids
 
         pca_model = self._fit_by_channel_global(sparsity, progress_bar)
@@ -492,10 +492,10 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         we = self.waveform_extractor
         p = self._params
         if sparsity is not None:
-            sparsity0 = sparsity[we.sorting.unit_ids[0]]
+            sparsity0 = sparsity[we.unit_ids[0]]
             assert all(len(chans) == len(sparsity0) for u, chans in sparsity.items()), ("When using sparsity in "
                 "concatenated mode, make sure each unit has the same number of sparse channels")
-        unit_ids = we.sorting.unit_ids
+        unit_ids = we.unit_ids
 
         # there is one unique PCA accross channels
         pca_model = IncrementalPCA(n_components=p['n_components'], whiten=p['whiten'])
@@ -524,7 +524,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         we = self.waveform_extractor
         p = self._params
 
-        unit_ids = we.sorting.unit_ids
+        unit_ids = we.unit_ids
 
         # there is one unique PCA accross channels
         pca_model = self._fit_concatenated(sparsity, progress_bar)

--- a/spikeinterface/postprocessing/principal_component.py
+++ b/spikeinterface/postprocessing/principal_component.py
@@ -36,8 +36,8 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
     def __repr__(self):
         we = self.waveform_extractor
         clsname = self.__class__.__name__
-        nseg = we.recording.get_num_segments()
-        nchan = we.recording.get_num_channels()
+        nseg = we.get_num_segments()
+        nchan = we.get_num_channels()
         txt = f'{clsname}: {nchan} channels - {nseg} segments'
         if len(self._params) > 0:
             mode = self._params['mode']
@@ -210,12 +210,12 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         """
         p = self._params
         we = self.waveform_extractor
-        num_chans = we.recording.get_num_channels()
+        num_chans = we.get_num_channels()
         sparsity = p["sparsity"]
 
         # prepare memmap files with npy
         projection_objects = {}
-        unit_ids = we.sorting.unit_ids
+        unit_ids = we.unit_ids
 
         for unit_id in unit_ids:
             n_spike = we.get_waveforms(unit_id).shape[0]
@@ -288,7 +288,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         all_spikes = sorting.get_all_spike_trains(outputs='unit_index')
         spike_times, spike_labels = all_spikes[0]
 
-        max_channels_per_template = min(max_channels_per_template, we.recording.get_num_channels())
+        max_channels_per_template = min(max_channels_per_template, we.get_num_channels())
 
         best_channels_index = get_template_channel_sparsity(we, outputs="index", peak_sign=peak_sign,
                                                             num_channels=max_channels_per_template)
@@ -326,7 +326,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         p = self._params
 
         unit_ids = we.sorting.unit_ids
-        channel_ids = we.recording.channel_ids
+        channel_ids = we.channel_ids
 
         # there is one PCA per channel for independent fit per channel
         pca_models = [IncrementalPCA(n_components=p['n_components'], whiten=p['whiten']) for _ in channel_ids]
@@ -393,7 +393,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         p = self._params
 
         unit_ids = we.sorting.unit_ids
-        channel_ids = we.recording.channel_ids
+        channel_ids = we.channel_ids
 
         pca_model = self._fit_by_channel_local(sparsity, n_jobs, progress_bar)
 
@@ -429,7 +429,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         p = self._params
 
         unit_ids = we.sorting.unit_ids
-        channel_ids = we.recording.channel_ids
+        channel_ids = we.channel_ids
 
         # there is one unique PCA accross channels
         pca_model = IncrementalPCA(n_components=p['n_components'], whiten=p['whiten'])
@@ -465,7 +465,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         p = self._params
 
         unit_ids = we.sorting.unit_ids
-        channel_ids = we.recording.channel_ids
+        channel_ids = we.channel_ids
 
         pca_model = self._fit_by_channel_global(sparsity, progress_bar)
 
@@ -481,7 +481,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
                 sparse_channel_ids = sparsity[unit_id]
             else:
                 sparse_channel_ids = channel_ids
-            sparse_channel_inds = we.recording.ids_to_indices(sparse_channel_ids)
+            sparse_channel_inds = we.ids_to_indices(sparse_channel_ids)
             if wfs.size == 0:
                 continue
             for wf_ind, chan_ind in enumerate(sparse_channel_inds):

--- a/spikeinterface/postprocessing/spike_amplitudes.py
+++ b/spikeinterface/postprocessing/spike_amplitudes.py
@@ -58,7 +58,7 @@ class SpikeAmplitudesCalculator(BaseWaveformExtractorExtension):
         
         if return_scaled:
             # check if has scaled values:
-            if not we.recording.has_scaled_traces():
+            if not recording.has_scaled_traces():
                 print("Setting 'return_scaled' to False")
                 return_scaled = False
 

--- a/spikeinterface/postprocessing/template_tools.py
+++ b/spikeinterface/postprocessing/template_tools.py
@@ -147,8 +147,8 @@ def get_template_channel_sparsity(
     assert outputs in ("id", "index")
     we = waveform_extractor
 
-    unit_ids = we.sorting.unit_ids
-    channel_ids = we.recording.channel_ids
+    unit_ids = we.unit_ids
+    channel_ids = we.channel_ids
 
     sparsity_with_index = {}
     if method == "best_channels":

--- a/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -60,8 +60,8 @@ class PrincipalComponentsExtensionTest(WaveformExtensionCommonTestSuite, unittes
 
     def test_sparse(self):
         we = self.we2
-        unit_ids = we.sorting.unit_ids
-        num_channels = we.recording.get_num_channels()
+        unit_ids = we.unit_ids
+        num_channels = we.get_num_channels()
         pc = self.extension_class(we)
 
         sparsity_radius = get_template_channel_sparsity(we, method="radius",
@@ -110,10 +110,10 @@ class PrincipalComponentsExtensionTest(WaveformExtensionCommonTestSuite, unittes
         we = self.we1
         if we.is_extension("principal_components"):
             we.delete_extension("principal_components")
-        we_cp = we.select_units(we.sorting.unit_ids, self.cache_folder / 'toy_waveforms_1seg_cp')
+        we_cp = we.select_units(we.unit_ids, self.cache_folder / 'toy_waveforms_1seg_cp')
 
 
-        wfs0 = we.get_waveforms(unit_id=we.sorting.unit_ids[0])
+        wfs0 = we.get_waveforms(unit_id=we.unit_ids[0])
         n_samples = wfs0.shape[1]
         n_channels = wfs0.shape[2]
         n_components = 5
@@ -128,8 +128,8 @@ class PrincipalComponentsExtensionTest(WaveformExtensionCommonTestSuite, unittes
         all_pca = pc_local.get_pca_model()
         all_pca_par = pc_local_par.get_pca_model()
 
-        assert len(all_pca) == we.recording.get_num_channels()
-        assert len(all_pca_par) == we.recording.get_num_channels()
+        assert len(all_pca) == we.get_num_channels()
+        assert len(all_pca_par) == we.get_num_channels()
 
         for (pc, pc_par) in zip(all_pca, all_pca_par):
             assert np.allclose(pc.components_, pc_par.components_)

--- a/spikeinterface/postprocessing/tests/test_template_similarity.py
+++ b/spikeinterface/postprocessing/tests/test_template_similarity.py
@@ -13,9 +13,9 @@ class SimilarityExtensionTest(WaveformExtensionCommonTestSuite, unittest.TestCas
     # extend common test 
     def test_check_equal_template_with_distribution_overlap(self):
         we = self.we1
-        for unit_id0 in we.sorting.unit_ids:
+        for unit_id0 in we.unit_ids:
             waveforms0 = we.get_waveforms(unit_id0)
-            for unit_id1 in we.sorting.unit_ids:
+            for unit_id1 in we.unit_ids:
                 if unit_id0 == unit_id1:
                     continue
                 waveforms1 = we.get_waveforms(unit_id1)

--- a/spikeinterface/postprocessing/tests/test_template_tools.py
+++ b/spikeinterface/postprocessing/tests/test_template_tools.py
@@ -54,7 +54,7 @@ def test_get_template_extremum_channel_peak_shift():
     # DEBUG
     # import matplotlib.pyplot as plt
     # extremum_channels_ids = get_template_extremum_channel(we, peak_sign='both')
-    # for unit_id in we.sorting.unit_ids:
+    # for unit_id in we.unit_ids:
     #     chan_id = extremum_channels_ids[unit_id]
     #     chan_ind = we.recording.id_to_index(chan_id)
     #     template = we.get_template(unit_id)

--- a/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/spikeinterface/qualitymetrics/pca_metrics.py
@@ -85,8 +85,8 @@ def calculate_pc_metrics(pca, metric_names=None, sparsity=None, max_spikes_for_n
     we = pca.waveform_extractor
     extremum_channels = get_template_extremum_channel(we)
 
-    unit_ids = we.sorting.unit_ids
-    channel_ids = we.recording.channel_ids
+    unit_ids = we.unit_ids
+    channel_ids = we.channel_ids
 
     # create output dict of dict  pc_metrics['metric_name'][unit_id]
     pc_metrics = {k: {} for k in metric_names}

--- a/spikeinterface/sortingcomponents/benchmark/benchmark_matching.py
+++ b/spikeinterface/sortingcomponents/benchmark/benchmark_matching.py
@@ -122,14 +122,14 @@ def plot_errors_matching(benchmark, unit_id, nb_spikes=200, metric='cosine'):
 
 def plot_errors_matching_all_neurons(benchmark, nb_spikes=200, metric='cosine'):
     templates = benchmark.templates
-    nb_units = len(benchmark.we.sorting.unit_ids)
+    nb_units = len(benchmark.we.unit_ids)
     colors = ['r', 'b']
 
     results = {'TP' : {'mean' : [], 'std' : []}, 
                'FN' : {'mean' : [], 'std' : []}}
     
     for i in range(nb_units):
-        unit_id = benchmark.we.sorting.unit_ids[i]
+        unit_id = benchmark.we.unit_ids[i]
         idx_2 = benchmark.we.get_sampled_indices(unit_id)['spike_index']
         wfs = benchmark.we.get_waveforms(unit_id)
         template = benchmark.we.get_template(unit_id)

--- a/spikeinterface/sortingcomponents/matching/tdc.py
+++ b/spikeinterface/sortingcomponents/matching/tdc.py
@@ -57,10 +57,10 @@ class TridesclousPeeler(BaseTemplateMatchingEngine):
         assert isinstance(d['waveform_extractor'], WaveformExtractor)
         
         we = d['waveform_extractor']
-        unit_ids = we.sorting.unit_ids
-        channel_ids = we.recording.channel_ids
+        unit_ids = we.unit_ids
+        channel_ids = we.channel_ids
         
-        sr = we.recording.get_sampling_frequency()
+        sr = we.get_sampling_frequency()
 
 
         # TODO load as sharedmem

--- a/spikeinterface/widgets/_legacy_mpl_widgets/depthamplitude.py
+++ b/spikeinterface/widgets/_legacy_mpl_widgets/depthamplitude.py
@@ -22,10 +22,10 @@ class UnitsDepthAmplitudeWidget(BaseWidget):
     def plot(self):
         ax = self.ax
         we = self.we
-        unit_ids = we.sorting.unit_ids
+        unit_ids = we.unit_ids
 
         channels_index = get_template_extremum_channel(we, peak_sign=self.peak_sign, outputs='index')
-        contact_positions = we.recording.get_channel_locations()
+        contact_positions = we.get_channel_locations()
 
         channel_depth = contact_positions[:, self.depth_axis]
         unit_depth = [channel_depth[channels_index[unit_id]] for unit_id in unit_ids]
@@ -37,7 +37,7 @@ class UnitsDepthAmplitudeWidget(BaseWidget):
 
         num_spikes = np.zeros(len(unit_ids))
         for i, unit_id in enumerate(unit_ids):
-            for segment_index in range(we.sorting.get_num_segments()):
+            for segment_index in range(we.get_num_segments()):
                 st = we.sorting.get_unit_spike_train(unit_id=unit_id, segment_index=segment_index)
                 num_spikes[i] += st.size
 

--- a/spikeinterface/widgets/_legacy_mpl_widgets/unitlocalization_.py
+++ b/spikeinterface/widgets/_legacy_mpl_widgets/unitlocalization_.py
@@ -58,7 +58,7 @@ class UnitLocalizationWidget(BaseWidget):
 
     def plot(self):
         we = self.waveform_extractor
-        unit_ids = we.sorting.unit_ids
+        unit_ids = we.unit_ids
 
         if we.is_extension('unit_locations'):
             unit_locations = we.load_extension('unit_locations').get_data()
@@ -66,7 +66,7 @@ class UnitLocalizationWidget(BaseWidget):
             unit_locations = compute_unit_locations(we, method=self.method, **self.method_kwargs)
 
         ax = self.ax
-        probegroup = we.recording.get_probegroup()
+        probegroup = we.get_probegroup()
         probe_shape_kwargs = dict(facecolor='w', edgecolor='k', lw=0.5, alpha=1.)
         contacts_kargs = dict(alpha=1., edgecolor='k', lw=0.5)
         

--- a/spikeinterface/widgets/_legacy_mpl_widgets/unitprobemap.py
+++ b/spikeinterface/widgets/_legacy_mpl_widgets/unitprobemap.py
@@ -57,7 +57,7 @@ class UnitProbeMapWidget(BaseWidget):
 
     def plot(self):
         we = self.waveform_extractor
-        probe = we.recording.get_probe()
+        probe = we.get_probe()
 
         probe_shape_kwargs = dict(facecolor='w', edgecolor='k', lw=0.5, alpha=1.)
 

--- a/spikeinterface/widgets/ipywidgets/amplitudes.py
+++ b/spikeinterface/widgets/ipywidgets/amplitudes.py
@@ -35,7 +35,7 @@ class AmplitudesPlotter(IpywidgetsPlotter):
                 plt.show()
 
         data_plot['unit_ids'] = data_plot['unit_ids'][:1]
-        unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'], we.sorting.unit_ids,
+        unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'], we.unit_ids,
                                                             ratios[0] * width_cm, height_cm)
 
         plot_histograms = widgets.Checkbox(

--- a/spikeinterface/widgets/ipywidgets/spikes_on_traces.py
+++ b/spikeinterface/widgets/ipywidgets/spikes_on_traces.py
@@ -35,7 +35,7 @@ class SpikesOnTracesPlotter(IpywidgetsPlotter):
         ts_updater = tsplotter.updater
         
         we = data_plot['waveform_extractor']
-        unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'], we.sorting.unit_ids,
+        unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'], we.unit_ids,
                                                             ratios[0] * width_cm, height_cm)
         
         self.controller = ts_updater.controller

--- a/spikeinterface/widgets/ipywidgets/unit_waveforms.py
+++ b/spikeinterface/widgets/ipywidgets/unit_waveforms.py
@@ -39,7 +39,7 @@ class UnitWaveformPlotter(IpywidgetsPlotter):
                 plt.show()
 
         data_plot['unit_ids'] = data_plot['unit_ids'][:1]
-        unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'], we.sorting.unit_ids,
+        unit_widget, unit_controller = make_unit_controller(data_plot['unit_ids'], we.unit_ids,
                                                             ratios[0] * width_cm, height_cm)
 
         same_axis_button = widgets.Checkbox(
@@ -140,7 +140,7 @@ class PlotUpdater:
                     ax.axis("off")
 
         # update probe plot
-        channel_locations = self.we.recording.get_channel_locations()
+        channel_locations = self.we.get_channel_locations()
         self.ax_probe.plot(channel_locations[:, 0], channel_locations[:, 1], ls="", marker="o", color="gray",
                            markersize=2, alpha=0.5)
         self.ax_probe.axis("off")

--- a/spikeinterface/widgets/tests/test_widgets.py
+++ b/spikeinterface/widgets/tests/test_widgets.py
@@ -148,7 +148,7 @@ class TestWidgets(unittest.TestCase):
         for backend in possible_backends:
             if backend not in self.skip_backends:
                 sw.plot_amplitudes(self.we, backend=backend, **self.backend_kwargs[backend])
-                unit_ids = self.we.sorting.unit_ids[:4]
+                unit_ids = self.we.unit_ids[:4]
                 sw.plot_amplitudes(self.we, unit_ids=unit_ids, backend=backend, **self.backend_kwargs[backend])
                 sw.plot_amplitudes(self.we, unit_ids=unit_ids, plot_histograms=True,
                                    backend=backend, **self.backend_kwargs[backend])

--- a/spikeinterface/widgets/unit_waveforms_density_map.py
+++ b/spikeinterface/widgets/unit_waveforms_density_map.py
@@ -44,10 +44,10 @@ class UnitWaveformDensityMapWidget(BaseWidget):
         we = waveform_extractor
 
         if channel_ids is None:
-            channel_ids = we.recording.channel_ids
+            channel_ids = we.channel_ids
 
         if unit_ids is None:
-            unit_ids = we.sorting.unit_ids
+            unit_ids = we.unit_ids
 
         if unit_colors is None:
             unit_colors = get_unit_colors(we.sorting)
@@ -119,7 +119,7 @@ class UnitWaveformDensityMapWidget(BaseWidget):
         plot_data = dict(
             unit_ids=unit_ids,
             unit_colors=unit_colors,
-            channel_ids=we.recording.channel_ids,
+            channel_ids=we.channel_ids,
             channel_inds=channel_inds,
             radius_um=radius_um,
             max_channels=max_channels,


### PR DESCRIPTION
This would replace the #967.

In #967 introduce the dummy recording/sorintg concept to have waveform extractor without data.
The idea wasa for plotting.
I think this will lead to many unpredictible error everywhere inmany modules.

Here a more strict implementation without the dummy object concept:
  * only recording can be None
  * when some operation (plotting, computing) when to acces the recording a clear error is given
  * some attribute (channel_ids, samplign freq, probe, num segment) are directly accessible in WaveformExtractor

