### PR TITLE
Make auto_merge less verbose

### DIFF
--- a/spikeinterface/curation/auto_merge.py
+++ b/spikeinterface/curation/auto_merge.py
@@ -119,8 +119,6 @@ def get_potential_auto_merge(
     
     if steps is None:
         steps = ['min_spikes', 'remove_contaminated', 'unit_positions', 'correlogram', 'template_similarity', 'check_increase_score']
-    
-    print(f'Running steps: {steps}')
 
     n = unit_ids.size
     pair_mask = np.ones((n, n), dtype='bool')


### PR DESCRIPTION
Another option would be to make an argument `verbose`, but I don't really see the point in printing the steps.