### PR TITLE
use proper annotation key instead of 'k'

### DIFF
--- a/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -123,7 +123,7 @@ class NeoBaseRecordingExtractor(_NeoBaseExtractor, BaseRecording):
             # scalar annotations
             for k, v in sig_ann.items():
                 if not k.startswith('__'):
-                    self.annotate(k=v)
+                    self.set_annotation(k, v)
             # vector array_annotations are channel properties
             for k, values in sig_ann['__array_annotations__'].items():
                 self.set_property(k, values)


### PR DESCRIPTION
`self.annotate(k=v)` results in the letter 'k' being used as key instead of the actual content of the variable `k`. Using `set_annotation` correctly uses the content of the variable `k` instead.