### PR TITLE
[bug-core] Use absolute folder in NpySnippetsFolder

### DIFF
--- a/spikeinterface/core/npyfoldersnippets.py
+++ b/spikeinterface/core/npyfoldersnippets.py
@@ -47,7 +47,7 @@ class NpyFolderSnippets(NpySnippetsExtractor):
         folder_metadata = folder_path
         self.load_metadata_from_folder(folder_metadata)
 
-        self._kwargs = dict(folder_path=str(folder_path))
+        self._kwargs = dict(folder_path=str(folder_path.absolute()))
         self._bin_kwargs = d['kwargs']
 
 


### PR DESCRIPTION
This is needed to correctly map volumes when using Docker/singularity