### PR TITLE
Use fix installation method for datalad git-annex

### DIFF
--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -71,7 +71,7 @@ jobs:
           git config --global user.name "CI Almighty"
           python -m pip install -U pip  # Official recommended way
           pip install datalad-installer
-          datalad-installer --sudo ok git-annex --method auto
+          datalad-installer --sudo ok git-annex --method datalad/packages
           pip install datalad
           git config --global filter.annex.process "git-annex filter-process"  # recommended for efficiency
       - name: Download dataset


### PR DESCRIPTION
I forgot to fix the installation method for datalad git-annex (I was using auto which sometimes uses conda instead of the recommended method). This one line change fixes that. 