### PR TITLE
[bug-comparison] Fix networkx deprecation and clean up comparison tests cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,8 @@ extractors = [
     "pynwb>=2.1.0",
     "pyedflib>=0.1.30",
     # "nixio>=1.5.0",
-    # "shybrid>=0.4.2",
-    # "pyyaml>=5.4.1  for shybrid",
+    # "shybrid>=0.4.2",
+    # "pyyaml>=5.4.1 for shybrid",
     "sonpy;python_version>'3.7'",
     # lxml for neuroscope
     "lxml",

--- a/spikeinterface/comparison/multicomparisons.py
+++ b/spikeinterface/comparison/multicomparisons.py
@@ -1,6 +1,7 @@
 import numpy as np
 from pathlib import Path
 import json
+import pickle
 
 from spikeinterface.core import load_extractor, BaseSorting, BaseSortingSegment
 from spikeinterface.core.core_tools import define_function_from_class
@@ -172,7 +173,8 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
         save_folder = Path(save_folder)
         save_folder.mkdir(parents=True, exist_ok=True)
         filename = str(save_folder / 'multicomparison.gpickle')
-        nx.write_gpickle(self.graph, filename)
+        with open(filename, 'wb') as f:
+            pickle.dump(self.graph, f, pickle.HIGHEST_PROTOCOL)
         kwargs = {'delta_time': float(self.delta_time),
                   'match_score': float(self.match_score), 'chance_score': float(self.chance_score)}
         with (save_folder / 'kwargs.json').open('w') as f:
@@ -194,8 +196,9 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
         sorting_list = [load_extractor(v) for v in dict_sortings.values()]
         mcmp = MultiSortingComparison(sorting_list=sorting_list, name_list=list(
             name_list), do_matching=False, **kwargs)
-        mcmp.graph = nx.read_gpickle(
-            str(folder_path / 'multicomparison.gpickle'))
+        filename = str(folder_path / 'multicomparison.gpickle')
+        with open(filename, 'rb') as f:
+            mcmp.graph = pickle.load(f)
         # do step 3 and 4
         mcmp._clean_graph()
         mcmp._do_agreement()

--- a/spikeinterface/comparison/tests/test_groundtruthstudy.py
+++ b/spikeinterface/comparison/tests/test_groundtruthstudy.py
@@ -1,19 +1,23 @@
-import os
 import shutil
-import time
-import pickle
-
 import pytest
+from pathlib import Path
 
 from spikeinterface.extractors import toy_example
 from spikeinterface.sorters import installed_sorters
 from spikeinterface.comparison import GroundTruthStudy
 
-study_folder = 'test_groundtruthstudy/'
+
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "comparison"
+else:
+    cache_folder = Path("cache_folder") / "comparison"
+    cache_folder.mkdir(exist_ok=True, parents=True)
+
+study_folder = cache_folder / 'test_groundtruthstudy/'
 
 
 def setup_module():
-    if os.path.exists(study_folder):
+    if study_folder.is_dir():
         shutil.rmtree(study_folder)
     _setup_comparison_study()
 

--- a/spikeinterface/comparison/tests/test_multisortingcomparison.py
+++ b/spikeinterface/comparison/tests/test_multisortingcomparison.py
@@ -1,16 +1,26 @@
-import os, shutil
+import shutil
+import pytest
+from pathlib import Path
 
 import pytest
 import numpy as np
-from numpy.testing import assert_array_equal
 
 from spikeinterface.extractors import NumpySorting, toy_example
 from spikeinterface.comparison import compare_multiple_sorters, MultiSortingComparison
 
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "comparison"
+else:
+    cache_folder = Path("cache_folder") / "comparison"
+
+
+multicomparison_folder = cache_folder / 'saved_multisorting_comparison'
+
 
 def setup_module():
-    if os.path.exists('saved_multisorting_comparison'):
-        shutil.rmtree('saved_multisorting_comparison')
+    if multicomparison_folder.is_dir():
+        shutil.rmtree(multicomparison_folder)
+
 
 def make_sorting(times1, labels1, times2, labels2, times3, labels3):
     sampling_frequency = 30000.
@@ -52,9 +62,9 @@ def test_compare_multiple_sorters():
     agreement_2 = msc.get_agreement_sorting(minimum_agreement_count=2, minimum_agreement_count_only=True)
     assert np.all([agreement_2.get_unit_property(u, 'agreement_number')] == 2 for u in agreement_2.get_unit_ids())
     
-    msc.save_to_folder('saved_multisorting_comparison')
+    msc.save_to_folder(multicomparison_folder)
     
-    msc = MultiSortingComparison.load_from_folder('saved_multisorting_comparison')
+    msc = MultiSortingComparison.load_from_folder(multicomparison_folder)
     
     # import spikeinterface.widgets  as sw
     # import matplotlib.pyplot as plt

--- a/spikeinterface/comparison/tests/test_studytools.py
+++ b/spikeinterface/comparison/tests/test_studytools.py
@@ -1,7 +1,6 @@
 import os
 import shutil
-import time
-import pickle
+from pathlib import Path
 
 import pytest
 
@@ -10,11 +9,17 @@ from spikeinterface.comparison.studytools import (setup_comparison_study,
                                                   iter_computed_names, iter_computed_sorting,
                                                   get_rec_names, get_ground_truths, get_recordings)
 
-study_folder = 'test_studytools/'
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "comparison"
+else:
+    cache_folder = Path("cache_folder") / "comparison"
+
+
+study_folder = cache_folder / 'test_studytools'
 
 
 def setup_module():
-    if os.path.exists(study_folder):
+    if study_folder.is_dir():
         shutil.rmtree(study_folder)
 
 

--- a/spikeinterface/comparison/tests/test_templatecomparison.py
+++ b/spikeinterface/comparison/tests/test_templatecomparison.py
@@ -1,4 +1,5 @@
 import shutil
+import pytest
 from pathlib import Path
 import numpy as np
 
@@ -7,9 +8,17 @@ from spikeinterface.extractors import toy_example
 from spikeinterface.comparison import compare_templates, compare_multiple_templates
 
 
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "comparison"
+else:
+    cache_folder = Path("cache_folder") / "comparison"
+
+
+test_dir = cache_folder / "temp_comp_test"
+
+
 def setup_module():
-    test_dir = Path("temp_comp_test")
-    if test_dir.exists():
+    if test_dir.is_dir():
         shutil.rmtree(test_dir)
     test_dir.mkdir(exist_ok=True)
 


### PR DESCRIPTION
Tests are failing due to a networkx deprecation error: https://github.com/SpikeInterface/spikeinterface/actions/runs/3875551062/jobs/6608245287

Also see https://networkx.org/documentation/stable/release/migration_guide_from_2.x_to_3.0.html (Deprecated code)

This PR also cleans up tests for the comparison module to properly use cache folders.