### PR TITLE
Fix sortingview timeseries bug

### DIFF
--- a/spikeinterface/widgets/utils.py
+++ b/spikeinterface/widgets/utils.py
@@ -144,14 +144,13 @@ def array_to_image(data,
 
     num_timepoints = data.shape[0]
     num_channels = data.shape[1]
-    num_channels_after_scaling = int(num_channels * spatial_zoom[1])
     spacing = int(num_channels * spatial_zoom[1] * row_spacing)
 
-    num_timepoints_after_scaling = int(num_timepoints * spatial_zoom[0])
-    num_timepoints_per_row_after_scaling = int(np.min([num_timepoints_per_row, num_timepoints]) * spatial_zoom[0])
 
     cmap = plt.get_cmap(colormap)
     zoomed_data = zoom(data, spatial_zoom)
+    num_timepoints_after_scaling, num_channels_after_scaling = zoomed_data.shape
+    num_timepoints_per_row_after_scaling = int(np.min([num_timepoints_per_row, num_timepoints]) * spatial_zoom[0])
 
     scaled_data = zoomed_data
     scaled_data[scaled_data < clim[0]] = clim[0]


### PR DESCRIPTION
This bug is due to a rounding of the traces shape when applying the zoom for the sortingview backend.

Fixed by grabbing the correct shapes after applying the zoom