### PR TITLE
[bug-sorters] Added sample2volt for IBL version of pykilosort

### DIFF
--- a/spikeinterface/sorters/pykilosort/pykilosort.py
+++ b/spikeinterface/sorters/pykilosort/pykilosort.py
@@ -176,7 +176,14 @@ class PyKilosortSorter(BaseSorter):
         ks_probe.xc = locations[:, 0]
         ks_probe.yc = locations[:, 1]
         ks_probe.shank = None
-        ks_probe.sample2volt = 1e-6
+        if recording.get_channel_gains() is not None:
+            gains = recording.get_channel_gains()
+            if len(np.unique(gains)) == 1:
+                ks_probe.sample2volt = gains[0] * 1e-6
+            else:
+                ks_probe.sample2volt = np.median(gains) * 1e-6
+        else:
+            ks_probe.sample2volt = 1e-6
 
         run(
             dat_path,

--- a/spikeinterface/sorters/pykilosort/pykilosort.py
+++ b/spikeinterface/sorters/pykilosort/pykilosort.py
@@ -181,7 +181,7 @@ class PyKilosortSorter(BaseSorter):
             if len(np.unique(gains)) == 1:
                 ks_probe.sample2volt = gains[0] * 1e-6
             else:
-                UserWarning('Multiple gains detected fir different channels. Median gain will be used')
+                UserWarning('Multiple gains detected for different channels. Median gain will be used')
                 ks_probe.sample2volt = np.median(gains) * 1e-6
         else:
             ks_probe.sample2volt = 1e-6

--- a/spikeinterface/sorters/pykilosort/pykilosort.py
+++ b/spikeinterface/sorters/pykilosort/pykilosort.py
@@ -176,6 +176,7 @@ class PyKilosortSorter(BaseSorter):
         ks_probe.xc = locations[:, 0]
         ks_probe.yc = locations[:, 1]
         ks_probe.shank = None
+        ks_probe.sample2volt = 1e-6
 
         run(
             dat_path,

--- a/spikeinterface/sorters/pykilosort/pykilosort.py
+++ b/spikeinterface/sorters/pykilosort/pykilosort.py
@@ -181,6 +181,7 @@ class PyKilosortSorter(BaseSorter):
             if len(np.unique(gains)) == 1:
                 ks_probe.sample2volt = gains[0] * 1e-6
             else:
+                UserWarning('Multiple gains detected fir different channels. Median gain will be used')
                 ks_probe.sample2volt = np.median(gains) * 1e-6
         else:
             ks_probe.sample2volt = 1e-6

--- a/spikeinterface/sorters/pykilosort/pykilosort.py
+++ b/spikeinterface/sorters/pykilosort/pykilosort.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import numpy as np
+import warnings
 
 from spikeinterface.core import load_extractor
 from spikeinterface.extractors import KiloSortSortingExtractor
@@ -181,7 +182,7 @@ class PyKilosortSorter(BaseSorter):
             if len(np.unique(gains)) == 1:
                 ks_probe.sample2volt = gains[0] * 1e-6
             else:
-                UserWarning('Multiple gains detected for different channels. Median gain will be used')
+                warnings.warn('Multiple gains detected for different channels. Median gain will be used')
                 ks_probe.sample2volt = np.median(gains) * 1e-6
         else:
             ks_probe.sample2volt = 1e-6


### PR DESCRIPTION
It seems that the IBL version of pykilosort requires a probe.sample2volt argument for the preprocessing steps. Otherwise I get this error in the spikesorting logs

`{
    "sorter_name": "pykilosort",
    "sorter_version": "ibl_1.4.1",
    "datetime": "2023-01-19T17:44:43.361326",
    "runtime_trace": [],
    "error": true,
    "error_trace": "Traceback (most recent call last):\n  File \"C:\\Users\\Mammoth\\miniconda3\\envs\\pykilosort\\lib\\site-packages\\spikeinterface\\sorters\\basesorter.py\", line 230, in run_from_folder\n    SorterClass._run_from_folder(sorter_output_folder, sorter_params, verbose)\n  File \"C:\\Users\\Mammoth\\miniconda3\\envs\\pykilosort\\lib\\site-packages\\spikeinterface\\sorters\\pykilosort\\pykilosort.py\", line 180, in _run_from_folder\n    run(\n  File \"C:\\Users\\Mammoth\\miniconda3\\envs\\pykilosort\\lib\\site-packages\\pykilosort-ibl_1.4.1-py3.9.egg\\pykilosort\\main.py\", line 95, in run\n    probe.good_channels, probe.channels_labels = get_good_channels(\n  File \"C:\\Users\\Mammoth\\miniconda3\\envs\\pykilosort\\lib\\site-packages\\pykilosort-ibl_1.4.1-py3.9.egg\\pykilosort\\preprocess.py\", line 280, in get_good_channels\n    return get_good_channels_raw_correlations(raw_data, probe, params, **kwargs)\n  File \"C:\\Users\\Mammoth\\miniconda3\\envs\\pykilosort\\lib\\site-packages\\pykilosort-ibl_1.4.1-py3.9.egg\\pykilosort\\preprocess.py\", line 299, in get_good_channels_raw_correlations\n    raw = raw_data[s0][:, :probe.Nchan].T.astype(np.float32) * probe['sample2volt']\nKeyError: 'sample2volt'\n",
    "run_time": null
}`

I have set this value to 1e-6, assuming that the raw traces are in μV. But maybe there is a property of the recording object with this information.