### PR TITLE
Allow to load objects when 'properties' folder is missing

### DIFF
--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -384,11 +384,12 @@ class BaseExtractor:
 
         # load properties
         prop_folder = folder_metadata / 'properties'
-        for prop_file in prop_folder.iterdir():
-            if prop_file.suffix == '.npy':
-                values = np.load(prop_file, allow_pickle=True)
-                key = prop_file.stem
-                self.set_property(key, values)
+        if prop_folder.is_dir():
+            for prop_file in prop_folder.iterdir():
+                if prop_file.suffix == '.npy':
+                    values = np.load(prop_file, allow_pickle=True)
+                    key = prop_file.stem
+                    self.set_property(key, values)
 
     def save_metadata_to_folder(self, folder_metadata):
         self._extra_metadata_to_folder(folder_metadata)


### PR DESCRIPTION
Some cloud storage systems do not allow to store empty folders. If a SI object without properties (quite common for sorting objects) is saved, then the `properties` sub-folder disappears.

This simple PR checks if the `properties` folder exists before looping through it