### PR TITLE
Add a margin parameter to get_random_data_chunks

### DIFF
--- a/spikeinterface/core/recording_tools.py
+++ b/spikeinterface/core/recording_tools.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 def get_random_data_chunks(recording, return_scaled=False, num_chunks_per_segment=20, 
-                           chunk_size=10000, concatenated=True, seed=0):
+                           chunk_size=10000, concatenated=True, seed=0, margin_frames=0):
     """
     Exctract random chunks across segments
 
@@ -39,7 +39,8 @@ def get_random_data_chunks(recording, return_scaled=False, num_chunks_per_segmen
     chunk_list = []
     for segment_index in range(recording.get_num_segments()):
         length = recording.get_num_frames(segment_index)
-        random_starts = np.random.RandomState(seed=seed).randint(0, length - chunk_size, size=num_chunks_per_segment)
+        
+        random_starts = np.random.RandomState(seed=seed).randint(margin_frames, length - chunk_size - margin_frames, size=num_chunks_per_segment)
         for start_frame in random_starts:
             chunk = recording.get_traces(start_frame=start_frame,
                                          end_frame=start_frame + chunk_size,


### PR DESCRIPTION
Wonder if SI would consider extending the API of `get_random_data_chunks` in some way along these lines? Use case: for instance when calling `si.zscore()`, we can exclude the border to avoid issues at the edge of the recording -- that could be helpful for other functions as well, like estimating noise levels. I also considered parameterizing by `min_frame/max_frame`, but that doesn't generalize as well across segments.