### PR TITLE
Remove the rest of to_dict mechanisms from sorting components

### DIFF
--- a/spikeinterface/sortingcomponents/benchmark/benchmark_motion_correction.py
+++ b/spikeinterface/sortingcomponents/benchmark/benchmark_motion_correction.py
@@ -542,7 +542,7 @@ class ResidualRecording(BasePreprocessor):
             rec_segment = DifferenceRecordingSegment(parent_recording_segment_1, parent_recording_segment_2)
             self.add_recording_segment(rec_segment)
 
-        self._kwargs = dict(recording_1=recording_1.to_dict(), recording_2=recording_2.to_dict())
+        self._kwargs = dict(recording_1=recording_1, recording_2=recording_2)
 
 
 class DifferenceRecordingSegment(BasePreprocessorSegment):

--- a/spikeinterface/sortingcomponents/matching/main.py
+++ b/spikeinterface/sortingcomponents/matching/main.py
@@ -56,7 +56,7 @@ def find_spikes_from_templates(recording, method='naive', method_kwargs={}, extr
     # and run
     func = _find_spikes_chunk
     init_func = _init_worker_find_spikes
-    init_args = (recording.to_dict(), method, method_kwargs_seralized)
+    init_args = (recording, method, method_kwargs_seralized)
     processor = ChunkRecordingExecutor(recording, func, init_func, init_args,
                                        handle_returns=True, job_name=f'find spikes ({method})', **job_kwargs)
     spikes = processor.run()
@@ -71,10 +71,6 @@ def find_spikes_from_templates(recording, method='naive', method_kwargs={}, extr
 
 def _init_worker_find_spikes(recording, method, method_kwargs):
     """Initialize worker for finding spikes."""
-
-    if isinstance(recording, dict):
-        from spikeinterface.core import load_extractor
-        recording = load_extractor(recording)
 
     from .method_list import matching_methods
     method_class = matching_methods[method]

--- a/spikeinterface/sortingcomponents/matching/naive.py
+++ b/spikeinterface/sortingcomponents/matching/naive.py
@@ -117,8 +117,8 @@ class NaiveMatching(BaseTemplateMatchingEngine):
             i0 = peak_sample_ind[i] - nbefore
             i1 = peak_sample_ind[i] + nafter
             
-            wf = traces[i0:i1, :]
-            dist = np.sum(np.sum((templates - wf[None, : , :])**2, axis=1), axis=1)
+            waveforms = traces[i0:i1, :]
+            dist = np.sum(np.sum((templates - waveforms[None, : , :])**2, axis=1), axis=1)
             cluster_ind = np.argmin(dist)
 
             spikes['cluster_ind'][i] = cluster_ind

--- a/spikeinterface/sortingcomponents/motion_correction.py
+++ b/spikeinterface/sortingcomponents/motion_correction.py
@@ -298,7 +298,7 @@ class CorrectMotionRecording(BasePreprocessor):
                                                         spatial_interpolation_method, spatial_interpolation_kwargs, channel_inds, )
             self.add_recording_segment(rec_segment)
 
-        self._kwargs = dict(recording=recording.to_dict(), motion=motion, temporal_bins=temporal_bins,
+        self._kwargs = dict(recording=recording, motion=motion, temporal_bins=temporal_bins,
                             spatial_bins=spatial_bins, direction=direction, border_mode=border_mode,
                             spatial_interpolation_method=spatial_interpolation_method,
                             sigma_um=sigma_um, p=p, num_closest=num_closest)

--- a/spikeinterface/sortingcomponents/peak_detection.py
+++ b/spikeinterface/sortingcomponents/peak_detection.py
@@ -57,21 +57,14 @@ def detect_peaks(recording, method='by_channel', pipeline_nodes=None, **kwargs):
     # prepare args
     method_args = method_class.check_params(recording, **method_kwargs)
 
+    extra_margin = 0
     if pipeline_nodes is not None:
         check_graph(pipeline_nodes)
-        
-        if job_kwargs['n_jobs'] > 1:
-            pipeline_nodes_ = [(node.__class__, node.to_dict()) for node in pipeline_nodes]
-        else:
-            pipeline_nodes_ = pipeline_nodes
         extra_margin = max(node.get_trace_margin() for node in pipeline_nodes)
-    else:
-        pipeline_nodes_ = None
-        extra_margin = 0
 
     func = _detect_peaks_chunk
     init_func = _init_worker_detect_peaks
-    init_args = (recording, method, method_args, extra_margin, pipeline_nodes_)
+    init_args = (recording, method, method_args, extra_margin, pipeline_nodes)
     processor = ChunkRecordingExecutor(recording, func, init_func, init_args,
                                        handle_returns=True, job_name='detect peaks',
                                        **job_kwargs)

--- a/spikeinterface/sortingcomponents/peak_pipeline.py
+++ b/spikeinterface/sortingcomponents/peak_pipeline.py
@@ -37,12 +37,6 @@ class PipelineNode:
         if parents is not None:
             self._kwargs['parents'] = parents
         
-    @classmethod
-    def from_dict(cls, recording, kwargs):
-        return cls(recording, **kwargs)
-
-    def to_dict(self):
-        return self._kwargs
             
     def post_check(self):
         # can optionaly be overwritten

--- a/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -20,7 +20,7 @@ def test_detect_peaks():
         repo=repo, remote_path=remote_path, local_folder=None)
     recording = MEArecRecordingExtractor(local_path)
     
-    job_kwargs = dict(n_jobs=1, chunk_size=10000, progress_bar=True)
+    job_kwargs = dict(n_jobs=2, chunk_size=10000, progress_bar=True)
     # by_channel
     peaks = detect_peaks(recording, method='by_channel',
                          peak_sign='neg', detect_threshold=5, exclude_sweep_ms=0.1,

--- a/spikeinterface/sortingcomponents/tests/test_peak_pipeline.py
+++ b/spikeinterface/sortingcomponents/tests/test_peak_pipeline.py
@@ -106,12 +106,6 @@ def test_run_peak_pipeline():
     assert waveforms_rms.shape[0] == num_peaks
     assert waveforms_rms.shape[1] == num_channels
     
-
-    # Test to_dict mechanism
-    for node in nodes:
-        cls, kwargs = node.__class__, node.to_dict()
-        node2 = cls.from_dict(recording, kwargs)
-    
     # Test pickle mechanism
     for node in nodes:
         import pickle

--- a/spikeinterface/sortingcomponents/tests/test_peak_selection.py
+++ b/spikeinterface/sortingcomponents/tests/test_peak_selection.py
@@ -28,7 +28,7 @@ def test_detect_peaks():
                          chunk_size=10000, verbose=1, progress_bar=False, noise_levels=noise_levels)
 
     peak_locations = localize_peaks(recording, peaks, method='center_of_mass',
-                                    n_jobs=1, chunk_size=10000, verbose=True, progress_bar=True)
+                                    n_jobs=2, chunk_size=10000, verbose=True, progress_bar=True)
 
     subset_peaks = select_peaks(peaks, 'uniform', n_peaks=100)
     subset_peaks = select_peaks(peaks, 'uniform', n_peaks=100, select_per_channel=True)

--- a/spikeinterface/sortingcomponents/tests/test_template_matching.py
+++ b/spikeinterface/sortingcomponents/tests/test_template_matching.py
@@ -44,7 +44,7 @@ def test_find_spikes_from_templates():
             # too slow to be tested on CI
             continue
         spikes = find_spikes_from_templates(recording, method=method, method_kwargs=method_kwargs,
-                                            n_jobs=1, chunk_size=1000, progress_bar=True)
+                                            n_jobs=2, chunk_size=1000, progress_bar=True)
 
         result[method] = NumpySorting.from_times_labels(
             spikes['sample_ind'], spikes['cluster_ind'], sampling_frequency)


### PR DESCRIPTION
Within the scope of #1235. 

A continuation of #1272 as rquested by @samuelgarcia 

Removing the rest of the `to_dict` mechanisms for the recording extractors