### PR TITLE
Correctly find parent folders for concatenate recording/sorting objects

### DIFF
--- a/spikeinterface/core/core_tools.py
+++ b/spikeinterface/core/core_tools.py
@@ -769,6 +769,12 @@ def recursive_path_modifier(d, func, target='path', copy=True):
             if isinstance(v, dict) and is_dict_extractor(v):
                 nested_extractor_dict = v
                 recursive_path_modifier(nested_extractor_dict, func, copy=False)
+            # deal with list of extractor objects (e.g. concatenate_recordings)
+            elif isinstance(v, list):
+                for vl in v:
+                    if isinstance(vl, dict) and is_dict_extractor(vl):
+                        nested_extractor_dict = vl
+                        recursive_path_modifier(nested_extractor_dict, func, copy=False)
 
         return dc
     else:


### PR DESCRIPTION
Fixes #1226

@vncntprvst @samuelgarcia the problem was that the `recording_list` was not correctly accessed by the recursive path modifier used to find common parent folders. This fix simply loops through lists and checks if there are extractors there