### PR TITLE
Fix doc index.html image

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,10 +6,6 @@ Welcome to SpikeInterface's documentation!
   :scale: 100 %
   :align: center
 
-.. image:: images/overview.png
-  :scale: 100 %
-  :align: center
-
 
 Spikeinterface is a Python module designed to improve the accessibility, reliability, and reproducibility
 of spike sorting and all its associated computations.
@@ -29,6 +25,11 @@ With SpikeInterface, users can:
 - offer a powerful Qt-based viewer in separate package `spikeinterface-gui <https://https://github.com/SpikeInterface/spikeinterface-gui>`_
 - have some powerful sorting components to build your own sorter.
 
+Overview of SpikeInterface modules
+----------------------------------
+
+.. image:: images/overview.png
+  :align: center
 
 .. toctree::
     :maxdepth: 2
@@ -58,7 +59,8 @@ For more information, please have a look at:
 - A collection of analysis notebook `SpikeInterface Reports <https://spikeinterface.github.io/>`_
 
 
-**Versions and compatibility**
+Versions and compatibility
+--------------------------
 
 We released a major version of SpikeInterface in July 2021 (version 0.90.0)
 


### PR DESCRIPTION
Placed overview image in `Overview of SpikeInterface module` and remove "scale" so it displays well