### PR TITLE
Improve Phy+PCA sparsity handling

### DIFF
--- a/spikeinterface/exporters/tests/test_export_to_phy.py
+++ b/spikeinterface/exporters/tests/test_export_to_phy.py
@@ -7,6 +7,7 @@ import numpy as np
 from spikeinterface import extract_waveforms, download_dataset
 import spikeinterface.extractors as se
 from spikeinterface.exporters import export_to_phy
+from spikeinterface.postprocessing import get_template_channel_sparsity, compute_principal_components
 
 if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "exporters"
@@ -33,8 +34,8 @@ def test_export_to_phy():
     export_to_phy(waveform_extractor, output_folder,
                   compute_pc_features=True,
                   compute_amplitudes=True,
-                  max_channels_per_template=8,
-                  n_jobs=1, chunk_size=10000, progress_bar=True)
+                  n_jobs=1, chunk_size=10000,
+                  progress_bar=True)
 
 
 def test_export_to_phy_by_property():
@@ -58,12 +59,11 @@ def test_export_to_phy_by_property():
     sorting = sorting.save(folder=sort_folder)
 
     waveform_extractor = extract_waveforms(recording, sorting, waveform_folder)
-
+    sparsity_group = get_template_channel_sparsity(waveform_extractor, method="by_property", by_property="group")
     export_to_phy(waveform_extractor, output_folder,
                   compute_pc_features=True,
                   compute_amplitudes=True,
-                  max_channels_per_template=8,
-                  sparsity_dict=dict(method="by_property", by_property="group"),
+                  sparsity=sparsity_group,
                   n_jobs=1, chunk_size=10000, progress_bar=True)
 
     template_inds = np.load(output_folder / "template_ind.npy")
@@ -72,13 +72,14 @@ def test_export_to_phy_by_property():
     # Remove one channel
     recording_rm = recording.channel_slice([0, 2, 3, 4, 5, 6, 7])
     waveform_extractor_rm = extract_waveforms(recording_rm, sorting, waveform_folder_rm)
+    sparsity_group = get_template_channel_sparsity(waveform_extractor_rm, method="by_property", by_property="group")
 
     export_to_phy(waveform_extractor_rm, output_folder_rm,
                   compute_pc_features=True,
                   compute_amplitudes=True,
-                  max_channels_per_template=8,
-                  sparsity_dict=dict(method="by_property", by_property="group"),
-                  n_jobs=1, chunk_size=10000, progress_bar=True)
+                  sparsity=sparsity_group,
+                  n_jobs=1, chunk_size=10000,
+                  progress_bar=True)
 
     template_inds = np.load(output_folder_rm / "template_ind.npy")
     assert template_inds.shape == (num_units, 4)
@@ -94,35 +95,43 @@ def test_export_to_phy_by_sparsity():
 
     waveform_folder = cache_folder / 'waveforms'
     output_folder_radius = cache_folder / 'phy_output_radius'
-    output_folder_thr = cache_folder / 'phy_output_thr'
+    output_folder_multi_sparse = cache_folder / 'phy_output_multi_sparse'
 
-    for f in (waveform_folder, output_folder_radius, output_folder_thr):
+    for f in (waveform_folder, output_folder_radius, output_folder_multi_sparse):
         if f.is_dir():
             shutil.rmtree(f)
 
     waveform_extractor = extract_waveforms(recording, sorting, waveform_folder)
-
+    sparsity_radius = get_template_channel_sparsity(waveform_extractor, method="radius", radius_um=50)
     export_to_phy(waveform_extractor, output_folder_radius,
                   compute_pc_features=True,
                   compute_amplitudes=True,
-                  max_channels_per_template=None,
-                  sparsity_dict=dict(method="radius", radius_um=50),
+                  sparsity=sparsity_radius,
                   n_jobs=1, chunk_size=10000, progress_bar=True)
 
     template_ind = np.load(output_folder_radius / "template_ind.npy")
+    pc_ind = np.load(output_folder_radius / "pc_feature_ind.npy")
     # templates have different shapes!
     assert -1 in template_ind
+    assert -1 in pc_ind
 
-    export_to_phy(waveform_extractor, output_folder_thr,
+    # pre-compute PC with sparsity
+    sparsity_radius_small = get_template_channel_sparsity(waveform_extractor, method="radius", radius_um=30)
+    pc = compute_principal_components(waveform_extractor, sparsity=sparsity_radius_small)
+    export_to_phy(waveform_extractor, output_folder_multi_sparse,
                   compute_pc_features=True,
                   compute_amplitudes=True,
-                  max_channels_per_template=None,
-                  sparsity_dict=dict(method="threshold", threshold=2),
-                  n_jobs=1, chunk_size=10000, progress_bar=True)
+                  sparsity=sparsity_radius,
+                  n_jobs=1, chunk_size=10000,
+                  progress_bar=True)
 
-    template_ind = np.load(output_folder_thr / "template_ind.npy")
+    template_ind = np.load(output_folder_multi_sparse / "template_ind.npy")
+    pc_ind = np.load(output_folder_multi_sparse / "pc_feature_ind.npy")
     # templates have different shapes!
     assert -1 in template_ind
+    assert -1 in pc_ind
+    # PC sparsity is more stringent than teplate sparsity
+    assert pc_ind.shape[1] < template_ind.shape[1]
 
 
 if __name__ == '__main__':

--- a/spikeinterface/postprocessing/principal_component.py
+++ b/spikeinterface/postprocessing/principal_component.py
@@ -198,7 +198,17 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
 
         return projections
 
-    #TODO
+    def get_sparsity(self):
+        """
+        Returns sparsity used in PC computation
+
+        Returns
+        -------
+        dict
+            The sparsity dictionary (key: unit_id, value: list of channel_ids)
+        """
+        return self._params["sparsity"]
+
     def _run(self, n_jobs=1, progress_bar=False):
         """
         Compute the PCs on waveforms extacted within the WaveformExtarctor.
@@ -255,8 +265,8 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
     def get_extension_function():
         return compute_principal_components
 
-    def run_for_all_spikes(self, file_path, max_channels_per_template=16, peak_sign='neg',
-                           **job_kwargs):
+    def run_for_all_spikes(self, file_path=None, peak_sign='neg',
+                           sparsity=None, **job_kwargs):
         """
         Project all spikes from the sorting on the PCA model.
         This is a long computation because waveform need to be extracted from each spikes.
@@ -267,12 +277,19 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
 
         Parameters
         ----------
-        file_path : str or Path
-            Path to npy file that will store the PCA projections
-        max_channels_per_template : int, optionl
-            Maximum number of best channels to compute PCA projections on
+        file_path : str or Path or None
+            Path to npy file that will store the PCA projections.
+            If None, output is saved in principal_components/all_pcs.npy
         peak_sign : str, optional
             Peak sign to get best channels ('neg', 'pos', 'both'), by default 'neg'
+        sparsity : dict, optional
+            The sparsity to use for PC projection computation (by default None):
+            * If None and the principal_component extension has been computed with sparsity, the same
+            sparsity is used. 
+            * If given and sparsity has not been used to compute principal components,
+            the provided sparsity is used (dictionary with unit_id as key and list of channel_ids as values).
+            * If None and principal components are not sparse, no sparsity is applied and PC projections are 
+            computed on all channels
         {}
         """
         p = self._params
@@ -286,24 +303,39 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         assert sorting.get_num_segments() == 1
         assert p['mode'] in ('by_channel_local', 'by_channel_global')
 
+        if file_path is None:
+            file_path = self.extension_folder / "all_pcs.npy"
         file_path = Path(file_path)
 
         all_spikes = sorting.get_all_spike_trains(outputs='unit_index')
         spike_times, spike_labels = all_spikes[0]
 
-        max_channels_per_template = min(max_channels_per_template, we.get_num_channels())
+        if sparsity is not None:
+            if p["sparsity"] is not None:
+                for unit_id, sparse_channels in sparsity.items():
+                    assert np.all(sparse_channels == p["sparsity"][unit_id]), \
+                        ("The provided sparsity does not match the sparsity used to estimate PC models. "
+                         "Use sparsity=None to use correct sparsity")
+        else:
+            sparsity = p["sparsity"]
 
-        best_channels_index = get_template_channel_sparsity(we, outputs="index", peak_sign=peak_sign,
-                                                            num_channels=max_channels_per_template)
+        if sparsity is None:
+            sparse_channels_indices = {unit_id: np.arange(we.get_num_channels()) for unit_id in we.unit_ids}
+            max_channels_per_template = we.get_num_channels()
+        else:
+            sparse_channels_indices = {unit_id: self.waveform_extractor.channel_ids_to_indices(sparsity[unit_id])
+                                       for unit_id in sorting.unit_ids}
+            max_sparse_channels = np.max([len(best_channels) for best_channels in sparse_channels_indices.values()])
+            max_channels_per_template = max_sparse_channels
 
-        unit_channels = [best_channels_index[unit_id] for unit_id in sorting.unit_ids]
+        unit_channels = [sparse_channels_indices[unit_id] for unit_id in sorting.unit_ids]
 
         pca_model = self.get_pca_model()
         if p['mode'] in ['by_channel_global', 'concatenated']:
             pca_model = [pca_model] * recording.get_num_channels()
 
         # nSpikes, nFeaturesPerChannel, nPCFeatures
-        # this come from  phy template-gui
+        # this comes from  phy template-gui
         # https://github.com/kwikteam/phy-contrib/blob/master/docs/template-gui.md#datasets
         shape = (spike_times.size, p['n_components'], max_channels_per_template)
         all_pcs = np.lib.format.open_memmap(filename=file_path, mode='w+', dtype='float32', shape=shape)

--- a/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -1,5 +1,5 @@
 import unittest
-import shutil
+import pytest
 from pathlib import Path
 
 import numpy as np
@@ -10,6 +10,11 @@ from spikeinterface.extractors import toy_example
 from spikeinterface.postprocessing import (WaveformPrincipalComponent, compute_principal_components,
                                            get_template_channel_sparsity)
 from spikeinterface.postprocessing.tests.common_extension_tests import WaveformExtensionCommonTestSuite
+
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "postprocessing"
+else:
+    cache_folder = Path("cache_folder") / "postprocessing"
 
 
 DEBUG = False
@@ -48,15 +53,30 @@ class PrincipalComponentsExtensionTest(WaveformExtensionCommonTestSuite, unittes
 
         pc_file1 = pc.extension_folder / 'all_pc1.npy'
         pc.run_for_all_spikes(
-            pc_file1, max_channels_per_template=7, chunk_size=10000, n_jobs=1)
+            pc_file1, sparsity=None, chunk_size=10000, n_jobs=1)
         all_pc1 = np.load(pc_file1)
 
         pc_file2 = pc.extension_folder / 'all_pc2.npy'
         pc.run_for_all_spikes(
-            pc_file2, max_channels_per_template=7, chunk_size=10000, n_jobs=2)
+            pc_file2, sparsity=None, chunk_size=10000, n_jobs=2)
         all_pc2 = np.load(pc_file2)
 
         assert np.array_equal(all_pc1, all_pc2)
+
+        # test with sparsity
+        sparsity = get_template_channel_sparsity(we, method="radius",
+                                                 radius_um=50)
+        we_copy = we.save(folder=cache_folder / "we_copy")
+        pc_sparse = self.extension_class.get_extension_function()(we_copy, sparsity=sparsity, load_if_exists=False)
+        pc_file_sparse = pc.extension_folder / 'all_pc_sparse.npy'
+        pc_sparse.run_for_all_spikes(pc_file_sparse, sparsity=sparsity, chunk_size=10000, n_jobs=1)
+        all_pc_sparse = np.load(pc_file_sparse)
+        all_spikes = we_copy.sorting.get_all_spike_trains(outputs='unit_id')
+        _, spike_labels = all_spikes[0]
+        for unit_id, sparse_channel_ids in sparsity.items():
+            # check dimensions
+            pc_unit = all_pc_sparse[spike_labels == unit_id]
+            assert np.allclose(pc_unit[:, :, len(sparse_channel_ids):], 0)
 
     def test_sparse(self):
         we = self.we2


### PR DESCRIPTION
The `export_to_phy()` function had several options to handle sparsity:
- explicitly passing a `sparsity_dict` 
- when `sparsity_dict` was None, automatically select best channels with `max_templates_per_spikes`
- when running pc for all spikes, sparsity was not taken into consideration

In addition, if PC were pre-computed with a different sparsity, this was not taken into account and it could have resulted in a `NotFittedError` (see #1071).

This PR simplifies the way Phy handles sparsity by only using a single `sparsity` argument, which is the output of the `get_template_channel_sparsity(output="id")` function. 

- If `sparsity` is `None`, no sparsity is applied (if `num_channels>64` a warning is printed)
- If `sparsity` is given, it controls both template sparsity and PC sparsity (only if PC was not computed with sparsity)
- If PC is pre-computed and sparse, `sparsity` only controls template sparsity, while PC sparsity uses the pre-computed sparsity for consistency (to make sure we don't get a `NotFittedError`)

We also needed a modification of the `WaveformPrincipaComponents.run_for_all_spikes()` to consider sparsity (either pre-computed, or passed on-the-fly)


fixes #1071