### PR TITLE
[feat-widgets] Updates for SV

### DIFF
--- a/spikeinterface/widgets/sorting_summary.py
+++ b/spikeinterface/widgets/sorting_summary.py
@@ -39,7 +39,7 @@ class SortingSummaryWidget(BaseWidget):
     
     def __init__(self, waveform_extractor: WaveformExtractor, unit_ids=None,
                  sparsity=None, max_amplitudes_per_unit=None, curation=False,
-                 unit_table_properties=None, backend=None, **backend_kwargs):
+                 unit_table_properties=None, label_choices=None, backend=None, **backend_kwargs):
         self.check_extensions(waveform_extractor, ['correlograms', 'spike_amplitudes',
                                                    'unit_locations', 'similarity'])
         we = waveform_extractor
@@ -62,7 +62,7 @@ class SortingSummaryWidget(BaseWidget):
                                           hide_unit_selector=True).plot_data
         locs_plot_data = UnitLocationsWidget(we, unit_ids=unit_ids, hide_unit_selector=True).plot_data
         sim_plot_data = TemplateSimilarityWidget(we, unit_ids=unit_ids).plot_data
-        
+
         plot_data = dict(
             waveform_extractor=waveform_extractor,
             unit_ids=unit_ids,
@@ -72,7 +72,8 @@ class SortingSummaryWidget(BaseWidget):
             similarity=sim_plot_data,
             unit_locations=locs_plot_data,
             unit_table_properties=unit_table_properties,
-            curation=curation
+            curation=curation,
+            label_choices=label_choices
         )
 
         BaseWidget.__init__(self, plot_data, backend=backend, **backend_kwargs)

--- a/spikeinterface/widgets/sortingview/base_sortingview.py
+++ b/spikeinterface/widgets/sortingview/base_sortingview.py
@@ -67,7 +67,7 @@ class SortingviewPlotter(BackendPlotter):
         self.url = url
 
 
-def generate_unit_table_view(sorting, unit_properties=None):
+def generate_unit_table_view(sorting, unit_properties=None, similarity_scores=None):
     import sortingview.views as vv
     if unit_properties is None:
         ut_columns = []
@@ -109,5 +109,5 @@ def generate_unit_table_view(sorting, unit_properties=None):
                 values[prop_name] = property_values[ui]
             ut_rows.append(vv.UnitsTableRow(unit_id=unit, values=check_json(values)))
             
-    v_units_table = vv.UnitsTable(rows=ut_rows, columns=ut_columns)
+    v_units_table = vv.UnitsTable(rows=ut_rows, columns=ut_columns, similarity_scores=similarity_scores)
     return v_units_table

--- a/spikeinterface/widgets/sortingview/sorting_summary.py
+++ b/spikeinterface/widgets/sortingview/sorting_summary.py
@@ -33,16 +33,23 @@ class SortingSummaryPlotter(SortingviewPlotter):
         unitlocation_plotter = UnitLocationsPlotter()
         v_unit_locations = unitlocation_plotter.do_plot(dp.unit_locations, generate_url=False, 
                                                         display=False, backend="sortingview")
-        template_sim_plotter = TemplateSimilarityPlotter()
-        v_unit_similarity = template_sim_plotter.do_plot(dp.similarity, generate_url=False, 
-                                                         display=False, backend="sortingview")
+        # similarity
+        similarity_scores = []
+        for i1, u1 in enumerate(unit_ids):
+            for i2, u2 in enumerate(unit_ids):
+                similarity_scores.append(vv.UnitSimilarityScore(
+                    unit_id1=u1,
+                    unit_id2=u2,
+                    similarity=dp.similarity['similarity'][i1, i2].astype("float32")
+                    ))
 
         # unit ids
         v_units_table = generate_unit_table_view(dp.waveform_extractor.sorting, 
-                                                 dp.unit_table_properties)
+                                                 dp.unit_table_properties,
+                                                 similarity_scores=similarity_scores)
 
         if dp.curation:
-            v_curation = vv.SortingCuration2()
+            v_curation = vv.SortingCuration2(label_choices=dp.label_choices)
             v1 = vv.Splitter(
                 direction='vertical',
                 item1=vv.LayoutItem(v_units_table),
@@ -61,13 +68,7 @@ class SortingSummaryPlotter(SortingviewPlotter):
                                 vv.Splitter(
                                     direction='vertical',
                                     item1=vv.LayoutItem(v_spike_amplitudes),
-                                    item2=vv.LayoutItem(
-                                        vv.Splitter(
-                                            direction='horizontal',
-                                            item1=vv.LayoutItem(v_cross_correlograms, stretch=2),
-                                            item2=vv.LayoutItem(v_unit_similarity, stretch=2)
-                                                )
-                                            )
+                                    item2=vv.LayoutItem(v_cross_correlograms),
                                         )
                                     )
                                 )


### PR DESCRIPTION
New Sortingview backend features and updates:
- Removed `TemplateSimilarityView` from `plot_sorting_summary` (it's not very useful)
- Unit table now uses `similarity_score` (and can sort selected unit by it)
- Option to pass `label_choices` for curation

Example here: https://figurl.org/f?v=gs://figurl/spikesortingview-10&d=sha1://7098c74b3901c8390ca2c85d2c13e8b04dfc3aab&label=SpikeInterface%20-%20Sorting%20Summary