### PR TITLE
replace "optional, default" with "default"

### DIFF
--- a/spikeinterface/extractors/alfsortingextractor.py
+++ b/spikeinterface/extractors/alfsortingextractor.py
@@ -19,7 +19,7 @@ class ALFSortingExtractor(BaseSorting):
     ----------
     folder_path : str or Path
         Path to the ALF folder.
-    sampling_frequency : int, optional, default: 30000
+    sampling_frequency : int, default: 30000
         The sampling frequency.
 
     Returns

--- a/spikeinterface/extractors/cbin_ibl.py
+++ b/spikeinterface/extractors/cbin_ibl.py
@@ -27,7 +27,7 @@ class CompressedBinaryIblExtractor(BaseRecording):
     ----------
     folder_path: str or Path
         Path to ibl folder.
-    load_sync_channel: bool, optional, default: False
+    load_sync_channel: bool, default: False
         Load or not the last channel (sync).
         If not then the probe is loaded.
 

--- a/spikeinterface/extractors/combinatoextractors.py
+++ b/spikeinterface/extractors/combinatoextractors.py
@@ -19,13 +19,13 @@ class CombinatoSortingExtractor(BaseSorting):
     ----------
     folder_path : str or Path
         Path to the Combinato folder.
-    sampling_frequency : int, optional, default: 30000
+    sampling_frequency : int, default: 30000
         The sampling frequency.
     user : str
         The username that ran the sorting. Defaults to 'simple'.
     det_sign : {'both', 'pos', 'neg'}
         Which sign was used for detection.
-    keep_good_only : bool, optional, default: True
+    keep_good_only : bool, default: True
         Whether to only keep good units.
 
     Returns

--- a/spikeinterface/extractors/hdsortextractors.py
+++ b/spikeinterface/extractors/hdsortextractors.py
@@ -15,7 +15,7 @@ class HDSortSortingExtractor(MatlabHelper, BaseSorting):
     ----------
     file_path : str or Path
         Path to HDSort mat file.
-    keep_good_only : bool, optional, default: True
+    keep_good_only : bool, default: True
         Whether to only keep good units.
 
     Returns

--- a/spikeinterface/extractors/herdingspikesextractors.py
+++ b/spikeinterface/extractors/herdingspikesextractors.py
@@ -19,7 +19,7 @@ class HerdingspikesSortingExtractor(BaseSorting):
     ----------
     folder_path : str or Path
         Path to the ALF folder.
-    load_unit_info : bool, optional, default: True
+    load_unit_info : bool, default: True
         Whether to load the unit info from the file.
 
     Returns

--- a/spikeinterface/extractors/mcsh5extractors.py
+++ b/spikeinterface/extractors/mcsh5extractors.py
@@ -19,7 +19,7 @@ class MCSH5RecordingExtractor(BaseRecording):
     ----------
     file_path : str or Path
         The path to the MCS h5 file.
-    stream_id : int, optional, default: 0
+    stream_id : int, default: 0
         The stream ID to load.
 
     Returns

--- a/spikeinterface/extractors/neoextractors/alphaomega.py
+++ b/spikeinterface/extractors/neoextractors/alphaomega.py
@@ -19,7 +19,7 @@ class AlphaOmegaRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = "folder"

--- a/spikeinterface/extractors/neoextractors/axona.py
+++ b/spikeinterface/extractors/neoextractors/axona.py
@@ -13,7 +13,7 @@ class AxonaRecordingExtractor(NeoBaseRecordingExtractor):
     ----------
     file_path: str
         The file path to load the recordings from.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'folder'

--- a/spikeinterface/extractors/neoextractors/blackrock.py
+++ b/spikeinterface/extractors/neoextractors/blackrock.py
@@ -17,7 +17,7 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'

--- a/spikeinterface/extractors/neoextractors/ced.py
+++ b/spikeinterface/extractors/neoextractors/ced.py
@@ -21,7 +21,7 @@ class CedRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     block_index: int, optional
         If there are several blocks, specify the block index you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'

--- a/spikeinterface/extractors/neoextractors/edf.py
+++ b/spikeinterface/extractors/neoextractors/edf.py
@@ -18,7 +18,7 @@ class EDFRecordingExtractor(NeoBaseRecordingExtractor):
         For this neo reader streams are defined by their sampling frequency.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'

--- a/spikeinterface/extractors/neoextractors/intan.py
+++ b/spikeinterface/extractors/neoextractors/intan.py
@@ -17,7 +17,7 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'

--- a/spikeinterface/extractors/neoextractors/maxwell.py
+++ b/spikeinterface/extractors/neoextractors/maxwell.py
@@ -25,12 +25,12 @@ class MaxwellRecordingExtractor(NeoBaseRecordingExtractor):
         need to specify stream_id='well000' or 'well0001', etc.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     rec_name: str, optional
         When the file contains several recordings you need to specify the one
         you want to extract. (rec_name='rec0000').
-    install_maxwell_plugin: bool, optional, default: False
+    install_maxwell_plugin: bool, default: False
         If True, install the maxwell plugin for neo.
     """
     mode = 'file'

--- a/spikeinterface/extractors/neoextractors/mcsraw.py
+++ b/spikeinterface/extractors/neoextractors/mcsraw.py
@@ -22,7 +22,7 @@ class MCSRawRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     block_index: int, optional
         If there are several blocks, specify the block index you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'

--- a/spikeinterface/extractors/neoextractors/mearec.py
+++ b/spikeinterface/extractors/neoextractors/mearec.py
@@ -13,7 +13,7 @@ class MEArecRecordingExtractor(NeoBaseRecordingExtractor):
     ----------
     file_path: str
         The file path to load the recordings from.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'

--- a/spikeinterface/extractors/neoextractors/neuralynx.py
+++ b/spikeinterface/extractors/neoextractors/neuralynx.py
@@ -17,7 +17,7 @@ class NeuralynxRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'folder'

--- a/spikeinterface/extractors/neoextractors/neuroscope.py
+++ b/spikeinterface/extractors/neoextractors/neuroscope.py
@@ -34,7 +34,7 @@ class NeuroScopeRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'

--- a/spikeinterface/extractors/neoextractors/nix.py
+++ b/spikeinterface/extractors/neoextractors/nix.py
@@ -19,7 +19,7 @@ class NixRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     block_index: int, optional
         If there are several blocks, specify the block index you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'

--- a/spikeinterface/extractors/neoextractors/plexon.py
+++ b/spikeinterface/extractors/neoextractors/plexon.py
@@ -17,7 +17,7 @@ class PlexonRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'

--- a/spikeinterface/extractors/neoextractors/spike2.py
+++ b/spikeinterface/extractors/neoextractors/spike2.py
@@ -18,7 +18,7 @@ class Spike2RecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'

--- a/spikeinterface/extractors/neoextractors/spikegadgets.py
+++ b/spikeinterface/extractors/neoextractors/spikegadgets.py
@@ -17,7 +17,7 @@ class SpikeGadgetsRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'file'

--- a/spikeinterface/extractors/neoextractors/spikeglx.py
+++ b/spikeinterface/extractors/neoextractors/spikeglx.py
@@ -38,7 +38,7 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
         For example, 'imec0.ap' 'nidq' or 'imec0.lf'.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = "folder"

--- a/spikeinterface/extractors/neoextractors/tdt.py
+++ b/spikeinterface/extractors/neoextractors/tdt.py
@@ -17,7 +17,7 @@ class TdtRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
         If there are several streams, specify the stream name you want to load.
-    all_annotations: bool, optional, default: False
+    all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
     """
     mode = 'folder'

--- a/spikeinterface/extractors/neuropixels_utils.py
+++ b/spikeinterface/extractors/neuropixels_utils.py
@@ -15,10 +15,10 @@ def get_neuropixels_sample_shifts(num_channels=384, num_channels_per_adc=12):
 
     Parameters
     ----------
-    num_channels : int, optional, default: 384
+    num_channels : int, default: 384
         The total number of channels in a recording.
         All currently available Neuropixels variants have 384 channels.
-    num_channels_per_adc : int, optional, default: 12
+    num_channels_per_adc : int, default: 12
         The number of channels per ADC on the probe.
         Neuropixels 1.0 probes have 12 ADCs.
         Neuropixels 2.0 probes have 16 ADCs.
@@ -63,10 +63,10 @@ def get_neuropixels_channel_groups(num_channels=384, num_adcs=12):
 
     Parameters
     ----------
-    num_channels : int, optional, default: 384
+    num_channels : int, default: 384
         The total number of channels in a recording.
         All currently available Neuropixels variants have 384 channels.
-    num_channels_per_adc : int, optional, default: 12
+    num_channels_per_adc : int, default: 12
         The number of channels per ADC on the probe.
         Neuropixels 1.0 probes have 12 ADCs.
         Neuropixels 2.0 probes have 16 ADCs.

--- a/spikeinterface/extractors/nwbextractors.py
+++ b/spikeinterface/extractors/nwbextractors.py
@@ -62,9 +62,9 @@ class NwbRecordingExtractor(BaseRecording):
         Path to NWB file or s3 url.
     electrical_series_name: str, optional
         The name of the ElectricalSeries. Used if multiple ElectricalSeries are present.
-    load_time_vector: bool, optional, default: False
+    load_time_vector: bool, default: False
         If True, the time vector is loaded to the recording object.
-    samples_for_rate_estimation: int, optional, default: 100000
+    samples_for_rate_estimation: int, default: 100000
         The number of timestamp samples to use to estimate the rate.
         Used if 'rate' is not specified in the ElectricalSeries.
     stream_mode: str, optional
@@ -335,7 +335,7 @@ class NwbSortingExtractor(BaseSorting):
         The name of the ElectricalSeries (if multiple ElectricalSeries are present).
     sampling_frequency: float, optional
         The sampling frequency in Hz (required if no ElectricalSeries is available).
-    samples_for_rate_estimation: int, optional, default: 100000
+    samples_for_rate_estimation: int, default: 100000
         The number of timestamp samples to use to estimate the rate.
         Used if 'rate' is not specified in the ElectricalSeries.
     stream_mode: str, optional
@@ -486,9 +486,9 @@ def read_nwb(file_path, load_recording=True, load_sorting=False, electrical_seri
     ----------
     file_path: str or Path
         Path to NWB file.
-    load_recording : bool, optional, default: True
+    load_recording : bool, default: True
         If True, the recording object is loaded.
-    load_sorting : bool, optional, default: False
+    load_sorting : bool, default: False
         If True, the recording object is loaded.
     electrical_series_name: str, optional
         The name of the ElectricalSeries (if multiple ElectricalSeries are present)

--- a/spikeinterface/extractors/phykilosortextractors.py
+++ b/spikeinterface/extractors/phykilosortextractors.py
@@ -15,7 +15,7 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
         Path to the output Phy folder (containing the params.py)
     exclude_cluster_groups: list or str, optional
         Cluster groups to exclude (e.g. "noise" or ["noise", "mua"]).
-    keep_good_only : bool, optional, default: True
+    keep_good_only : bool, default: True
         Whether to only keep good units.
     """
     extractor_name = 'BasePhyKilosortSorting'
@@ -199,7 +199,7 @@ class KiloSortSortingExtractor(BasePhyKilosortSortingExtractor):
         Path to the output Phy folder (containing the params.py).
     exclude_cluster_groups: list or str, optional
         Cluster groups to exclude (e.g. "noise" or ["noise", "mua"]).
-    keep_good_only : bool, optional, default: True
+    keep_good_only : bool, default: True
         Whether to only keep good units.
         If True, only Kilosort-labeled 'good' units are returned.
 

--- a/spikeinterface/extractors/waveclustextractors.py
+++ b/spikeinterface/extractors/waveclustextractors.py
@@ -14,7 +14,7 @@ class WaveClusSortingExtractor(MatlabHelper, BaseSorting):
     ----------
     file_path : str or Path
         Path to the WaveClus file.
-    keep_good_only : bool, optional, default: True
+    keep_good_only : bool, default: True
         Whether to only keep good units.
 
     Returns

--- a/spikeinterface/postprocessing/correlograms.py
+++ b/spikeinterface/postprocessing/correlograms.py
@@ -153,7 +153,7 @@ def compute_correlograms(waveform_or_sorting_extractor,
     ----------
     waveform_or_sorting_extractor : WaveformExtractor or BaseSorting
         If WaveformExtractor, the correlograms are saved as WaveformExtensions.
-    load_if_exists : bool, optional, default: False
+    load_if_exists : bool, default: False
         Whether to load precomputed crosscorrelograms, if they already exist.
     window_ms : float, optional
         The window in ms, by default 100.0.

--- a/spikeinterface/postprocessing/isi.py
+++ b/spikeinterface/postprocessing/isi.py
@@ -132,7 +132,7 @@ def compute_isi_histograms(waveform_or_sorting_extractor, load_if_exists=False,
     ----------
     waveform_or_sorting_extractor : WaveformExtractor or BaseSorting
         If WaveformExtractor, the ISI histograms are saved as WaveformExtensions.
-    load_if_exists : bool, optional, default: False
+    load_if_exists : bool, default: False
         Whether to load precomputed crosscorrelograms, if they already exist.
     window_ms : float, optional
         The window in ms, by default 50.0.

--- a/spikeinterface/postprocessing/spike_amplitudes.py
+++ b/spikeinterface/postprocessing/spike_amplitudes.py
@@ -149,7 +149,7 @@ def compute_spike_amplitudes(waveform_extractor, load_if_exists=False,
     ----------
     waveform_extractor: WaveformExtractor
         The waveform extractor object
-    load_if_exists : bool, optional, default: False
+    load_if_exists : bool, default: False
         Whether to load precomputed spike amplitudes, if they already exist.
     peak_sign: str
         The sign to compute maximum channel:

--- a/spikeinterface/postprocessing/spike_locations.py
+++ b/spikeinterface/postprocessing/spike_locations.py
@@ -115,7 +115,7 @@ def compute_spike_locations(waveform_extractor, load_if_exists=False,
     ----------
     waveform_extractor : WaveformExtractor
         A waveform extractor object.
-    load_if_exists : bool, optional, default: False
+    load_if_exists : bool, default: False
         Whether to load precomputed spike locations, if they already exist.
     ms_before : float
         The left window, before a peak, in milliseconds.

--- a/spikeinterface/postprocessing/template_metrics.py
+++ b/spikeinterface/postprocessing/template_metrics.py
@@ -150,7 +150,7 @@ def compute_template_metrics(waveform_extractor, load_if_exists=False,
     ----------
     waveform_extractor : WaveformExtractor, optional
         The waveform extractor used to compute template metrics
-    load_if_exists : bool, optional, default: False
+    load_if_exists : bool, default: False
         Whether to load precomputed template metrics, if they already exist.
     metric_names : list, optional
         List of metrics to compute (see si.postprocessing.get_template_metric_names()), by default None

--- a/spikeinterface/postprocessing/template_similarity.py
+++ b/spikeinterface/postprocessing/template_similarity.py
@@ -89,7 +89,7 @@ def compute_template_similarity(waveform_extractor,
     ----------
     waveform_extractor: WaveformExtractor
         A waveform extractor object
-    load_if_exists : bool, optional, default: False
+    load_if_exists : bool, default: False
         Whether to load precomputed similarity, if is already exists.
     method: str
         Method name ('cosine_similarity')

--- a/spikeinterface/postprocessing/unit_localization.py
+++ b/spikeinterface/postprocessing/unit_localization.py
@@ -105,7 +105,7 @@ def compute_unit_locations(waveform_extractor,
     ----------
     waveform_extractor: WaveformExtractor
         A waveform extractor object.
-    load_if_exists : bool, optional, default: False
+    load_if_exists : bool, default: False
         Whether to load precomputed unit locations, if they already exist.
     method: str
         'center_of_mass' / 'monopolar_triangulation'

--- a/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/spikeinterface/qualitymetrics/misc_metrics.py
@@ -93,7 +93,7 @@ def compute_presence_ratios(waveform_extractor, bin_duration_s=60):
     ----------
     waveform_extractor : WaveformExtractor
         The waveform extractor object.
-    bin_duration_s : float, optional, default: 60
+    bin_duration_s : float, default: 60
         The duration of each bin in seconds. If the duration is less than this value, 
         presence_ratio is set to NaN
 
@@ -215,10 +215,10 @@ def compute_isi_violations(waveform_extractor, isi_threshold_ms=1.5, min_isi_ms=
     ----------
     waveform_extractor : WaveformExtractor
         The waveform extractor object
-    isi_threshold_ms : float, optional, default: 1.5
+    isi_threshold_ms : float, default: 1.5
         Threshold for classifying adjacent spikes as an ISI violation, in ms.
         This is the biophysical refractory period (default=1.5).
-    min_isi_ms : float, optional, default: 0
+    min_isi_ms : float, default: 0
         Minimum possible inter-spike interval, in ms.
         This is the artificial refractory period enforced
         by the data acquisition system or post-processing algorithms.
@@ -296,9 +296,9 @@ def compute_refrac_period_violations(waveform_extractor, refractory_period_ms: f
     ----------
     waveform_extractor : WaveformExtractor
         The waveform extractor object
-    refractory_period_ms : float, optional, default: 1.0
+    refractory_period_ms : float, default: 1.0
         The period (in ms) where no 2 good spikes can occur.
-    censored_period_ùs : float, optional, default: 0.0
+    censored_period_ùs : float, default: 0.0
         The period (in ms) where no 2 spikes can occur (because they are not detected, or
         because they were removed by another mean).
 
@@ -436,11 +436,11 @@ def compute_amplitude_cutoffs(waveform_extractor, peak_sign='neg',
         The waveform extractor object.
     peak_sign : {'neg', 'pos', 'both'}
         The sign of the peaks.
-    num_histogram_bins : int, optional, default: 100
+    num_histogram_bins : int, default: 100
         The number of bins to use to compute the amplitude histogram.
-    histogram_smoothing_value : int, optional, default: 3
+    histogram_smoothing_value : int, default: 3
         Controls the smoothing applied to the amplitude histogram.
-    amplitudes_bins_min_ratio : int, optional, default: 5
+    amplitudes_bins_min_ratio : int, default: 5
         The minimum ratio between number of amplitudes for a unit and the number of bins.
         If the ratio is less than this threshold, the amplitude_cutoff for the unit is set 
         to NaN.
@@ -760,7 +760,7 @@ def presence_ratio(spike_train, total_length, bin_edges=None, num_bin_edges=None
         Total length of the recording in samples
     bin_edges : np.array
         Pre-computed bin edges (mutually exclusive with num_bin_edges).
-    num_bin_edges : int, optional, default: 101
+    num_bin_edges : int, default: 101
         The number of bins edges to use to compute the presence ratio.
         (mutually exclusive with bin_edges).
 
@@ -794,10 +794,10 @@ def isi_violations(spike_trains, total_duration_s,
         The spike times for each recording segment for one unit, in seconds
     total_duration_s : float
         The total duration of the recording (in seconds)
-    isi_threshold_s : float, optional, default: 0.0015
+    isi_threshold_s : float, default: 0.0015
         Threshold for classifying adjacent spikes as an ISI violation, in seconds.
         This is the biophysical refractory period (default=1.5).
-    min_isi_s : float, optional, default: 0
+    min_isi_s : float, default: 0
         Minimum possible inter-spike interval, in seconds.
         This is the artificial refractory period enforced
         by the data acquisition system or post-processing algorithms.
@@ -850,11 +850,11 @@ def amplitude_cutoff(amplitudes, num_histogram_bins=500, histogram_smoothing_val
         The amplitudes (in uV) of the spikes for one unit.
     peak_sign : {'neg', 'pos', 'both'}
         The sign of the template to compute best channels.
-    num_histogram_bins : int, optional, default: 500
+    num_histogram_bins : int, default: 500
         The number of bins to use to compute the amplitude histogram.
-    histogram_smoothing_value : int, optional, default: 3
+    histogram_smoothing_value : int, default: 3
         Controls the smoothing applied to the amplitude histogram.
-    amplitudes_bins_min_ratio : int, optional, default: 5
+    amplitudes_bins_min_ratio : int, default: 5
         The minimum ratio between number of amplitudes for a unit and the number of bins.
         If the ratio is less than this threshold, the amplitude_cutoff for the unit is set 
         to NaN.

--- a/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/spikeinterface/qualitymetrics/pca_metrics.py
@@ -77,7 +77,7 @@ def calculate_pc_metrics(pca, metric_names=None, sparsity=None, qm_params=None,
         for each unit.
     qm_params : dict or None
         Dictionary with parameters for each PC metric function.
-    seed : int, optional, default: None
+    seed : int, default: None
         Random seed value.
     n_jobs : int
         Number of jobs to parallelize metric computations.
@@ -347,24 +347,24 @@ def nearest_neighbors_isolation(waveform_extractor: WaveformExtractor, this_unit
         The waveform extractor object.
     this_unit_id : int
         The ID for the unit to calculate these metrics for.
-    max_spikes : int, optional, default: 1000
+    max_spikes : int, default: 1000
         Max number of spikes to use per unit.
     min_spikes : int, optional, defalt: 10
         Min number of spikes a unit must have to go through with metric computation.
         Units with spikes < min_spikes gets numpy.NaN as the quality metric.
-    n_neighbors : int, optional, default: 5
+    n_neighbors : int, default: 5
         Number of neighbors to check membership of.
-    n_components : int, optional, default: 10
+    n_components : int, default: 10
         The number of PC components to use to project the snippets to.
-    radius_um : float, optional, default: 100
+    radius_um : float, default: 100
         The radius, in um, that channels need to be within the peak channel to be included.
-    peak_sign: str, optional, default: 'neg'
+    peak_sign: str, default: 'neg'
         The peak_sign used to compute sparsity and neighbor units. Used if waveform_extractor 
         is not sparse already.
-    min_spatial_overlap : float, optional, default: 100
+    min_spatial_overlap : float, default: 100
         In case waveform_extractor is sparse, other units are selected if they share at least 
         `min_spatial_overlap` times `n_target_unit_channels` with the target unit
-    seed : int, optional, default: None
+    seed : int, default: None
         Seed for random subsampling of spikes.
 
     Returns
@@ -502,21 +502,21 @@ def nearest_neighbors_noise_overlap(waveform_extractor: WaveformExtractor,
         The waveform extractor object.
     this_unit_id : int
         The ID of the unit to calculate this metric on.
-    max_spikes : int, optional, default: 1000
+    max_spikes : int, default: 1000
         The max number of spikes to use per cluster.
     min_spikes : int, optional, defalt: 10
         Min number of spikes a unit must have to go through with metric computation.
         Units with spikes < min_spikes gets numpy.NaN as the quality metric.
-    n_neighbors : int, optional, default: 5
+    n_neighbors : int, default: 5
         The number of neighbors to check membership.
-    n_components : int, optional, default: 10
+    n_components : int, default: 10
         The number of PC components to use to project the snippets to.
-    radius_um : float, optional, default: 100
+    radius_um : float, default: 100
         The radius, in um, that channels need to be within the peak channel to be included.
-    peak_sign: str, optional, default: 'neg'
+    peak_sign: str, default: 'neg'
         The peak_sign used to compute sparsity and neighbor units. Used if waveform_extractor 
         is not sparse already.
-    seed : int, optional, default: 0
+    seed : int, default: 0
         Random seed for subsampling spikes.
 
     Returns

--- a/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -168,7 +168,7 @@ def compute_quality_metrics(waveform_extractor, load_if_exists=False,
     ----------
     waveform_extractor: WaveformExtractor
         The waveform extractor to compute metrics on.
-    load_if_exists : bool, optional, default: False
+    load_if_exists : bool, default: False
         Whether to load precomputed quality metrics, if they already exist.
     metric_names : list or None
         List of quality metrics to compute.


### PR DESCRIPTION
In the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html) you can either use ", optional" or ", default: ", not both. Having a default value implies that the argument is optional.