### PR TITLE
[core] Improve handling of not dumpable objects

### DIFF
--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -13,7 +13,7 @@ from copy import deepcopy
 import numpy as np
 
 from .default_folders import get_global_tmp_folder, is_set_global_tmp_folder
-from .core_tools import check_json, is_dict_extractor, recursive_path_modifier
+from .core_tools import check_json, is_dict_extractor, recursive_path_modifier, NotDumpableError
 from .job_tools import _shared_job_kwargs_doc
 
 
@@ -281,7 +281,7 @@ class BaseExtractor:
         if self._preferred_mp_context is not None:
             other._preferred_mp_context = self._preferred_mp_context
 
-    def to_dict(self, include_annotations=False, include_properties=False, include_features=False,
+    def to_dict(self, include_annotations=False, include_properties=False,
                 relative_to=None, folder_metadata=None):
         """
         Make a nested serialized dictionary out of the extractor. The dictionary be used to re-initialize an
@@ -290,13 +290,11 @@ class BaseExtractor:
         Parameters
         ----------
         include_annotations: bool
-            If True, all annotations are added to the dict
+            If True, all annotations are added to the dict, by default False
         include_properties: bool
-            If True, all properties are added to the dict
-        include_features: bool
-            If True, all features are added to the dict
+            If True, all properties are added to the dict, by default False
         relative_to: str, Path, or None
-            If not None, file_paths are serialized relative to this path
+            If not None, file_paths are serialized relative to this path, by default None
 
         Returns
         -------
@@ -407,7 +405,7 @@ class BaseExtractor:
         """
         Clones an existing extractor into a new instance.
         """
-        d = self.to_dict(include_annotations=True, include_properties=True, include_features=True)
+        d = self.to_dict(include_annotations=True, include_properties=True)
         clone = BaseExtractor.from_dict(d)
         return clone
 
@@ -483,7 +481,6 @@ class BaseExtractor:
         assert self.check_if_dumpable()
         dump_dict = self.to_dict(include_annotations=True,
                                  include_properties=False,
-                                 include_features=False,
                                  relative_to=relative_to,
                                  folder_metadata=folder_metadata)
         file_path = self._get_file_path(file_path, ['.json'])
@@ -492,7 +489,7 @@ class BaseExtractor:
             encoding='utf8'
         )
 
-    def dump_to_pickle(self, file_path=None, include_properties=True, include_features=True,
+    def dump_to_pickle(self, file_path=None, include_properties=True,
                        relative_to=None, folder_metadata=None):
         """
         Dump recording extractor to a pickle file.
@@ -504,15 +501,12 @@ class BaseExtractor:
             Path of the json file
         include_properties: bool
             If True, all properties are dumped
-        include_features: bool
-            If True, all features are dumped
         relative_to: str, Path, or None
             If not None, file_paths are serialized relative to this path
         """
         assert self.check_if_dumpable()
         dump_dict = self.to_dict(include_annotations=True,
                                  include_properties=include_properties,
-                                 include_features=include_features,
                                  relative_to=relative_to,
                                  folder_metadata=folder_metadata)
         file_path = self._get_file_path(file_path, ['.pkl', '.pickle'])

--- a/spikeinterface/core/core_tools.py
+++ b/spikeinterface/core/core_tools.py
@@ -11,7 +11,14 @@ import inspect
 
 from .job_tools import ensure_chunk_size, ensure_n_jobs, divide_segment_into_chunks, ChunkRecordingExecutor, \
     _shared_job_kwargs_doc
-    
+
+
+class NotDumpableError(RuntimeError):
+    """Raised whenever attempting to dump/save a non-dumpable object"""
+    def __init__(self, message="The object is not dumpable. Use `save()` function to make the object dumpable."):
+        self.message = message
+        super().__init__(self.message)
+
     
 def copy_signature(source_fct):
     def copy(target_fct):

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -5,13 +5,14 @@ import json
 
 import numpy as np
 from copy import deepcopy
+from warnings import warn
 
-from .base import load_extractor
-
-from .core_tools import check_json
-from .job_tools import _shared_job_kwargs_doc
 from spikeinterface.core.waveform_tools import extract_waveforms_to_buffers
 import probeinterface
+
+from .base import load_extractor
+from .core_tools import check_json
+from .job_tools import _shared_job_kwargs_doc
 from .recording_tools import check_probe_do_not_overlap
 
 _possible_template_modes = ('average', 'std', 'median')
@@ -238,6 +239,9 @@ class WaveformExtractor:
                 recording.dump(folder / 'recording.json', relative_to=relative_to)
             if sorting.is_dumpable:
                 sorting.dump(folder / 'sorting.json', relative_to=relative_to)
+            else:
+                warn("Sorting object is not dumpable, which might result in downstream errors for "
+                     "parallel processing. To make the sorting dumpable, use the `sorting.save()` function.")
             
             # dump some attributes of the recording for the mode with_recording=False at next load
             rec_attributes_file = folder / 'recording_info' / 'recording_attributes.json'
@@ -663,6 +667,9 @@ class WaveformExtractor:
                     self.recording.dump(folder / 'recording.json', relative_to=relative_to)
             if self.sorting.is_dumpable:
                 self.sorting.dump(folder / 'sorting.json', relative_to=relative_to)
+            else:
+                warn("Sorting object is not dumpable, which might result in downstream errors for "
+                     "parallel processing. To make the sorting dumpable, use the `sorting.save()` function.")
 
             # dump some attributes of the recording for the mode with_recording=False at next load
             rec_attributes_file = folder / 'recording_info' / 'recording_attributes.json'
@@ -712,6 +719,9 @@ class WaveformExtractor:
             if self.sorting.is_dumpable:
                 sort_dict = self.sorting.to_dict(relative_to=relative_to)
                 zarr_root.attrs['sorting'] = check_json(sort_dict)
+            else:
+                warn("Sorting object is not dumpable, which might result in downstream errors for "
+                     "parallel processing. To make the sorting dumpable, use the `sorting.save()` function.")
             recording_info = zarr_root.create_group('recording_info')
             recording_info.attrs['recording_attributes'] = check_json(rec_attributes)
             if probegroup is not None:

--- a/spikeinterface/postprocessing/spike_amplitudes.py
+++ b/spikeinterface/postprocessing/spike_amplitudes.py
@@ -69,6 +69,11 @@ class SpikeAmplitudesCalculator(BaseWaveformExtractorExtension):
         if n_jobs == 1:
             init_args = (recording, sorting)
         else:
+            # TODO: avoid dumping sorting and use spike vector and peak pipeline instead
+            assert sorting.check_if_dumpable(), (
+                "The soring object is not dumpable and cannot be processed in parallel. You can use the "
+                "`sorting.save()` function to make it dumpable"
+            )
             init_args = (recording.to_dict(), sorting.to_dict())
         init_args = init_args + (extremum_channels_index, peak_shifts, return_scaled)
         processor = ChunkRecordingExecutor(recording, func, init_func, init_args,


### PR DESCRIPTION
this PR improves the way we handle non dumpable objects (both recording and sorting) by:
- raise a `NotDumpableError` if attempting to process a non-dumpable recording in parallel
- warn users when a waveform extractor with non-dumpable sorting is created
- assert that sorting is dumpable in `compute_spike_amplitudes` (fixes #1088)