### PR TITLE
Add return waveform functionality to peak pipeline

### DIFF
--- a/spikeinterface/sortingcomponents/tests/test_peak_pipeline.py
+++ b/spikeinterface/sortingcomponents/tests/test_peak_pipeline.py
@@ -73,6 +73,16 @@ def test_run_peak_pipeline():
     assert step_two.shape[0] == peaks.shape[0]
     assert step_two.shape[1] == recording.get_num_channels()
 
+    # two step, adding waveforms
+    ms_before = 0.5
+    ms_after = 1.0
+    steps = [MyStep(recording, param0=5.5), MyStepWithWaveforms(recording, ms_before=ms_before, ms_after=ms_after)]
+    waveforms, step_one, step_two = run_peak_pipeline(recording, peaks, steps, job_kwargs, return_waveforms=True)
+    
+    num_timestamps = int((ms_after + ms_before) * recording.get_sampling_frequency() / 1000)
+    assert waveforms.shape[0] == peaks.shape[0]
+    assert waveforms.shape[1] == num_timestamps
+    assert waveforms.shape[2] == recording.get_num_channels()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added functionality so the peak pipeline in the sorting components module can return the waveforms. That is, a keyword argument is used so besides the operations indicated on each of the steps the waveforms are always returned (always at the beginning). 

While I was working on #1145 I found myself on need of something like this both for testing and debugging process and I think it might be useful in general.

I added a simple test to PR as well.