### PR TITLE
Fixed template_tools warning in 'postprocessing'

### DIFF
--- a/spikeinterface/curation/auto_merge.py
+++ b/spikeinterface/curation/auto_merge.py
@@ -3,7 +3,8 @@ import numpy as np
 import scipy.signal
 import scipy.spatial
 
-from ..postprocessing import compute_correlograms, get_template_extremum_channel
+from ..core.template_tools import get_template_extremum_channel
+from ..postprocessing import compute_correlograms
 from ..qualitymetrics import compute_refrac_period_violations, compute_firing_rate
 
 from .mergeunitssorting import MergeUnitsSorting

--- a/spikeinterface/postprocessing/alignsorting.py
+++ b/spikeinterface/postprocessing/alignsorting.py
@@ -3,8 +3,7 @@ from typing import Optional
 
 from spikeinterface import BaseSorting, BaseSortingSegment
 from spikeinterface.core.core_tools import define_function_from_class
-
-from ..postprocessing import get_template_extremum_channel_peak_shift
+from spikeinterface.core.template_tools import get_template_extremum_channel_peak_shift
 
 
 class AlignSortingExtractor(BaseSorting):

--- a/spikeinterface/postprocessing/principal_component.py
+++ b/spikeinterface/postprocessing/principal_component.py
@@ -9,11 +9,9 @@ import numpy as np
 from sklearn.decomposition import IncrementalPCA
 from sklearn.exceptions import NotFittedError
 
-from spikeinterface.core.job_tools import ChunkRecordingExecutor, ensure_n_jobs
+from spikeinterface.core.job_tools import ChunkRecordingExecutor, ensure_n_jobs, _shared_job_kwargs_doc
+from spikeinterface.core.template_tools import get_template_channel_sparsity
 from spikeinterface.core.waveform_extractor import WaveformExtractor, BaseWaveformExtractorExtension
-from .template_tools import get_template_channel_sparsity
-
-from spikeinterface.core.job_tools import _shared_job_kwargs_doc
 
 _possible_modes = ['by_channel_local', 'by_channel_global', 'concatenated']
 

--- a/spikeinterface/postprocessing/spike_amplitudes.py
+++ b/spikeinterface/postprocessing/spike_amplitudes.py
@@ -3,10 +3,10 @@ import shutil
 
 from spikeinterface.core.job_tools import ChunkRecordingExecutor, _shared_job_kwargs_doc, ensure_n_jobs
 
-from spikeinterface.core.waveform_extractor import WaveformExtractor, BaseWaveformExtractorExtension
+from spikeinterface.core.template_tools import (get_template_extremum_channel,
+                                                get_template_extremum_channel_peak_shift)
 
-from .template_tools import (get_template_extremum_channel,
-                             get_template_extremum_channel_peak_shift)
+from spikeinterface.core.waveform_extractor import WaveformExtractor, BaseWaveformExtractorExtension
 
 
 class SpikeAmplitudesCalculator(BaseWaveformExtractorExtension):

--- a/spikeinterface/postprocessing/spike_locations.py
+++ b/spikeinterface/postprocessing/spike_locations.py
@@ -2,10 +2,10 @@ import numpy as np
 
 from spikeinterface.core.job_tools import _shared_job_kwargs_doc
 
-from spikeinterface.core.waveform_extractor import WaveformExtractor, BaseWaveformExtractorExtension
+from spikeinterface.core.template_tools import (get_template_extremum_channel,
+                                                get_template_extremum_channel_peak_shift)
 
-from .template_tools import (get_template_extremum_channel,
-                             get_template_extremum_channel_peak_shift)
+from spikeinterface.core.waveform_extractor import WaveformExtractor, BaseWaveformExtractorExtension
 
 
 class SpikeLocationsCalculator(BaseWaveformExtractorExtension):

--- a/spikeinterface/postprocessing/template_metrics.py
+++ b/spikeinterface/postprocessing/template_metrics.py
@@ -11,8 +11,8 @@ import scipy.stats
 from scipy.signal import resample_poly
 
 from ..core import WaveformExtractor
+from ..core.template_tools import get_template_extremum_channel, get_template_channel_sparsity
 from ..core.waveform_extractor import BaseWaveformExtractorExtension
-from .template_tools import get_template_extremum_channel, get_template_channel_sparsity
 import warnings
 
 

--- a/spikeinterface/postprocessing/unit_localization.py
+++ b/spikeinterface/postprocessing/unit_localization.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     HAVE_NUMBA = False
 
-from .template_tools import get_template_channel_sparsity
+from spikeinterface.core.template_tools import get_template_channel_sparsity
 from spikeinterface.core.waveform_extractor import WaveformExtractor, BaseWaveformExtractorExtension
 
 

--- a/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/spikeinterface/qualitymetrics/misc_metrics.py
@@ -15,7 +15,7 @@ import warnings
 import scipy.ndimage
 
 from ..core import get_noise_levels
-from ..postprocessing import (
+from ..core.template_tools import (
     get_template_extremum_channel,
     get_template_extremum_amplitude,
 )

--- a/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/spikeinterface/qualitymetrics/pca_metrics.py
@@ -17,7 +17,7 @@ from copy import deepcopy
 import spikeinterface as si
 from ..core import get_random_data_chunks
 from ..core.job_tools import tqdm_joblib
-from ..postprocessing import get_template_channel_sparsity
+from ..core.template_tools import get_template_channel_sparsity
 
 from ..postprocessing import WaveformPrincipalComponent
 


### PR DESCRIPTION
Moving `template_tools` to core created a bunch of warnings in the `postprocessing` submodule.

This hopefully fixes them all.