### PR TITLE
Robust method for checking gpu-nvidia availability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ test = [
     # Sorters
     "python-cuda",
 
-
     ## sliding_nn
     "pymde",
     "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ full = [
     "networkx",
     "distinctipy",
     "matplotlib",
+    "cuda-python",
 ]
 
 widgets = [
@@ -109,9 +110,6 @@ test = [
 
     ## install tridesclous for testing ##
     "tridesclous>=1.6.6.1",
-
-    # Sorters
-    "cuda-python",
 
     ## sliding_nn
     "pymde",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,10 @@ test = [
     ## install tridesclous for testing ##
     "tridesclous>=1.6.6.1",
 
+    # Sorters
+    "python-cuda",
+
+
     ## sliding_nn
     "pymde",
     "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ test = [
     "tridesclous>=1.6.6.1",
 
     # Sorters
-    "python-cuda",
+    "cuda-python",
 
     ## sliding_nn
     "pymde",

--- a/spikeinterface/sorters/utils/misc.py
+++ b/spikeinterface/sorters/utils/misc.py
@@ -62,8 +62,12 @@ def has_nvidia():
     """
     Checks if the machine has nvidia capability.
     """
+    from cuda import cuda
+        
     try:
-        check_output('nvidia-smi')
-        return True
-    except Exception:  # this command not being found can raise quite a few different errors depending on the configuration
+        cu_result_init,  = cuda.cuInit(0)
+        cu_result, cu_string = cuda.cuGetErrorString(cu_result_init)
+        cu_result_device_count, device_count = cuda.cuDeviceGetCount()
+        return device_count > 0
+    except RuntimeError: #  Failed to dlopen libcuda.so
         return False


### PR DESCRIPTION
This is related to #705 and once we are done with this it probably should be closed.

This method works on dandi-hub when I tested it a while ago, the only problem is that it requires a dependency:
https://nvidia.github.io/cuda-python/overview.html

I am also not sure how to add this as a dependency.

What do you think?