### PR TITLE
`find_spikes_from_templates` is failing on main

### DIFF
--- a/spikeinterface/sortingcomponents/matching/main.py
+++ b/spikeinterface/sortingcomponents/matching/main.py
@@ -9,7 +9,8 @@ from spikeinterface.core import get_chunk_with_margin
 
 def find_spikes_from_templates(recording, method='naive', method_kwargs={}, extra_outputs=False,
                               **job_kwargs):
-    """Find spike from a recording from given templates.
+    """
+    Find spikes in recording from given templates.
 
     Parameters
     ----------


### PR DESCRIPTION
This is failing on my system. Draft right now to see if this is failing on the CI as well.