### PR TITLE
Remove `to_dict()` mechanism in comparisons module

### DIFF
--- a/spikeinterface/comparison/hybrid.py
+++ b/spikeinterface/comparison/hybrid.py
@@ -82,9 +82,9 @@ class HybridUnitsRecording(InjectTemplatesRecording):
             self, self.injected_sorting, templates, nbefore, amplitude_factor, parent_recording, num_samples)
 
         self._kwargs = dict(
-            parent_recording=parent_recording.to_dict(),
+            parent_recording=parent_recording,
             templates=templates,
-            injected_sorting=self.injected_sorting.to_dict(),
+            injected_sorting=self.injected_sorting,
             nbefore=nbefore,
             firing_rate=firing_rate,
             amplitude_factor=amplitude_factor,

--- a/spikeinterface/preprocessing/average_across_direction.py
+++ b/spikeinterface/preprocessing/average_across_direction.py
@@ -92,7 +92,7 @@ class AverageAcrossDirectionRecording(BaseRecording):
             self.add_recording_segment(recording_segment)
 
         self._kwargs = dict(
-            parent_recording=parent_recording.to_dict(),
+            parent_recording=parent_recording,
             direction=direction,
             dtype=dtype,
         )

--- a/spikeinterface/preprocessing/directional_derivative.py
+++ b/spikeinterface/preprocessing/directional_derivative.py
@@ -66,7 +66,7 @@ class DirectionalDerivativeRecording(BasePreprocessor):
             self.add_recording_segment(rec_segment)
 
         self._kwargs = dict(
-            recording=recording.to_dict(),
+            recording=recording,
             direction=direction,
             order=order,
             edge_order=edge_order,

--- a/spikeinterface/preprocessing/tests/test_filter.py
+++ b/spikeinterface/preprocessing/tests/test_filter.py
@@ -91,7 +91,6 @@ def test_filter_opencl():
 
     print(rec.get_dtype())
     print(rec.is_dumpable)
-    # print(rec.to_dict())
 
     rec_filtered = filter(rec, engine='scipy')
     rec_filtered = rec_filtered.save(


### PR DESCRIPTION
Moving forward with https://github.com/SpikeInterface/spikeinterface/issues/1235, plus some other ones that I left back in pre-processing.