### PR TITLE
Fixed crash with empty sorting

### DIFF
--- a/spikeinterface/core/basesorting.py
+++ b/spikeinterface/core/basesorting.py
@@ -235,11 +235,17 @@ class BaseSorting(BaseExtractor):
                     spike_labels.append(np.array([unit_id] * st.size))
                 elif outputs == 'unit_index':
                     spike_labels.append(np.zeros(st.size, dtype='int64') + i)
-            spike_times = np.concatenate(spike_times)
-            spike_labels = np.concatenate(spike_labels)
-            order = np.argsort(spike_times)
-            spike_times = spike_times[order]
-            spike_labels = spike_labels[order]
+
+            if len(spike_times) > 0:
+                spike_times = np.concatenate(spike_times)
+                spike_labels = np.concatenate(spike_labels)
+                order = np.argsort(spike_times)
+                spike_times = spike_times[order]
+                spike_labels = spike_labels[order]
+            else:
+                spike_times = np.array([], dtype=np.int64)
+                spike_labels = np.array([], dtype=np.int64)
+
             spikes.append((spike_times, spike_labels))
         return spikes
 

--- a/spikeinterface/core/tests/test_basesorting.py
+++ b/spikeinterface/core/tests/test_basesorting.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 import numpy as np
 
-from spikeinterface.core import NpzSortingExtractor, load_extractor
+from spikeinterface.core import NumpySorting, NpzSortingExtractor, load_extractor
 from spikeinterface.core.base import BaseExtractor
 
 from spikeinterface.core.testing_tools import create_sorting_npz, generate_sorting
@@ -89,5 +89,20 @@ def test_BaseSorting():
         assert unit not in empty_units
 
 
+def test_empty_sorting():
+    sorting = NumpySorting.from_dict({}, 30000)
+
+    assert len(sorting.unit_ids) == 0
+
+    spikes = sorting.get_all_spike_trains()
+    assert len(spikes) == 1
+    assert len(spikes[0][0]) == 0
+    assert len(spikes[0][1]) == 0
+
+    spikes = sorting.to_spike_vector()
+    assert spikes.shape == (0, )
+
+
 if __name__ == '__main__':
     test_BaseSorting()
+    test_empty_sorting()


### PR DESCRIPTION
Fixed a crash where `sorting.get_all_spike_trains()` or `sorting.to_spike_vector()` would result in a crash for empty sorting objects.