### PR TITLE
Add possibility to use custom neo classes with NeoBaseExtractor

### DIFF
--- a/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -10,7 +10,10 @@ from spikeinterface.core import (BaseRecording, BaseSorting, BaseEvent,
 
 
 def get_reader(raw_class, **neo_kwargs):
-    neoIOclass = eval('neo.rawio.' + raw_class)
+    if isinstance(raw_class, str):
+        neoIOclass = eval('neo.rawio.' + raw_class)
+    else:
+        neoIOclass = raw_class
     neo_reader = neoIOclass(**neo_kwargs)
     neo_reader.parse_header()
 


### PR DESCRIPTION
I am using custom Neo classes to load my data (https://neo.readthedocs.io/en/stable/io_developers_guide.html) and this commit would allow to pass the custom Neo class directly to NeoBaseRecordingExtractor (I haven't tested for NeoBaseSortingExtractor). It's useful when working with custom Neo classes and spikeinterface.

Example of how this can be used here https://github.com/JulesLebert/spikesorting_scripts/blob/main/spikesorting_scripts/io/customtdtrecording_extractor.py