### PR TITLE
Fix Windows Error in Installation Tips

### DIFF
--- a/installation_tips/README.md
+++ b/installation_tips/README.md
@@ -13,7 +13,7 @@ This environment will install:
  * herdingspikes (not on windows)
 
 Kilosort, Ironclust and HDSort are MATLAB based and need to be installed from source.
-Klusta does not work anymore with python3.8 you should create a similar environment with python3.6
+Klusta does not work anymore with python3.8 you should create a similar environment with python3.6.
 
 ### Quick installation
 
@@ -24,14 +24,14 @@ Steps:
 3. Download with right click + save the file corresponding to your OS, and put it in "Documents" folder
     * [`full_spikeinterface_environment_windows.yml`](https://raw.githubusercontent.com/SpikeInterface/spikeinterface/master/installation_tips/full_spikeinterface_environment_windows.yml)
     * [`full_spikeinterface_environment_mac.yml`](https://raw.githubusercontent.com/SpikeInterface/spikeinterface/master/installation_tips/full_spikeinterface_environment_mac.yml)
-4. Then open the "Anaconda Command Prompt" (search in your applications)
-5. If not in Documents folder type `cd Documents`
-6. Then run this depending your OS:
+4. Then open the "Anaconda Command Prompt" (if Windows, search in your applications) or the Terminal (for Mac users)
+5. If not in the "Documents" folder type `cd Documents`
+6. Then run this depending on your OS:
     * `conda env create --file full_spikeinterface_environment_windows.yml`
     * `conda env create --file full_spikeinterface_environment_mac.yml`
 
 
-Done! Before running a spikeinterface script you will need "select" this "environment" with `conda activate si_env`.
+Done! Before running a spikeinterface script you will need to "select" this "environment" with `conda activate si_env`.
 
 Note for **linux** users : this conda recipe should work but we recommend strongly to use **pip + virtualenv**.
 
@@ -39,13 +39,13 @@ Note for **linux** users : this conda recipe should work but we recommend strong
 ### Check the installation
 
 
-If you want a first try you can:
+If you want to test the spikeinterface install you can:
 
 1. Download with right click + save the file [`check_your_install.py`](https://raw.githubusercontent.com/SpikeInterface/spikeinterface/master/installation_tips/check_your_install.py)
-    and put it in "Documents" folder
+    and put it into the "Documents" folder
 
-2. Open the Anaconda Command Prompt
-3. If not in your "Documents" folder `cd Documents`
+2. Open the Anaconda Command Prompt (Windows) or Terminal (Mac)
+3. If not in your "Documents" folder type `cd Documents`
 4. Run this:
     ```
     conda activate si_env

--- a/installation_tips/README.md
+++ b/installation_tips/README.md
@@ -1,8 +1,8 @@
 ## Installation tips
 
 If you are not (yet) an expert in Python installations (conda vs pip, mananging environements, etc.), 
-here we propose a simple recipe to install `spikeinterface` and several sorters inside a anaconda 
-environment for windows/mac user.
+here we propose a simple recipe to install `spikeinterface` and several sorters inside an anaconda 
+environment for windows/mac users.
 
 This environment will install:
  * spikeinterface full option
@@ -12,7 +12,7 @@ This environment will install:
  * spyking-circus (not on mac)
  * herdinspikes (not on windows)
 
-Kilosort, Ironclust and HDSort are MATLAB based and need to be installed by source.
+Kilosort, Ironclust and HDSort are MATLAB based and need to be installed from source.
 Klusta does not work anymore with python3.8 you should create a similar environment with python3.6
 
 ### Quick installation
@@ -25,14 +25,15 @@ Steps:
     * [`full_spikeinterface_environment_windows.yml`](https://raw.githubusercontent.com/SpikeInterface/spikeinterface/master/installation_tips/full_spikeinterface_environment_windows.yml)
     * [`full_spikeinterface_environment_mac.yml`](https://raw.githubusercontent.com/SpikeInterface/spikeinterface/master/installation_tips/full_spikeinterface_environment_mac.yml)
 4. Then open the "Anaconda Command Prompt" (search in your applications)
-5. Then run this depending your OS:
+5. If not in Documents folder type `cd Documents`
+6. Then run this depending your OS:
     * `conda env create --file full_spikeinterface_environment_windows.yml`
     * `conda env create --file full_spikeinterface_environment_mac.yml`
 
 
 Done! Before running a spikeinterface script you will need "select" this "environment" with `conda activate si_env`.
 
-Note for **linux** users : this conda recipe should work but we recommand strongly to use **pip + virtualenv**.
+Note for **linux** users : this conda recipe should work but we recommend strongly to use **pip + virtualenv**.
 
 
 ### Check the installation
@@ -44,18 +45,23 @@ If you want a first try you can:
     and put it in "Documents" folder
 
 2. Open the Anaconda Command Prompt
-3. Run this:
+3. If not in your "Documents" folder `cd Documents`
+4. Run this:
     ```
-    cd Documents
     conda activate si_env
     python check_your_install.py
     ```
-
+5. If a windows user to clean-up you will also need to right click + save [`cleanup_for_windows.py`](https://raw.githubusercontent.com/SpikeInterfacemaster/installation_tips/cleanup_for_windows.py)
+Then transfer `cleanup_for_windows.py` into your "Documents" folder. Finally run :
+   ```
+   python cleanup_for_windows.py
+   ```
+   
 This script tests the following:
-  * import spikeinterface
-  * run tridesclous
-  * run spyking-circus (not on mac)
-  * run herdinspikes (not on windows)
-  * open spikeinterface-gui
-  * export to Phy
-  * run Phy
+  * importing spikeinterface
+  * running tridesclous
+  * running spyking-circus (not on mac)
+  * running herdingspikes (not on windows)
+  * opening the spikeinterface-gui
+  * exporting to Phy
+

--- a/installation_tips/README.md
+++ b/installation_tips/README.md
@@ -10,7 +10,7 @@ This environment will install:
  * phy
  * tridesclous
  * spyking-circus (not on mac)
- * herdinspikes (not on windows)
+ * herdingspikes (not on windows)
 
 Kilosort, Ironclust and HDSort are MATLAB based and need to be installed from source.
 Klusta does not work anymore with python3.8 you should create a similar environment with python3.6

--- a/installation_tips/check_your_install.py
+++ b/installation_tips/check_your_install.py
@@ -106,5 +106,8 @@ if __name__ == '__main__':
         except:
             done = '...Fail'
         print(label, done)
-
-    _clean()
+        
+    if platform.system() == "Windows":
+        pass
+    else:
+        _clean()

--- a/installation_tips/cleanup_for_windows.py
+++ b/installation_tips/cleanup_for_windows.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import shutil
+
+
+def _clean():
+    # clean
+    folders = [
+        'toy_example_recording',
+        "tridesclous_output", "tridesclous_waveforms",
+        "spykingcircus_output", "spykingcircus_waveforms",
+        "phy_example"
+    ]
+    for folder in folders:
+        if Path(folder).exists():
+            shutil.rmtree(folder)
+        
+if __name__ == '__main__':
+
+    _clean()


### PR DESCRIPTION
This will solve #1395. I just copied the `_clean` and put it into a separate .py file. Once the initial script ends the process releases the file permissions on Windows so running the `cleanup_for_windows.py` that I added worked fine on my machine (Windows 10). In order to prevent some shutil issues I also added in a check for Windows before running `_clean` in the `check_your_install.py`. 

I updated the readme to link to the additional file I added. 

Finally I added in documentation for Mac users (ie they don't use the Anaconda prompt they use Terminal just like Linux). 