### PR TITLE
Fix `show_legend` flag in locations plots

### DIFF
--- a/spikeinterface/widgets/matplotlib/spike_locations.py
+++ b/spikeinterface/widgets/matplotlib/spike_locations.py
@@ -63,8 +63,8 @@ class SpikeLocationsPlotter(MplPlotter):
             
         handles = [Line2D([0], [0], ls="", marker='o', markersize=5, markeredgewidth=2, 
                           color=unit_colors[unit]) for unit in dp.unit_ids]
-            
-        self.figure.legend(handles, labels, loc='upper center', bbox_to_anchor=(0.5, 1.),
+        if dp.plot_legend:
+            self.figure.legend(handles, labels, loc='upper center', bbox_to_anchor=(0.5, 1.),
                            ncol=5, fancybox=True, shadow=True)
 
         # set proper axis limits

--- a/spikeinterface/widgets/matplotlib/unit_locations.py
+++ b/spikeinterface/widgets/matplotlib/unit_locations.py
@@ -66,8 +66,8 @@ class UnitLocationsPlotter(MplPlotter):
             self.ax.add_patch(p)
         handles = [Line2D([0], [0], ls="", marker='o', markersize=5, markeredgewidth=2, 
                           color=unit_colors[unit]) for unit in dp.unit_ids]
-            
-        self.figure.legend(handles, labels, loc='upper center', bbox_to_anchor=(0.5, 1.),
+        if dp.plot_legend:
+            self.figure.legend(handles, labels, loc='upper center', bbox_to_anchor=(0.5, 1.),
                            ncol=5, fancybox=True, shadow=True)
         if dp.hide_axis:
             self.ax.axis("off")


### PR DESCRIPTION
The show_legend flag is not used while it should. By the way, would it make sense to have a widget showing rates as function of time, for all cells? And/or the rates as function of the positions on the probe? Such widgets do not exists, do they?