### PR TITLE
Fix deprecation warning for HDsortSortingExtractor

### DIFF
--- a/spikeinterface/extractors/hdsortextractors.py
+++ b/spikeinterface/extractors/hdsortextractors.py
@@ -247,7 +247,7 @@ def _parse_units(file, _units):
 
 
 def _squeeze_ds(ds):
-    while not isinstance(ds, (int, float)):
+    while not isinstance(ds, (int, float, np.integer)):
         ds = ds[0]
     return ds
 

--- a/spikeinterface/extractors/hdsortextractors.py
+++ b/spikeinterface/extractors/hdsortextractors.py
@@ -247,7 +247,7 @@ def _parse_units(file, _units):
 
 
 def _squeeze_ds(ds):
-    while not isinstance(ds, (int, float, np.integer, np.float)):
+    while not isinstance(ds, (int, float)):
         ds = ds[0]
     return ds
 


### PR DESCRIPTION
remove `np.float`