### PR TITLE
Remove some deprecation warnings

### DIFF
--- a/.github/workflows/full-test-with-codecov.yml
+++ b/.github/workflows/full-test-with-codecov.yml
@@ -52,11 +52,8 @@ jobs:
             ${{ runner.os }}-datasets
       - name: Install dependencies
         run: |
-          sudo apt update
           # this is for datalad and download testing datasets
           sudo apt install git 
-          # this is for spyking circus
-          # sudo apt install mpich libmpich-dev
           # needed for correct operation of git/git-annex/DataLad
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"

--- a/.github/workflows/full-test-with-codecov.yml
+++ b/.github/workflows/full-test-with-codecov.yml
@@ -86,7 +86,7 @@ jobs:
       - name: run tests
         run: |
           source ~/test_env/bin/activate
-          pytest --cov=./ --cov-report xml:./coverage.xml -vv -ra --durations=0 | tee report_full.txt; test ${PIPESTATUS[0]} -eq 0 || fail
+          pytest --cov=./ --cov-report xml:./coverage.xml -vv -ra --durations=0 | tee report_full.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
           echo "# Timing profile of full tests" >> $GITHUB_STEP_SUMMARY 
           python ./.github/build_job_summary.py report_full.txt >> $GITHUB_STEP_SUMMARY 
           cat $GITHUB_STEP_SUMMARY

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Test core
         run: |
           source ~/test_env/bin/activate
-          pytest -m core -vv -ra --durations=0 --durations-min=0.001 | tee report_core.txt; test ${PIPESTATUS[0]} -eq 0 || fail
+          pytest -m core -vv -ra --durations=0 --durations-min=0.001 | tee report_core.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
           echo "# Timing profile of core tests" >> $GITHUB_STEP_SUMMARY 
           python ./.github/build_job_summary.py report_core.txt >> $GITHUB_STEP_SUMMARY  
           rm report_core.txt
@@ -157,7 +157,7 @@ jobs:
         if: ${{ steps.modules-changed.outputs.EXTRACTORS_CHANGED == 'true' }}
         run: |
           source ~/test_env/bin/activate
-          pytest -m extractors -vv -ra --durations=0 --durations-min=0.001 | tee report_extractors.txt; test ${PIPESTATUS[0]} -eq 0 || fail
+          pytest -m extractors -vv -ra --durations=0 --durations-min=0.001 | tee report_extractors.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
           echo "# Timing profile of extractors" >> $GITHUB_STEP_SUMMARY 
           python ./.github/build_job_summary.py report_extractors.txt >> $GITHUB_STEP_SUMMARY  
           rm report_extractors.txt
@@ -165,7 +165,7 @@ jobs:
         if: ${{ steps.modules-changed.outputs.PREPROCESSING_CHANGED == 'true' || steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
         run: |
           source ~/test_env/bin/activate
-          pytest -m preprocessing -vv -ra --durations=0 --durations-min=0.001 | tee report_preprocessing.txt; test ${PIPESTATUS[0]} -eq 0 || fail
+          pytest -m preprocessing -vv -ra --durations=0 --durations-min=0.001 | tee report_preprocessing.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
           echo "# Timing profile of preprocessing" >> $GITHUB_STEP_SUMMARY 
           python ./.github/build_job_summary.py report_preprocessing.txt >> $GITHUB_STEP_SUMMARY  
           rm report_preprocessing.txt
@@ -173,7 +173,7 @@ jobs:
         if: ${{ steps.modules-changed.outputs.POSTPROCESSING_CHANGED == 'true' || steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
         run: |
           source ~/test_env/bin/activate
-          pytest -m postprocessing -vv -ra --durations=0 --durations-min=0.001 | tee report_postprocessing.txt; test ${PIPESTATUS[0]} -eq 0 || fail
+          pytest -m postprocessing -vv -ra --durations=0 --durations-min=0.001 | tee report_postprocessing.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
           echo "# Timing profile of postprocessing" >> $GITHUB_STEP_SUMMARY 
           python ./.github/build_job_summary.py report_postprocessing.txt >> $GITHUB_STEP_SUMMARY  
           rm report_postprocessing.txt
@@ -181,7 +181,7 @@ jobs:
         if: ${{ steps.modules-changed.outputs.QUALITYMETRICS_CHANGED == 'true' || steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
         run: |
           source ~/test_env/bin/activate
-          pytest -m qualitymetrics -vv -ra --durations=0 --durations-min=0.001 | tee report_qualitymetrics.txt; test ${PIPESTATUS[0]} -eq 0 || fail
+          pytest -m qualitymetrics -vv -ra --durations=0 --durations-min=0.001 | tee report_qualitymetrics.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
           echo "# Timing profile of qualitymetrics" >> $GITHUB_STEP_SUMMARY 
           python ./.github/build_job_summary.py report_qualitymetrics.txt >> $GITHUB_STEP_SUMMARY  
           rm report_qualitymetrics.txt
@@ -189,7 +189,7 @@ jobs:
         if: ${{ steps.modules-changed.outputs.SORTERS_CHANGED == 'true' || steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
         run: |
           source ~/test_env/bin/activate
-          pytest -m sorters -vv -ra --durations=0 --durations-min=0.001 | tee report_sorters.txt; test ${PIPESTATUS[0]} -eq 0 || fail
+          pytest -m sorters -vv -ra --durations=0 --durations-min=0.001 | tee report_sorters.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
           echo "# Timing profile of sorters" >> $GITHUB_STEP_SUMMARY 
           python ./.github/build_job_summary.py report_sorters.txt >> $GITHUB_STEP_SUMMARY  
           rm report_sorters.txt
@@ -197,7 +197,7 @@ jobs:
         if: ${{ steps.modules-changed.outputs.COMPARISON_CHANGED == 'true' || steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
         run: |
           source ~/test_env/bin/activate
-          pytest -m comparison -vv -ra --durations=0 --durations-min=0.001 | tee report_comparison.txt; test ${PIPESTATUS[0]} -eq 0 || fail
+          pytest -m comparison -vv -ra --durations=0 --durations-min=0.001 | tee report_comparison.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
           echo "# Timing profile of comparison" >> $GITHUB_STEP_SUMMARY 
           python ./.github/build_job_summary.py report_comparison.txt >> $GITHUB_STEP_SUMMARY  
           rm report_comparison.txt
@@ -205,7 +205,7 @@ jobs:
         if: ${{ steps.modules-changed.outputs.CURATION_CHANGED == 'true' || steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
         run: |
           source ~/test_env/bin/activate
-          pytest -m curation -vv -ra --durations=0 --durations-min=0.001 | tee report_curation.txt; test ${PIPESTATUS[0]} -eq 0 || fail
+          pytest -m curation -vv -ra --durations=0 --durations-min=0.001 | tee report_curation.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
           echo "# Timing profile of curation" >> $GITHUB_STEP_SUMMARY 
           python ./.github/build_job_summary.py report_curation.txt >> $GITHUB_STEP_SUMMARY  
           rm report_curation.txt
@@ -213,7 +213,7 @@ jobs:
         if: ${{ steps.modules-changed.outputs.WIDGETS_CHANGED == 'true' || steps.modules-changed.outputs.CORE_CHANGED == 'true' || steps.modules-changed.outputs.QUALITYMETRICS_CHANGED == 'true' ||  steps.modules-changed.outputs.PREPROCESSING_CHANGED == 'true'}}
         run: |
           source ~/test_env/bin/activate
-          pytest -m widgets -vv -ra --durations=0 --durations-min=0.001 | tee report_widgets.txt; test ${PIPESTATUS[0]} -eq 0 || fail
+          pytest -m widgets -vv -ra --durations=0 --durations-min=0.001 | tee report_widgets.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
           echo "# Timing profile of widgets" >> $GITHUB_STEP_SUMMARY 
           python ./.github/build_job_summary.py report_widgets.txt >> $GITHUB_STEP_SUMMARY  
           rm report_widgets.txt
@@ -221,7 +221,7 @@ jobs:
         if: ${{ steps.modules-changed.outputs.EXPORTERS_CHANGED == 'true' || steps.modules-changed.outputs.CORE_CHANGED == 'true' || steps.modules-changed.outputs.WIDGETS_CHANGED == 'true' }}
         run: |
           source ~/test_env/bin/activate
-          pytest -m exporters -vv -ra --durations=0 --durations-min=0.001 | tee report_exporters.txt; test ${PIPESTATUS[0]} -eq 0 || fail
+          pytest -m exporters -vv -ra --durations=0 --durations-min=0.001 | tee report_exporters.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
           echo "# Timing profile of exporters" >> $GITHUB_STEP_SUMMARY 
           python ./.github/build_job_summary.py report_exporters.txt >> $GITHUB_STEP_SUMMARY  
           rm report_exporters.txt
@@ -229,7 +229,7 @@ jobs:
         if: ${{ steps.modules-changed.outputs.SORTINGCOMPONENTS_CHANGED == 'true' || steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
         run: |
           source ~/test_env/bin/activate
-          pytest -m sortingcomponents -vv -ra --durations=0 --durations-min=0.001 | tee report_sortingcomponents.txt; test ${PIPESTATUS[0]} -eq 0 || fail
+          pytest -m sortingcomponents -vv -ra --durations=0 --durations-min=0.001 | tee report_sortingcomponents.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
           echo "# Timing profile of sortingcomponents" >> $GITHUB_STEP_SUMMARY 
           python ./.github/build_job_summary.py report_sortingcomponents.txt >> $GITHUB_STEP_SUMMARY  
           rm report_sortingcomponents.txt
@@ -237,6 +237,6 @@ jobs:
         if: ${{ steps.modules-changed.outputs.SORTERS_INTERNAL_CHANGED == 'true' || steps.modules-changed.outputs.SORTINGCOMPONENTS_CHANGED || steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
         run: |
           source ~/test_env/bin/activate
-          pytest -m sorters_internal -vv -ra --durations=0 --durations-min=0.001 | tee report_sorters_internal.txt; test ${PIPESTATUS[0]} -eq 0 || fail
+          pytest -m sorters_internal -vv -ra --durations=0 --durations-min=0.001 | tee report_sorters_internal.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
           echo "# Timing profile of sorters_internal" >> $GITHUB_STEP_SUMMARY 
           python ./.github/build_job_summary.py report_sorters_internal.txt >> $GITHUB_STEP_SUMMARY 

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -55,11 +55,8 @@ jobs:
             ${{ runner.os }}-datasets
       - name: Install dependencies
         run: |
-          sudo apt update
           # this is for datalad and download testing datasets
           sudo apt install git 
-          # this is for spyking circus
-          # sudo apt install mpich libmpich-dev
           # needed for correct operation of git/git-annex/DataLad
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,9 +123,6 @@ test = [
 ]
 
 
-
-
-
 [tool.pytest.ini_options]
 markers = [
     "core",
@@ -141,4 +138,8 @@ markers = [
     "exporters",
     "widgets",
     "sortingcomponents",
+]
+filterwarnings =[
+    'ignore:.*distutils Version classes are deprecated.*:DeprecationWarning',
+    'ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning',
 ]

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -429,7 +429,7 @@ def test_portability():
     shutil.copytree(folder_to_move, folder_moved)
     wf_folder_moved = folder_moved / "waveform_extractor"
     we_loaded = extract_waveforms(
-        recording, sorting, wf_folder_moved, load_if_exists=True)
+        recording, sorting, wf_folder_moved, load_waveforms=True)
 
     assert we_loaded.recording is not None
     assert we_loaded.sorting is not None

--- a/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/spikeinterface/core/tests/test_waveform_extractor.py
@@ -428,8 +428,7 @@ def test_portability():
     # move all to a separate folder
     shutil.copytree(folder_to_move, folder_moved)
     wf_folder_moved = folder_moved / "waveform_extractor"
-    we_loaded = extract_waveforms(
-        recording, sorting, wf_folder_moved, load_waveforms=True)
+    we_loaded = load_waveforms(folder=wf_folder_moved, with_recording=True, sorting=sorting)
 
     assert we_loaded.recording is not None
     assert we_loaded.sorting is not None

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -1371,9 +1371,6 @@ def extract_waveforms(recording, sorting, folder=None,
         Default is False.
     seed: int or None
         Random seed for spike selection
-    load_if_exists: None or bool
-        If True and waveforms have already been extracted in the specified folder, they are loaded
-        and not recomputed.
 
     sparsity kwargs:
     {}

--- a/spikeinterface/preprocessing/tests/test_highpass_spatial_filter.py
+++ b/spikeinterface/preprocessing/tests/test_highpass_spatial_filter.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 import spikeinterface as si
 import spikeinterface.preprocessing as spre
 import spikeinterface.extractors as se
-from spikeinterface.core.testing_tools import generate_recording
+from spikeinterface.core import generate_recording
 import spikeinterface.widgets as sw
 
 try:


### PR DESCRIPTION
For the long-term project of improving coverage on core I wanted to see what type of warnings we were getting. This PR is the results of that. On it, the following things are done:
* Filter the warnings for deprecation of `distutils` and `imp` clasess which are used in some packages down the line and are non informative as we can't do anything about them (they come from datalad, setuptools and boto).
* Remove some deprecated use cases in our own library. One test is used the old testing module and the other is used a deprecated argument for the waveform extractor.