### PR TITLE
[feat-extractors] Add option to load synchronized timestamps in OpenEphys

### DIFF
--- a/spikeinterface/extractors/neoextractors/openephys.py
+++ b/spikeinterface/extractors/neoextractors/openephys.py
@@ -13,6 +13,7 @@ for more info.
 from pathlib import Path
 
 import numpy as np
+import warnings
 
 import probeinterface as pi
 
@@ -84,6 +85,10 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
     load_sync_channel : bool
         If False (default) and a SYNC channel is present (e.g. Neuropixels), this is not loaded.
         If True, the SYNC channel is loaded and can be accessed in the analog signals.
+    load_sync_channel : bool
+        If True, the synchronized_timestamps are loaded and set as times to the recording.
+        If False (default), only the t_start and sampling rate are set, and timestamps are assumed
+        to be uniform and linearly increasing.
     experiment_name: str, list, or None
         If multiple experiments are available, this argument allows users to select one
         or more experiments. If None, all experiements are loaded as blocks.
@@ -103,7 +108,7 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
     name = "openephys"
     has_default_locations = True
 
-    def __init__(self, folder_path, load_sync_channel=False, experiment_names=None,
+    def __init__(self, folder_path, load_sync_channel=False, load_sync_timestamps=False, experiment_names=None,
                  stream_id=None, stream_name=None, block_index=None, all_annotations=False):
         neo_kwargs = self.map_to_neo_kwargs(folder_path, load_sync_channel, experiment_names)
         NeoBaseRecordingExtractor.__init__(self, stream_id=stream_id,
@@ -118,18 +123,20 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
         elif stream_name is None:
             stream_name = stream_names[stream_ids.index(stream_id)]
 
+        # find settings file
+        if "#" in stream_name:
+            record_node, oe_stream = stream_name.split("#")
+        else:
+            record_node = ''
+            oe_stream = stream_name
+        exp_ids = sorted(list(self.neo_reader.folder_structure[record_node]["experiments"].keys()))
+        if block_index is None:
+            exp_id = exp_ids[0]
+        else:
+            exp_id = exp_ids[block_index]
+
         # do not load probe for NIDQ stream
         if "NI-DAQmx" not in stream_name:
-            # find settings file
-            if "#" in stream_name:
-                record_node = stream_name.split("#")[0]
-            else:
-                record_node = ''
-            exp_ids = sorted(list(self.neo_reader.folder_structure[record_node]["experiments"].keys()))
-            if block_index is None:
-                exp_id = exp_ids[0]
-            else:
-                exp_id = exp_ids[block_index]
             settings_file = self.neo_reader.folder_structure[record_node]["experiments"][exp_id]["settings_file"]
 
             if Path(settings_file).is_file():
@@ -148,8 +155,29 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
                     num_channels_per_adc = 12
                 sample_shifts = get_neuropixels_sample_shifts(self.get_num_channels(), num_channels_per_adc)
                 self.set_property("inter_sample_shift", sample_shifts)
+
+        # load synchronized timestamps and set_times to recording
+        if load_sync_timestamps:
+            recording_folder = Path(folder_path) / record_node
+            for segment_index in range(self.get_num_segments()):
+                stream_folder = recording_folder / f"experiment{exp_id}" / f"recording{segment_index+1}" / \
+                    "continuous" / oe_stream
+                if (stream_folder / "sample_numbers.npy").is_file():
+                    # OE version>=v0.6
+                    sync_times = np.load(stream_folder / "timestamps.npy")
+                elif (stream_folder / "synchronized_timestamps.npy").is_file():
+                    # version<v0.6
+                    sync_times = np.load(stream_folder / "synchronized_timestamps.npy")
+                else:
+                    sync_times = None
+                try:
+                    self.set_times(times=sync_times, segment_index=segment_index, with_warning=False)
+                except AssertionError:
+                    warnings.warn(f"Could not load synchronized timestamps for {stream_name}")
+
         self._kwargs.update(dict(folder_path=str(folder_path),
                                  load_sync_channel=load_sync_channel,
+                                 load_sync_timestamps=load_sync_timestamps,
                                  experiment_names=experiment_names))
 
 

--- a/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/spikeinterface/extractors/tests/test_neoextractors.py
@@ -50,7 +50,11 @@ class OpenEphysBinaryRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('openephysbinary/v0.6.x_neuropixels_multiexp_multistream',
         {'stream_id': '1', 'block_index': 1}),
         ('openephysbinary/v0.6.x_neuropixels_multiexp_multistream',
+        {'stream_id': '1', 'block_index': 1, 'load_sync_timestamps': True}),
+        ('openephysbinary/v0.6.x_neuropixels_multiexp_multistream',
         {'stream_id': '2', 'block_index': 2}),
+        ('openephysbinary/v0.6.x_neuropixels_multiexp_multistream',
+        {'stream_id': '2', 'block_index': 2, 'load_sync_timestamps': True})
     ]
 
 
@@ -281,9 +285,9 @@ if __name__ == '__main__':
     # test = SpikeGLXRecordingTest()
     # test = OpenEphysBinaryRecordingTest()
     # test = SpikeGLXRecordingTest()
-    # test = OpenEphysBinaryRecordingTest()
+    test = OpenEphysBinaryRecordingTest()
     # test = OpenEphysLegacyRecordingTest()
-    test = CellExplorerSortingTest()
+    # test = CellExplorerSortingTest()
     # test = ItanRecordingTest()
     # test = NeuroScopeRecordingTest()
     # test = PlexonRecordingTest()


### PR DESCRIPTION
The open-ephys system saves both the sample indices and syncrhonized timestmps across streams (in s).
NEO only loads the start time from the sample indices.

This PR offers the option to load and set syncrhonized timestamps to the recording.