### PR TITLE
Fix for sc2 on windows

### DIFF
--- a/spikeinterface/sortingcomponents/clustering/clustering_tools.py
+++ b/spikeinterface/sortingcomponents/clustering/clustering_tools.py
@@ -591,7 +591,6 @@ def remove_duplicates_via_matching(waveform_extractor, noise_levels, peak_labels
 
     del recording, sub_recording
     os.remove(tmp_filename)
-    os.rmdir(tmp_folder)
 
     return labels, new_labels
 

--- a/spikeinterface/sortingcomponents/clustering/clustering_tools.py
+++ b/spikeinterface/sortingcomponents/clustering/clustering_tools.py
@@ -489,7 +489,7 @@ def remove_duplicates(wfs_arrays, noise_levels, peak_labels, num_samples, num_ch
 
 
 
-def remove_duplicates_via_matching(waveform_extractor, noise_levels, peak_labels, sparsify_threshold=1, method_kwargs={}, job_kwargs={}):
+def remove_duplicates_via_matching(waveform_extractor, noise_levels, peak_labels, sparsify_threshold=1, method_kwargs={}, job_kwargs={}, tmp_folder=None):
 
     from spikeinterface.sortingcomponents.matching import find_spikes_from_templates
     from spikeinterface import get_noise_levels 
@@ -517,14 +517,10 @@ def remove_duplicates_via_matching(waveform_extractor, noise_levels, peak_labels
     padding = 2 * duration
     blanck = np.zeros(padding*num_chans, dtype=np.float32)
 
-    name = ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
-    tmp_folder = Path(os.path.join(get_global_tmp_folder(), name))
-    if tmp_folder.exists():
-        import shutils
-        shutils.rmtree(tmp_folder)
+    if tmp_folder is None:
+        tmp_folder = get_global_tmp_folder()
 
-    tmp_folder.mkdir()
-    tmp_filename = os.path.join(tmp_folder, 'tmp.raw')
+    tmp_filename = tmp_folder / 'tmp.raw'
 
     f = open(tmp_filename, 'wb')
     f.write(blanck)
@@ -593,7 +589,9 @@ def remove_duplicates_via_matching(waveform_extractor, noise_levels, peak_labels
     labels = np.unique(new_labels)
     labels = labels[labels>=0]
 
-    shutil.rmtree(tmp_folder)
+    del recording, sub_recording
+    import os
+    os.remove(tmp_filename)
 
     return labels, new_labels
 

--- a/spikeinterface/sortingcomponents/clustering/clustering_tools.py
+++ b/spikeinterface/sortingcomponents/clustering/clustering_tools.py
@@ -590,8 +590,8 @@ def remove_duplicates_via_matching(waveform_extractor, noise_levels, peak_labels
     labels = labels[labels>=0]
 
     del recording, sub_recording
-    import os
     os.remove(tmp_filename)
+    os.rmdir(tmp_folder)
 
     return labels, new_labels
 

--- a/spikeinterface/sortingcomponents/clustering/random_projections.py
+++ b/spikeinterface/sortingcomponents/clustering/random_projections.py
@@ -178,7 +178,8 @@ class RandomProjectionClustering:
                 name = ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
                 tmp_folder = get_global_tmp_folder() / name
             else:
-                tmp_folder = params["tmp_folder"]
+                tmp_folder = Path(params["tmp_folder"])
+
             if params['shared_memory']:
                 waveform_folder = None
                 mode = 'memory'
@@ -198,8 +199,11 @@ class RandomProjectionClustering:
             cleaning_matching_params['verbose'] = False
             cleaning_matching_params['progress_bar'] = False
 
+            cleaning_params = params['cleaning_kwargs'].copy()
+            cleaning_params['tmp_folder'] = tmp_folder
+
             labels, peak_labels = remove_duplicates_via_matching(we, noise_levels, peak_labels, 
-                                                                 job_kwargs=cleaning_matching_params, **params['cleaning_kwargs'])
+                                                                 job_kwargs=cleaning_matching_params, **cleaning_params)
     
             if params["tmp_folder"] is None:
                 shutil.rmtree(tmp_folder)


### PR DESCRIPTION
I was teaching today, and I made a notebook where all the students had to use spykingcircus2. Turned out this was crashing on windows with some PermissionDenied Error for temporary files. I guess this fix might fix it, despite the fact that I do not have windows here to test that. Weird that tests passed, I thought the sorters were tested also with windows VM. Is it not the case?