### PR TITLE
Use parent recording dtype for InjectTemplates

### DIFF
--- a/spikeinterface/core/injecttemplates.py
+++ b/spikeinterface/core/injecttemplates.py
@@ -43,7 +43,8 @@ class InjectTemplatesRecording(BaseRecording):
         self._check_templates(templates)
 
         channel_ids = parent_recording.channel_ids if parent_recording is not None else list(range(templates.shape[2]))
-        BaseRecording.__init__(self, sorting.get_sampling_frequency(), channel_ids, templates.dtype)
+        dtype = parent_recording.dtype if parent_recording is not None else templates.dtype
+        BaseRecording.__init__(self, sorting.get_sampling_frequency(), channel_ids, dtype)
         
         n_units = len(sorting.unit_ids)
         assert len(templates) == n_units


### PR DESCRIPTION
If `parent_recording` is given, should use this dtype first instead of the dtype of `templates`.