### PR TITLE
fix typo in class ClipRecording

### DIFF
--- a/spikeinterface/preprocessing/clip.py
+++ b/spikeinterface/preprocessing/clip.py
@@ -40,7 +40,7 @@ class ClipRecording(BasePreprocessor):
             self.add_recording_segment(rec_segment)
 
         self._kwargs = dict(recording=recording.to_dict(),
-                            a_min=a_max, a_max=a_max)
+                            a_min=a_min, a_max=a_max)
 
 
 class BlankSaturationRecording(BasePreprocessor):


### PR DESCRIPTION
Hi,

I found a typo while using the `preprocessing.clip`: when setting its `_kwargs`, the `a_min` property is set to `a_max` by accident. This typo has no effect when objects stay in memory; however, if the `ClipRecording` object is dumped to JSON and read from disk again (such as when we [run sorter from folder using MountainSort4](https://github.com/SpikeInterface/spikeinterface/blob/master/spikeinterface/sorters/external/mountainsort4.py#L91)), this causes the return of `get_trace()` to be a constant value.

Thanks!