### PR TITLE
Add some preprocessing tools (general and LFP-oriented)

### DIFF
--- a/spikeinterface/core/recording_tools.py
+++ b/spikeinterface/core/recording_tools.py
@@ -247,12 +247,13 @@ def get_chunk_with_margin(
             elif add_reflect_padding:
                 # in this case, we don't want to taper
                 traces_chunk = np.pad(
-                    traces_chunk,
-                    [(left_margin, right_margin), (0, 0)],
+                    traces_chunk.astype(dtype),
+                    [(left_pad, right_pad), (0, 0)],
                     mode="reflect",
                 )
             else:
-                assert False  # unreachable
+                # we need a copy to change the dtype
+                traces_chunk = np.asarray(traces_chunk, dtype=dtype)
 
     return traces_chunk, left_margin, right_margin
 

--- a/spikeinterface/core/recording_tools.py
+++ b/spikeinterface/core/recording_tools.py
@@ -301,7 +301,7 @@ def order_channels_by_depth(
             assert dim < ndim, "Invalid dimensions!"
             locations_to_sort += (locations[:, dim],)
         order_f = np.lexsort(locations_to_sort)
-    order_r = np.argsort(order_f)
+    order_r = np.argsort(order_f, kind="stable")
 
     return order_f, order_r
 

--- a/spikeinterface/core/recording_tools.py
+++ b/spikeinterface/core/recording_tools.py
@@ -150,6 +150,12 @@ def get_chunk_with_margin(
 ):
     """
     Helper to get chunk with margin
+
+    The margin is extracted from the recording when possible. If
+    at the edge of the recording, no margin is used unless one
+    of `add_zeros` or `add_reflect_padding` is True. In the first
+    case zero padding is used, in the second case np.pad is called
+    with mod="reflect".
     """
     length = rec_segment.get_num_samples()
 

--- a/spikeinterface/core/recording_tools.py
+++ b/spikeinterface/core/recording_tools.py
@@ -1,8 +1,15 @@
 import numpy as np
 
 
-def get_random_data_chunks(recording, return_scaled=False, num_chunks_per_segment=20, 
-                           chunk_size=10000, concatenated=True, seed=0, margin_frames=0):
+def get_random_data_chunks(
+    recording,
+    return_scaled=False,
+    num_chunks_per_segment=20,
+    chunk_size=10000,
+    concatenated=True,
+    seed=0,
+    margin_frames=0,
+):
     """
     Exctract random chunks across segments
 
@@ -31,22 +38,30 @@ def get_random_data_chunks(recording, return_scaled=False, num_chunks_per_segmen
     # Should be done by changing kwargs with total_num_chunks=XXX and total_duration=YYYY
     # And randomize the number of chunk per segment weighted by segment duration
 
-    # check chunk size    
+    # check chunk size
     for segment_index in range(recording.get_num_segments()):
-        assert chunk_size < recording.get_num_samples(segment_index), (f"chunk_size is greater than the number "
-                                                                        f"of samples for segment index {segment_index}. "
-                                                                        f"Use a smaller chunk_size!")
+        assert chunk_size < recording.get_num_samples(segment_index), (
+            f"chunk_size is greater than the number "
+            f"of samples for segment index {segment_index}. "
+            f"Use a smaller chunk_size!"
+        )
 
     chunk_list = []
     for segment_index in range(recording.get_num_segments()):
         length = recording.get_num_frames(segment_index)
-        
-        random_starts = np.random.RandomState(seed=seed).randint(margin_frames, length - chunk_size - margin_frames, size=num_chunks_per_segment)
+
+        random_starts = np.random.RandomState(seed=seed).randint(
+            margin_frames,
+            length - chunk_size - margin_frames,
+            size=num_chunks_per_segment,
+        )
         for start_frame in random_starts:
-            chunk = recording.get_traces(start_frame=start_frame,
-                                         end_frame=start_frame + chunk_size,
-                                         segment_index=segment_index,
-                                         return_scaled=return_scaled)
+            chunk = recording.get_traces(
+                start_frame=start_frame,
+                end_frame=start_frame + chunk_size,
+                segment_index=segment_index,
+                return_scaled=return_scaled,
+            )
             chunk_list.append(chunk)
     if concatenated:
         return np.concatenate(chunk_list, axis=0)
@@ -59,7 +74,9 @@ def get_channel_distances(recording):
     Distance between channel pairs
     """
     locations = recording.get_channel_locations()
-    channel_distances = np.linalg.norm(locations[:, np.newaxis] - locations[np.newaxis, :], axis=2)
+    channel_distances = np.linalg.norm(
+        locations[:, np.newaxis] - locations[np.newaxis, :], axis=2
+    )
 
     return channel_distances
 
@@ -95,8 +112,8 @@ def get_closest_channels(recording, channel_ids=None, num_channels=None):
     for i in range(locations.shape[0]):
         distances = np.linalg.norm(locations[i, :] - locations, axis=1)
         order = np.argsort(distances)
-        closest_channels_inds.append(order[1:num_channels + 1])
-        dists.append(distances[order][1:num_channels + 1])
+        closest_channels_inds.append(order[1 : num_channels + 1])
+        dists.append(distances[order][1 : num_channels + 1])
 
     return np.array(closest_channels_inds), np.array(dists)
 
@@ -104,21 +121,33 @@ def get_closest_channels(recording, channel_ids=None, num_channels=None):
 def get_noise_levels(recording, return_scaled=True, **random_chunk_kwargs):
     """
     Estimate noise for each channel using MAD methods.
-    
+
     Internally it sample some chunk across segment.
     And then, it use MAD estimator (more robust than STD)
-    
+
     """
-    random_chunks = get_random_data_chunks(recording, return_scaled=return_scaled, **random_chunk_kwargs)
+    random_chunks = get_random_data_chunks(
+        recording, return_scaled=return_scaled, **random_chunk_kwargs
+    )
     med = np.median(random_chunks, axis=0, keepdims=True)
     # hard-coded so that core doesn't depend on scipy
-    noise_levels = np.median(np.abs(random_chunks - med), axis=0) / 0.6744897501960817
+    noise_levels = (
+        np.median(np.abs(random_chunks - med), axis=0) / 0.6744897501960817
+    )
     return noise_levels
 
 
-def get_chunk_with_margin(rec_segment, start_frame, end_frame,
-                          channel_indices, margin, add_zeros=False, 
-                          window_on_margin=False, dtype=None):
+def get_chunk_with_margin(
+    rec_segment,
+    start_frame,
+    end_frame,
+    channel_indices,
+    margin,
+    add_zeros=False,
+    add_reflect_padding=False,
+    window_on_margin=False,
+    dtype=None,
+):
     """
     Helper to get chunk with margin
     """
@@ -127,8 +156,9 @@ def get_chunk_with_margin(rec_segment, start_frame, end_frame,
     if channel_indices is None:
         channel_indices = slice(None)
 
-    if not add_zeros:
-        assert not window_on_margin, 'window_mon_margin can be used only for add_zeros=True'
+    if not (add_zeros or add_reflect_padding):
+        if window_on_margin and not add_zeros:
+            raise ValueError("window_on_margin requires add_zeros=True")
         if start_frame is None:
             left_margin = 0
             start_frame = 0
@@ -144,10 +174,14 @@ def get_chunk_with_margin(rec_segment, start_frame, end_frame,
             right_margin = length - end_frame
         else:
             right_margin = margin
-        traces_chunk = rec_segment.get_traces(start_frame - left_margin, end_frame + right_margin, channel_indices)
+        traces_chunk = rec_segment.get_traces(
+            start_frame - left_margin,
+            end_frame + right_margin,
+            channel_indices,
+        )
 
     else:
-        # add_zeros=True
+        # either add_zeros or reflect_padding
         assert start_frame is not None
         assert end_frame is not None
         chunk_size = end_frame - start_frame
@@ -167,41 +201,65 @@ def get_chunk_with_margin(rec_segment, start_frame, end_frame,
             end_frame2 = end_frame + margin
             right_pad = 0
 
-        traces_chunk = rec_segment.get_traces(start_frame2, end_frame2, channel_indices)
-        
-        
-        if dtype is not None or window_on_margin or left_pad > 0 or right_pad > 0:
+        traces_chunk = rec_segment.get_traces(
+            start_frame2, end_frame2, channel_indices
+        )
+
+        if (
+            dtype is not None
+            or window_on_margin
+            or left_pad > 0
+            or right_pad > 0
+        ):
             need_copy = True
         else:
             need_copy = False
 
+        left_margin = margin
+        right_margin = margin
+
         if need_copy:
             if dtype is None:
                 dtype = traces_chunk.dtype
-            traces_chunk2 = np.zeros((full_size, traces_chunk.shape[1]), dtype=dtype)
-            i0 = left_pad
-            i1 = left_pad + traces_chunk.shape[0]
-            traces_chunk2[i0: i1, :] = traces_chunk
+
             left_margin = margin
             if end_frame < (length + margin):
                 right_margin = margin
             else:
                 right_margin = end_frame + margin - length
-            if window_on_margin:
-                # apply inplace taper  on border
-                taper = (1 - np.cos(np.arange(margin) / margin * np.pi)) / 2
-                taper = taper[:, np.newaxis]
-                traces_chunk2[:margin] *= taper
-                traces_chunk2[-margin:] *= taper[::-1]
-            traces_chunk = traces_chunk2
-        else:
-            left_margin = margin
-            right_margin = margin
+
+            if add_zeros:
+                traces_chunk2 = np.zeros(
+                    (full_size, traces_chunk.shape[1]), dtype=dtype
+                )
+                i0 = left_pad
+                i1 = left_pad + traces_chunk.shape[0]
+                traces_chunk2[i0:i1, :] = traces_chunk
+                if window_on_margin:
+                    # apply inplace taper on border
+                    taper = (
+                        1 - np.cos(np.arange(margin) / margin * np.pi)
+                    ) / 2
+                    taper = taper[:, np.newaxis]
+                    traces_chunk2[:margin] *= taper
+                    traces_chunk2[-margin:] *= taper[::-1]
+                traces_chunk = traces_chunk2
+            elif add_reflect_padding:
+                # in this case, we don't want to taper
+                traces_chunk = np.pad(
+                    traces_chunk,
+                    [(left_margin, right_margin), (0, 0)],
+                    mode="reflect",
+                )
+            else:
+                assert False  # unreachable
 
     return traces_chunk, left_margin, right_margin
 
 
-def order_channels_by_depth(recording, channel_ids=None, dimensions=('x', 'y')):
+def order_channels_by_depth(
+    recording, channel_ids=None, dimensions=("x", "y")
+):
     """
     Order channels by depth, by first ordering the x-axis, and then the y-axis.
 
@@ -213,7 +271,7 @@ def order_channels_by_depth(recording, channel_ids=None, dimensions=('x', 'y')):
         If given, a subset of channels to order locations for
     dimensions : str or tuple
         If str, it needs to be 'x', 'y', 'z'.
-        If tuple, it sorts the locations in two dimensions using lexsort. 
+        If tuple, it sorts the locations in two dimensions using lexsort.
         This approach is recommended since there is less ambiguity, by default ('x', 'y')
 
     Returns
@@ -229,16 +287,18 @@ def order_channels_by_depth(recording, channel_ids=None, dimensions=('x', 'y')):
     locations = locations[channel_inds, :]
 
     if isinstance(dimensions, str):
-        dim = ['x', 'y', 'z'].index(dimensions)
+        dim = ["x", "y", "z"].index(dimensions)
         assert dim < ndim, "Invalid dimensions!"
-        order_f = np.argsort(locations[:, dim])
+        order_f = np.argsort(locations[:, dim], kind="stable")
     else:
-        assert isinstance(dimensions, tuple), "dimensions can be a str or a tuple"
+        assert isinstance(
+            dimensions, tuple
+        ), "dimensions can be a str or a tuple"
         locations_to_sort = ()
         for dim in dimensions:
-            dim = ['x', 'y', 'z'].index(dim)
+            dim = ["x", "y", "z"].index(dim)
             assert dim < ndim, "Invalid dimensions!"
-            locations_to_sort += (locations[:, dim], )
+            locations_to_sort += (locations[:, dim],)
         order_f = np.lexsort(locations_to_sort)
     order_r = np.argsort(order_f)
 
@@ -253,21 +313,27 @@ def check_probe_do_not_overlap(probes):
     for i in range(len(probes)):
         probe_i = probes[i]
         # check that all positions in probe_j are outside probe_i boundaries
-        x_bounds_i = [np.min(probe_i.contact_positions[:, 0]),
-                      np.max(probe_i.contact_positions[:, 0])]
-        y_bounds_i = [np.min(probe_i.contact_positions[:, 1]),
-                      np.max(probe_i.contact_positions[:, 1])]
+        x_bounds_i = [
+            np.min(probe_i.contact_positions[:, 0]),
+            np.max(probe_i.contact_positions[:, 0]),
+        ]
+        y_bounds_i = [
+            np.min(probe_i.contact_positions[:, 1]),
+            np.max(probe_i.contact_positions[:, 1]),
+        ]
 
         for j in range(i + 1, len(probes)):
             probe_j = probes[j]
 
-            if np.any(np.array([x_bounds_i[0] < cp[0] < x_bounds_i[1] and
-                                y_bounds_i[0] < cp[1] < y_bounds_i[1]
-                                for cp in probe_j.contact_positions])):
+            if np.any(
+                np.array(
+                    [
+                        x_bounds_i[0] < cp[0] < x_bounds_i[1]
+                        and y_bounds_i[0] < cp[1] < y_bounds_i[1]
+                        for cp in probe_j.contact_positions
+                    ]
+                )
+            ):
                 raise Exception(
-                    "Probes are overlapping! Retrieve locations of single probes separately")
-
-
-
-
-
+                    "Probes are overlapping! Retrieve locations of single probes separately"
+                )

--- a/spikeinterface/preprocessing/average_across_direction.py
+++ b/spikeinterface/preprocessing/average_across_direction.py
@@ -49,7 +49,7 @@ class AverageAcrossDirectionRecording(BaseRecording):
 
         # join the original channel ids in each group with -
         joined_channel_ids = [
-            "-".join(parent_recording.channel_ids[same_along_dim_chans == i])
+            "-".join(map(str, parent_recording.channel_ids[same_along_dim_chans == i]))
             for i in range(dim_unique_pos.size)
         ]
         joined_channel_ids = np.array(joined_channel_ids)
@@ -74,7 +74,7 @@ class AverageAcrossDirectionRecording(BaseRecording):
         other_dim = np.arange(parent_channel_locations.shape[1]) != dim
         for i in range(dim_unique_pos.size):
             chans_in_group = np.flatnonzero(same_along_dim_chans == i)
-            channel_locations[chans_in_group, other_dim] = np.mean(
+            channel_locations[i, other_dim] = np.mean(
                 parent_channel_locations[chans_in_group, other_dim]
             )
         channel_locations[:, dim] = dim_unique_pos

--- a/spikeinterface/preprocessing/average_across_direction.py
+++ b/spikeinterface/preprocessing/average_across_direction.py
@@ -4,8 +4,8 @@ from .basepreprocessor import BasePreprocessorSegment
 from spikeinterface.core.core_tools import define_function_from_class
 
 
-class DirectionalAverageRecording(BaseRecording):
-    name = "directional_average"
+class AverageAcrossDirectionRecording(BaseRecording):
+    name = "average_across_direction"
     installed = True
 
     def __init__(
@@ -63,7 +63,7 @@ class DirectionalAverageRecording(BaseRecording):
         self.parent_recording = parent_recording
         self.num_channels = n_pos_unique
         for segment in parent_recording._recording_segments:
-            recording_segment = DirectionalAverageRecordingSegment(
+            recording_segment = AverageAcrossDirectionRecordingSegment(
                 segment,
                 self.num_channels,
                 same_along_dim_chans,
@@ -99,7 +99,7 @@ class DirectionalAverageRecording(BaseRecording):
         )
 
 
-class DirectionalAverageRecordingSegment(BasePreprocessorSegment):
+class AverageAcrossDirectionRecordingSegment(BasePreprocessorSegment):
     def __init__(
         self,
         parent_recording_segment: BaseRecordingSegment,
@@ -148,6 +148,6 @@ class DirectionalAverageRecordingSegment(BasePreprocessorSegment):
 
 
 # function for API
-directional_average = define_function_from_class(
-    source_class=DirectionalAverageRecording, name="directional_average"
+average_across_direction = define_function_from_class(
+    source_class=AverageAcrossDirectionRecording, name="average_across_direction"
 )

--- a/spikeinterface/preprocessing/average_across_direction.py
+++ b/spikeinterface/preprocessing/average_across_direction.py
@@ -55,7 +55,6 @@ class AverageAcrossDirectionRecording(BaseRecording):
         joined_channel_ids = np.array(joined_channel_ids)
 
         dtype_ = dtype
-        # kind == "f"
         if dtype_ is None and parent_recording.dtype.kind != "f":
             dtype_ = "float32"
 

--- a/spikeinterface/preprocessing/average_across_direction.py
+++ b/spikeinterface/preprocessing/average_across_direction.py
@@ -33,7 +33,6 @@ class AverageAcrossDirectionRecording(BaseRecording):
             to float32 by default, or kept as its floating type otherwise.
         """
         parent_channel_locations = parent_recording.get_channel_locations()
-        parent_channels = parent_recording.ids_to_indices(None, prefer_slice=True)
         dim = ["x", "y", "z"].index(direction)
         if dim > parent_channel_locations.shape[1]:
             raise ValueError(
@@ -66,7 +65,6 @@ class AverageAcrossDirectionRecording(BaseRecording):
         for segment in parent_recording._recording_segments:
             recording_segment = AverageAcrossDirectionRecordingSegment(
                 segment,
-                parent_channels,
                 self.num_channels,
                 same_along_dim_chans,
                 n_chans_each_pos,
@@ -105,7 +103,6 @@ class AverageAcrossDirectionRecordingSegment(BasePreprocessorSegment):
     def __init__(
         self,
         parent_recording_segment: BaseRecordingSegment,
-        parent_channels,
         num_channels: int,
         same_along_dim_chans: np.array,
         n_chans_each_pos: np.array,
@@ -113,7 +110,6 @@ class AverageAcrossDirectionRecordingSegment(BasePreprocessorSegment):
     ):
         BasePreprocessorSegment.__init__(self, parent_recording_segment)
         self.parent_recording_segment = parent_recording_segment
-        self.parent_channels = parent_channels
         self.num_channels = num_channels
         self.same_along_dim_chans = same_along_dim_chans
         self.n_chans_each_pos = n_chans_each_pos
@@ -131,7 +127,7 @@ class AverageAcrossDirectionRecordingSegment(BasePreprocessorSegment):
         parent_traces = self.parent_recording_segment.get_traces(
             start_frame=start_frame,
             end_frame=end_frame,
-            channel_indices=self.parent_channels,
+            channel_indices=slice(None),
         )
         traces = np.zeros(
             (parent_traces.shape[0], self.num_channels),

--- a/spikeinterface/preprocessing/average_across_direction.py
+++ b/spikeinterface/preprocessing/average_across_direction.py
@@ -12,7 +12,7 @@ class AverageAcrossDirectionRecording(BaseRecording):
         self,
         parent_recording: BaseRecording,
         direction: str = "y",
-        dtype=None,
+        dtype="float32",
     ):
         """Averages channels at the same position along `direction
 
@@ -28,9 +28,8 @@ class AverageAcrossDirectionRecording(BaseRecording):
             Channels living at unique positions along this direction
             will be averaged.
         dtype : optional numpy dtype
-            If supplied, convert recording to this type before averaging.
-            If unset, if the recording is not a floating type, it is converted
-            to float32 by default, or kept as its floating type otherwise.
+            If unset, parent dtype is preserved, but the average will
+            lose accuracy, so float32 by default.
         """
         parent_channel_locations = parent_recording.get_channel_locations()
         dim = ["x", "y", "z"].index(direction)
@@ -55,8 +54,8 @@ class AverageAcrossDirectionRecording(BaseRecording):
         joined_channel_ids = np.array(joined_channel_ids)
 
         dtype_ = dtype
-        if dtype_ is None and parent_recording.dtype.kind != "f":
-            dtype_ = "float32"
+        if dtype_ is None:
+            dtype_ = parent_recording.dtype
 
         BaseRecording.__init__(
             self,

--- a/spikeinterface/preprocessing/depth_order.py
+++ b/spikeinterface/preprocessing/depth_order.py
@@ -28,7 +28,6 @@ class DepthOrderRecording(ChannelSliceRecording):
         order_f, order_r = order_channels_by_depth(
             parent_recording, channel_ids=channel_ids, dimensions=dimensions
         )
-        channel_ids = parent_recording.get_channel_ids()
         reordered_channel_ids = parent_recording.channel_ids[order_f]
         ChannelSliceRecording.__init__(
             self,

--- a/spikeinterface/preprocessing/depth_order.py
+++ b/spikeinterface/preprocessing/depth_order.py
@@ -1,0 +1,40 @@
+from ..core import order_channels_by_depth, ChannelSliceRecording
+from ..core.core_tools import define_function_from_class
+
+
+class DepthOrderRecording(ChannelSliceRecording):
+    """Re-orders the recording (channel IDs, channel locations, and traces)
+
+    Sorts channels lexicographically according to the dimensions in
+    `dimensions`. See the documentation for `order_channels_by_depth`.
+
+    Parameters
+    ----------
+    recording : BaseRecording
+        The recording to re-order.
+    channel_ids : list/array or None
+        If given, a subset of channels to order locations for
+    dimensions : str or tuple
+        If str, it needs to be 'x', 'y', 'z'.
+        If tuple, it sorts the locations in two dimensions using lexsort.
+        This approach is recommended since there is less ambiguity, by default ('x', 'y')
+    """
+
+    def __init__(
+        self, parent_recording, channel_ids=None, dimensions=("x", "y")
+    ):
+        order_f, order_r = order_channels_by_depth(
+            parent_recording, channel_ids=channel_ids, dimensions=dimensions
+        )
+        channel_ids = parent_recording.get_channel_ids()
+        reordered_channel_ids = [channel_ids[o] for o in order_f]
+        ChannelSliceRecording.__init__(
+            self,
+            parent_recording,
+            channel_ids=reordered_channel_ids,
+        )
+
+
+depth_order = define_function_from_class(
+    source_class=DepthOrderRecording, name="depth_order"
+)

--- a/spikeinterface/preprocessing/depth_order.py
+++ b/spikeinterface/preprocessing/depth_order.py
@@ -19,6 +19,8 @@ class DepthOrderRecording(ChannelSliceRecording):
         If tuple, it sorts the locations in two dimensions using lexsort.
         This approach is recommended since there is less ambiguity, by default ('x', 'y')
     """
+    name = "depth_order"
+    installed = True
 
     def __init__(
         self, parent_recording, channel_ids=None, dimensions=("x", "y")

--- a/spikeinterface/preprocessing/detect_bad_channels.py
+++ b/spikeinterface/preprocessing/detect_bad_channels.py
@@ -157,7 +157,7 @@ def detect_bad_channels(recording,
         # If location are not sorted, estimate forward and reverse sorting
         channel_locations = recording.get_channel_locations()
         dim = ["x", "y", "z"].index(direction)
-        assert dim < channel_locations.ndim, f"Direction {direction} is wrong"
+        assert dim < channel_locations.shape[1], f"Direction {direction} is wrong"
         locs_depth = channel_locations[:, dim]
         if np.array_equal(np.sort(locs_depth), locs_depth):
             order_f = None

--- a/spikeinterface/preprocessing/directional_average.py
+++ b/spikeinterface/preprocessing/directional_average.py
@@ -1,0 +1,153 @@
+import numpy as np
+from spikeinterface.core import BaseRecording, BaseRecordingSegment
+from .basepreprocessor import BasePreprocessorSegment
+from spikeinterface.core.core_tools import define_function_from_class
+
+
+class DirectionalAverageRecording(BaseRecording):
+    name = "directional_average"
+    installed = True
+
+    def __init__(
+        self,
+        parent_recording: BaseRecording,
+        direction: str = "y",
+        dtype=None,
+    ):
+        """Averages channels at the same position along `direction
+
+        The resulting recording will live on virtual channels located
+        at each *sorted* unique position along direction, and with other
+        direction's positions set to 0.
+
+        Parameters
+        ----------
+        parent_recording : BaseRecording
+            recording to zero-pad
+        direction : str
+            Channels living at unique positions along this direction
+            will be averaged.
+        dtype : optional numpy dtype
+            If supplied, convert to this type before recording. Otherwise,
+            if the recording is not a floating type, it is converted to
+            float32 by default, or kept as its floating type otherwise.
+        """
+        parent_channel_locations = parent_recording.get_channel_locations()
+        dim = ["x", "y", "z"].index(direction)
+        if dim > parent_channel_locations.shape[1]:
+            raise ValueError(
+                f"Direction {direction} not present in this recording."
+            )
+        locs_dim = parent_channel_locations[:, dim]
+        # note np.unique returns sorted dim_unique
+        # same_along_dim_chans is the inverse mapping: same_along_dim_chans[i]
+        # is such that parent_channel_locations[i, dim] == dim_unique[same_along_dim_chans[i]]
+        dim_unique_pos, same_along_dim_chans, n_chans_each_pos = np.unique(
+            locs_dim, return_inverse=True, return_counts=True
+        )
+        n_pos_unique = dim_unique_pos.size
+
+        if dtype is None and not np.issubdtype(
+            parent_recording.dtype, np.floating
+        ):
+            dtype = "float32"
+        self._dtype = dtype
+
+        BaseRecording.__init__(
+            self,
+            parent_recording.get_sampling_frequency(),
+            np.arange(n_pos_unique),
+            parent_recording.get_dtype(),
+        )
+
+        self.parent_recording = parent_recording
+        self.num_channels = n_pos_unique
+        for segment in parent_recording._recording_segments:
+            recording_segment = DirectionalAverageRecordingSegment(
+                segment,
+                self.num_channels,
+                same_along_dim_chans,
+                n_chans_each_pos,
+                dtype,
+            )
+            self.add_recording_segment(recording_segment)
+
+        # only copy relevant metadata and properties
+        parent_recording.copy_metadata(self, only_main=True)
+
+        # TODO: not sure what to do with properties here
+        #       this is a guess
+        for k in parent_recording.get_property_keys():
+            if k not in ("contact_vector", "location"):
+                values = self.get_property(k)
+                if values is not None:
+                    self.set_property(
+                        k, values, ids=self.channel_ids[self.channel_mapping]
+                    )
+
+        # my geometry
+        channel_locations = np.zeros(
+            (n_pos_unique, parent_channel_locations.shape[1]),
+            dtype=parent_channel_locations.dtype,
+        )
+        channel_locations[:, dim] = dim_unique_pos
+        self.set_property("location", channel_locations)
+
+        self._kwargs = dict(
+            parent_recording=parent_recording.to_dict(),
+            direction=direction,
+        )
+
+
+class DirectionalAverageRecordingSegment(BasePreprocessorSegment):
+    def __init__(
+        self,
+        parent_recording_segment: BaseRecordingSegment,
+        num_channels: int,
+        same_along_dim_chans: np.array,
+        n_chans_each_pos: np.array,
+        dtype,
+    ):
+        BasePreprocessorSegment.__init__(self, parent_recording_segment)
+        self.parent_recording_segment = parent_recording_segment
+        self.num_channels = num_channels
+        self.same_along_dim_chans = same_along_dim_chans
+        self.n_chans_each_pos = n_chans_each_pos
+        self._dtype = dtype
+
+    def get_num_samples(self):
+        return self.parent_recording_segment.get_num_samples()
+
+    def get_traces(self, start_frame, end_frame, channel_indices):
+        if start_frame is None:
+            start_frame = 0
+        if end_frame is None:
+            end_frame = self.get_num_samples()
+
+        parent_traces = self.parent_recording_segment.get_traces(
+            start_frame=start_frame,
+            end_frame=end_frame,
+            channel_indices=np.arange(self.num_channels),
+        )
+        traces = np.zeros(
+            (parent_traces.shape[0], self.num_channels),
+            dtype=self._dtype,
+        )
+
+        # average channels at each depth without resorting to for loop
+        # first, add in the traces from all of the channels at each position
+        # np.add.at is necessary -- it will add multiple times in the same
+        # position, which + and += do not do
+        np.add.at(
+            traces, (slice(None), self.same_along_dim_chans), parent_traces
+        )
+        # now, divide by the number of channels at that position
+        traces /= self.n_chans_each_pos
+
+        return traces
+
+
+# function for API
+directional_average = define_function_from_class(
+    source_class=DirectionalAverageRecording, name="directional_average"
+)

--- a/spikeinterface/preprocessing/directional_derivative.py
+++ b/spikeinterface/preprocessing/directional_derivative.py
@@ -128,15 +128,17 @@ class DirectionalDerivativeRecordingSegment(BasePreprocessorSegment):
                 chans_in_column, self.dim
             ]
 
-            column_traces = parent_traces[:, chans_in_column]
-
-            for _ in range(self.order):
-                column_traces = np.gradient(
-                    column_traces,
-                    dim_pos_in_column,
-                    axis=1,
-                    edge_order=self.edge_order,
-                )
+            if dim_pos_in_column.size == 1:
+                column_traces = np.zeros((parent_traces.shape[0], 1), dtype=self._dtype)
+            else:
+                column_traces = parent_traces[:, chans_in_column]
+                for _ in range(self.order):
+                    column_traces = np.gradient(
+                        column_traces,
+                        dim_pos_in_column,
+                        axis=1,
+                        edge_order=self.edge_order,
+                    )
 
             # when order=0, do a spatial common reference
             if self.order == 0:

--- a/spikeinterface/preprocessing/directional_derivative.py
+++ b/spikeinterface/preprocessing/directional_derivative.py
@@ -14,7 +14,7 @@ class DirectionalDerivativeRecording(BasePreprocessor):
         direction: str = "y",
         order: int = 1,
         edge_order: int = 2,
-        dtype=None,
+        dtype="float32",
     ):
         """Take derivative of any `order` along `direction`
 
@@ -37,9 +37,8 @@ class DirectionalDerivativeRecording(BasePreprocessor):
         edge_order : int
             Order of gradient accuracy at edges; see np.gradient for details.
         dtype : optional numpy dtype
-            If supplied, convert recording to this type before taking grad.
-            If unset, if the recording is not a floating type, it is converted
-            to float32 by default, or kept as its floating type otherwise.
+            If unset, parent dtype is preserved, but the derivative can
+            overflow or lose accuracy, so "float32" by default.
         """
         parent_channel_locations = recording.get_channel_locations()
         dim = ["x", "y", "z"].index(direction)
@@ -50,8 +49,8 @@ class DirectionalDerivativeRecording(BasePreprocessor):
 
         # float32 by default if parent recording is integer
         dtype_ = dtype
-        if dtype is None and recording.dtype.kind != "f":
-            dtype_ = "float32"
+        if dtype_ is None:
+            dtype_ = recording.dtype
 
         BasePreprocessor.__init__(self, recording, dtype=dtype_)
 

--- a/spikeinterface/preprocessing/directional_derivative.py
+++ b/spikeinterface/preprocessing/directional_derivative.py
@@ -1,0 +1,156 @@
+import numpy as np
+from spikeinterface.core import BaseRecording, BaseRecordingSegment
+from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
+from spikeinterface.core.core_tools import define_function_from_class
+
+
+class DirectionalDerivativeRecording(BasePreprocessor):
+    name = "directional_derivative"
+    installed = True
+
+    def __init__(
+        self,
+        recording: BaseRecording,
+        direction: str = "y",
+        order: int = 1,
+        edge_order: int = 2,
+        dtype=None,
+    ):
+        """Take derivative of any `order` along `direction`
+
+        np.gradient is applied independently along each colum (direction='y')
+        or row (direction='x'). Accounts for channel spacings and boundary
+        issues using np.gradient -- see that function's documentation for
+        more information about `edge_order`.
+
+        When order=0, the column means are subtracted at each frame
+        (spatial common reference).
+
+        Parameters
+        ----------
+        recording : BaseRecording
+            recording to zero-pad
+        direction : str
+            Gradients will be taken along this dimension.
+        order : int
+            np.gradient will be applied this many times.
+        edge_order : int
+            Order of gradient accuracy at edges; see np.gradient for details.
+        dtype : optional numpy dtype
+            If supplied, convert recording to this type before taking grad.
+            If unset, if the recording is not a floating type, it is converted
+            to float32 by default, or kept as its floating type otherwise.
+        """
+        parent_channel_locations = recording.get_channel_locations()
+        dim = ["x", "y", "z"].index(direction)
+        if dim > parent_channel_locations.shape[1]:
+            raise ValueError(
+                f"Direction {direction} not present in this recording."
+            )
+
+        # float32 by default if parent recording is integer
+        dtype_ = dtype
+        if dtype is None and not np.issubdtype(recording.dtype, np.floating):
+            dtype_ = "float32"
+
+        BasePreprocessor.__init__(self, recording, dtype=dtype_)
+
+        for parent_segment in recording._recording_segments:
+            rec_segment = DirectionalDerivativeRecordingSegment(
+                parent_segment,
+                parent_channel_locations,
+                dim,
+                order,
+                edge_order,
+                dtype_,
+            )
+            self.add_recording_segment(rec_segment)
+
+        self._kwargs = dict(
+            recording=recording.to_dict(),
+            direction=direction,
+            order=order,
+            edge_order=edge_order,
+            dtype=dtype,
+        )
+
+
+class DirectionalDerivativeRecordingSegment(BasePreprocessorSegment):
+    def __init__(
+        self,
+        parent_recording_segment: BaseRecordingSegment,
+        channel_locations: np.array,
+        dim: int,
+        order: int,
+        edge_order: int,
+        dtype,
+    ):
+        BasePreprocessorSegment.__init__(self, parent_recording_segment)
+        self.parent_recording_segment = parent_recording_segment
+        self.channel_locations = channel_locations
+        self.order = order
+        self.edge_order = edge_order
+        self.dim = dim
+        self._dtype = dtype
+
+    def get_num_samples(self):
+        return self.parent_recording_segment.get_num_samples()
+
+    def get_traces(self, start_frame, end_frame, channel_indices):
+        if start_frame is None:
+            start_frame = 0
+        if end_frame is None:
+            end_frame = self.get_num_samples()
+
+        parent_traces = self.parent_recording_segment.get_traces(
+            start_frame=start_frame,
+            end_frame=end_frame,
+            channel_indices=slice(None),
+        )
+        parent_traces = parent_traces.astype(self._dtype)
+
+        # get unique positions along dims other than `direction`
+        # channels at the same positions along these other dims are considered
+        # to belong to a "column"/"row", and the derivative is applied in these
+        # groups along `direction`
+        ndim = self.channel_locations.shape[1]
+        geom_other_dims = self.channel_locations[
+            :, np.arange(ndim) != self.dim
+        ]
+        # column_inds is the column grouping by channel,
+        # so that geom_other_dims[i] == unique_pos_other_dims[column_inds[i]]
+        unique_pos_other_dims, column_inds = np.unique(
+            geom_other_dims, axis=0, return_inverse=True
+        )
+
+        # calculate derivative independently in each column
+        derivative_traces = np.empty_like(parent_traces)
+        for column_ix, other_pos in enumerate(unique_pos_other_dims):
+            chans_in_column = np.flatnonzero(column_inds == column_ix)
+            dim_pos_in_column = self.channel_locations[
+                chans_in_column, self.dim
+            ]
+
+            column_traces = parent_traces[:, chans_in_column]
+
+            for _ in range(self.order):
+                column_traces = np.gradient(
+                    column_traces,
+                    dim_pos_in_column,
+                    axis=1,
+                    edge_order=self.edge_order,
+                )
+
+            # when order=0, do a spatial common reference
+            if self.order == 0:
+                column_traces -= column_traces.mean(axis=1, keepdims=True)
+
+            derivative_traces[:, chans_in_column] = column_traces
+
+        return derivative_traces
+
+
+# function for API
+directional_derivative = define_function_from_class(
+    source_class=DirectionalDerivativeRecording, name="directional_derivative"
+)

--- a/spikeinterface/preprocessing/directional_derivative.py
+++ b/spikeinterface/preprocessing/directional_derivative.py
@@ -50,7 +50,7 @@ class DirectionalDerivativeRecording(BasePreprocessor):
 
         # float32 by default if parent recording is integer
         dtype_ = dtype
-        if dtype is None and dtype.kind != "f":
+        if dtype is None and recording.dtype.kind != "f":
             dtype_ = "float32"
 
         BasePreprocessor.__init__(self, recording, dtype=dtype_)

--- a/spikeinterface/preprocessing/normalize_scale.py
+++ b/spikeinterface/preprocessing/normalize_scale.py
@@ -257,7 +257,7 @@ class ZScoreRecording(BasePreprocessor):
         The centered traces recording extractor object
     """
 
-    name = "center"
+    name = "zscore"
 
     def __init__(
         self,

--- a/spikeinterface/preprocessing/normalize_scale.py
+++ b/spikeinterface/preprocessing/normalize_scale.py
@@ -16,8 +16,13 @@ class ScaleRecordingSegment(BasePreprocessorSegment):
         self._dtype = dtype
 
     def get_traces(self, start_frame, end_frame, channel_indices):
-        traces = self.parent_recording_segment.get_traces(start_frame, end_frame, channel_indices)
-        scaled_traces = traces * self.gain[:, channel_indices] + self.offset[:, channel_indices] 
+        traces = self.parent_recording_segment.get_traces(
+            start_frame, end_frame, channel_indices
+        )
+        scaled_traces = (
+            traces * self.gain[:, channel_indices]
+            + self.offset[:, channel_indices]
+        )
         return scaled_traces.astype(self._dtype)
 
 
@@ -40,40 +45,54 @@ class NormalizeByQuantileRecording(BasePreprocessor):
     q1: float (default 0.01)
         Lower quantile used for measuring the scale
     q1: float (default 0.99)
-        Upper quantile used for measuring the 
+        Upper quantile used for measuring the
     seed: int
         Random seed for reproducibility
     dtype: str or np.dtype
         The dtype of the output traces. Default "float32"
     **random_chunk_kwargs: keyword arguments for `get_random_data_chunks()` function
-    
+
     Returns
     -------
     rescaled_traces: NormalizeByQuantileRecording
         The rescaled traces recording extractor object
     """
-    name = 'normalize_by_quantile'
 
-    def __init__(self, recording, scale=1.0, median=0.0, q1=0.01, q2=0.99,
-                 mode='by_channel', dtype="float32", **random_chunk_kwargs):
+    name = "normalize_by_quantile"
 
-        assert mode in ('pool_channel', 'by_channel')
+    def __init__(
+        self,
+        recording,
+        scale=1.0,
+        median=0.0,
+        q1=0.01,
+        q2=0.99,
+        mode="by_channel",
+        dtype="float32",
+        **random_chunk_kwargs
+    ):
+
+        assert mode in ("pool_channel", "by_channel")
 
         random_data = get_random_data_chunks(recording, **random_chunk_kwargs)
 
-        if mode == 'pool_channel':
+        if mode == "pool_channel":
             num_chans = recording.get_num_channels()
             # old behavior
-            loc_q1, pre_median, loc_q2 = np.quantile(random_data, q=[q1, 0.5, q2])
+            loc_q1, pre_median, loc_q2 = np.quantile(
+                random_data, q=[q1, 0.5, q2]
+            )
             pre_scale = abs(loc_q2 - loc_q1)
             gain = scale / pre_scale
             offset = median - pre_median * gain
             gain = np.ones((1, num_chans)) * gain
             offset = np.ones((1, num_chans)) * offset
 
-        elif mode == 'by_channel':
+        elif mode == "by_channel":
             # new behavior gain.offset indepenant by chans
-            loc_q1, pre_median, loc_q2 = np.quantile(random_data, q=[q1, 0.5, q2], axis=0)
+            loc_q1, pre_median, loc_q2 = np.quantile(
+                random_data, q=[q1, 0.5, q2], axis=0
+            )
             pre_scale = abs(loc_q2 - loc_q1)
             gain = scale / pre_scale
             offset = median - pre_median * gain
@@ -84,11 +103,20 @@ class NormalizeByQuantileRecording(BasePreprocessor):
         BasePreprocessor.__init__(self, recording, dtype=dtype)
 
         for parent_segment in recording._recording_segments:
-            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset, dtype=self._dtype)
+            rec_segment = ScaleRecordingSegment(
+                parent_segment, gain, offset, dtype=self._dtype
+            )
             self.add_recording_segment(rec_segment)
 
-        self._kwargs = dict(recording=recording.to_dict(), scale=scale, median=median,
-                            q1=q1, q2=q2, mode=mode, dtype=np.dtype(self._dtype).str)
+        self._kwargs = dict(
+            recording=recording.to_dict(),
+            scale=scale,
+            median=median,
+            q1=q1,
+            q2=q2,
+            mode=mode,
+            dtype=np.dtype(self._dtype).str,
+        )
         self._kwargs.update(random_chunk_kwargs)
 
 
@@ -113,9 +141,10 @@ class ScaleRecording(BasePreprocessor):
     transform_traces: ScaleRecording
         The transformed traces recording extractor object
     """
-    name = 'scale'
 
-    def __init__(self, recording, gain=1.0, offset=0., dtype="float32"):
+    name = "scale"
+
+    def __init__(self, recording, gain=1.0, offset=0.0, dtype="float32"):
 
         if dtype is None:
             dtype = recording.get_dtype()
@@ -142,11 +171,17 @@ class ScaleRecording(BasePreprocessor):
         BasePreprocessor.__init__(self, recording, dtype=dtype)
 
         for parent_segment in recording._recording_segments:
-            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset, self._dtype)
+            rec_segment = ScaleRecordingSegment(
+                parent_segment, gain, offset, self._dtype
+            )
             self.add_recording_segment(rec_segment)
 
-        self._kwargs = dict(recording=recording.to_dict(), gain=gain, 
-                            offset=offset, dtype=np.dtype(self._dtype).str)
+        self._kwargs = dict(
+            recording=recording.to_dict(),
+            gain=gain,
+            offset=offset,
+            dtype=np.dtype(self._dtype).str,
+        )
 
 
 class CenterRecording(BasePreprocessor):
@@ -162,23 +197,25 @@ class CenterRecording(BasePreprocessor):
     dtype: str or np.dtype
         The dtype of the output traces. Default "float32"
     **random_chunk_kwargs: keyword arguments for `get_random_data_chunks()` function
-    
+
     Returns
     -------
     centered_traces: ScaleRecording
         The centered traces recording extractor object
     """
-    name = 'center'
 
-    def __init__(self, recording, mode='median',
-                 dtype="float32", **random_chunk_kwargs):
+    name = "center"
 
-        assert mode in ('median', 'mean')
+    def __init__(
+        self, recording, mode="median", dtype="float32", **random_chunk_kwargs
+    ):
+
+        assert mode in ("median", "mean")
         random_data = get_random_data_chunks(recording, **random_chunk_kwargs)
 
-        if mode == 'mean':
+        if mode == "mean":
             offset = -np.mean(random_data, axis=0)
-        elif mode == 'median':
+        elif mode == "median":
             offset = -np.median(random_data, axis=0)
         offset = offset[None, :]
         gain = np.ones(offset.shape)
@@ -186,10 +223,16 @@ class CenterRecording(BasePreprocessor):
         BasePreprocessor.__init__(self, recording, dtype=dtype)
 
         for parent_segment in recording._recording_segments:
-            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset, dtype=self._dtype)
+            rec_segment = ScaleRecordingSegment(
+                parent_segment, gain, offset, dtype=self._dtype
+            )
             self.add_recording_segment(rec_segment)
 
-        self._kwargs = dict(recording=recording.to_dict(), mode=mode, dtype=np.dtype(self._dtype).str)
+        self._kwargs = dict(
+            recording=recording.to_dict(),
+            mode=mode,
+            dtype=np.dtype(self._dtype).str,
+        )
         self._kwargs.update(random_chunk_kwargs)
 
 
@@ -207,17 +250,23 @@ class ZScoreRecording(BasePreprocessor):
     dtype: str or np.dtype
         The dtype of the output traces. Default "float32"
     **random_chunk_kwargs: keyword arguments for `get_random_data_chunks()` function
-    
+
     Returns
     -------
     centered_traces: ScaleRecording
         The centered traces recording extractor object
     """
-    name = 'center'
 
-    def __init__(self, recording, mode="median+mad",
-                 dtype="float32", **random_chunk_kwargs):
-        
+    name = "center"
+
+    def __init__(
+        self,
+        recording,
+        mode="median+mad",
+        dtype="float32",
+        **random_chunk_kwargs
+    ):
+
         assert mode in ("median+mad", "mean+std")
 
         random_data = get_random_data_chunks(recording, **random_chunk_kwargs)
@@ -226,29 +275,41 @@ class ZScoreRecording(BasePreprocessor):
             medians = np.median(random_data, axis=0)
             medians = medians[None, :]
             mads = np.median(np.abs(random_data - medians), axis=0) / 0.6745
-            mads = mads[None, :] 
+            mads = mads[None, :]
             gain = 1 / mads
             offset = -medians / mads
         else:
             means = np.mean(random_data, axis=0)
             means = means[None, :]
             stds = np.std(random_data, axis=0)
-            stds = stds[None, :] 
+            stds = stds[None, :]
             gain = 1 / stds
             offset = -means / stds
-        
+
         BasePreprocessor.__init__(self, recording, dtype=dtype)
 
         for parent_segment in recording._recording_segments:
-            rec_segment = ScaleRecordingSegment(parent_segment, gain, offset, dtype=self._dtype)
+            rec_segment = ScaleRecordingSegment(
+                parent_segment, gain, offset, dtype=self._dtype
+            )
             self.add_recording_segment(rec_segment)
 
-        self._kwargs = dict(recording=recording.to_dict(), dtype=np.dtype(self._dtype).str)
+        self._kwargs = dict(
+            recording=recording.to_dict(),
+            dtype=np.dtype(self._dtype).str,
+            mode=mode,
+        )
         self._kwargs.update(random_chunk_kwargs)
 
 
 # functions for API
-normalize_by_quantile = define_function_from_class(source_class=NormalizeByQuantileRecording, name="normalize_by_quantile")
+normalize_by_quantile = define_function_from_class(
+    source_class=NormalizeByQuantileRecording, name="normalize_by_quantile"
+)
 scale = define_function_from_class(source_class=ScaleRecording, name="scale")
-center = define_function_from_class(source_class=CenterRecording, name="center")
-zscore = define_function_from_class(source_class=ZScoreRecording, name="zscore")
+center = define_function_from_class(
+    source_class=CenterRecording, name="center"
+)
+zscore = define_function_from_class(
+    source_class=ZScoreRecording, name="zscore"
+)

--- a/spikeinterface/preprocessing/preprocessinglist.py
+++ b/spikeinterface/preprocessing/preprocessinglist.py
@@ -23,6 +23,7 @@ from .deepinterpolation import DeepInterpolatedRecording, deepinterpolate
 from .highpass_spatial_filter import HighpassSpatialFilterRecording, highpass_spatial_filter
 from .interpolate_bad_channels import InterpolateBadChannelsRecording, interpolate_bad_channels
 from .average_across_direction import AverageAcrossDirectionRecording, average_across_direction
+from .directional_derivative import DirectionalDerivativeRecording, directional_derivative
 from .depth_order import DepthOrderRecording, depth_order
 
 
@@ -58,6 +59,7 @@ preprocessers_full_list = [
     InterpolateBadChannelsRecording,
     DepthOrderRecording,
     AverageAcrossDirectionRecording,
+    DirectionalDerivativeRecording,
 ]
 
 installed_preprocessers_list = [pp for pp in preprocessers_full_list if pp.installed]

--- a/spikeinterface/preprocessing/preprocessinglist.py
+++ b/spikeinterface/preprocessing/preprocessinglist.py
@@ -23,6 +23,8 @@ from .zero_channel_pad import ZeroChannelPaddedRecording, zero_channel_pad
 from .deepinterpolation import DeepInterpolatedRecording, deepinterpolate
 from .highpass_spatial_filter import HighpassSpatialFilterRecording, highpass_spatial_filter
 from .interpolate_bad_channels import InterpolateBadChannelsRecording, interpolate_bad_channels
+from .directional_average import DirectionalAverageRecording, directional_average
+from .depth_order import DepthOrderRecording, depth_order
 
 
 preprocessers_full_list = [
@@ -43,7 +45,6 @@ preprocessers_full_list = [
 
     # re-reference
     CommonReferenceRecording,
-    
     PhaseShiftRecording,
 
     # misc
@@ -55,7 +56,9 @@ preprocessers_full_list = [
     DeepInterpolatedRecording,
     ResampleRecording,
     HighpassSpatialFilterRecording,
-    InterpolateBadChannelsRecording
+    InterpolateBadChannelsRecording,
+    DepthOrderRecording,
+    DirectionalAverageRecording,
 ]
 
 installed_preprocessers_list = [pp for pp in preprocessers_full_list if pp.installed]

--- a/spikeinterface/preprocessing/preprocessinglist.py
+++ b/spikeinterface/preprocessing/preprocessinglist.py
@@ -1,5 +1,5 @@
 ### PREPROCESSORS ###
-from .resample import ResampleRecording
+from .resample import ResampleRecording, resample
 from .filter import (FilterRecording, filter,
                      BandpassFilterRecording, bandpass_filter,
                      NotchFilterRecording, notch_filter,
@@ -17,13 +17,12 @@ from .clip import (
     ClipRecording, clip)
 from .common_reference import CommonReferenceRecording, common_reference
 from .remove_artifacts import RemoveArtifactsRecording, remove_artifacts
-from .resample import ResampleRecording, resample
 from .phase_shift import PhaseShiftRecording, phase_shift
 from .zero_channel_pad import ZeroChannelPaddedRecording, zero_channel_pad
 from .deepinterpolation import DeepInterpolatedRecording, deepinterpolate
 from .highpass_spatial_filter import HighpassSpatialFilterRecording, highpass_spatial_filter
 from .interpolate_bad_channels import InterpolateBadChannelsRecording, interpolate_bad_channels
-from .directional_average import DirectionalAverageRecording, directional_average
+from .average_across_direction import AverageAcrossDirectionRecording, average_across_direction
 from .depth_order import DepthOrderRecording, depth_order
 
 
@@ -58,7 +57,7 @@ preprocessers_full_list = [
     HighpassSpatialFilterRecording,
     InterpolateBadChannelsRecording,
     DepthOrderRecording,
-    DirectionalAverageRecording,
+    AverageAcrossDirectionRecording,
 ]
 
 installed_preprocessers_list = [pp for pp in preprocessers_full_list if pp.installed]

--- a/spikeinterface/preprocessing/resample.py
+++ b/spikeinterface/preprocessing/resample.py
@@ -2,7 +2,10 @@ import numpy as np
 from scipy import signal
 import warnings
 
-from spikeinterface.core.core_tools import define_function_from_class, recursive_key_finder
+from spikeinterface.core.core_tools import (
+    define_function_from_class,
+    recursive_key_finder,
+)
 
 from .basepreprocessor import BasePreprocessor
 from .filter import fix_dtype
@@ -30,7 +33,7 @@ class ResampleRecording(BasePreprocessor):
         The dtype of the returned traces. If None, the dtype of the parent recording is used.
     skip_checks : bool
         If True, checks on sampling frequencies and cutoff filter frequencies are skipped, by default False
-    
+
     Returns
     -------
     resample_recording: ResampleRecording
@@ -44,9 +47,9 @@ class ResampleRecording(BasePreprocessor):
         self,
         recording,
         resample_rate,
-        margin_ms=100.,
+        margin_ms=100.0,
         dtype=None,
-        skip_checks=False
+        skip_checks=False,
     ):
         # Floating point resampling rates can lead to unexpected results, avoid actively
         msg = "Non integer resampling rates can lead to unexpected results."
@@ -59,8 +62,9 @@ class ResampleRecording(BasePreprocessor):
         dtype = fix_dtype(recording, dtype).str
         # Ensure that the requested resample rate is doable:
         if skip_checks:
-            assert check_nyquist(recording, resample_rate), \
-                "The requested resample rate would induce errors!"
+            assert check_nyquist(
+                recording, resample_rate
+            ), "The requested resample rate would induce errors!"
 
         # Get a margin to avoid issues later
         margin = int(margin_ms * recording.get_sampling_frequency() / 1000)
@@ -86,48 +90,69 @@ class ResampleRecording(BasePreprocessor):
             resample_rate=resample_rate,
             margin_ms=margin_ms,
             dtype=dtype,
-            skip_checks=skip_checks
+            skip_checks=skip_checks,
         )
 
 
 class ResampleRecordingSegment(BaseRecordingSegment):
-    def __init__(self, parent_recording_segment, resample_rate, parent_rate, margin, dtype):
+    def __init__(
+        self,
+        parent_recording_segment,
+        resample_rate,
+        parent_rate,
+        margin,
+        dtype,
+    ):
         # Do not use BasePreprocessorSegment bcause we have to reset the sampling rate!
-        BaseRecordingSegment.__init__(self, sampling_frequency=resample_rate,
-                                      t_start=parent_recording_segment.t_start)
+        BaseRecordingSegment.__init__(
+            self,
+            sampling_frequency=resample_rate,
+            t_start=parent_recording_segment.t_start,
+        )
         self._parent_segment = parent_recording_segment
         self._parent_rate = parent_rate
         self._margin = margin
         self._dtype = dtype
 
     def get_num_samples(self):
-        return int(self._parent_segment.get_num_samples() / self._parent_rate * self.sampling_frequency)
+        return int(
+            self._parent_segment.get_num_samples()
+            / self._parent_rate
+            * self.sampling_frequency
+        )
 
     def get_traces(self, start_frame, end_frame, channel_indices):
-        if start_frame == None:
+        if start_frame is None:
             start_frame = 0
-        if end_frame == None:
+        if end_frame is None:
             end_frame = self.get_num_samples()
 
-        # get parent traces with margin        
+        # get parent traces with margin
         parent_start_frame, parent_end_frame = [
             int((frame / self.sampling_frequency) * self._parent_rate)
             for frame in [start_frame, end_frame]
         ]
         parent_traces, left_margin, right_margin = get_chunk_with_margin(
             self._parent_segment,
-            parent_start_frame, parent_end_frame, channel_indices, self._margin,
-            window_on_margin=False, add_zeros=False, dtype=np.float32,
+            parent_start_frame,
+            parent_end_frame,
+            channel_indices,
+            self._margin,
+            window_on_margin=False,
+            add_zeros=False,
+            dtype=np.float32,
         )
         # get left and right margins for the resampled case
         left_margin_rs, right_margin_rs = [
             int((margin / self._parent_rate) * self.sampling_frequency)
             for margin in [left_margin, right_margin]
         ]
-        
+
         # get the size for the resampled traces in case of resample:
-        num = int((end_frame + right_margin_rs) - (start_frame - left_margin_rs))
-        
+        num = int(
+            (end_frame + right_margin_rs) - (start_frame - left_margin_rs)
+        )
+
         # Decimate can misbehave on some cases, while resample allways looks nice enough.
         # Check which method to use:
         if np.mod(self._parent_rate, self.sampling_frequency) == 0:
@@ -141,22 +166,25 @@ class ResampleRecordingSegment(BaseRecordingSegment):
         else:
             resampled_traces = signal.resample(parent_traces, num, axis=0)
 
-        # now take care of the edges:
-        if right_margin > 0:
-            resampled_traces = resampled_traces[left_margin_rs:-right_margin_rs, :]
-        else:
-            resampled_traces = resampled_traces[left_margin_rs:, :]
+        # now take care of the edges
+        resampled_traces = resampled_traces[
+            left_margin_rs : left_margin_rs + num - right_margin_rs
+        ]
         return resampled_traces.astype(self._dtype)
 
 
-resample = define_function_from_class(source_class=ResampleRecording, name="resample")
+resample = define_function_from_class(
+    source_class=ResampleRecording, name="resample"
+)
 
 
 # Some helpers to do checks
 def check_nyquist(recording, resample_rate):
     # Check that the original and requested sampling rates will not induce aliasing
     # Basic test, compare the sampling frequency with the resample rate
-    sampling_frequency_check = recording.get_sampling_frequency() / 2 > resample_rate
+    sampling_frequency_check = (
+        recording.get_sampling_frequency() / 2 > resample_rate
+    )
     # Check that the signal, if it has been filtered, is still not violating
     if recording.is_filtered():
         # Check if we have access to the highcut frequency
@@ -167,11 +195,15 @@ def check_nyquist(recording, resample_rate):
             lowpass_cutoff_check = freq_max / 2 > resample_rate
         else:
             # If has been filterd but unknown high cutoff, give warning and asume the best
-            warnings.warn("The recording is filtered, but we can't ensure that it complies with the Nyquist limit.")
+            warnings.warn(
+                "The recording is filtered, but we can't ensure that it complies with the Nyquist limit."
+            )
             lowpass_cutoff_check = True
     else:
         # If it hasn't been filtered, we only depend on the previous test
-        warnings.warn("The recording is not filtered, so cutoff frequencies cannot be checked. "
-                      "Use resampling with caution")
+        warnings.warn(
+            "The recording is not filtered, so cutoff frequencies cannot be checked. "
+            "Use resampling with caution"
+        )
         lowpass_cutoff_check = True
     return all([sampling_frequency_check, lowpass_cutoff_check])

--- a/spikeinterface/preprocessing/resample.py
+++ b/spikeinterface/preprocessing/resample.py
@@ -138,7 +138,6 @@ class ResampleRecordingSegment(BaseRecordingSegment):
             parent_end_frame,
             channel_indices,
             self._margin,
-            window_on_margin=False,
             add_reflect_padding=True,
             dtype=np.float32,
         )
@@ -153,7 +152,7 @@ class ResampleRecordingSegment(BaseRecordingSegment):
             (end_frame + right_margin_rs) - (start_frame - left_margin_rs)
         )
 
-        # Decimate can misbehave on some cases, while resample allways looks nice enough.
+        # Decimate can misbehave on some cases, while resample always looks nice enough.
         # Check which method to use:
         if np.mod(self._parent_rate, self.sampling_frequency) == 0:
             # Ratio between sampling frequencies
@@ -168,7 +167,7 @@ class ResampleRecordingSegment(BaseRecordingSegment):
 
         # now take care of the edges
         resampled_traces = resampled_traces[
-            left_margin_rs : left_margin_rs + num - right_margin_rs
+            left_margin_rs : num - right_margin_rs
         ]
         return resampled_traces.astype(self._dtype)
 

--- a/spikeinterface/preprocessing/resample.py
+++ b/spikeinterface/preprocessing/resample.py
@@ -139,7 +139,7 @@ class ResampleRecordingSegment(BaseRecordingSegment):
             channel_indices,
             self._margin,
             window_on_margin=False,
-            add_zeros=False,
+            add_reflect_padding=True,
             dtype=np.float32,
         )
         # get left and right margins for the resampled case

--- a/spikeinterface/preprocessing/tests/test_average_across_direction.py
+++ b/spikeinterface/preprocessing/tests/test_average_across_direction.py
@@ -18,7 +18,7 @@ set_global_tmp_folder(cache_folder)
 
 def test_average_across_direction():
     # gradient recording with 100 samples and 10 channels
-    rec = np.arange(6, dtype="float32")[None, :] * np.ones((100, 1))
+    rec_arr = np.arange(6, dtype="float32")[None, :] * np.ones((100, 1))
 
     # test geometry with chans at the same y position
     geom = np.zeros((6, 2), dtype="float32")
@@ -29,7 +29,7 @@ def test_average_across_direction():
     # have the x position change as well to test the geometry
     geom[[4, 5], 0] = [1, 2]
 
-    rec = NumpyRecording(rec, 10)
+    rec = NumpyRecording(rec_arr, 10)
     rec.set_dummy_probe_from_locations(geom)
 
     # test averaging across y
@@ -54,6 +54,16 @@ def test_average_across_direction():
     assert np.all(traces[:, 0] == 1.5)
     assert np.all(traces[:, 1] == 4)
     assert np.all(traces[:, 2] == 5)
+
+    # int16 test
+    rec = NumpyRecording(rec_arr.astype("int16"), 10)
+    rec.set_dummy_probe_from_locations(geom)
+    rec_avgy = average_across_direction(rec, dtype=None)
+    try:
+        traces = rec_avgy.get_traces()
+        assert False
+    except np.core._exceptions._UFuncOutputCastingError:
+        pass
 
 
 if __name__ == '__main__':

--- a/spikeinterface/preprocessing/tests/test_average_across_direction.py
+++ b/spikeinterface/preprocessing/tests/test_average_across_direction.py
@@ -1,0 +1,60 @@
+import pytest
+from pathlib import Path
+
+from spikeinterface import set_global_tmp_folder
+from spikeinterface.core import NumpyRecording
+
+from spikeinterface.preprocessing import AverageAcrossDirectionRecording, average_across_direction
+
+import numpy as np
+
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "preprocessing"
+else:
+    cache_folder = Path("cache_folder") / "preprocessing"
+
+set_global_tmp_folder(cache_folder)
+
+
+def test_average_across_direction():
+    # gradient recording with 100 samples and 10 channels
+    rec = np.arange(6, dtype="float32")[None, :] * np.ones((100, 1))
+
+    # test geometry with chans at the same y position
+    geom = np.zeros((6, 2), dtype="float32")
+    geom[[0, 1], 1] = 1
+    geom[[2, 3], 1] = 2
+    geom[[4, 5], 1] = 3
+
+    # have the x position change as well to test the geometry
+    geom[[4, 5], 0] = [1, 2]
+
+    rec = NumpyRecording(rec, 10)
+    rec.set_dummy_probe_from_locations(geom)
+
+    # test averaging across y
+    rec_avgy = average_across_direction(rec)
+    traces = rec_avgy.get_traces()
+    assert traces.shape == (100, 3)
+    # correct averages
+    assert np.all(traces[:, 0] == 0.5)
+    assert np.all(traces[:, 1] == 2.5)
+    assert np.all(traces[:, 2] == 4.5)
+    geom_avgy = rec_avgy.get_channel_locations()
+    assert np.all(geom_avgy[:2, 0] == 0)
+    assert np.all(geom_avgy[2, 0] == 1.5)
+
+    # test averaging across x
+    rec_avgx = average_across_direction(rec, direction="x")
+    traces = rec_avgx.get_traces()
+    assert traces.shape == (100, 3)
+    # correct averages
+    # the chans at x=0 are [0, 1, 2, 3]
+    assert rec_avgx.get_channel_ids()[0] == "0-1-2-3"
+    assert np.all(traces[:, 0] == 1.5)
+    assert np.all(traces[:, 1] == 4)
+    assert np.all(traces[:, 2] == 5)
+
+
+if __name__ == '__main__':
+    test_average_across_direction()

--- a/spikeinterface/preprocessing/tests/test_depth_order.py
+++ b/spikeinterface/preprocessing/tests/test_depth_order.py
@@ -1,0 +1,51 @@
+import pytest
+from pathlib import Path
+
+from spikeinterface import set_global_tmp_folder
+from spikeinterface.core import NumpyRecording
+
+from spikeinterface.preprocessing import DepthOrderRecording, depth_order
+
+import numpy as np
+
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "preprocessing"
+else:
+    cache_folder = Path("cache_folder") / "preprocessing"
+
+set_global_tmp_folder(cache_folder)
+
+
+def test_depth_order():
+    # gradient recording with 100 samples and 10 channels
+    orig_traces = np.arange(5, dtype="float32")[None, :] * np.ones((100, 1))
+
+    # geometry in order
+    geom = np.zeros((5, 2), dtype="float32")
+    geom[:, 1] = np.arange(5)
+    rec = NumpyRecording(orig_traces, 10)
+    rec.set_dummy_probe_from_locations(geom)
+    rec_sorted = depth_order(rec)
+    assert np.array_equal(rec_sorted.get_channel_ids(), rec.get_channel_ids())
+    assert np.array_equal(rec_sorted.get_traces(), orig_traces)
+
+    # geometry flat -- needs to be stable!
+    geom = np.zeros((5, 2), dtype="float32")
+    rec = NumpyRecording(orig_traces, 10)
+    rec.set_dummy_probe_from_locations(geom)
+    rec_sorted = depth_order(rec)
+    assert np.array_equal(rec_sorted.get_channel_ids(), rec.get_channel_ids())
+    assert np.array_equal(rec_sorted.get_traces(), orig_traces)
+
+    # geometry out of order with a duplicate
+    geom = np.zeros((5, 2), dtype="float32")
+    geom[:, 1] = [3, 2, 1, 0, 0]
+    rec = NumpyRecording(orig_traces, 10)
+    rec.set_dummy_probe_from_locations(geom)
+    rec_sorted = depth_order(rec)
+    assert np.array_equal(rec_sorted.get_channel_ids(), [3, 4, 2, 1, 0])
+    assert np.array_equal(rec_sorted.get_traces(), orig_traces[:, [3, 4, 2, 1, 0]])
+
+
+if __name__ == '__main__':
+    test_depth_order()

--- a/spikeinterface/preprocessing/tests/test_directional_derivative.py
+++ b/spikeinterface/preprocessing/tests/test_directional_derivative.py
@@ -42,6 +42,18 @@ def test_directional_derivative():
     traces = rec_x_ddy.get_traces()
     assert (traces == 0).all()
 
+    # int16 test
+    geom_x = np.zeros((10, 2), dtype="float32")
+    geom_x[:, 0] = np.arange(10)
+    rec_x = NumpyRecording(rec.astype("int16"), 10)
+    rec_x.set_dummy_probe_from_locations(geom_x)
+    rec_x_ddx = directional_derivative(rec_x, direction="x", dtype=None)
+    traces = rec_x_ddx.get_traces()
+    assert (traces == 1).all()
+    rec_x_ddy = directional_derivative(rec_x, direction="y")
+    traces = rec_x_ddy.get_traces()
+    assert (traces == 0).all()
+
 
 if __name__ == '__main__':
     test_directional_derivative()

--- a/spikeinterface/preprocessing/tests/test_directional_derivative.py
+++ b/spikeinterface/preprocessing/tests/test_directional_derivative.py
@@ -1,0 +1,47 @@
+import pytest
+from pathlib import Path
+
+from spikeinterface import set_global_tmp_folder
+from spikeinterface.core import NumpyRecording
+
+from spikeinterface.preprocessing import DirectionalDerivativeRecording, directional_derivative
+
+import numpy as np
+
+if hasattr(pytest, "global_test_folder"):
+    cache_folder = pytest.global_test_folder / "preprocessing"
+else:
+    cache_folder = Path("cache_folder") / "preprocessing"
+
+set_global_tmp_folder(cache_folder)
+
+
+def test_directional_derivative():
+    # gradient recording with 100 samples and 10 channels
+    rec = np.arange(10, dtype="float32")[None, :] * np.ones((100, 1))
+
+    geom_y = np.zeros((10, 2), dtype="float32")
+    geom_y[:, 1] = np.arange(10)
+    rec_y = NumpyRecording(rec, 10)
+    rec_y.set_dummy_probe_from_locations(geom_y)
+    rec_y_ddy = directional_derivative(rec_y)
+    traces = rec_y_ddy.get_traces()
+    assert (traces == 1).all()
+    rec_y_ddx = directional_derivative(rec_y, direction="x")
+    traces = rec_y_ddx.get_traces()
+    assert (traces == 0).all()
+
+    geom_x = np.zeros((10, 2), dtype="float32")
+    geom_x[:, 0] = np.arange(10)
+    rec_x = NumpyRecording(rec, 10)
+    rec_x.set_dummy_probe_from_locations(geom_x)
+    rec_x_ddx = directional_derivative(rec_x, direction="x")
+    traces = rec_x_ddx.get_traces()
+    assert (traces == 1).all()
+    rec_x_ddy = directional_derivative(rec_x, direction="y")
+    traces = rec_x_ddy.get_traces()
+    assert (traces == 0).all()
+
+
+if __name__ == '__main__':
+    test_directional_derivative()

--- a/spikeinterface/preprocessing/tests/test_resample.py
+++ b/spikeinterface/preprocessing/tests/test_resample.py
@@ -15,7 +15,7 @@ else:
     cache_folder = Path("cache_folder") / "preprocessing"
 
 DEBUG = False
-# DEBUG = True
+# DEBUG = True
 
 if DEBUG:
     import matplotlib.pyplot as plt
@@ -176,7 +176,7 @@ def test_resample_by_chunks():
     resample_rates = [1000, 2000] #[500, 1000, 2500]
     margins_ms = [100, 1000] # [100, 200, 1000]
     chunk_durations = [0.5, 1] #[1, 2, 3]
-    
+
     for resample_rate in resample_rates:
         for margin_ms in margins_ms:
             for chunk_size in [int(resample_rate * chunk_multi) for chunk_multi in chunk_durations]:
@@ -188,8 +188,6 @@ def test_resample_by_chunks():
 
                 traces2 = rec2.get_traces()
                 traces3 = rec3.get_traces()
-                
-                
 
                 # error between full and chunked
                 # for error first and last chunk is removed
@@ -198,7 +196,7 @@ def test_resample_by_chunks():
                 error_max = np.sqrt(np.max((traces2[sl] - traces3[sl])**2))
 
                 # this will never be possible:
-                #      assert np.allclose(traces2, traces3)
+                # assert np.allclose(traces2, traces3)
                 # so we check that the diff between chunk processing and not chunked is small
                 # print()
                 # print(dtype, margin_ms, chunk_size)

--- a/spikeinterface/preprocessing/zero_channel_pad.py
+++ b/spikeinterface/preprocessing/zero_channel_pad.py
@@ -56,7 +56,7 @@ class ZeroChannelPaddedRecording(BaseRecording):
             if values is not None:
                 self.set_property(k, values, ids=self.channel_ids[self.channel_mapping])
 
-        self._kwargs = dict(recording=parent_recording.to_dict(),
+        self._kwargs = dict(parent_recording=parent_recording.to_dict(),
                             num_channels=num_channels, channel_mapping=channel_mapping)
 
 
@@ -67,9 +67,6 @@ class ZeroChannelPaddedRecordingSegment(BasePreprocessorSegment):
         self.parent_recording_segment = parent_recording_segment
         self.num_channels = num_channels
         self.channel_mapping = channel_mapping
-
-    def get_num_samples(self):
-        return self.parent_recording_segment.get_num_samples()
 
     def get_traces(self, start_frame, end_frame, channel_indices):
         if start_frame is None:


### PR DESCRIPTION
Hi @samuelgarcia , here is a small draft PR with two preprocessing tools: a simple one (`depth_order`) which will save me a lot of typing, and one for averaging across channels at the same depth (or a dimension other than depth, `average_across_direction`). I'm curious if I have done all of the metadata bookkeeping as you would have done.

Let me know your thoughts -- once I'm going in the right direction I'll add something like a `directional_derivative(recording, direction='y', order=2)` for computing spatial derivatives.