### PR TITLE
Fix order_channel_by_depth with multiple layers

### DIFF
--- a/spikeinterface/widgets/tests/test_widgets.py
+++ b/spikeinterface/widgets/tests/test_widgets.py
@@ -197,10 +197,10 @@ if __name__ == '__main__':
     mytest = TestWidgets()
     mytest.setUp()
     
-    # mytest.test_plot_timeseries()
+    mytest.test_plot_timeseries()
     
     # mytest.test_plot_unit_waveforms()
     # mytest.test_plot_unit_templates()
-    mytest.test_plot_unit_templates()
+    # mytest.test_plot_unit_templates()
 
     plt.show()

--- a/spikeinterface/widgets/timeseries.py
+++ b/spikeinterface/widgets/timeseries.py
@@ -215,8 +215,7 @@ def _get_trace_list(recordings, channel_ids, time_range, segment_index, order=No
 
         if order is not None:
             traces = traces[:, order]
-            channel_ids = np.asarray(channel_ids)[order]
-
         list_traces.append(traces)
-    
+    channel_ids = np.asarray(channel_ids)[order]
+
     return times, list_traces, frame_range, channel_ids

--- a/spikeinterface/widgets/timeseries.py
+++ b/spikeinterface/widgets/timeseries.py
@@ -204,6 +204,9 @@ def _get_trace_list(recordings, channel_ids, time_range, segment_index, order=No
     time_range = frame_range / fs
     times = np.arange(frame_range[0], frame_range[1]) / fs
 
+    if order is not None:
+        channel_ids = np.array(channel_ids)[order]
+
     list_traces = []
     for rec_name, rec in recordings.items():
         traces = rec.get_traces(
@@ -216,6 +219,5 @@ def _get_trace_list(recordings, channel_ids, time_range, segment_index, order=No
         if order is not None:
             traces = traces[:, order]
         list_traces.append(traces)
-    channel_ids = np.asarray(channel_ids)[order]
 
     return times, list_traces, frame_range, channel_ids


### PR DESCRIPTION
@samuelgarcia found the bug!!! For multiple layers, we were resorting the channel ids multiple times!
The plot then [loops through the `channel_ids`](https://github.com/SpikeInterface/spikeinterface/blob/master/spikeinterface/widgets/matplotlib/timeseries.py#L29)


Closes https://github.com/SpikeInterface/spikeinterface/issues/569