### PR TITLE
Remove to dict_mechanism in Motion Correction

### DIFF
--- a/spikeinterface/core/base.py
+++ b/spikeinterface/core/base.py
@@ -480,8 +480,9 @@ class BaseExtractor:
                                  relative_to=relative_to,
                                  folder_metadata=folder_metadata)
         file_path = self._get_file_path(file_path, ['.json'])
+        json_recorder = check_json(dump_dict)
         file_path.write_text(
-            json.dumps(check_json(dump_dict), indent=4),
+            json.dumps(json_recorder, indent=4),
             encoding='utf8'
         )
 

--- a/spikeinterface/core/core_tools.py
+++ b/spikeinterface/core/core_tools.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import os
 import sys
+import warnings
 import datetime
 from copy import deepcopy
 import gc
@@ -11,6 +12,7 @@ import inspect
 
 from .job_tools import (ensure_chunk_size, ensure_n_jobs, divide_segment_into_chunks, fix_job_kwargs, 
                         ChunkRecordingExecutor, _shared_job_kwargs_doc)
+import spikeinterface.core.base as base
 
 def copy_signature(source_fct):
     def copy(target_fct):
@@ -79,7 +81,20 @@ def write_python(path, dict):
                 f.write(str(k) + " = " + str(v) + "\n")
 
 
-def check_json(d):
+
+def check_json(d: dict) -> dict:  # TODO: Use a proper JSONEncoder 
+    """
+    Function that transforms a dictionary into a json writable dictionary ()
+
+    Parameters
+    ----------
+    d : A dictionary
+
+    Returns
+    -------
+    dc : A json writable dictionary
+    """
+    
     dc = deepcopy(d)
     # quick hack to ensure json writable
     for k, v in d.items():
@@ -90,8 +105,13 @@ def check_json(d):
         if isinstance(k, np.floating):
             del dc[k]
             dc[float(k)] = v
+        
+        # Now the values
         if isinstance(v, dict):
             dc[k] = check_json(v)
+        elif isinstance(v, base.BaseExtractor):
+            del dc[k]
+            dc[str(k)] = check_json(v.to_dict())  # Transform recording to dictionary
         elif isinstance(v, Path):
             dc[k] = str(v.absolute())
         elif isinstance(v, (bool, np.bool_)):
@@ -112,7 +132,7 @@ def check_json(d):
                 else:
                     v_arr = np.array(v)
                     if v_arr.dtype.kind not in ("b", "i", "u", "f", "S", "U", "O"):
-                        print(f'Skipping field {k}: only int, uint, bool, float, or str types can be serialized')
+                        warnings.warn(f'Skipping field {k}: only int, uint, bool, float, or str types can be serialized')
                         continue
                     # 64-bit types are not serializable
                     if v_arr.dtype == np.dtype('int64'):

--- a/spikeinterface/sortingcomponents/motion_correction.py
+++ b/spikeinterface/sortingcomponents/motion_correction.py
@@ -298,7 +298,7 @@ class CorrectMotionRecording(BasePreprocessor):
                                                         spatial_interpolation_method, spatial_interpolation_kwargs, channel_inds, )
             self.add_recording_segment(rec_segment)
 
-        self._kwargs = dict(recording=recording.to_dict(), motion=motion, temporal_bins=temporal_bins,
+        self._kwargs = dict(recording=recording, motion=motion, temporal_bins=temporal_bins,
                             spatial_bins=spatial_bins, direction=direction, border_mode=border_mode,
                             spatial_interpolation_method=spatial_interpolation_method,
                             sigma_um=sigma_um, p=p, num_closest=num_closest)

--- a/spikeinterface/sortingcomponents/tests/test_motion_estimation.py
+++ b/spikeinterface/sortingcomponents/tests/test_motion_estimation.py
@@ -9,6 +9,8 @@ from spikeinterface.sortingcomponents.peak_detection import detect_peaks
 from spikeinterface.sortingcomponents.motion_estimation import (estimate_motion, make_2d_motion_histogram,
                                                                 compute_pairwise_displacement, 
                                                                 compute_global_displacement)
+
+from spikeinterface.sortingcomponents.motion_correction import CorrectMotionRecording
 from spikeinterface.sortingcomponents.peak_pipeline import ExtractDenseWaveforms
 from spikeinterface.sortingcomponents.peak_localization import LocalizeCenterOfMass
 
@@ -173,7 +175,10 @@ def test_estimate_motion():
             assert motion.shape[1] == 1
         else:
             assert motion.shape[1] > 1
-            
+        
+        # Test saving to disk
+        corrected_rec = CorrectMotionRecording(recording, motion, temporal_bins, spatial_bins, border_mode="force_extrapolate")
+        corrected_rec.save()
 
         if DEBUG:
             fig, ax = plt.subplots()


### PR DESCRIPTION
Related to #1345 and to #1235. 

This fixes the regresion that was introduced with #1325 and temporarily fixed in #1367. 

It adds a regression tests to motion correction in sorting components and the machinery in `check_json` so the recordings are made completley dumpable in json with that function. 

OK, this is working. This should close #1345. I will try to remove the rest of the `to_dict` mechanisms in a subsequent PR. 