### PR TITLE
Use full tests with code coverage for build status in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 <tr>
   <td>Build Status</td>
   <td>
-    <a href="https://github.com/SpikeInterface/spikeinterface/actions/workflows/full-test.yml/badge.svg">
-    <img src="https://github.com/SpikeInterface/spikeinterface/actions/workflows/full-test.yml/badge.svg" alt="travis build status" />
+    <a href="https://github.com/SpikeInterface/spikeinterface/actions/workflows/full-test-with-codecov.yml/badge.svg">
+    <img src="https://github.com/SpikeInterface/spikeinterface/actions/workflows/full-test-with-codecov.yml/badge.svg" alt="CI build status" />
     </a>
   </td>
 </tr>


### PR DESCRIPTION
As discussed in slack, changing from the full tests to the chron job full built for the build status.