### PR TITLE
Add function to remove excess spikes

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -317,6 +317,7 @@ spikeinterface.curation
     .. autofunction:: find_redundant_units
     .. autofunction:: remove_redundant_units
     .. autofunction:: remove_duplicated_spikes
+    .. autofunction:: remove_excess_spikes
     .. autofunction:: apply_sortingview_curation
 
 

--- a/doc/modules/curation.rst
+++ b/doc/modules/curation.rst
@@ -130,4 +130,6 @@ We have other tools for cleaning spike sorting outputs:
  * :py:func:`~spikeinterface.curation.find_duplicated_spikes` : find duplicated spikes in the spike trains
  * | :py:func:`~spikeinterface.curation.remove_duplicated_spikes` : remove all duplicated spikes from a 
    | :py:class:`~spikeinterface.core.BaseSorting` object (internally using the previous function)
+ * | :py:func:`~spikeinterface.curation.remove_excess_spikes` : remove spikes whose times are greater than the 
+   | recording's number of samples (by segment)
 

--- a/spikeinterface/core/recording_tools.py
+++ b/spikeinterface/core/recording_tools.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def get_random_data_chunks(recording, return_scaled=False, num_chunks_per_segment=20, 
                            chunk_size=10000, concatenated=True, seed=0, margin_frames=0):
     """

--- a/spikeinterface/core/waveform_extractor.py
+++ b/spikeinterface/core/waveform_extractor.py
@@ -13,7 +13,7 @@ from .base import load_extractor
 from .core_tools import check_json
 from .job_tools import _shared_job_kwargs_doc, split_job_kwargs, fix_job_kwargs
 from .recording_tools import check_probe_do_not_overlap
-from .waveform_tools import extract_waveforms_to_buffers
+from .waveform_tools import extract_waveforms_to_buffers, has_exceeding_spikes
 from .sparsity import ChannelSparsity, compute_sparsity, _sparsity_doc
 
 _possible_template_modes = ('average', 'std', 'median')
@@ -245,6 +245,11 @@ class WaveformExtractor:
         properties_to_attrs = deepcopy(recording._properties)
         if 'contact_vector' in properties_to_attrs:
             del properties_to_attrs['contact_vector']
+        if has_exceeding_spikes(recording, sorting):
+            raise ValueError(
+                    "The sorting object has spikes exceeding the recording duration. You have to remove those spikes "
+                    "with the `spikeinterface.curation.remove_excess_spikes()` function"
+                )
         rec_attributes = dict(
             channel_ids=recording.channel_ids,
             sampling_frequency=recording.get_sampling_frequency(),

--- a/spikeinterface/core/waveform_tools.py
+++ b/spikeinterface/core/waveform_tools.py
@@ -352,3 +352,27 @@ def _waveform_extractor_chunk(segment_index, start_frame, end_frame, worker_ctx)
                     wfs[pos, :, :] = wf
                 else:
                     wfs[pos, :, :] = wf[:, sparsity_mask[unit_ind]]
+
+
+def has_exceeding_spikes(recording, sorting):
+    """
+    Check if the sorting objects has spikes exceeding the recording number of samples, for all segments
+
+    Parameters
+    ----------
+    recording : BaseRecording
+        The recording object
+    sorting : BaseSorting
+        The sorting object
+
+    Returns
+    -------
+    bool
+        True if exceeding spikes, False otherwise
+    """
+    spike_vector = sorting.to_spike_vector()
+    for segment_index in range(recording.get_num_segments()):
+        spike_vector_seg = spike_vector[spike_vector["segment_ind"] == segment_index]
+        if np.max(spike_vector_seg["sample_ind"]) > recording.get_num_samples(segment_index=segment_index) - 1:
+            return True
+    return False

--- a/spikeinterface/core/waveform_tools.py
+++ b/spikeinterface/core/waveform_tools.py
@@ -373,6 +373,7 @@ def has_exceeding_spikes(recording, sorting):
     spike_vector = sorting.to_spike_vector()
     for segment_index in range(recording.get_num_segments()):
         spike_vector_seg = spike_vector[spike_vector["segment_ind"] == segment_index]
-        if np.max(spike_vector_seg["sample_ind"]) > recording.get_num_samples(segment_index=segment_index) - 1:
-            return True
+        if len(spike_vector_seg) > 0:
+            if np.max(spike_vector_seg["sample_ind"]) > recording.get_num_samples(segment_index=segment_index) - 1:
+                return True
     return False

--- a/spikeinterface/curation/__init__.py
+++ b/spikeinterface/curation/__init__.py
@@ -1,7 +1,8 @@
 from .curation_tools import find_duplicated_spikes
 
 from .remove_redundant import remove_redundant_units, find_redundant_units
-from .remove_duplicated_spikes import RemoveDuplicatedSpikesSorting, remove_duplicated_spikes
+from .remove_duplicated_spikes import remove_duplicated_spikes
+from .remove_excess_spikes import remove_excess_spikes
 from .auto_merge import get_potential_auto_merge
 
 

--- a/spikeinterface/curation/remove_excess_spikes.py
+++ b/spikeinterface/curation/remove_excess_spikes.py
@@ -1,0 +1,80 @@
+from typing import Optional
+import numpy as np
+
+from ..core import BaseSorting, BaseSortingSegment, BaseRecording
+from ..core.waveform_tools import has_exceeding_spikes
+
+
+class RemoveExcessSpikesSorting(BaseSorting):
+    """
+    Class to remove excess spikes from the spike trains.
+    Excess spikes are the ones exceeding a recording number of samples, for each segment
+
+    Parameters
+    ----------
+    sorting: BaseSorting
+        The parent sorting.
+    recording: BaseRecording
+        The recording to use to get number of samples.
+
+    Returns
+    -------
+    sorting_without_excess_spikes: RemoveExcessSpikesSorting
+        The sorting without any excess spikes.
+    """
+
+    def __init__(self, sorting: BaseSorting, recording: BaseRecording) -> None:
+        super().__init__(sorting.get_sampling_frequency(), sorting.unit_ids)
+
+        assert sorting.get_num_segments() == recording.get_num_segments(), \
+            "The sorting and recording objects must have the same number of samples!"
+
+        for segment_index in range(sorting.get_num_segments()):
+            sorting_segment = sorting._sorting_segments[segment_index]
+            num_samples = recording.get_num_samples(segment_index=segment_index)
+            self.add_sorting_segment(RemoveExcessSpikesSortingSegment(sorting_segment, num_samples))
+
+        sorting.copy_metadata(self, only_main=False)
+        if sorting.has_recording():
+            self.register_recording(sorting._recording)
+
+        self._kwargs = {
+            'sorting': sorting.to_dict(),
+            'recording': recording.to_dict()
+        }
+
+
+class RemoveExcessSpikesSortingSegment(BaseSortingSegment):
+    def __init__(self, parent_segment: BaseSortingSegment, num_samples: int) -> None:
+        super().__init__()
+        self._parent_segment = parent_segment
+        self._num_samples = num_samples
+
+    def get_unit_spike_train(self, unit_id, start_frame: Optional[int] = None,
+                             end_frame: Optional[int] = None) -> np.ndarray:
+        spike_train = self._parent_segment.get_unit_spike_train(unit_id, start_frame=start_frame, end_frame=end_frame)
+
+        return spike_train[spike_train < self._num_samples - 1]
+
+
+def remove_excess_spikes(sorting, recording):
+    """
+    Remove excess spikes from the spike trains.
+    Excess spikes are the ones exceeding a recording number of samples, for each segment
+
+    Parameters
+    ----------
+    sorting: BaseSorting
+        The parent sorting.
+    recording: BaseRecording
+        The recording to use to get number of samples.
+
+    Returns
+    -------
+    sorting_without_excess_spikes: Sorting
+        The sorting without any excess spikes.
+    """
+    if has_exceeding_spikes(recording=recording, sorting=sorting):
+        return RemoveExcessSpikesSorting(sorting=sorting, recording=recording)
+    else:
+        return sorting

--- a/spikeinterface/curation/tests/test_remove_excess_spikes.py
+++ b/spikeinterface/curation/tests/test_remove_excess_spikes.py
@@ -1,0 +1,40 @@
+import numpy as np
+from spikeinterface.core.generate import generate_recording, NumpySorting
+from spikeinterface.core.waveform_tools import has_exceeding_spikes
+from spikeinterface.curation import remove_excess_spikes
+
+
+def test_remove_excess_spikes():
+    durations = [5, 4]
+    sampling_frequency = 30000
+    recording = generate_recording(durations=durations, sampling_frequency=sampling_frequency)
+
+    # create two units with excess 5 excess spikes each in each segment
+    num_units = 2
+    num_spikes = 100
+    num_excess_spikes_per_segment = 5
+    times = []
+    labels = []
+    for segment_index in range(recording.get_num_segments()):
+        num_samples = recording.get_num_samples(segment_index=segment_index)
+        times_segment = np.array([], dtype=int)
+        labels_segment = np.array([], dtype=int)
+        for unit in range(num_units):
+            spike_times = np.random.randint(0, num_samples - 1, num_spikes)
+            excess_spikes = np.random.randint(num_samples, num_samples + 100, num_excess_spikes_per_segment)
+            spike_times = np.sort(np.concatenate((spike_times, excess_spikes)))
+            spike_labels = unit * np.ones_like(spike_times)
+            times_segment = np.concatenate((times_segment, spike_times))
+            labels_segment = np.concatenate((labels_segment, spike_labels))
+        times.append(times_segment)
+        labels.append(labels_segment)
+
+    sorting = NumpySorting.from_times_labels(times, labels, sampling_frequency=sampling_frequency)
+    assert has_exceeding_spikes(recording, sorting)
+
+    sorting_excess = remove_excess_spikes(sorting, recording)
+    assert not has_exceeding_spikes(recording, sorting_excess)
+
+
+if __name__ == "__main__":
+    test_remove_excess_spikes()


### PR DESCRIPTION
Sometimes KS returns spikes outside the number of samples. 

This PR:
- asserts that this is not the case when extracting waveforms
- implements a curation function `remove_excess_spikes` that filters out these extra spikes