### PR TITLE
[fix-postprocessing/qm] Quality metrics and postprocessing fixes for sparsity and global job_kwargs

### DIFF
--- a/spikeinterface/core/globals.py
+++ b/spikeinterface/core/globals.py
@@ -122,7 +122,9 @@ def set_global_job_kwargs(**job_kwargs):
     for k in job_kwargs:
         assert k in job_keys, (f"{k} is not a valid job keyword argument. "
                                f"Available keyword arguments are: {list(job_keys)}")
-    global_job_kwargs = job_kwargs
+    current_global_kwargs = get_global_job_kwargs()
+    current_global_kwargs.update(job_kwargs)
+    global_job_kwargs = current_global_kwargs
     global global_job_kwargs_set
     global_job_kwargs_set = True
 

--- a/spikeinterface/core/sparsity.py
+++ b/spikeinterface/core/sparsity.py
@@ -162,7 +162,8 @@ class ChannelSparsity:
         from .template_tools import get_template_extremum_channel
 
         mask = np.zeros((we.unit_ids.size, we.channel_ids.size), dtype='bool')
-        distances = get_channel_distances(we.recording)
+        locations = we.get_channel_locations()
+        distances = np.linalg.norm(locations[:, np.newaxis] - locations[np.newaxis, :], axis=2)
         best_chan = get_template_extremum_channel(we, peak_sign=peak_sign, outputs="index")
         for unit_ind, unit_id in enumerate(we.unit_ids):
             chan_ind = best_chan[unit_id]

--- a/spikeinterface/core/tests/test_globals.py
+++ b/spikeinterface/core/tests/test_globals.py
@@ -36,6 +36,12 @@ def test_global_job_kwargs():
     assert global_job_kwargs == dict(n_jobs=1, chunk_duration="1s", progress_bar=True)
     set_global_job_kwargs(**job_kwargs)
     assert get_global_job_kwargs() == job_kwargs
+    # test updating only one field
+    partial_job_kwargs = dict(n_jobs=2)
+    set_global_job_kwargs(**partial_job_kwargs)
+    global_job_kwargs = get_global_job_kwargs()
+    assert global_job_kwargs == dict(n_jobs=2, chunk_duration="1s", progress_bar=True)
+    # test that fix_job_kwargs grabs global kwargs
     new_job_kwargs = dict(n_jobs=10)
     job_kwargs_split = fix_job_kwargs(new_job_kwargs)
     assert job_kwargs_split['n_jobs'] == new_job_kwargs['n_jobs']

--- a/spikeinterface/exporters/tests/test_export_to_phy.py
+++ b/spikeinterface/exporters/tests/test_export_to_phy.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import numpy as np
 
-from spikeinterface import extract_waveforms, download_dataset, ChannelSparsity
+from spikeinterface import extract_waveforms, download_dataset, compute_sparsity
 import spikeinterface.extractors as se
 from spikeinterface.exporters import export_to_phy
 from spikeinterface.postprocessing import compute_principal_components
@@ -59,7 +59,8 @@ def test_export_to_phy_by_property():
     sorting = sorting.save(folder=sort_folder)
 
     waveform_extractor = extract_waveforms(recording, sorting, waveform_folder)
-    sparsity_group = ChannelSparsity.from_property(waveform_extractor, "group")
+    sparsity_group = compute_sparsity(waveform_extractor, method="by_property",
+                                      by_property="group")
     export_to_phy(waveform_extractor, output_folder,
                   compute_pc_features=True,
                   compute_amplitudes=True,
@@ -72,7 +73,8 @@ def test_export_to_phy_by_property():
     # Remove one channel
     recording_rm = recording.channel_slice([0, 2, 3, 4, 5, 6, 7])
     waveform_extractor_rm = extract_waveforms(recording_rm, sorting, waveform_folder_rm)
-    sparsity_group = ChannelSparsity.from_property(waveform_extractor_rm, "group")
+    sparsity_group = compute_sparsity(waveform_extractor_rm, method="by_property",
+                                      by_property="group")
 
     export_to_phy(waveform_extractor_rm, output_folder_rm,
                   compute_pc_features=True,
@@ -102,7 +104,7 @@ def test_export_to_phy_by_sparsity():
             shutil.rmtree(f)
 
     waveform_extractor = extract_waveforms(recording, sorting, waveform_folder)
-    sparsity_radius = ChannelSparsity.from_radius(waveform_extractor, 50.)
+    sparsity_radius = compute_sparsity(waveform_extractor, method="radius", radius_um=50.)
     export_to_phy(waveform_extractor, output_folder_radius,
                   compute_pc_features=True,
                   compute_amplitudes=True,
@@ -116,7 +118,7 @@ def test_export_to_phy_by_sparsity():
     assert -1 in pc_ind
 
     # pre-compute PC with another sparsity
-    sparsity_radius_small = ChannelSparsity.from_radius(waveform_extractor, 30.)
+    sparsity_radius_small = compute_sparsity(waveform_extractor, method="radius", radius_um=30.)
     pc = compute_principal_components(waveform_extractor, sparsity=sparsity_radius_small)
     export_to_phy(waveform_extractor, output_folder_multi_sparse,
                   compute_pc_features=True,

--- a/spikeinterface/postprocessing/principal_component.py
+++ b/spikeinterface/postprocessing/principal_component.py
@@ -127,8 +127,6 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         all_projections: np.array
             The PCA projections (num_all_waveforms, num_components, num_channels)
         """
-        recording = self.waveform_extractor.recording
-
         if unit_ids is None:
             unit_ids = self.waveform_extractor.sorting.unit_ids
 
@@ -137,7 +135,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         for unit_index, unit_id in enumerate(unit_ids):
             proj = self.get_projections(unit_id)
             if channel_ids is not None:
-                chan_inds = recording.ids_to_indices(channel_ids)
+                chan_inds = self.waveform_extractor.channel_ids_to_indices(channel_ids)
                 proj = proj[:, :, chan_inds]
             n = proj.shape[0]
             if outputs == 'id':
@@ -231,8 +229,8 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
 
         # update job_kwargs with global ones
         job_kwargs = fix_job_kwargs(job_kwargs)
-        n_jobs = job_kwargs['n_jobs'] if 'n_jobs' in job_kwargs else 1
-        progress_bar = job_kwargs['progress_bar'] if 'progress_bar' in job_kwargs else False
+        n_jobs = job_kwargs['n_jobs']
+        progress_bar = job_kwargs['progress_bar']
 
         # prepare memmap files with npy
         projection_objects = {}

--- a/spikeinterface/postprocessing/principal_component.py
+++ b/spikeinterface/postprocessing/principal_component.py
@@ -686,7 +686,9 @@ def compute_principal_components(waveform_extractor, load_if_exists=False,
         pc = WaveformPrincipalComponent.create(waveform_extractor)
         pc.set_params(n_components=n_components, mode=mode, whiten=whiten, dtype=dtype,
                       sparsity=sparsity)
-        pc.run(n_jobs=n_jobs, progress_bar=progress_bar)
+        # update job_kwargs with global ones
+        job_kwargs = fix_job_kwargs(dict(n_jobs=n_jobs, progress_bar=progress_bar))
+        pc.run(n_jobs=job_kwargs['n_jobs'], progress_bar=job_kwargs['progress_bar'])
 
     return pc
 

--- a/spikeinterface/postprocessing/principal_component.py
+++ b/spikeinterface/postprocessing/principal_component.py
@@ -376,6 +376,8 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
 
         for unit_ind, unit_id in units_loop:
             wfs, channel_inds = self._get_sparse_waveforms(unit_id)
+            if len(wfs) < p['n_components']:
+                continue
             if n_jobs in (0, 1):
                 for wf_ind, chan_ind in enumerate(channel_inds):
                     pca = pca_models[chan_ind]
@@ -449,10 +451,10 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         # with 'by_channel_global' we can't parallelize over channels
         for unit_ind, unit_id in units_loop:
             wfs, _ = self._get_sparse_waveforms(unit_id)
-            if wfs.size == 0:
+            shape = wfs.shape
+            if shape[0] * shape[2] < p['n_components']:
                 continue
             # avoid loop with reshape
-            shape = wfs.shape
             wfs_concat = wfs.transpose(0, 2, 1).reshape(shape[0] * shape[2], shape[1])
             pca_model.partial_fit(wfs_concat)
 
@@ -509,6 +511,8 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         for unit_ind, unit_id in units_loop:
             wfs, _ = self._get_sparse_waveforms(unit_id)
             wfs_flat = wfs.reshape(wfs.shape[0], -1)
+            if len(wfs_flat) < p['n_components']:
+                continue
             pca_model.partial_fit(wfs_flat)
 
         # save

--- a/spikeinterface/postprocessing/template_metrics.py
+++ b/spikeinterface/postprocessing/template_metrics.py
@@ -11,7 +11,7 @@ import scipy.stats
 from scipy.signal import resample_poly
 
 from ..core import WaveformExtractor
-from ..core.template_tools import get_template_extremum_channel, get_template_channel_sparsity
+from ..core.template_tools import get_template_extremum_channel
 from ..core.waveform_extractor import BaseWaveformExtractorExtension
 import warnings
 

--- a/spikeinterface/postprocessing/template_metrics.py
+++ b/spikeinterface/postprocessing/template_metrics.py
@@ -70,12 +70,12 @@ class TemplateMetricsCalculator(BaseWaveformExtractorExtension):
                 index=unit_ids, columns=metric_names)
         else:
             extremum_channels_ids = sparsity.unit_id_to_channel_ids
-            unit_ids = []
-            channel_ids = []
+            index_unit_ids = []
+            index_channel_ids = []
             for unit_id, sparse_channels in extremum_channels_ids.items():
-                unit_ids += [unit_id] * len(sparse_channels)
-                channel_ids += list(sparse_channels)
-            multi_index = pd.MultiIndex.from_tuples(list(zip(unit_ids, channel_ids)),
+                index_unit_ids += [unit_id] * len(sparse_channels)
+                index_channel_ids += list(sparse_channels)
+            multi_index = pd.MultiIndex.from_tuples(list(zip(index_unit_ids, index_channel_ids)),
                                                     names=["unit_id", "channel_id"])
             template_metrics = pd.DataFrame(
                 index=multi_index, columns=metric_names)

--- a/spikeinterface/postprocessing/tests/common_extension_tests.py
+++ b/spikeinterface/postprocessing/tests/common_extension_tests.py
@@ -4,7 +4,7 @@ import pandas as pd
 import shutil
 from pathlib import Path
 
-from spikeinterface import extract_waveforms, load_extractor, ChannelSparsity
+from spikeinterface import extract_waveforms, load_extractor, compute_sparsity
 from spikeinterface.extractors import toy_example
 
 if hasattr(pytest, "global_test_folder"):
@@ -41,7 +41,7 @@ class WaveformExtensionCommonTestSuite:
                                 ms_before=3., ms_after=4., max_spikes_per_unit=500,
                                 n_jobs=1, chunk_size=30000, overwrite=True)
         self.we1 = we1
-        self.sparsity1 = ChannelSparsity.from_radius(we1, radius_um=50)
+        self.sparsity1 = compute_sparsity(we1, method="radius", radius_um=50)
 
         # 2-segments
         recording, sorting = toy_example(num_segments=2, num_units=10)
@@ -59,7 +59,7 @@ class WaveformExtensionCommonTestSuite:
                                 ms_before=3., ms_after=4., max_spikes_per_unit=500,
                                 n_jobs=1, chunk_size=30000, overwrite=True)
         self.we2 = we2
-        self.sparsity2 = ChannelSparsity.from_radius(we2, radius_um=30)
+        self.sparsity2 = compute_sparsity(we2, method="radius", radius_um=30)
         we_memory = extract_waveforms(recording, sorting, mode="memory",
                                       ms_before=3., ms_after=4., max_spikes_per_unit=500,
                                       n_jobs=1, chunk_size=30000)
@@ -69,7 +69,7 @@ class WaveformExtensionCommonTestSuite:
                                        overwrite=True, format="zarr")
         
         # use best channels for PC-concatenated
-        sparsity = ChannelSparsity.from_best_channels(we_memory, num_channels=2)
+        sparsity = compute_sparsity(we_memory, method="best_channels", num_channels=2)
         self.we_sparse = we_memory.save(folder=cache_folder / 'toy_sorting_2seg_sparse', format="binary",
                                         sparsity=sparsity, overwrite=True)
 

--- a/spikeinterface/postprocessing/tests/common_extension_tests.py
+++ b/spikeinterface/postprocessing/tests/common_extension_tests.py
@@ -2,10 +2,10 @@ import pytest
 import numpy as np
 import pandas as pd
 import shutil
+from pathlib import Path
+
 from spikeinterface import extract_waveforms, load_extractor, ChannelSparsity
 from spikeinterface.extractors import toy_example
-from spikeinterface.core import get_template_channel_sparsity
-from pathlib import Path
 
 if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "postprocessing"
@@ -41,7 +41,7 @@ class WaveformExtensionCommonTestSuite:
                                 ms_before=3., ms_after=4., max_spikes_per_unit=500,
                                 n_jobs=1, chunk_size=30000, overwrite=True)
         self.we1 = we1
-        self.sparsity1 = ChannelSparsity.from_radius(we1, radius_um=30)
+        self.sparsity1 = ChannelSparsity.from_radius(we1, radius_um=50)
 
         # 2-segments
         recording, sorting = toy_example(num_segments=2, num_units=10)
@@ -59,7 +59,7 @@ class WaveformExtensionCommonTestSuite:
                                 ms_before=3., ms_after=4., max_spikes_per_unit=500,
                                 n_jobs=1, chunk_size=30000, overwrite=True)
         self.we2 = we2
-        self.sparsity2 = ChannelSparsity.from_radius(we1, radius_um=30)
+        self.sparsity2 = ChannelSparsity.from_radius(we2, radius_um=30)
         we_memory = extract_waveforms(recording, sorting, mode="memory",
                                       ms_before=3., ms_after=4., max_spikes_per_unit=500,
                                       n_jobs=1, chunk_size=30000)
@@ -69,7 +69,7 @@ class WaveformExtensionCommonTestSuite:
                                        overwrite=True, format="zarr")
         
         # use best channels for PC-concatenated
-        sparsity = ChannelSparsity.from_best_channels(we_memory, num_channels=4)
+        sparsity = ChannelSparsity.from_best_channels(we_memory, num_channels=2)
         self.we_sparse = we_memory.save(folder=cache_folder / 'toy_sorting_2seg_sparse', format="binary",
                                         sparsity=sparsity, overwrite=True)
 

--- a/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -4,9 +4,7 @@ from pathlib import Path
 
 import numpy as np
 
-from spikeinterface import ChannelSparsity
-from spikeinterface.extractors import toy_example
-
+from spikeinterface import compute_sparsity
 from spikeinterface.postprocessing import WaveformPrincipalComponent, compute_principal_components
 from spikeinterface.postprocessing.tests.common_extension_tests import WaveformExtensionCommonTestSuite
 
@@ -61,7 +59,7 @@ class PrincipalComponentsExtensionTest(WaveformExtensionCommonTestSuite, unittes
         assert np.array_equal(all_pc1, all_pc2)
 
         # test with sparsity
-        sparsity = ChannelSparsity.from_radius(we, radius_um=50)
+        sparsity = compute_sparsity(we, method="radius", radius_um=50)
         we_copy = we.save(folder=cache_folder / "we_copy")
         pc_sparse = self.extension_class.get_extension_function()(we_copy, sparsity=sparsity, load_if_exists=False)
         pc_file_sparse = pc.extension_folder / 'all_pc_sparse.npy'
@@ -80,8 +78,8 @@ class PrincipalComponentsExtensionTest(WaveformExtensionCommonTestSuite, unittes
         num_channels = we.get_num_channels()
         pc = self.extension_class(we)
         
-        sparsity_radius = ChannelSparsity.from_radius(we, radius_um=50)
-        sparsity_best = ChannelSparsity.from_best_channels(we, num_channels=2)
+        sparsity_radius = compute_sparsity(we, method="radius", radius_um=50)
+        sparsity_best = compute_sparsity(we, method="best_channels", num_channels=2)
         sparsities = [sparsity_radius, sparsity_best]
         print(sparsities)
 

--- a/spikeinterface/postprocessing/tests/test_template_metrics.py
+++ b/spikeinterface/postprocessing/tests/test_template_metrics.py
@@ -3,8 +3,7 @@ import unittest
 from spikeinterface import extract_waveforms, WaveformExtractor
 from spikeinterface.extractors import toy_example
 
-from spikeinterface.postprocessing import (compute_template_metrics, get_template_channel_sparsity, 
-                                           TemplateMetricsCalculator)
+from spikeinterface.postprocessing import TemplateMetricsCalculator
 
 from spikeinterface.postprocessing.tests.common_extension_tests import WaveformExtensionCommonTestSuite
 

--- a/spikeinterface/postprocessing/tests/test_unit_localization.py
+++ b/spikeinterface/postprocessing/tests/test_unit_localization.py
@@ -9,8 +9,8 @@ class UnitLocationsExtensionTest(WaveformExtensionCommonTestSuite, unittest.Test
     extension_class = UnitLocationsCalculator
     extension_data_names = ["unit_locations"]
     extension_function_kwargs_list = [
-        dict(method='center_of_mass',  num_channels=4),
-        dict(method='center_of_mass',  num_channels=4, outputs='by_unit'),
+        dict(method='center_of_mass', radius_um=100),
+        dict(method='center_of_mass', radius_um=100, outputs='by_unit'),
         dict(method='monopolar_triangulation', radius_um=150),
         dict(method='monopolar_triangulation', radius_um=150, outputs='by_unit'),
         dict(method='monopolar_triangulation', radius_um=150, outputs='by_unit',

--- a/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/spikeinterface/qualitymetrics/misc_metrics.py
@@ -442,7 +442,10 @@ def compute_amplitudes_cutoff(waveform_extractor, peak_sign='neg',
         if spike_amplitudes is None:
             waveforms = waveform_extractor.get_waveforms(unit_id)
             chan_id = extremum_channels_ids[unit_id]
-            chan_ind = recording.id_to_index(chan_id)
+            if waveform_extractor.is_sparse():
+                chan_ind = np.where(waveform_extractor.sparsity.unit_id_to_channel_ids[unit_id] == chan_id)[0]
+            else:
+                chan_ind = recording.id_to_index(chan_id)
             amplitudes = waveforms[:, before, chan_ind]
         else:
             amplitudes = np.concatenate([spike_amps[unit_id] for spike_amps in spike_amplitudes])

--- a/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/spikeinterface/qualitymetrics/pca_metrics.py
@@ -35,6 +35,7 @@ _default_params = dict(
         n_neighbors=4,
         n_components=10,
         radius_um=100,
+        peak_sign='neg'
     ),
     nn_noise_overlap=dict(
         max_spikes=10000,
@@ -42,6 +43,7 @@ _default_params = dict(
         n_neighbors=4,
         n_components=10,
         radius_um=100,
+        peak_sign='neg'
     )
 )
 
@@ -326,7 +328,7 @@ def nearest_neighbors_metrics(all_pcs, all_labels, this_unit_id, max_spikes, n_n
 
 def nearest_neighbors_isolation(waveform_extractor: WaveformExtractor, this_unit_id: int,
                                 max_spikes: int = 1000, min_spikes: int = 10, n_neighbors: int = 5,
-                                n_components: int = 10, radius_um: float = 100,
+                                n_components: int = 10, radius_um: float = 100, peak_sign: str = 'neg',
                                 min_spatial_overlap: float = 0.5, seed=None):
     """Calculates unit isolation based on NearestNeighbors search in PCA space.
 
@@ -347,6 +349,9 @@ def nearest_neighbors_isolation(waveform_extractor: WaveformExtractor, this_unit
         The number of PC components to use to project the snippets to.
     radius_um : float, optional, default: 100
         The radius, in um, that channels need to be within the peak channel to be included.
+    peak_sign: str, optional, default: 'neg'
+        The peak_sign used to compute sparsity and neighbor units. Used if waveform_extractor 
+        is not sparse already.
     min_spatial_overlap : float, optional, default: 100
         In case waveform_extractor is sparse, other units are selected if they share at least 
         `min_spatial_overlap * n_target_unit_channels` with the target unit
@@ -416,7 +421,7 @@ def nearest_neighbors_isolation(waveform_extractor: WaveformExtractor, this_unit
         if waveform_extractor.is_sparse():
             sparsity = waveform_extractor.sparsity
         else:
-            sparsity = compute_sparsity(waveform_extractor, method='radius', peak_sign='both',
+            sparsity = compute_sparsity(waveform_extractor, method='radius', peak_sign=peak_sign,
                                         radius_um=radius_um)
         closest_chans_target_unit = sparsity.unit_id_to_channel_indices[this_unit_id]
         n_channels_target_unit = len(closest_chans_target_unit)
@@ -475,7 +480,8 @@ def nearest_neighbors_isolation(waveform_extractor: WaveformExtractor, this_unit
 def nearest_neighbors_noise_overlap(waveform_extractor: WaveformExtractor,
                                     this_unit_id: int, max_spikes: int = 1000,
                                     min_spikes: int = 10, n_neighbors: int = 5,
-                                    n_components: int = 10, radius_um: float = 100, seed=None):
+                                    n_components: int = 10, radius_um: float = 100,
+                                    peak_sign: str = 'neg', seed=None):
     """Calculates unit noise overlap based on NearestNeighbors search in PCA space.
 
     Parameters
@@ -495,6 +501,9 @@ def nearest_neighbors_noise_overlap(waveform_extractor: WaveformExtractor,
         The number of PC components to use to project the snippets to.
     radius_um : float, optional, default: 100
         The radius, in um, that channels need to be within the peak channel to be included.
+    peak_sign: str, optional, default: 'neg'
+        The peak_sign used to compute sparsity and neighbor units. Used if waveform_extractor 
+        is not sparse already.
     seed : int, optional, default: 0
         Random seed for subsampling spikes.
 
@@ -558,7 +567,7 @@ def nearest_neighbors_noise_overlap(waveform_extractor: WaveformExtractor,
         if waveform_extractor.is_sparse():
             sparsity = waveform_extractor.sparsity
         else:
-            sparsity = compute_sparsity(waveform_extractor, method='radius', peak_sign='both',
+            sparsity = compute_sparsity(waveform_extractor, method='radius', peak_sign=peak_sign,
                                         radius_um=radius_um)
         noise_cluster = noise_cluster[:, :, sparsity.unit_id_to_channel_indices[this_unit_id]]
 

--- a/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/spikeinterface/qualitymetrics/pca_metrics.py
@@ -10,16 +10,15 @@ from sklearn.neighbors import NearestNeighbors
 from sklearn.decomposition import IncrementalPCA
 from joblib import delayed, Parallel
 from copy import deepcopy
-
-
-import spikeinterface as si
-from ..core import get_random_data_chunks, WaveformExtractor
-from ..core.job_tools import tqdm_joblib
-from ..core.template_tools import get_template_channel_sparsity, get_template_extremum_channel
-
-from ..postprocessing import WaveformPrincipalComponent
+import warnings
 
 from .misc_metrics import compute_num_spikes
+
+from ..core import get_random_data_chunks, load_waveforms, compute_sparsity, WaveformExtractor
+from ..core.job_tools import tqdm_joblib
+from ..core.template_tools import get_template_extremum_channel
+from ..postprocessing import WaveformPrincipalComponent
+
 
 _possible_pc_metric_names = ['isolation_distance', 'l_ratio', 'd_prime',
                              'nearest_neighbor', 'nn_isolation', 'nn_noise_overlap']
@@ -28,8 +27,7 @@ _possible_pc_metric_names = ['isolation_distance', 'l_ratio', 'd_prime',
 _default_params = dict(
     nearest_neighbor=dict(
         max_spikes=10000,
-        min_spikes=10,
-        n_neighbors=4,
+        n_neighbors=5,
     ),
     nn_isolation=dict(
         max_spikes=10000,
@@ -50,7 +48,6 @@ _default_params = dict(
 
 def get_quality_pca_metric_list():
     """Get a list of the available PCA-based quality metrics."""
-
     return deepcopy(_possible_pc_metric_names)
 
 
@@ -83,7 +80,6 @@ def calculate_pc_metrics(pca, metric_names=None, sparsity=None, qm_params=None,
     pc_metrics : dict
         The computed PC metrics.
     """
-
     if metric_names is None:
         metric_names = _possible_pc_metric_names
     if qm_params is None:
@@ -112,20 +108,26 @@ def calculate_pc_metrics(pca, metric_names=None, sparsity=None, qm_params=None,
     if run_in_parallel:
         parallel_functions = []
 
-    neighbor_unit_ids = unit_ids
-    neighbor_channel_ids = channel_ids
+    all_labels, all_pcs = pca.get_all_projections()
     for unit_ind, unit_id in units_loop:        
-        if sparsity is None:
-            neighbor_channel_ids = channel_ids
-            neighbor_unit_ids = unit_ids
-        else:
+        if we.is_sparse():
+            neighbor_channel_ids = we.sparsity.unit_id_to_channel_ids[unit_id]
+            neighbor_unit_ids = [other_unit for other_unit in unit_ids
+                                 if extremum_channels[other_unit] in neighbor_channel_ids]
+        elif sparsity is not None:
             neighbor_channel_ids = sparsity.unit_id_to_channel_ids[unit_id]
             neighbor_unit_ids = [other_unit for other_unit in unit_ids 
                                  if extremum_channels[other_unit] in neighbor_channel_ids]
-        
-        func_args = (we.folder, metric_names, unit_id, neighbor_channel_ids, neighbor_unit_ids, unit_ids, 
-                     qm_params, seed,)
-            
+        else:
+            neighbor_channel_ids = channel_ids
+            neighbor_unit_ids = unit_ids
+        neighbor_channel_indices = we.channel_ids_to_indices(neighbor_channel_ids)
+
+        labels = all_labels[np.in1d(all_labels, neighbor_unit_ids)]
+        pcs = all_pcs[np.in1d(all_labels, neighbor_unit_ids)][:, :, neighbor_channel_indices]
+        pcs_flat = pcs.reshape(pcs.shape[0], -1)
+
+        func_args = (pcs_flat, labels, metric_names, unit_id, unit_ids, qm_params, seed, we.folder)
 
         if not run_in_parallel:
             pca_metrics_unit = pca_metrics_one_unit(*func_args)
@@ -133,7 +135,7 @@ def calculate_pc_metrics(pca, metric_names=None, sparsity=None, qm_params=None,
                 pc_metrics[metric_name][unit_id] = metric
         else:
             parallel_functions.append(delayed(pca_metrics_one_unit)(*func_args))
-            
+
     if run_in_parallel:
         if progress_bar:
             units_loop = tqdm(units_loop, desc="Computing PCA metrics", total=len(unit_ids))
@@ -291,34 +293,41 @@ def nearest_neighbors_metrics(all_pcs, all_labels, this_unit_id, max_spikes, n_n
 
     total_spikes = all_pcs.shape[0]
     ratio = max_spikes / total_spikes
+
+    # if no other units in the vicinity, return best possible option
+    if len(np.unique(all_labels)) == 1:
+        warnings.warn(f"No other units found in the vicinity of {this_unit}. Setting nn_hit_rate=1 and nn_miss_rate=0")
+        return 1.0, 0.0
+
     this_unit = all_labels == this_unit_id
+    this_unit_pcs = all_pcs[this_unit, :]
+    other_units_pcs = all_pcs[np.invert(this_unit), :]
+    X = np.concatenate((this_unit_pcs, other_units_pcs), 0)
 
-    X = np.concatenate(
-        (all_pcs[this_unit, :], all_pcs[np.invert(this_unit), :]), 0)
-
-    n = np.sum(this_unit)
+    num_obs_this_unit = np.sum(this_unit)
 
     if ratio < 1:
         inds = np.arange(0, X.shape[0] - 1, 1 / ratio).astype('int')
         X = X[inds, :]
-        n = int(n * ratio)
+        num_obs_this_unit = int(num_obs_this_unit * ratio)
 
     nbrs = NearestNeighbors(n_neighbors=n_neighbors,
                             algorithm='ball_tree').fit(X)
     distances, indices = nbrs.kneighbors(X)
 
-    this_cluster_nearest = indices[:n, 1:].flatten()
-    other_cluster_nearest = indices[n:, 1:].flatten()
+    this_cluster_nearest = indices[:num_obs_this_unit, 1:].flatten()
+    other_cluster_nearest = indices[num_obs_this_unit:, 1:].flatten()
 
-    hit_rate = np.mean(this_cluster_nearest < n)
-    miss_rate = np.mean(other_cluster_nearest < n)
+    hit_rate = np.mean(this_cluster_nearest < num_obs_this_unit)
+    miss_rate = np.mean(other_cluster_nearest < num_obs_this_unit)
 
     return hit_rate, miss_rate
 
 
-def nearest_neighbors_isolation(waveform_extractor: si.WaveformExtractor, this_unit_id: int,
+def nearest_neighbors_isolation(waveform_extractor: WaveformExtractor, this_unit_id: int,
                                 max_spikes: int = 1000, min_spikes: int = 10, n_neighbors: int = 5,
-                                n_components: int = 10, radius_um: float = 100, seed=None):
+                                n_components: int = 10, radius_um: float = 100,
+                                min_spatial_overlap: float = 0.5, seed=None):
     """Calculates unit isolation based on NearestNeighbors search in PCA space.
 
     Parameters
@@ -338,6 +347,9 @@ def nearest_neighbors_isolation(waveform_extractor: si.WaveformExtractor, this_u
         The number of PC components to use to project the snippets to.
     radius_um : float, optional, default: 100
         The radius, in um, that channels need to be within the peak channel to be included.
+    min_spatial_overlap : float, optional, default: 100
+        In case waveform_extractor is sparse, other units are selected if they share at least 
+        `min_spatial_overlap * n_target_unit_channels` with the target unit
     seed : int, optional, default: None
         Seed for random subsampling of spikes.
 
@@ -374,7 +386,6 @@ def nearest_neighbors_isolation(waveform_extractor: si.WaveformExtractor, this_u
     ---------
     Based on isolation metric described in Chung et al. (2017) Neuron 95: 1381-1394.
     """
-
     rng = np.random.default_rng(seed=seed)
 
     sorting = waveform_extractor.sorting
@@ -383,9 +394,9 @@ def nearest_neighbors_isolation(waveform_extractor: si.WaveformExtractor, this_u
 
     # if target unit has fewer than `min_spikes` spikes, print out a warning and return NaN
     if n_spikes_all_units[this_unit_id] < min_spikes:
-        print(f'Warning: unit {this_unit_id} has fewer spikes than ',
-              f'specified by `min_spikes` ({min_spikes}); ',
-              'returning NaN as the quality metric...')
+        warnings.warn(f'Warning: unit {this_unit_id} has fewer spikes than ',
+                      f'specified by `min_spikes` ({min_spikes}); ',
+                      f'returning NaN as the quality metric...')
         return np.nan
     else:
         # first remove the units with too few spikes
@@ -397,46 +408,52 @@ def nearest_neighbors_isolation(waveform_extractor: si.WaveformExtractor, this_u
         other_units_ids = np.setdiff1d(all_units_ids, this_unit_id)
 
         # get waveforms of target unit
-        waveforms_target_unit = waveform_extractor.get_waveforms(
-            unit_id=this_unit_id)
+        waveforms_target_unit = waveform_extractor.get_waveforms(unit_id=this_unit_id)
         n_spikes_target_unit = waveforms_target_unit.shape[0]
 
         # find units whose signal channels (i.e. channels inside some radius around
         # the channel with largest amplitude) overlap with signal channels of the target unit
-        closest_chans_all = get_template_channel_sparsity(waveform_extractor, method='radius',
-                                                          outputs='index', peak_sign='both',
-                                                          radius_um=radius_um)
-        closest_chans_target_unit = closest_chans_all[this_unit_id]
+        if waveform_extractor.is_sparse():
+            sparsity = waveform_extractor.sparsity
+        else:
+            sparsity = compute_sparsity(waveform_extractor, method='radius', peak_sign='both',
+                                        radius_um=radius_um)
+        closest_chans_target_unit = sparsity.unit_id_to_channel_indices[this_unit_id]
+        n_channels_target_unit = len(closest_chans_target_unit)
+        # select other units that have a minimum spatial overlap with target unit
         other_units_ids = [unit_id for unit_id in other_units_ids if
-                           np.any(np.in1d(closest_chans_all[unit_id], closest_chans_target_unit))]
+                           np.sum(np.in1d(sparsity.unit_id_to_channel_indices[unit_id], closest_chans_target_unit))
+                           >= (n_channels_target_unit * min_spatial_overlap)]
 
         # if no unit is within neighborhood of target unit, then just say isolation is 1 (best possible)
         if not other_units_ids:
             nn_isolation = 1
-
         # if there are units to compare, then compute isolation with each
         else:
             isolation = np.zeros(len(other_units_ids),)
             for other_unit_id in other_units_ids:
-                waveforms_other_unit = waveform_extractor.get_waveforms(
-                    unit_id=other_unit_id)
+                waveforms_other_unit = waveform_extractor.get_waveforms(unit_id=other_unit_id)
                 n_spikes_other_unit = waveforms_other_unit.shape[0]
-
-                n_snippets = np.min(
-                    [n_spikes_target_unit, n_spikes_other_unit, max_spikes])
+                closest_chans_other_unit = sparsity.unit_id_to_channel_indices[other_unit_id]
+                n_snippets = np.min([n_spikes_target_unit, n_spikes_other_unit, max_spikes])
 
                 # make the two clusters equal in terms of: number of spikes & channels with signal
-                waveforms_target_unit_idx = rng.choice(
-                    n_spikes_target_unit, size=n_snippets, replace=False)
+                waveforms_target_unit_idx = rng.choice(n_spikes_target_unit, size=n_snippets, replace=False)
                 waveforms_target_unit_sampled = waveforms_target_unit[waveforms_target_unit_idx]
-                waveforms_target_unit_sampled = waveforms_target_unit_sampled[:,
-                                                                              :, closest_chans_target_unit]
-
-                waveforms_other_unit_idx = rng.choice(
-                    n_spikes_other_unit, size=n_snippets, replace=False)
+                waveforms_other_unit_idx = rng.choice(n_spikes_other_unit, size=n_snippets, replace=False)
                 waveforms_other_unit_sampled = waveforms_other_unit[waveforms_other_unit_idx]
-                waveforms_other_unit_sampled = waveforms_other_unit_sampled[:,
-                                                                            :, closest_chans_target_unit]
+
+                # project this unit and other unit waveforms on common subspace
+                common_channel_idxs = np.intersect1d(closest_chans_target_unit, closest_chans_other_unit)
+                if waveform_extractor.is_sparse():
+                    # in this case, waveforms are sparse so we need to do some smart indexing
+                    waveforms_target_unit_sampled = \
+                        waveforms_target_unit_sampled[:, :, np.in1d(closest_chans_target_unit, common_channel_idxs)]
+                    waveforms_other_unit_sampled = \
+                        waveforms_other_unit_sampled[:, :, np.in1d(closest_chans_other_unit, common_channel_idxs)]
+                else:
+                    waveforms_target_unit_sampled = waveforms_target_unit_sampled[:, :, common_channel_idxs]
+                    waveforms_other_unit_sampled = waveforms_other_unit_sampled[:, :, common_channel_idxs]
 
                 # compute principal components after concatenation
                 all_snippets = np.concatenate([waveforms_target_unit_sampled.reshape((n_snippets, -1)),
@@ -455,7 +472,7 @@ def nearest_neighbors_isolation(waveform_extractor: si.WaveformExtractor, this_u
         return nn_isolation
 
 
-def nearest_neighbors_noise_overlap(waveform_extractor: si.WaveformExtractor,
+def nearest_neighbors_noise_overlap(waveform_extractor: WaveformExtractor,
                                     this_unit_id: int, max_spikes: int = 1000,
                                     min_spikes: int = 10, n_neighbors: int = 5,
                                     n_components: int = 10, radius_um: float = 100, seed=None):
@@ -506,14 +523,13 @@ def nearest_neighbors_noise_overlap(waveform_extractor: si.WaveformExtractor,
     """
     rng = np.random.default_rng(seed=seed)
 
-    sorting = waveform_extractor.sorting
     n_spikes_all_units = compute_num_spikes(waveform_extractor)
 
     # if target unit has fewer than `min_spikes` spikes, print out a warning and return NaN
     if n_spikes_all_units[this_unit_id] < min_spikes:
-        print(f'Warning: unit {this_unit_id} has fewer spikes than ',
-              f'specified by `min_spikes` ({min_spikes}); ',
-              'returning NaN as the quality metric...')
+        warnings.warn(f'Warning: unit {this_unit_id} has fewer spikes than ',
+                      f'specified by `min_spikes` ({min_spikes}); ',
+                      f'returning NaN as the quality metric...')
         return np.nan
     else:
         # get random snippets from the recording to create a noise cluster
@@ -521,52 +537,51 @@ def nearest_neighbors_noise_overlap(waveform_extractor: si.WaveformExtractor,
         noise_cluster = get_random_data_chunks(recording, return_scaled=waveform_extractor.return_scaled,
                                                num_chunks_per_segment=max_spikes,
                                                chunk_size=waveform_extractor.nsamples, seed=seed)
-
-        noise_cluster = np.reshape(
-            noise_cluster, (max_spikes, waveform_extractor.nsamples, -1))
+        noise_cluster = np.reshape(noise_cluster, (max_spikes, waveform_extractor.nsamples, -1))
 
         # get waveforms for target cluster
-        waveforms = waveform_extractor.get_waveforms(unit_id=this_unit_id)
+        waveforms = waveform_extractor.get_waveforms(unit_id=this_unit_id).copy()
 
         # adjust the size of the target and noise clusters to be equal
         if waveforms.shape[0] > max_spikes:
-            wf_ind = rng.choice(
-                waveforms.shape[0], max_spikes, replace=False)
+            wf_ind = rng.choice(waveforms.shape[0], max_spikes, replace=False)
             waveforms = waveforms[wf_ind]
             n_snippets = max_spikes
         elif waveforms.shape[0] < max_spikes:
-            noise_ind = rng.choice(
-                noise_cluster.shape[0], waveforms.shape[0], replace=False)
+            noise_ind = rng.choice(noise_cluster.shape[0], waveforms.shape[0], replace=False)
             noise_cluster = noise_cluster[noise_ind]
             n_snippets = waveforms.shape[0]
         else:
             n_snippets = max_spikes
 
         # restrict to channels with significant signal
-        closest_chans_idx = get_template_channel_sparsity(waveform_extractor, method='radius',
-                                                          outputs='index', peak_sign='both',
-                                                          radius_um=radius_um)
-        waveforms = waveforms[:, :, closest_chans_idx[this_unit_id]]
-        noise_cluster = noise_cluster[:, :, closest_chans_idx[this_unit_id]]
+        if waveform_extractor.is_sparse():
+            sparsity = waveform_extractor.sparsity
+        else:
+            sparsity = compute_sparsity(waveform_extractor, method='radius', peak_sign='both',
+                                        radius_um=radius_um)
+        noise_cluster = noise_cluster[:, :, sparsity.unit_id_to_channel_indices[this_unit_id]]
 
         # compute weighted noise snippet (Z)
-        median_waveform = waveform_extractor.get_template(
-            unit_id=this_unit_id, mode='median')
-        median_waveform = median_waveform[:, closest_chans_idx[this_unit_id]]
-        tmax, chmax = np.unravel_index(
-            np.argmax(np.abs(median_waveform)), median_waveform.shape)
+        median_waveform = waveform_extractor.get_template(unit_id=this_unit_id, mode='median')
+
+        # in case waveform_extractor is sparse, waveforms and templates are already sparse
+        if not waveform_extractor.is_sparse():
+            waveforms = waveforms[:, :, sparsity.unit_id_to_channel_indices[this_unit_id]]
+            median_waveform = median_waveform[:, sparsity.unit_id_to_channel_indices[this_unit_id]]
+
+        tmax, chmax = np.unravel_index(np.argmax(np.abs(median_waveform)), median_waveform.shape)
         weights = [noise_clip[tmax, chmax] for noise_clip in noise_cluster]
         weights = np.asarray(weights)
         weights = weights / np.sum(weights)
-        weighted_noise_snippet = np.sum(
-            weights * noise_cluster.swapaxes(0, 2), axis=2).swapaxes(0, 1)
+        weighted_noise_snippet = np.sum(weights * noise_cluster.swapaxes(0, 2), axis=2).swapaxes(0, 1)
 
         # subtract projection onto weighted noise snippet
         for snippet in range(n_snippets):
-            waveforms[snippet, :, :] = _subtract_clip_component(
-                waveforms[snippet, :, :], weighted_noise_snippet)
-            noise_cluster[snippet, :, :] = _subtract_clip_component(
-                noise_cluster[snippet, :, :], weighted_noise_snippet)
+            waveforms[snippet, :, :] = \
+                _subtract_clip_component(waveforms[snippet, :, :], weighted_noise_snippet)
+            noise_cluster[snippet, :, :] = \
+                _subtract_clip_component(noise_cluster[snippet, :, :], weighted_noise_snippet)
 
         # compute principal components after concatenation
         all_snippets = np.concatenate([waveforms.reshape((n_snippets, -1)),
@@ -626,8 +641,7 @@ def _compute_isolation(pcs_target_unit, pcs_other_unit, n_neighbors: int):
 
     # concatenate
     pcs_concat = np.concatenate((pcs_target_unit, pcs_other_unit), axis=0)
-    label_concat = np.concatenate(
-        (np.zeros(n_spikes_target), np.ones(n_spikes_other)))
+    label_concat = np.concatenate((np.zeros(n_spikes_target), np.ones(n_spikes_other)))
 
     # if n_neighbors is greater than the number of spikes in both clusters, set it to max possible
     if n_neighbors > len(label_concat):
@@ -638,29 +652,20 @@ def _compute_isolation(pcs_target_unit, pcs_other_unit, n_neighbors: int):
     _, membership_ind = NearestNeighbors(
         n_neighbors=n_neighbors_adjusted, algorithm='auto').fit(pcs_concat).kneighbors()
 
-    target_nn_in_target = np.sum(
-        label_concat[membership_ind[:n_spikes_target]] == 0)
-    other_nn_in_other = np.sum(
-        label_concat[membership_ind[n_spikes_target:]] == 1)
+    target_nn_in_target = np.sum(label_concat[membership_ind[:n_spikes_target]] == 0)
+    other_nn_in_other = np.sum(label_concat[membership_ind[n_spikes_target:]] == 1)
 
-    isolation = (target_nn_in_target + other_nn_in_other) / \
-        (n_spikes_target+n_spikes_other) / n_neighbors_adjusted
+    isolation = (target_nn_in_target + other_nn_in_other) / (n_spikes_target+n_spikes_other) / n_neighbors_adjusted
 
     return isolation
 
 
-def pca_metrics_one_unit(we_folder, metric_names, unit_id, neighbor_channel_ids, neighbor_unit_ids,
-                         unit_ids, qm_params, seed):
-    we = WaveformExtractor.load(we_folder)
-    pca = WaveformPrincipalComponent.load(we_folder)
-
-    labels, pcs = pca.get_all_projections(
-        channel_ids=neighbor_channel_ids, unit_ids=neighbor_unit_ids)
-
-    pcs_flat = pcs.reshape(pcs.shape[0], -1)
+def pca_metrics_one_unit(pcs_flat, labels, metric_names, unit_id,
+                         unit_ids, qm_params, seed, we_folder):
+    if 'nn_isolation' in metric_names or 'nn_noise_overlap' in metric_names:
+        we = load_waveforms(we_folder)
 
     pc_metrics = {}
-
     # metrics
     if 'isolation_distance' in metric_names or 'l_ratio' in metric_names:
         try:

--- a/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import numpy as np
 import pandas as pd
 
+from spikeinterface.core.job_tools import fix_job_kwargs
 from spikeinterface.core.waveform_extractor import WaveformExtractor, BaseWaveformExtractorExtension
 
 from .quality_metric_list import (_misc_metric_name_to_func,
@@ -188,7 +189,9 @@ def compute_quality_metrics(waveform_extractor, load_if_exists=False,
         qmc = QualityMetricCalculator(waveform_extractor)
         qmc.set_params(metric_names=metric_names, qm_params=qm_params, peak_sign=peak_sign, seed=seed,
                        sparsity=sparsity, skip_pc_metrics=skip_pc_metrics)
-        qmc.run(n_jobs=n_jobs, verbose=verbose, progress_bar=progress_bar)
+        # update job_kwargs with global ones
+        job_kwargs = fix_job_kwargs(dict(n_jobs=n_jobs, progress_bar=progress_bar))
+        qmc.run(n_jobs=job_kwargs['n_jobs'], progress_bar=job_kwargs['progress_bar'], verbose=verbose)
 
     metrics = qmc.get_data()
 

--- a/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -51,9 +51,10 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
             metric_names = list(_misc_metric_name_to_func.keys())
             # if PC is available, PC metrics are automatically added to the list
             if self.principal_component is not None:
-                # by default 'nearest_neightbor' is removed because too slow
+                # by default 'nearest_neightbor' metrics are removed because too slow
                 pc_metrics = _possible_pc_metric_names.copy()
-                pc_metrics.remove("nearest_neighbor")
+                pc_metrics.remove("nn_isolation")
+                pc_metrics.remove("nn_noise_overlap")
                 metric_names += pc_metrics
         qm_params_ = get_default_qm_params()
         for k in qm_params_:
@@ -87,8 +88,8 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
 
         # update job_kwargs with global ones
         job_kwargs = fix_job_kwargs(job_kwargs)
-        n_jobs = job_kwargs['n_jobs'] if 'n_jobs' in job_kwargs else 1
-        progress_bar = job_kwargs['progress_bar'] if 'progress_bar' in job_kwargs else False
+        n_jobs = job_kwargs['n_jobs']
+        progress_bar = job_kwargs['progress_bar']
 
         unit_ids = self.sorting.unit_ids
         metrics = pd.DataFrame(index=unit_ids)
@@ -101,7 +102,7 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
             if verbose:
                 if metric_name not in _possible_pc_metric_names:
                     print(f"Computing {metric_name}")
-            
+
             func = _misc_metric_name_to_func[metric_name]
 
             res = func(self.waveform_extractor, **qm_params[metric_name])

--- a/spikeinterface/qualitymetrics/tests/test_quality_metric_calculator.py
+++ b/spikeinterface/qualitymetrics/tests/test_quality_metric_calculator.py
@@ -4,7 +4,7 @@ import warnings
 from pathlib import Path
 import numpy as np
 
-from spikeinterface import (WaveformExtractor, ChannelSparsity, load_extractor, extract_waveforms,
+from spikeinterface import (WaveformExtractor, compute_sparsity, load_extractor, extract_waveforms,
                             split_recording, select_segment_sorting)
 from spikeinterface.extractors import toy_example
 from spikeinterface.core import get_template_channel_sparsity
@@ -62,7 +62,7 @@ class QualityMetricsExtensionTest(WaveformExtensionCommonTestSuite, unittest.Tes
                                      max_spikes_per_unit=500,
                                      overwrite=True,
                                      seed=0)
-        self.sparsity_long = ChannelSparsity.from_radius(we_long, radius_um=50)
+        self.sparsity_long = compute_sparsity(we_long, method="radius", radius_um=50)
         self.we_long = we_long
         self.we_short = we_short
 

--- a/spikeinterface/qualitymetrics/tests/test_quality_metric_calculator.py
+++ b/spikeinterface/qualitymetrics/tests/test_quality_metric_calculator.py
@@ -206,6 +206,6 @@ class QualityMetricsExtensionTest(WaveformExtensionCommonTestSuite, unittest.Tes
 if __name__ == '__main__':
     test = QualityMetricsExtensionTest()
     test.setUp()
-    # test.test_extension()
-    test.test_nn_metrics()
+    test.test_extension()
+    # test.test_nn_metrics()
     # test.test_peak_sign()

--- a/spikeinterface/qualitymetrics/tests/test_quality_metric_calculator.py
+++ b/spikeinterface/qualitymetrics/tests/test_quality_metric_calculator.py
@@ -174,10 +174,38 @@ class QualityMetricsExtensionTest(WaveformExtensionCommonTestSuite, unittest.Tes
         assert np.allclose(metrics["amplitude_cutoff"].values,
                            metrics_inv["amplitude_cutoff"].values, atol=1e-5)
 
+    def test_nn_metrics(self):
+        we_dense = self.we1
+        we_sparse = self.we_sparse
+        sparsity = self.sparsity1
+        print(sparsity)
+
+        metric_names = ['nearest_neighbor', 'nn_isolation', 'nn_noise_overlap']
+
+        # with external sparsity on dense waveforms
+        _ = compute_principal_components(we_dense, n_components=5, mode='by_channel_local')
+        metrics = self.extension_class.get_extension_function()(we_dense, metric_names=metric_names,
+                                                                sparsity=sparsity, seed=0)
+        print(metrics)
+
+        # with sparse waveforms
+        _ = compute_principal_components(we_sparse, n_components=5, mode='by_channel_local')
+        metrics = self.extension_class.get_extension_function()(we_sparse, metric_names=metric_names,
+                                                                sparsity=None, seed=0)
+        print(metrics)
+
+        # with 2 jobs
+        # with sparse waveforms
+        _ = compute_principal_components(we_sparse, n_components=5, mode='by_channel_local')
+        metrics_par = self.extension_class.get_extension_function()(we_sparse, metric_names=metric_names,
+                                                                    sparsity=None, seed=0, n_jobs=2)
+        for metric_name in metrics.columns:
+            assert np.allclose(metrics[metric_name], metrics_par[metric_name])
+
 
 if __name__ == '__main__':
     test = QualityMetricsExtensionTest()
     test.setUp()
     # test.test_extension()
-    test.test_presence_ratio()
+    test.test_nn_metrics()
     # test.test_peak_sign()

--- a/spikeinterface/widgets/tests/test_widgets.py
+++ b/spikeinterface/widgets/tests/test_widgets.py
@@ -11,7 +11,7 @@ if __name__ != '__main__':
 import matplotlib.pyplot as plt
 
 
-from spikeinterface import extract_waveforms, download_dataset, ChannelSparsity
+from spikeinterface import extract_waveforms, download_dataset, compute_sparsity
 
 from spikeinterface.widgets import HAVE_MPL, HAVE_SV
 
@@ -58,8 +58,8 @@ class TestWidgets(unittest.TestCase):
         _ = compute_template_similarity(cls.we)
 
         # make sparse waveforms
-        cls.sparsity_radius =  ChannelSparsity.from_radius(cls.we, radius_um=50)
-        cls.sparsity_best =  ChannelSparsity.from_best_channels(cls.we, num_channels=5)
+        cls.sparsity_radius =  compute_sparsity(cls.we, method="radius", radius_um=50)
+        cls.sparsity_best =  compute_sparsity(cls.we, method="best_channels", num_channels=5)
         cls.we_sparse = cls.we.save(folder=cache_folder / 'mearec_test_sparse', sparsity=cls.sparsity_radius)
 
         cls.skip_backends = ["ipywidgets"]


### PR DESCRIPTION
This PR solves several issues in the postprocessing and quality metrics modules.

### General fixes

- `set_global_job_kwargs()` updates existing global_kwargs with new entries
- sparsity by radius can work with waveform_extractor without recording
- propagated `compute_sparsity` instead of `ChannelSparsity.from_...` for better readability
- the `compute_principal_components` and `compute_metrics` can also use a subset of `job_kwargs`.

### Fixes to quality metrics

- changed the construction of the `pca_metrics_one_unit()` to already pass unit-specific pca scores and labels (including the target unit and its neighbor) and avoid reloading several times the pca files with calls to the `get_all_projections()` function.
- the PCA metrics have been refactored to use the new sparsity approach (either sparse waveforms, or an external `ChannelSparsity` object). In particular, the `nn_isolation` is computed by taking the intersection of the sparsity of different units. Only units with at least 50% shared channels (by default), are considered overlapping and are used to compute nn_isolation.
- added **MISSING** tests for `nearest_neihgbor` (`nn_hit_rate`, `nn_miss_rate`), `nn_isolation`, and `nn_noise_overlap`
- remove `nn_isolation` and `nn_noise_overlap`from default metrics because they can be very slow, since they fit a PCA model to every pair of neighbor units. **NOTE**: the computation becomes much more efficient with sparsity ;)
