### PR TITLE
Fix IBL tests on master

### DIFF
--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -154,7 +154,7 @@ jobs:
           python ./.github/build_job_summary.py report_core.txt >> $GITHUB_STEP_SUMMARY  
           rm report_core.txt
       - name: Test extractors
-        if: ${{ steps.modules-changed.outputs.EXTRACTORS_CHANGED == 'true' }}
+        if: ${{ steps.modules-changed.outputs.EXTRACTORS_CHANGED == 'true' || steps.modules-changed.outputs.CORE_CHANGED == 'true' }}
         run: |
           source ~/test_env/bin/activate
           pytest -m extractors -vv -ra --durations=0 --durations-min=0.001 | tee report_extractors.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1

--- a/spikeinterface/core/baserecording.py
+++ b/spikeinterface/core/baserecording.py
@@ -43,8 +43,9 @@ class BaseRecording(BaseRecordingSnippets):
         nchan = self.get_num_channels()
         sf_khz = self.get_sampling_frequency() / 1000.
         duration = self.get_total_duration()
+        dtype = self.get_dtype()
         memory_size = self.get_memory_size()
-        txt = f"{clsname}: {nchan} channels - {nseg} segments - {sf_khz:0.1f}kHz - {duration:0.3f}s - {memory_size}"
+        txt = f"{clsname}: {nchan} channels - {nseg} segments - {sf_khz:0.1f}kHz - {duration:0.3f}s - {dtype} type - {memory_size}"
         if 'file_paths' in self._kwargs:
             txt += '\n  file_paths: {}'.format(self._kwargs['file_paths'])
         if 'file_path' in self._kwargs:

--- a/spikeinterface/core/core_tools.py
+++ b/spikeinterface/core/core_tools.py
@@ -815,13 +815,32 @@ def recursive_key_finder(d, key):
 
 def convert_bytes_to_str(byte_value:int ) -> str:
     """
-    Converts a number of bytes to a value in either KiB, MiB, GiB, or TiB.
+    Convert a number of bytes to a human-readable string with an appropriate unit.
 
-    Args:
-        byte_value (int): The number of bytes to convert.
+    This function converts a given number of bytes into a human-readable string
+    representing the value in either bytes (B), kibibytes (KiB), mebibytes (MiB),
+    gibibytes (GiB), or tebibytes (TiB). The function uses the IEC binary prefixes
+    (1 KiB = 1024 B, 1 MiB = 1024 KiB, etc.) to determine the appropriate unit.
 
-    Returns:
-        str: The converted value with the appropriate unit (KiB, MiB, GiB, or TiB).
+    Parameters
+    ----------
+    byte_value : int
+        The number of bytes to convert.
+
+    Returns
+    -------
+    str
+        The converted value as a formatted string with two decimal places,
+        followed by a space and the appropriate unit (B, KiB, MiB, GiB, or TiB).
+
+    Examples
+    --------
+    >>> convert_bytes_to_str(1024)
+    '1.00 KiB'
+    >>> convert_bytes_to_str(1048576)
+    '1.00 MiB'
+    >>> convert_bytes_to_str(45056)
+    '43.99 KiB'
     """
     suffixes = ['B', 'KiB', 'MiB', 'GiB', 'TiB']
     i = 0

--- a/spikeinterface/extractors/tests/test_iblstreamingrecording.py
+++ b/spikeinterface/extractors/tests/test_iblstreamingrecording.py
@@ -25,7 +25,7 @@ class TestDefaultIblStreamingRecordingExtractorApBand(TestCase):
         self.assertCountEqual(first=stream_names, second=expected_stream_names)
 
     def test_representation(self):
-        expected_recording_representation = "IblStreamingRecordingExtractor: 384 channels - 1 segments - 30.0kHz - 5812.311s - 124.72 GiB"
+        expected_recording_representation = "IblStreamingRecordingExtractor: 384 channels - 1 segments - 30.0kHz - 5812.311s - int16 type - 124.72 GiB"
         assert repr(self.recording) == expected_recording_representation
 
     def test_dtype(self):

--- a/spikeinterface/extractors/tests/test_iblstreamingrecording.py
+++ b/spikeinterface/extractors/tests/test_iblstreamingrecording.py
@@ -25,7 +25,7 @@ class TestDefaultIblStreamingRecordingExtractorApBand(TestCase):
         self.assertCountEqual(first=stream_names, second=expected_stream_names)
 
     def test_representation(self):
-        expected_recording_representation = "IblStreamingRecordingExtractor: 384 channels - 1 segments - 30.0kHz - 5812.311s"
+        expected_recording_representation = "IblStreamingRecordingExtractor: 384 channels - 1 segments - 30.0kHz - 5812.311s - 124.72 GiB"
         assert repr(self.recording) == expected_recording_representation
 
     def test_dtype(self):
@@ -88,7 +88,7 @@ class TestIblStreamingRecordingExtractorApBandWithLoadSyncChannel(TestCase):
         cls.small_unscaled_trace = cls.recording.get_traces(start_frame=5, end_frame=26)  # return_scaled=False is SI default
 
     def test_representation(self):
-        expected_recording_representation = "IblStreamingRecordingExtractor: 385 channels - 1 segments - 30.0kHz - 5812.311s"
+        expected_recording_representation = "IblStreamingRecordingExtractor: 385 channels - 1 segments - 30.0kHz - 5812.311s - int16 type - 125.04 GiB"
         assert repr(self.recording) == expected_recording_representation
 
     def test_dtype(self):


### PR DESCRIPTION
The full tests are failing on master. This PR is meant to address it.

The reason:
After the `__repr__` was modified to also display the memory of the full traces https://github.com/SpikeInterface/spikeinterface/pull/1452 the extractor tests were not triggered. The extractor tests for IBL has a repr tests that failed.

This PR does the following:
1) It adds a check so modifications on master trigger the extractor tests. This makes sense to me as this omission allow this failure to slip through.
2) Fixes the tests for IBL.
3) Add `dtype` to the `__repr__`, something that @samuelgarcia mentioned but I forgot in #1452 . 
4) I also expanded the docstring of the method that I used in `__repr__` I had in a commit that did not go through on #1452.

