### PR TITLE
Fix ids_to_indices when channel_ids is None

### DIFF
--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -96,7 +96,7 @@ class BaseExtractor:
             if prefer_slice:
                 indices = slice(None)
             else:
-                indices = self._main_ids
+                indices = np.arange(len(self._main_ids))
         else:
             _main_ids = self._main_ids.tolist()
             indices = np.array([_main_ids.index(id) for id in ids], dtype=int)

--- a/spikeinterface/core/recording_tools.py
+++ b/spikeinterface/core/recording_tools.py
@@ -223,7 +223,7 @@ def order_channels_by_depth(recording, channel_ids=None, dimensions=('x', 'y')):
     """
     locations = recording.get_channel_locations()
     ndim = locations.shape[1]
-    channel_inds = recording.ids_to_indices(channel_ids)
+    channel_inds = recording.ids_to_indices(ids=channel_ids, prefer_slice=True)
     locations = locations[channel_inds, :]
 
     if isinstance(dimensions, str):


### PR DESCRIPTION
fixes #1333

there was a bug when using `ids_to_indices` with `ids=None` (which normally is not used)