### PR TITLE
skip `CedRecordingExtractor` test in systems with python.version > 3.8

### DIFF
--- a/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/spikeinterface/extractors/tests/test_neoextractors.py
@@ -1,4 +1,7 @@
 import unittest
+from platform import python_version
+from sys import platform
+from packaging import version
 
 import pytest
 import numpy as np
@@ -201,7 +204,10 @@ class Spike2RecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ('spike2/130322-1LY.smr', {'stream_id': '1'}),
     ]
 
-
+@pytest.mark.skipif(
+        version.parse(python_version()) >= version.parse("3.8"),
+        reason="Sonpy only testing with Python < 3.8!",
+)
 class CedRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     ExtractorClass = CedRecordingExtractor
     downloads = [

--- a/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/spikeinterface/extractors/tests/test_neoextractors.py
@@ -1,6 +1,5 @@
 import unittest
 from platform import python_version
-from sys import platform
 from packaging import version
 
 import pytest
@@ -205,8 +204,8 @@ class Spike2RecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     ]
 
 @pytest.mark.skipif(
-        version.parse(python_version()) >= version.parse("3.8"),
-        reason="Sonpy only testing with Python < 3.8!",
+        version.parse(python_version()) >= version.parse("3.10"),
+        reason="Sonpy only testing with Python < 3.10!",
 )
 class CedRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     ExtractorClass = CedRecordingExtractor


### PR DESCRIPTION
I would like to run the test suit on my own system without the tests failing because I can't install `sonpy`. I propose to add a simple marker to skip the tests in newer platforms that will avoid this problem for everyone that wants to run test on their own personal systems and use python that is newer than 3.10.

What do you think?

P.D. Took the solution from neuroconv. Writing link here for provenance / reference:
https://github.com/catalystneuro/neuroconv/pull/102#discussion_r952486777