### PR TITLE
Fix slicing channels of remove artifact median/avg modes

### DIFF
--- a/spikeinterface/preprocessing/remove_artifacts.py
+++ b/spikeinterface/preprocessing/remove_artifacts.py
@@ -218,7 +218,10 @@ class RemoveArtifactsRecordingSegment(BasePreprocessorSegment):
 
     def get_traces(self, start_frame, end_frame, channel_indices):
 
-        traces = self.parent_recording_segment.get_traces(start_frame, end_frame, channel_indices)
+        if self.mode in ['average', 'median']:
+            traces = self.parent_recording_segment.get_traces(start_frame, end_frame)
+        else:
+            traces = self.parent_recording_segment.get_traces(start_frame, end_frame, channel_indices)
         traces = traces.copy()
 
         if start_frame is None:
@@ -400,6 +403,7 @@ class RemoveArtifactsRecordingSegment(BasePreprocessorSegment):
                 else:
                     traces[trace_slice] -= \
                         (best_amp * self.artifacts[label][artifact_slice]).astype(traces.dtype)
+            traces = traces[:, channel_indices]
 
         return traces
 


### PR DESCRIPTION
The median/average rm artefact needs all traces at the beginning. Slicing channels moved at the end