### PR TITLE
Fix sonpy dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The `[full]` option installs all the extra dependencies for all the different su
 To install all interactive widget backends, you can use:
 
 ```bash
- pip install spikeinterface[full, widgets]
+ pip install spikeinterface[full,widgets]
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ extractors = [
     "MEArec>=1.8",
     "pynwb>=2.1.0",
     "pyedflib>=0.1.30",
-    "sonpy;python_version>'3.7'",
+    "sonpy;python_version<'3.10'",
     "lxml", # lxml for neuroscope
     "hdf5storage", # hdf5storage and scipy for cellexplorer
     "scipy",


### PR DESCRIPTION
Sonpy is not supported for Python>=3.10. SpikeInterface requires >=3.8.

(also fixed a small typo in the README)