### PR TITLE
Make caches on branches read only

### DIFF
--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -2,10 +2,14 @@ name: Create caches for gin ecephys data and virtual env
 
 on: 
   workflow_dispatch:
+  push:  # When someting is pushed into main this checks if caches need to re-created
+    branches:
+      - main
   schedule:
     - cron: "0 12 * * *"  # Daily at noon UTC
 
 jobs:
+  
   create-virtual-env-cache-if-missing:
     name: Caching virtual env
     runs-on: "ubuntu-latest"

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -3,7 +3,7 @@ name: Testing core
 on:
   pull_request:
     branches: [master]
-    types: [synchronize, opened, reopened, ready_for_review]
+    types: [synchronize, opened, reopened]
 
 concurrency:  # Cancel previous workflows on the same pull request
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.9'
       - name: Install dependencies
         run: |
           python -m pip install -U pip  # Official recommended way

--- a/.github/workflows/full-test-with-codecov.yml
+++ b/.github/workflows/full-test-with-codecov.yml
@@ -3,7 +3,7 @@ name: Full spikeinterface tests codecov
 on: 
   workflow_dispatch:
   schedule:
-    - cron: "0 12 * * *"  # Daily at noon UCT
+    - cron: "0 12 * * *"  # Daily at noon UTC
 
 env:
   KACHERY_CLOUD_CLIENT_ID: ${{ secrets.KACHERY_CLOUD_CLIENT_ID }}
@@ -34,16 +34,15 @@ jobs:
           sudo apt update
           # this is for datalad and download testing datasets
           sudo apt install git 
-          # needed for correct operation of git/git-annex/DataLad
-          git config --global user.email "CI@example.com"
-          git config --global user.name "CI Almighty"
           # this is for spyking circus
           # sudo apt install mpich libmpich-dev
-          # create an environement (better for caching)
+          # needed for correct operation of git/git-annex/DataLad
+          git config --global user.email "CI@example.com"
+          git config --global user.name "CI Almighty
           python -m venv ~/test_env
-          source ~/test_env/bin/activate
           python -m pip install -U pip  # Official recommended way
-          pip install setuptools wheel twine
+          source ~/test_env/bin/activate
+          pip install tabulate  # This produces summaries at the end
           ## clean some cache to avoid using old cache
           pip cache remove numpy
           pip cache remove hdbscan
@@ -51,7 +50,6 @@ jobs:
           # herdingspikes need numpy to installed first, this numpy pre install will be removed when HS remove from testing
           pip install numpy==1.22
           pip install -e .[test,extractors,full]
-          pip install tabulate
       - name: git-annex install
         run: |
           wget https://downloads.kitenet.net/git-annex/linux/current/git-annex-standalone-amd64.tar.gz

--- a/.github/workflows/full-test-with-codecov.yml
+++ b/.github/workflows/full-test-with-codecov.yml
@@ -38,7 +38,7 @@ jobs:
           # sudo apt install mpich libmpich-dev
           # needed for correct operation of git/git-annex/DataLad
           git config --global user.email "CI@example.com"
-          git config --global user.name "CI Almighty
+          git config --global user.name "CI Almighty"
           python -m venv ~/test_env
           python -m pip install -U pip  # Official recommended way
           source ~/test_env/bin/activate

--- a/.github/workflows/full-test-with-codecov.yml
+++ b/.github/workflows/full-test-with-codecov.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get current year-month
         id: date
         run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         id: cache-venv
         with:
           path: ~/test_env
@@ -67,7 +67,7 @@ jobs:
         id: vars
         run: |
           echo "HASH_EPHY_DATASET=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         id: cache-datasets
         env:
           # the key depend on the last comit repo https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -48,7 +48,7 @@ jobs:
           # sudo apt install mpich libmpich-dev
           # needed for correct operation of git/git-annex/DataLad
           git config --global user.email "CI@example.com"
-          git config --global user.name "CI Almighty
+          git config --global user.name "CI Almighty"
           python -m venv ~/test_env
           python -m pip install -U pip  # Official recommended way
           source ~/test_env/bin/activate

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Get current year-month
         id: date
         run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
       - uses: actions/cache/restore@v3
         id: cache-venv
         with:
@@ -78,7 +77,6 @@ jobs:
         id: vars
         run: |
           echo "HASH_EPHY_DATASET=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
       - uses: actions/cache/restore@v3
         id: cache-datasets
         env:

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -2,13 +2,13 @@ name: Full spikeinterface tests
 
 on:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
+    types: [synchronize, opened, reopened]
 
 concurrency:  # Cancel previous workflows on the same pull request
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
+env:  #  For the sortingview backend
   KACHERY_CLOUD_CLIENT_ID: ${{ secrets.KACHERY_CLOUD_CLIENT_ID }}
   KACHERY_CLOUD_PRIVATE_KEY: ${{ secrets.KACHERY_CLOUD_PRIVATE_KEY }}
 
@@ -30,10 +30,13 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         id: cache-venv
         with:
           path: ~/test_env
           key: ${{ runner.os }}-venv-${{ hashFiles('**/pyproject.toml') }}-${{ steps.date.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-venv-
       - name: Python version
         run: |
           python --version
@@ -42,16 +45,14 @@ jobs:
           sudo apt update
           # this is for datalad and download testing datasets
           sudo apt install git 
-          # needed for correct operation of git/git-annex/DataLad
-          git config --global user.email "CI@example.com"
-          git config --global user.name "CI Almighty"
           # this is for spyking circus
           # sudo apt install mpich libmpich-dev
-          # create an environement (better for caching)
+          # needed for correct operation of git/git-annex/DataLad
+          git config --global user.email "CI@example.com"
+          git config --global user.name "CI Almighty
           python -m venv ~/test_env
-          source ~/test_env/bin/activate
           python -m pip install -U pip  # Official recommended way
-          pip install setuptools wheel twine
+          source ~/test_env/bin/activate
           pip install tabulate  # This produces summaries at the end
           ## clean some cache to avoid using old cache
           pip cache remove numpy
@@ -78,6 +79,7 @@ jobs:
         run: |
           echo "HASH_EPHY_DATASET=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         id: cache-datasets
         env:
           # the key depend on the last comit repo https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,13 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.9'
       - name: Install dependencies for testing
         run: |
+          python -m pip install -U pip  # Official recommended way
           pip install pytest
           pip install zarr
           pip install setuptools wheel twine build

--- a/.github/workflows/s3-nwb-test.yml
+++ b/.github/workflows/s3-nwb-test.yml
@@ -2,7 +2,7 @@ name: S3 NWB Test
 on:
   pull_request:
     branches: [master]
-    types: [synchronize, opened, reopened, ready_for_review]
+    types: [synchronize, opened, reopened]
 
 concurrency:  # Cancel previous workflows on the same pull request
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Related to #1311. 

This PR introduces two futher things:
1) The caches are not modified by PRs from the branches (only checked-out but not modified) so we don't fill the quota.
2) Everytime a PR is merged the action that creates the caches on master will check if new caches are necessary.