### PR TITLE
Improve Documentation - III

### DIFF
--- a/doc/modules/qualitymetrics/amplitude_cutoff.rst
+++ b/doc/modules/qualitymetrics/amplitude_cutoff.rst
@@ -11,10 +11,10 @@ A histogram of spike amplitudes is created and deviations from the expected symm
 Expectation and use
 -------------------
 
-Deviations from the expected Gaussian distributions are used to estimate the number of spikes missing from the unit.
+Deviations from the expected Gaussian distribution are used to estimate the number of spikes missing from the unit.
 This yields an estimate of the number of spikes missing from the unit (false negative rate).
-A smaller value for this metric is preferred, as this indicates few false negatives.
-The distributions can be computed on chunks for larger recording, as drift can impact the spike amplitudes (and thus not give a Gaussian distribution anymore).
+A smaller value for this metric is preferred, as this indicates fewer false negatives.
+The distribution can be computed on chunks for larger recording, as drift can impact the spike amplitudes (and thus not give a Gaussian distribution anymore).
 
 Example code
 ------------
@@ -26,7 +26,7 @@ Example code
 	# It is also recommended to run `compute_spike_amplitudes(wvf_extractor)`
 	# in order to use amplitudes from all spikes
 	fraction_missing = qm.compute_amplitude_cutoffs(wvf_extractor, peak_sign="neg")
-	# fraction_missing is a dict containing the units' ID as keys,
+	# fraction_missing is a dict containing the units' IDs as keys,
 	# and their estimated fraction of missing spikes as values.
 
 Reference

--- a/doc/modules/qualitymetrics/amplitude_median.rst
+++ b/doc/modules/qualitymetrics/amplitude_median.rst
@@ -12,7 +12,7 @@ The metric is then converted back to original units.
 Expectation and use
 -------------------
 
-A larger value (larger signal) is taken to indicate a better unit.
+A larger value (larger signal) indicates a better unit.
 
 
 Example code
@@ -25,7 +25,7 @@ Example code
 	# It is also recommended to run `compute_spike_amplitudes(wvf_extractor)`
 	# in order to use amplitude values from all spikes.
 	amplitude_medians = qm.compute_amplitude_medians(wvf_extractor)
-	# amplitude_medians is a dict containing the units' ID as keys,
+	# amplitude_medians is a dict containing the units' IDs as keys,
 	# and their estimated amplitude medians as values.
 
 Reference

--- a/doc/modules/qualitymetrics/drift.rst
+++ b/doc/modules/qualitymetrics/drift.rst
@@ -23,7 +23,7 @@ In addition the Allen Institute implementation assumes linear and equally spaced
 Finally, the original "cumulative_drift" and "max_drift" metrics have been refactored/modified 
 for the following reasons:
 
-- "max_drift" is calculated with the the peak-to-peak, so it's been renamed "drift_ptp"
+- "max_drift" is calculated with the peak-to-peak, so it's been renamed "drift_ptp"
 - | "cumulative_drift" sums the absolute value of the drift signal for each interval. This makes it very sensitive to 
   | the number of bins (and hence the recording duration)! The "drift_std" and "drift_mad", instead, are measures of 
   | the dispersion of the drift signal and are insensitive to the recording duration.

--- a/doc/modules/qualitymetrics/firing_rate.rst
+++ b/doc/modules/qualitymetrics/firing_rate.rst
@@ -16,8 +16,8 @@ Firing rate is simply the average number of spikes within the recording per seco
 Expectation and use
 -------------------
 
-Both very high and very low values of firing rate can indicate errors.
-Highly contaminated units (type I error) may have high firing rates as a result of inclusion of other neurons' spikes.
+Both very high and very low firing rates can indicate errors.
+Highly contaminated units (type I error) may have high firing rates as a result of the inclusion of other neurons' spikes.
 Low firing rate units are likely to be incomplete (type II error), although this is not always the case (some neurons have highly selective firing patterns).
 The firing rate is expected to be approximately log-normally distributed [Buzsáki]_.
 
@@ -41,8 +41,8 @@ With SpikeInterface:
 
     # Make recording, sorting and wvf_extractor object for your data.
     firing_rate = qm.compute_firing_rates(wvf_extractor)
-    # firing_rate is a dict containing the units' ID as keys,
-    # and their firing rate across segments as values (in Hz).
+    # firing_rate is a dict containing the units' IDs as keys,
+    # and their firing rates across segments as values (in Hz).
 
 References
 ----------

--- a/doc/modules/qualitymetrics/isi_violations.rst
+++ b/doc/modules/qualitymetrics/isi_violations.rst
@@ -10,9 +10,10 @@ Calculation
 Neurons have a refractory period after a spiking event during which they cannot fire again.
 Inter-spike-interval (ISI) violations refers to the rate of refractory period violations (as described by [Hill]_).
 
-The calculation works under the assumption that the contaminant events happen randomly, or comes from another neuron that is not correlated with our unit. A correlation will lead to an over-estimation of the contamination, whereas an anti-correlation will lead to an under-estimation.
+The calculation works under the assumption that the contaminant events happen randomly or come from another neuron that is not correlated with our unit. 
+A correlation will lead to an overestimation of the contamination, whereas an anti-correlation will lead to an underestimation.
 
-Different formulas were developped over the years.
+Different formulas have been developed over the years.
 
 Calculation from the [Hill]_ paper
 ----------------------------------
@@ -22,7 +23,7 @@ The following quantities are required:
 - :math:`ISI_t` : biological threshold for ISI violation.
 - :math:`ISI_{min}`: minimum ISI threshold enforced by the data recording system used.
 - :math:`ISI_s` : the array of ISI violations which are observed in the unit's spike train.
-- :math:`\#`: denote count.
+- :math:`\#`: denotes count.
 
 The threshold for ISI violations is the biological ISI threshold, :math:`ISI_t`, minus the minimum ISI threshold, :math:`ISI_{min}` enforced by the data recording system used.
 The array of inter-spike-intervals observed in the unit's spike train, :math:`ISI_s`, is used to identify the count (:math:`\#`) of observed ISI's below this threshold.
@@ -57,7 +58,7 @@ Expectation and use
 -------------------
 
 ISI violations identifies unit contamination - a high value indicates a highly contaminated unit.
-Despite being a ratio, ISI violations can exceed 1 (or become a complex number in the [Llobet]_ formula). This is usually due to the contaminant events being correlated with our neuron, and their number are greater than a purely random spike train.
+Despite being a ratio, ISI violations can exceed 1 (or become a complex number in the [Llobet]_ formula). This is usually due to the contaminant events being correlated with our neuron, and their number is greater than a purely random spike train.
 
 Example code
 ------------

--- a/doc/modules/qualitymetrics/isolation_distance.rst
+++ b/doc/modules/qualitymetrics/isolation_distance.rst
@@ -6,21 +6,21 @@ Calculation
 
 - :math:`C` : cluster of interest.
 - :math:`N_s` : number of spikes within cluster :math:`C`.
-- :math:`N_n` : number of spikes outwith cluster :math:`C`.
+- :math:`N_n` : number of spikes outside of cluster :math:`C`.
 - :math:`N_{min}` : minimum of :math:`N_s` and :math:`N_n`.
-- :math:`\mu_C`, :math:`\Sigma_C` : mean vector and covariance matrix for spikes within :math:`C` (where Each spike within :math:`C` is represented by a vector of principal components (PCs)).
-- :math:`D_{i,C}^2` : for every spike :math:`i` (represented by vector :math:`x_i`) outwith cluster :math:`C`, the Mahalanobis distance (as below) between :math:`\mu_c` and :math:`x_i` is calculated. These distances are ordered from smallest to largest. The :math:`N_{min}`'th entry in this list is the isolation distance.
+- :math:`\mu_C`, :math:`\Sigma_C` : mean vector and covariance matrix for spikes within :math:`C` (where each spike within :math:`C` is represented by a vector of principal components (PCs)).
+- :math:`D_{i,C}^2` : for every spike :math:`i` (represented by vector :math:`x_i`) outside of cluster :math:`C`, the Mahalanobis distance (as below) between :math:`\mu_c` and :math:`x_i` is calculated. These distances are ordered from smallest to largest. The :math:`N_{min}`'th entry in this list is the isolation distance.
 
 .. math::
     D_{i,C}^2 = (x_i - \mu_C)^T \Sigma_C^{-1} (x_i - \mu_C)
 
-Geometrically, the isolation distance for unit :math:`C` is the radius of the circle which contains :math:`N_{min}` spikes from unit :math:`C` and :math:`N_{min}` spikes from outwith unit :math:`C`.
+Geometrically, the isolation distance for cluster :math:`C` is the radius of the circle which contains :math:`N_{min}` spikes from cluster :math:`C` and :math:`N_{min}` spikes outside of the cluster :math:`C`.
 
 
 Expectation and use
 -------------------
 
-Isolation distance can be interpreted as a measure of distance from the unit to the nearest cluster.
+Isolation distance can be interpreted as a measure of distance from the cluster to the nearest other cluster.
 A well isolated unit should have a large isolation distance.
 
 References

--- a/doc/modules/qualitymetrics/l_ratio.rst
+++ b/doc/modules/qualitymetrics/l_ratio.rst
@@ -4,7 +4,7 @@ L-ratio (:code:`l_ratio`)
 Calculation
 -----------
 
-This description assumes a tetrode is used as an example. 
+This example assumes use of a tetrode. 
 
 L-ratio uses 4 principal components (PCs) for each tetrode channel (the first being energy, the square root of the sum of squares of each sample in the waveform, followed by the first 3 PCs of the energy normalised waveform).
 This yields spikes which are each represented as a point in 16 dimensional space.
@@ -18,7 +18,7 @@ Define for each cluster :math:`C`, the value :math:`L(C)`, representing the amou
     L(C) = \sum_{i \notin \mathrm{C}} 1 - \mathrm{CDF}_{\chi^2_{\mathrm{df}}}(D^2_{i, C})
 
 
-:math:`L` is then the sum of probabilities that each spike which is not a cluster member of :math:`C` should be included in the cluster.
+:math:`L` is then the sum of probabilities that each spike which is not a member of cluster :math:`C` should be.
 Therefore the inverse of this cumulative distribution yields the probability of cluster membership for each spike :math:`i`.
 :math:`L` is then normalised by the number of spikes :math:`N_s` in :math:`C` to allow larger clusters to tolerate more contamination.
 This yields L-ratio, which can be expressed as:

--- a/doc/modules/qualitymetrics/nearest_neighbor.rst
+++ b/doc/modules/qualitymetrics/nearest_neighbor.rst
@@ -18,7 +18,7 @@ All options involve non-parametric calculations in PCA space.
 ------------------------
 
 The membership function, :math:`\rho` is defined such that for any spike :math:`g_i`` in some cluster :math:`G`, :math:`\rho(g_i) = G`.
-Additionally, the nearest neighbour function :math:`n_k(g_i)` is defined such that the output of the function is the set of :math:`k` spikes which are closest to :math:`g_i`.
+Additionally, the nearest neighbor function :math:`n_k(g_i)` is defined such that the output of the function is the set of :math:`k` spikes which are closest to :math:`g_i`.
 
 For a unit associated with cluster :math:`C`, a subset of spikes are randomly drawn to form the cluster  :math:`A`.
 A subset of spikes which are not in  :math:`C` are drawn to form the cluster  :math:`B`.

--- a/doc/modules/qualitymetrics/presence_ratio.rst
+++ b/doc/modules/qualitymetrics/presence_ratio.rst
@@ -28,7 +28,7 @@ Example code
     # Make recording, sorting and wvf_extractor object for your data.
 
     presence_ratio = qm.compute_presence_ratios(wvf_extractor)
-    # presence_ratio is a dict containing the units' ID as keys
+    # presence_ratio is a dict containing the units' IDs as keys
     # and their presence ratio (between 0 and 1) as values.
 
 Links to original implementations

--- a/doc/modules/qualitymetrics/sliding_rp_violations.rst
+++ b/doc/modules/qualitymetrics/sliding_rp_violations.rst
@@ -16,8 +16,8 @@ Expectation and use
 -------------------
 
 Similar to the :ref:`ISI violations <ISI>` metric, this metric quantifies the number of refractory period violations seen in the recording of the unit.
-This is an estimate of false positive rate.
-A high number of violations indicates contamination, so a low value is expected for true units.
+This is an estimate of the false positive rate.
+A high number of violations indicates contamination, so a low value is expected for high quality units.
 
 
 Example code

--- a/doc/modules/qualitymetrics/snr.rst
+++ b/doc/modules/qualitymetrics/snr.rst
@@ -46,7 +46,7 @@ With SpikeInterface:
     # Make recording, sorting and wvf_extractor object for your data.
 
     SNRs = qm.compute_snrs(wvf_extractor)
-    # SNRs is a dict containing the units' ID as keys and their SNR as values.
+    # SNRs is a dict containing the units' IDs as keys and their SNRs as values.
 
 Links to original implementations
 ---------------------------------


### PR DESCRIPTION
doc/modules/qualitymetrics

I just fixed a few typos for these other than isolation distance, which used a lot of 'unit' terminology mixed with 'cluster'. In my commit for that file I explain my logic for regularizing it all to 'cluster', but let me know if that needs fixes. 

I've got a bunch of data analysis to do tomorrow, so I'll hop onto the next round of docs next week, but when I get comments I can do updates for this request this weekend.