### PR TITLE
Smoother deprecation of `core.testing_tools`

### DIFF
--- a/spikeinterface/core/testing_tools.py
+++ b/spikeinterface/core/testing_tools.py
@@ -1,0 +1,7 @@
+import warnings
+
+warnings.warn("The 'testing_tools' submodule is deprecated. "
+              "Use spikeinterface.core.generate instead",
+              DeprecationWarning, stacklevel=2)
+
+from .generate import *


### PR DESCRIPTION
in favor of `core.generate`

Should fix:  https://github.com/catalystneuro/neuroconv/pull/208