### PR TITLE
Improve Documentation V

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,7 +7,7 @@ Welcome to SpikeInterface's documentation!
   :align: center
 
 
-Spikeinterface is a Python module to analyze extracellular electrophysiology data.
+SpikeInterface is a Python module to analyze extracellular electrophysiology data.
 
 With a few lines of code, SpikeInterface enables you to load and pre-process the recording, run several 
 state-of-the-art spike sorters, post-process and curate the output, compute quality metrics, and visualize the results.
@@ -29,7 +29,7 @@ SpikeInterface is made of several modules to deal with different aspects of the 
 - compare and benchmark spike sorting outputs.
 - compute quality metrics to validate and curate spike sorting outputs.
 - visualize recordings and spike sorting outputs.
-- export report and export to Phy.
+- export a report and/or export to Phy.
 - offer a powerful Qt-based viewer in a separate package `spikeinterface-gui <https://https://github.com/SpikeInterface/spikeinterface-gui>`_
 - have some powerful sorting components to build your own sorter.
 
@@ -63,7 +63,7 @@ To get started with SpikeInterface, you can take a look at the following additio
   | figures of SpikeInterface-based papers and to showcase the latest features of SpikeInterface.
 
 - | The `2020 eLife paper <https://elifesciences.org/articles/61834>`_ introduces the concept and motivation and 
-  | performs an in-depth comparison of multiple sorters (spolier alert: they strongly disagree between each other!). 
+  | performs an in-depth comparison of multiple sorters (spoiler alert: they strongly disagree with each other!). 
   | **Note**: the code-base and implementation have changed a lot since the "paper" version published in 2020. 
   | For detailed documentation we therefore suggest more recent resources, like this documentation and :code:`spiketutorials`.
 

--- a/doc/install_sorters.rst
+++ b/doc/install_sorters.rst
@@ -4,18 +4,18 @@ Installing Spike Sorters
 ========================
 
 
-An important aspect of spikeinterface is the :py:mod:`spikeinterface.sorters` module.
+An important aspect of SpikeInterface is the :py:mod:`spikeinterface.sorters` module.
 This module wraps many popular spike sorting tools, allowing you to run multiple sorters on the same dataset with
 only a few lines of code and through Python.
 
 Installing spike sorters can be painful! Many of them come with several requirements that could cause conflicts in 
-your Python environment. To make things easier, we have created docker images for most of these sorters, 
-and in many cases the easiest way to run them is to do so via docker or singularity. 
+your Python environment. To make things easier, we have created Docker images for most of these sorters, 
+and in many cases the easiest way to run them is to do so via Docker or Singularity. 
 **This is the approach we recommend for all users.** 
 To run containerized sorters see our documentation here: :ref:`containerizedsorters`.
 
 There are some cases where users will need to install the spike sorting algorithms in their own environment. If you
-are on a system where it is infeasible to run docker or singularity containers, or if you are actively developing the
+are on a system where it is infeasible to run Docker or Singularity containers, or if you are actively developing the
 spike sorting software, you will likely need to install each spike sorter yourself.
 
 Some of theses sorters are written in Matlab, so you will also need to install Matlab if you want
@@ -50,6 +50,7 @@ Herdingspikes2
 
     pip install herdingspikes
 
+
 HDSort
 ^^^^^^
 
@@ -62,17 +63,19 @@ HDSort
       # provide installation path by setting the HDSORT_PATH environment variable
       # or using HDSortSorter.set_hdsort_path()
 
+
 IronClust
 ^^^^^^^^^
 
 * Matlab
 * Url: https://github.com/jamesjun/ironclust
 * Authors: James J. Jun
-* Installation need Matlab::
+* Installation needs Matlab::
 
       git clone https://github.com/jamesjun/ironclust
       # provide installation path by setting the IRONCLUST_PATH environment variable
       # or using IronClustSorter.set_ironclust_path()
+
 
 Kilosort
 ^^^^^^^^
@@ -86,7 +89,8 @@ Kilosort
       # provide installation path by setting the KILOSORT_PATH environment variable
       # or using KilosortSorter.set_kilosort_path()
 
-* See also for Matlab/cuda: https://www.mathworks.com/help/parallel-computing/gpu-support-by-release.html
+* See also for Matlab/CUDA: https://www.mathworks.com/help/parallel-computing/gpu-support-by-release.html
+
 
 Kilosort2
 ^^^^^^^^^
@@ -100,7 +104,7 @@ Kilosort2
       # provide installation path by setting the KILOSORT2_PATH environment variable
       # or using Kilosort2Sorter.set_kilosort2_path()
 
-* See also for Matlab/cuda: https://www.mathworks.com/help/parallel-computing/gpu-support-by-release.html
+* See also for Matlab/CUDA: https://www.mathworks.com/help/parallel-computing/gpu-support-by-release.html
 
 
 Kilosort2.5
@@ -115,7 +119,8 @@ Kilosort2.5
       # provide installation path by setting the KILOSORT2_5_PATH environment variable
       # or using Kilosort2_5Sorter.set_kilosort2_path()
 
-* See also for Matlab/cuda: https://www.mathworks.com/help/parallel-computing/gpu-support-by-release.html
+* See also for Matlab/CUDA: https://www.mathworks.com/help/parallel-computing/gpu-support-by-release.html
+
 
 Kilosort3
 ^^^^^^^^^
@@ -129,12 +134,13 @@ Kilosort3
       # provide installation path by setting the KILOSORT3_PATH environment variable
       # or using Kilosort3Sorter.set_kilosort3_path()
 
-* See also for Matlab/cuda: https://www.mathworks.com/help/parallel-computing/gpu-support-by-release.html
+* See also for Matlab/CUDA: https://www.mathworks.com/help/parallel-computing/gpu-support-by-release.html
+
 
 pyKilosort
 ^^^^^^^^^^
 
-* Python, requires cuda
+* Python, requires CUDA
 * Url: https://github.com/int-brain-lab/pykilosort / https://github.com/MouseLand/pykilosort
 * Authors: Marius Pachitariu, Shashwat Sridhar, Alexander Morley, Cyrille Rossant, Kush Bunga
 
@@ -175,9 +181,8 @@ Mountainsort4
       pip install mountainsort4
 
 
-SpykingCircus
+SpyKING CIRCUS
 ^^^^^^^^^^^^^
-
 
 * Python, requires MPICH
 * Url: https://spyking-circus.readthedocs.io
@@ -201,11 +206,12 @@ Tridesclous
 
 * Optional installation of opencl ICD and pyopencl for hardware acceleration::
 
-        sudo apt-get install beignet (optional if intel GPU)
-        sudo apt-get install nvidia-opencl-XXX (optional if nvidia GPU)
+        sudo apt-get install beignet (optional if Intel GPU)
+        sudo apt-get install nvidia-opencl-XXX (optional if NVIDIA GPU)
         sudo apt-get install pocl-opencl-icd (optional for multi core CPU)
         sudo apt-get install opencl-headers ocl-icd-opencl-dev libclc-dev ocl-icd-libopencl1
         pip install pyopencl
+
 
 Waveclus
 ^^^^^^^^
@@ -250,11 +256,11 @@ Klusta (LEGACY)
 
 * See also: https://github.com/kwikteam/phy
 
+
 Yass (LEGACY)
 ^^^^^^^^^^^^^
 
-
-* Python, cuda, torch
+* Python, CUDA, torch
 * Requires SpikeInterface<0.96.0 (and Python 3.7)
 * Url: https://github.com/paninski-lab/yass
 * Authors: JinHyung Lee, Catalin Mitelut, Liam Paninski

--- a/doc/modules/comparison.rst
+++ b/doc/modules/comparison.rst
@@ -2,7 +2,7 @@ Comparison module
 =================
 
 
-SpikeInterface has a :py:mod:`~spikeinterface.comparison` module contains functions and tools to compare 
+SpikeInterface has a :py:mod:`~spikeinterface.comparison` module, which contains functions and tools to compare 
 spike trains and templates (useful for tracking units over multiple sessions).
 
 In addition, the :py:mod:`~spikeinterface.comparison` module contains advanced benchmarking tools to evaluate 
@@ -34,14 +34,14 @@ available ground-truth datasets on a daily basis. For more details see
 This is the main workflow used to compute performance metrics:
 
 Given:
-  * **i = 1, ..., n_gt** the list ground-truth (GT) units
+  * **i = 1, ..., n_gt** the list of ground-truth (GT) units
   * **k = 1, ...., n_tested** the list of tested units from spike sorting output
-  * **event_counts_GT[i]** the number of spikes for each units of GT unit
-  * **event_counts_ST[k]** the number of spikes for each units of tested unit
+  * **event_counts_GT[i]** the number of spikes for each unit of the GT units
+  * **event_counts_ST[k]** the number of spikes for each unit of the tested units
 
   1. **Matching firing events**
 
-    For all pairs of GT unit and tested unit we first count how many
+    For all pairs of a GT unit and a tested unit we first count how many
     events are matched within a *delta_time* tolerance (0.4 ms by default).
 
     This gives a matrix called **match_event_count** of size *(n_gt X n_tested)*. This is an example of the matrix:
@@ -58,7 +58,7 @@ Given:
 
   2. **Compute agreement score**
 
-    Given the **match_event_count** we can then compute the **agreement_score**, which is normalized in the range [0, 1].
+    Given the **match_event_count** we can then compute the **agreement_score**, which is normalized to the range [0, 1].
 
     This is done as follows:
 
@@ -98,12 +98,12 @@ Given:
 
       The `hungarian method <https://en.wikipedia.org/wiki/Hungarian_algorithm>`_
       finds the best association between GT and tested units. With this method, both GT and tested units can be matched
-      only to another unit, or not matched at all.
+      only to one other unit or are not matched at all.
 
       For the **best** method, each GT unit is associated to a tested unit that has
       the **best** agreement_score, independently of all others units. Using this method
       several tested units can be associated to the same GT unit. Note that for the "best match" the minimum
-      score is not the match_Score, but the **chance_score** (0.1 by default).
+      score is not the match_score, but the **chance_score** (0.1 by default).
 
       Here is an example of matching with the **hungarian** method. The first column represents the GT unit id
       and the second column the tested unit id. -1 means that the tested unit is not matched:
@@ -139,7 +139,7 @@ Given:
         * miss_rate = fn / num_gt
 
       The overall performances can be visualised with the **confusion matrix**, where
-      the last columns counts **FN** and the last row counts **FP**.
+      the last column contains the **FN** counts and the last row contains the **FP** counts.
 
     .. image:: ../images/spikecomparison_confusion.png
         :scale: 100 %
@@ -162,11 +162,11 @@ More information about **hungarian** or **best** match methods
         * Hit score near chance levels are set to zero
         * Good FP estimation
 
-
       * Cons
 
         * Does not catch units that are split into several sub-units. Only the best match will be listed
         * More complicated implementation
+
 
     * **Best**
 
@@ -230,7 +230,7 @@ An **over-merged** unit has a relatively high agreement (>= 0.2 by default) for 
 
 
     # The confusion matrix is also a good summary of the score as it has
-    # the same shape as agreement matrix, but it contains an extra column for FN
+    # the same shape as an agreement matrix, but it contains an extra column for FN
     # and an extra row for FP
     plot_confusion_matrix(cmp_gt_HS)
 
@@ -245,23 +245,23 @@ An **over-merged** unit has a relatively high agreement (>= 0.2 by default) for 
 
 **Example: compare many sorters with a Ground Truth Study**
 
-We also have a high level class to compare many sorter against ground truth : 
+We also have a high level class to compare many sorters against ground truth: 
 :py:func:`~spiekinterface.comparison.GroundTruthStudy()`
 
 A study is a systematic performance comparison of several ground truth recordings with several sorters.
 
-The study class proposes high level tool functions to run many groundtruth comparisons with many sorters
+The study class proposes high-level tool functions to run many ground truth comparisons with many sorters
 on many recordings and then collect and aggregate results in an easy way.
 
 The all mechanism is based on an intrinsic organization into a "study_folder" with several subfolder:
 
-  * raw_files : contain a copy in binary format of recordings
-  * sorter_folders : contains output of sorters
-  * ground_truth : contains a copy of sorting ground  in npz format
+  * raw_files : contain a copy of recordings in binary format
+  * sorter_folders : contains outputs of sorters
+  * ground_truth : contains a copy of sorting ground truth in npz format
   * sortings: contains light copy of all sorting in npz format
-  * tables: some table in cvs format
+  * tables: some tables in csv format
 
-In order to run and rerun the computation all gt_sorting and recordings are copied to a fast and universal format :
+In order to run and rerun the computation all gt_sorting and recordings are copied to a fast and universal format:
 binary (for recordings) and npz (for sortings).
 
 
@@ -284,26 +284,26 @@ binary (for recordings) and npz (for sortings).
     study_folder = 'a_study_folder'
     study = GroundTruthStudy.create(study_folder, gt_dict)
 
-    # all sorters on all recordings in one functions.
+    # all sorters for all recordings in one function.
     sorter_list = ['herdingspikes', 'tridesclous', ]
     study.run_sorters(sorter_list, mode_if_folder_exists="keep")
 
-    # You can re run **run_study_sorters** as many time as you want.
-    # By default **mode='keep'** so only uncomputed sorters are rerun.
-    # For instance, so just remove the "sorter_folders/rec1/herdingspikes" to re-run
+    # You can re-run **run_study_sorters** as many times as you want.
+    # By default **mode='keep'** so only uncomputed sorters are re-run.
+    # For instance, just remove the "sorter_folders/rec1/herdingspikes" to re-run
     # only one sorter on one recording.
     #
     # Then we copy the spike sorting outputs into a separate subfolder.
-    # This allow to remove the "large" sorter_folders.
+    # This allow us to remove the "large" sorter_folders.
     study.copy_sortings()
 
     # Collect comparisons
     #  
     # You can collect in one shot all results and run the
     # GroundTruthComparison on it.
-    # So you can access finely to all individual results.
+    # So you can have fine access to all individual results.
     #  
-    # Note that exhaustive_gt=True when you know exactly how many
+    # Note: use exhaustive_gt=True when you know exactly how many
     # units in ground truth (for synthetic datasets)
 
     study.run_comparisons(exhaustive_gt=True)
@@ -355,18 +355,18 @@ binary (for recordings) and npz (for sortings).
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The comparison of two sorters is quite similar to the procedure of **compare to ground truth**.
-The difference is that no assumption is done on which of the units are ground-truth.
+The difference is that no assumption is made on which of the units are ground-truth.
 
 So the procedure is the following:
 
-  * **Matching firing events** : same a ground truth comparison
-  * **Compute agreement score** : same a ground truth comparison
+  * **Matching firing events** : same as the ground truth comparison
+  * **Compute agreement score** : same as the ground truth comparison
   * **Match units** : only with **hungarian** method
 
 As there is no ground-truth information, performance metrics are not computed.
 However, the confusion and agreement matrices can be visualised to assess the level of agreement.
 
-The :py:func:`~spikeinterface.comparison.compare_two_sorters()` return the comparison object to handle this.
+The :py:func:`~spikeinterface.comparison.compare_two_sorters()` returns the comparison object to handle this.
 
 
 **Example: compare 2 sorters**
@@ -378,11 +378,11 @@ The :py:func:`~spikeinterface.comparison.compare_two_sorters()` return the compa
     local_path = si.download_dataset(remote_path='mearec/mearec_test_10s.h5')
     recording, sorting = se.read_mearec(local_path)
 
-    # Then run two spike sorters and compare their output.
+    # Then run two spike sorters and compare their outputs.
     sorting_HS = ss.run_sorter('herdingspikes', recording)
     sorting_TDC = ss.run_sorter('tridesclous', recording)
 
-    # run the comparison
+    # Run the comparison
     # Let’s see how to inspect and access this matching.
     cmp_HS_TDC = sc.compare_two_sorters(
         sorting1=sorting_HS,
@@ -400,7 +400,7 @@ The :py:func:`~spikeinterface.comparison.compare_two_sorters()` return the compa
     print(cmp_HS_TDC.agreement_scores)
 
     # In order to check which units were matched, the :code:`get_matching`
-    # methods can be used. If units are not matched they are listed as -1.
+    # method can be used. If units are not matched they are listed as -1.
     sc_to_tdc, tdc_to_sc = cmp_HS_TDC.get_matching()
     print('matching HS to TDC')
     print(sc_to_tdc)
@@ -430,7 +430,7 @@ Comparison of multiple sorters uses the following procedure:
 
 .. code-block:: python
 
-    # download a simulated dataset
+    # Download a simulated dataset
     local_path = si.download_dataset(remote_path='mearec/mearec_test_10s.h5')
     recording, sorting = se.read_mearec(local_path)
 
@@ -446,7 +446,7 @@ Comparison of multiple sorters uses the following procedure:
         verbose=True,
     )
 
-    # The multiple sorters comparison internally computes pairwise comparison,
+    # The multiple sorters comparison internally computes pairwise comparisons,
     # that can be accessed as follows:
     print(mcmp.comparisons[('MS4', 'HS')].sorting1, mcmp.comparisons[('MS4', 'HS')].sorting2)
     print(mcmp.comparisons[('MS4', 'HS')].get_matching())
@@ -461,8 +461,8 @@ Comparison of multiple sorters uses the following procedure:
     #  
     # We can pull the units in agreement with different sorters using the
     # :py:func:`~spikeinterface.comparison.MultiSortingComparison.get_agreement_sorting` method.
-    # This allows to make spike sorting more robust by integrating the output of several algorithms.
-    # On the other hand, it might suffer from weak performance of single algorithms.
+    # This allows us to make spike sorting more robust by integrating the outputs of several algorithms.
+    # On the other hand, it might suffer from weak performances of single algorithms.
     # When extracting the units in agreement, the spike trains are modified so
     # that only the true positive spikes between the comparison with the best
     # match are used.

--- a/doc/modules/curation.rst
+++ b/doc/modules/curation.rst
@@ -7,8 +7,8 @@ The API of some of the functions could be changed/improved from time to time.
 Manual curation
 ---------------
 
-SpikeInterface offer a machinery to manually curate a sorting and keep track of the curation history.
-The curation has several "steps" that can be be repeated and chained:
+SpikeInterface offers machinery to manually curate a sorting output and keep track of the curation history.
+The curation has several "steps" that can be repeated and chained:
 
   * remove/select units
   * split units
@@ -35,7 +35,7 @@ The merging and splitting operations are handled by the :py:class:`~spikeinterfa
     cs.merge(['#11', '#21'])
 
     # make a split
-    split_index = ... # some creteria on spikes
+    split_index = ... # some criteria on spikes
     cs.split('#20', split_index)
 
     # here the final clean sorting

--- a/doc/modules/exporters.rst
+++ b/doc/modules/exporters.rst
@@ -14,11 +14,11 @@ results.
 
 **Note** : :py:func:`~spikeinterface.exporters.export_to_phy` speed and the size of the folder will highly depend
 on the sparsity of the :code:`WaveformExtractor` itself or the external specified sparsity.
-The Phy viewer enables one to explore PCA projections, spike amplitudes, waveforms and quality of the results. 
+The Phy viewer enables one to explore PCA projections, spike amplitudes, waveforms and quality of spike sorting results. 
 So if these pieces of information have already been computed as extensions (see :ref:`waveform_extensions`), 
 then exporting to Phy should be fast (and the user has better control of the parameters for the extensions).
 If not pre-computed, then the required extensions (e.g., :code:`spike_amplitudes`, :code:`principal_components`) 
-can be computed direcly at export time.
+can be computed directly at export time.
 
 The input of the :py:func:`~spikeinterface.exporters.export_to_phy` is a :code:`WaveformExtractor` object.
 
@@ -71,7 +71,7 @@ with many units!
     from spikeinterface.exporters import export_report
 
 
-    # the waveforms are sparse for better interpretable figures
+    # the waveforms are sparse for more interpretable figures
     we = extract_waveforms(recording, sorting, folder='path/to/wf', sparse=True)
 
     # some computations are done before to control all options

--- a/doc/modules/extractors.rst
+++ b/doc/modules/extractors.rst
@@ -14,7 +14,7 @@ Most of the :code:`Recording` classes are implemented by wrapping the
 Most of the :code:`Sorting` classes are instead directly implemented in SpikeInterface.
 
 
-Although spikeinterface is object-oriented (class-based), each object can also be loaded with a convenient
+Although SpikeInterface is object-oriented (class-based), each object can also be loaded with a convenient
 :code:`read_XXXXX()` function.
 
 
@@ -76,7 +76,7 @@ The actual reading will be done on demand using the :py:meth:`~spikeinterface.co
 
 .. code-block:: python
 
-    # open a 40GB SpikeGLX dataset is fast
+    # opening a 40GB SpikeGLX dataset is fast
     recording_spikeglx = read_spikeglx("spikeglx-folder")
 
     # this really does load the full 40GB into memory : not recommended!!!!!
@@ -98,12 +98,12 @@ Most formats are supported on top of `NEO <https://github.com/NeuralEnsemble/pyt
 Dependencies
 ------------
 
-The :code:`neo` package is a hard dependency of spikeinterface. So all formats handled by neo directly will be handled
-also in spikeinterface.
+The :code:`neo` package is a hard dependency of SpikeInterface. So all formats handled by Neo directly will also be handled
+in SpikeInterface.
 
-However, some formats are handled directly by spikeinterface and need extra installation.
+However, some formats are handled directly by SpikeInterface and need extra installation.
 
-You can install all extractors dependencies with:
+You can install all extractors' dependencies with:
 
 .. code-block:: python
 

--- a/doc/modules/postprocessing.rst
+++ b/doc/modules/postprocessing.rst
@@ -15,7 +15,7 @@ WaveformExtractor extensions
 There are several postprocessing tools available, and all 
 of them are implemented as a :py:class:`~spikeinterface.core.BaseWaveformExtractorExtension`. All computations on top
 of a WaveformExtractor will be saved along side the WaveformExtractor itself (sub  folder, zarr path or sub dict).
-This workflow is convenient to retrieve time-consuming computation (such as pca or spike amplitudes) when reloading  
+This workflow is convenient for retrieval of time-consuming computations (such as pca or spike amplitudes) when reloading a 
 WaveformExtractor.
 
 :py:class:`~spikeinterface.core.BaseWaveformExtractorExtension`  objects are tightly connected to the
@@ -35,7 +35,7 @@ To check what extensions are available for a :code:`WaveformExtractor` named :co
 
     ["principal_components", "spike_amplitudes"]
 
-In this case, for example, principal components and spike amplitudes have been already computed.
+In this case, for example, principal components and spike amplitudes have already been computed.
 To load the extension object you can run:
 
 .. code-block:: python
@@ -56,7 +56,7 @@ We can also delete an extension:
 
 
 
-Available postptocessing extensions
+Available postprocessing extensions
 -----------------------------------
 
 noise_levels
@@ -131,8 +131,8 @@ unit locations
 ^^^^^^^^^^^^^^
 
 
-This extension is similar to the :code:`spike_locations`, but instead to estimate a location for each spike it computes 
-at the unit level, using the templates instead of individual waveforms. The same localization methods 
+This extension is similar to the :code:`spike_locations`, but instead of estimating a location for each spike
+based on individual waveforms, it calculates at the unit level using templates. The same localization methods 
 (:code:`method="center_of_mass" | "monopolar_triangulation"`) are available.
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_unit_locations`
@@ -182,7 +182,7 @@ Other postprocessing tools
 align_sorting
 ^^^^^^^^^^^^^
 
-This function aligns the spike trains a :code:`BaseSorting` object using pre-computed shifts of misaligned templates.
+This function aligns the spike trains :code:`BaseSorting` object using pre-computed shifts of misaligned templates.
 To compute shifts, one can use the :py:func:`~spikeinterface.core.get_template_extremum_channel_peak_shift` function.
 
 For more information, see :py:func:`~spikeinterface.postprocessing.align_sorting`

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -32,12 +32,12 @@ These two preprocessors will not compute anything at instantiation, but the comp
 
     traces = recording_cmr.get_traces(start_frame=100_000, end_frame=200_000)
 
-Some internal sorters (see :ref:`si_based`) can work directly in these preprocessed objects so there is no need to 
-save the:
+Some internal sorters (see :ref:`si_based`) can work directly on these preprocessed objects so there is no need to 
+save the object:
 
 .. code-block:: python
 
-    # here the circus2 sorter engine directly uses the lazy "recording_cmr" object
+    # here the spykingcircus2 sorter engine directly uses the lazy "recording_cmr" object
     sorting = run_sorter(recording_cmr, 'spykingcircus2')
 
 Most of the external sorters, however, will need a binary file as input, so we can optionally save the processed 
@@ -58,7 +58,7 @@ Impact on recording dtype
 
 By default the dtype of a preprocessed recording does not change the recording's dtype, even if, internally, the 
 computation is performed using a different dtype.
-For instance if we have a :code:`int16`` recording, the application of a bandpass filter will conserve the original 
+For instance if we have a :code:`int16`` recording, the application of a bandpass filter will preserve the original 
 dtype (unless specified otherwise):
 
 
@@ -178,11 +178,11 @@ centered with unitary variance on each channel.
 whiten()
 ^^^^^^^^
 
-Many sorters use this pre-processing step internally, but if you want to combine this operation to other preprocessing 
+Many sorters use this pre-processing step internally, but if you want to combine this operation with other preprocessing 
 steps, you can use the :code:`whiten()` implemented in SpikeInterface.
 The whitenning matrix :code:`W` is constructed by estimating the covariance across channels and then inverting it.
 
-The whitened traces are then the dot product between the traces and :code:`W` matrix.
+The whitened traces are then the dot product between the traces and the :code:`W` matrix.
 
 .. code-block:: python
 
@@ -209,7 +209,7 @@ highpass_spatial_filter()
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :code:`highpass_spatial_filter()` is a preprocessing step introduced by the International Brain Laboratory [IBL_spikesorting]_.
-It applies a filter in the spatial axis of the tarces after ordering the channels by depth.
+It applies a filter in the spatial axis of the traces after ordering the channels by depth.
 It is similar to common reference, but it can deal with "stripes" that are uneven across depth. 
 This preprocessing step can be super useful for long probes like Neuropixels.
 
@@ -296,9 +296,9 @@ How to implement "IBL destriping" or "SpikeGLX CatGT" in SpikeInterface
 -----------------------------------------------------------------------
 
 
-SpikeGLX have a built-in function called `CatGT <https://billkarsh.github.io/SpikeGLX/help/dmx_vs_gbl/dmx_vs_gbl/>`_ 
+SpikeGLX has a built-in function called `CatGT <https://billkarsh.github.io/SpikeGLX/help/dmx_vs_gbl/dmx_vs_gbl/>`_ 
 to apply some preprocessing on the traces to remove noise and artifacts.
-IBL also have a standardized pipeline for preprocessed traces a bit similar to CatGT which is called "destriping" [IBL_spikesorting]_.
+IBL also has a standardized pipeline for preprocessed traces a bit similar to CatGT which is called "destriping" [IBL_spikesorting]_.
 In these both cases, the traces are entiely read, processed and written back to a file.
 
 SpikeInterface can reproduce similar results without the need to write back to a file by building a *lazy* 

--- a/doc/modules/sorters.rst
+++ b/doc/modules/sorters.rst
@@ -15,23 +15,23 @@ module. **Note that internal sorters are currently experimental and under develo
 A drawback of using external sorters is the installation of these tools. Sometimes they need MATLAB, 
 specific versions of CUDA, specific gcc versions vary or even worse outdated versions of
 Python/NumPy. In that case, SpikeInterface offer the mechanism of running external sorters inside a
-container (docker/singularity) with the sorter pre-installed. See :ref:`containerizedsorters`.
+container (Docker/Singularity) with the sorter pre-installed. See :ref:`containerizedsorters`.
 
 
 External sorters: the "wrapper" concept
 ---------------------------------------
 
-When running external sorters, we use the concept of "wrappers". In short, we have some Python code
+When running external sorters, we use the concept of "wrappers". In short, we have Python code
 that generates the external code needed to run the sorter (for instance, a MATLAB script) and also 
 external configuration files. Then, the generated code is run in the background with the appropriate 
 tools (e.g., Python, MATLAB, Command Line Interfaces).
-When the spike sorting process is finished, the output is loaded back in Python into a 
-the :py:class:`~spikeinterface.core.BaseSorting` object.
+When the spike sorting process is finished, the output is loaded back into Python into a
+:py:class:`~spikeinterface.core.BaseSorting` object.
 
-For instance, we the :code:`Kilosort2_5Sorter` will handle:
+For instance, the :code:`Kilosort2_5Sorter` will handle:
   * Formatting the data and parameters for Kilosort2.5, using :code:`Kilosort2_5Sorter.setup_recording()`
   * Running MATLAB and Kilosort2.5 code in the folder, using :code:`Kilosort2_5Sorter.run_from_folder()`
-  * Retriving the spike sorting output, using :code:`Kilosort2_5Sorter.get_result_from_folder()`
+  * Retrieving the spike sorting output, using :code:`Kilosort2_5Sorter.get_result_from_folder()`
 
 From the user's point of view all of this is in the background and it happens automatically when using the 
 :py:func:`~spikeinterface.sorters.run_sorter` function.
@@ -48,16 +48,16 @@ to easily run spike sorters:
 
     from spikeinterface.sorters import run_sorter
 
-    # run tridesclous
+    # run Tridesclous
     sorting_TDC = run_sorter("tridesclous", recording, output_folder="/folder_TDC")
-    # run kilosort.5
+    # run Kilosort2.5
     sorting_KS2_5 = run_sorter("kilosort2_5", recording, output_folder="/folder_KS2.5")
     # run IronClust
     sorting_IC = run_sorter("ironclust", recording, output_folder="/folder_IC")
-    # run pykilosort
+    # run pyKilosort
     sorting_pyKS = run_sorter("pykilosort", recording, output_folder="/folder_pyKS")
-    # run spykingcircus
-    sorting_SC = run_sorter("ironclust", recording, output_folder="/folder_SC")
+    # run SpykingCircus
+    sorting_SC = run_sorter("spykingcircus", recording, output_folder="/folder_SC")
 
 
 Then the output, which is a :py:class:`~spikeinterface.core.BaseSorting` object, can be easily 
@@ -73,7 +73,7 @@ The :py:func:`~spikeinterface.sorters.run_sorter` function has several options:
   * to remove or not the sorter working folder (:code:`output_folder/sorter_output`) 
     with: :code:`remove_existing_folder=True/False` (this can save lot of space because some sorters
     need data duplication!)
-  * to control ther verbosity: :code:`verbose=False/True`
+  * to control their verbosity: :code:`verbose=False/True`
   * to raise/not raise errors (if they fail): :code:`raise_error=False/True`
 
 Spike-sorter-specific parameters can be controlled directly from the 
@@ -129,7 +129,7 @@ Parameters from all sorters can be retrieved with these functions:
 
 .. _containerizedsorters:
 
-Running sorters in container docker/singularity
+Running sorters in Docker/Singularity Containers
 -----------------------------------------------
 
 One of the biggest bottlenecks for users is installing spike sorting software. To alleviate this,
@@ -147,7 +147,7 @@ The containers can be run in Docker or Singularity, so having Docker or Singular
 is a prerequisite.
 
 
-Running spike sorting in a docker container just requires:
+Running spike sorting in a Docker container just requires:
 
 1) have docker installed
 2) have docker Python SDK installed (:code:`pip install docker`)
@@ -157,9 +157,9 @@ or
 1) have singularity installed
 2) have `singularity python <https://singularityhub.github.io/singularity-cli/>`_ (:code:`pip install spython`)
 
-Some sorters are GPU required or optional. To run containerized sorters with GPU capabilities,
+Some sorters require (are can be accelerated) with use of a GPU. To run containerized sorters with GPU capabilities,
 CUDA and `nvidia-container-toolkit <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html>`_
-needs to be installed. Only NVIDIA GPUs are supported for now.
+need to be installed. Only NVIDIA GPUs are supported for now.
 
 
 For Docker users, you can either install `Docker Desktop <https://www.docker.com/products/docker-desktop/>`_ 
@@ -170,7 +170,7 @@ To enable :code:`Docker Desktop` to download the containers, you need to create 
 For :code:`Docker Engine`, you also need to enable Docker to run without :code:`sudo` privileges 
 following `this post-install guide <https://docs.docker.com/engine/install/linux-postinstall/>`_
 
-The containers are built with Docker, but Singularity has an internal mechanism to convert docker images.
+The containers are built with Docker, but Singularity has an internal mechanism to convert Docker images.
 Using Singularity is often preferred due to its simpler approach with regard to root privilege.
 
 The following code creates a test recording and runs a containerized spike sorter (Kilosort 3):
@@ -192,8 +192,8 @@ The following code creates a test recording and runs a containerized spike sorte
 
     print(sorting)
 
-This will automatically check if the latest compiled kilosort3 docker image is present on your
-workstation and if it is not the proper image will be downloaded from
+This will automatically check if the latest compiled kilosort3 Docker image is present on your
+workstation and if it is not, the proper image will be downloaded from
 `SpikeInterface's Docker Hub repository <https://hub.docker.com/u/spikeinterface>`_.
 The sorter will then run and output the results in the designated folder. 
 
@@ -216,7 +216,7 @@ e.g. ``singularity_image="spikeinterface/kilosort3-compiled-base:0.1.0"``.
 
 
 **NOTE:** the :code:`toy_example()` returns in-memory objects, which are not bound to a file on disk. 
-In order to run spike sorting in a container, the recording object MUST be persistent on disk, so
+In order to run a spike sorter in a container, the recording object MUST be persistent on disk, so
 that the container can reload it. The :code:`save()` function makes the recording persistent on disk,
 by saving the in-memory  :code:`test_recording` object to a binary file in the
 :code:`test-docker-folder` folder.
@@ -245,11 +245,11 @@ an :code:`engine` that supports parallel processing (such as :code:`joblib` or :
     for (rec_name, sorter_name), sorting in sorting_output.items():
         print(rec_name, sorter_name, ':', sorting.get_unit_ids())
 
-After the jobs are run, the :code:`sorting_outputs` is a dictionary with :code:`(rec_name, sorter_name)` as key (e.g.
+After the jobs are run, the :code:`sorting_outputs` is a dictionary with :code:`(rec_name, sorter_name)` as a key (e.g.
 :code:`('rec1', 'tridesclous')` in this example), and the corresponding :py:class:`~spikeinterface.core.BaseSorting` 
-as value.
+as a value.
 
-:py:func:`~spikeinterface.sorters.run_sorters` have several "engines" available to launch the computation:
+:py:func:`~spikeinterface.sorters.run_sorters` has several "engines" available to launch the computation:
 
 * "loop": sequential 
 * "joblib": in parallel
@@ -269,7 +269,7 @@ as value.
 Spike sorting by group
 ----------------------
 
-Sometimes you may want to spike sort using specific grouping, for example when working with tetrodes, with multi-shank
+Sometimes you may want to spike sort using a specific grouping, for example when working with tetrodes, with multi-shank
 probes, or if the recording has data from different probes.
 Alternatively, for long silicon probes, such as Neuropixels, one could think of spike sorting different areas 
 separately, for example using a different sorter for the hippocampus, the thalamus, or the cerebellum. 
@@ -278,7 +278,7 @@ Running spike sorting by group is indeed a very common need.
 A :py:class:`~spikeinterface.core.BaseRecording` object has the ability to split itself into a dictionary of 
 sub-recordings given a certain property (see :py:meth:`~spikeinterface.core.BaseRecording.split_by`).
 So it is easy to loop over this dictionary and sequentially run spike sorting on these sub-recordings.
-SpikeInterface also proposes a high-level function to automate the process of splitting the
+SpikeInterface also provides a high-level function to automate the process of splitting the
 recording and then aggregating the results with the :py:func:`~spikeinterface.sorters.run_sorter_by_property` function.
 
 In this example, we create a 16-channel recording with 4 tetrodes:
@@ -326,7 +326,7 @@ In this example, we create a 16-channel recording with 4 tetrodes:
 
 .. code-block:: python
 
-    # here the result is one sorting that agregate all sub sorting object
+    # here the result is one sorting that aggregates all sub sorting objects
     aggregate_sorting = run_sorter_by_property('kilosort2', recording_4_tetrodes,
                                                grouping_property='group',
                                                working_folder='working_path')
@@ -445,7 +445,7 @@ which outputs,
    'tridesclous']
 
 
-When trying to use an sorter that has not been installed in your environment, an installation
+When trying to use a sorter that has not been installed in your environment, an installation
 message will appear indicating how to install the given sorter,
 
 .. code:: python
@@ -469,17 +469,17 @@ Internal sorters
 ----------------
 
 In 2022, we started the :py:mod:`spikeinterface.sortingcomponents` module to break into components a sorting pipeline.
-Theses components can be gathered to create a new sorter. We already have 2 sorters to showcase this new module:
+These components can be gathered to create a new sorter. We already have 2 sorters to showcase this new module:
 
 * :code:`spykingcircus2` (experimental, but ready to be tested) 
 * :code:`tridesclous2` (experimental, not ready to be used)
 
 There are some benefits of using these sorters:
-  * they handle directly SpikeInterface objects, so they do not need any data copy.
+  * they directly handle SpikeInterface objects, so they do not need any data copy.
   * they only require a few extra dependencies (like :code:`hdbscan`)
 
 
-From the user's perspective, they behave exactly like "normal" sorters:
+From the user's perspective, they behave exactly like the external sorters:
 
 .. code-block:: python
 

--- a/doc/modules/sorters.rst
+++ b/doc/modules/sorters.rst
@@ -157,7 +157,7 @@ or
 1) have singularity installed
 2) have `singularity python <https://singularityhub.github.io/singularity-cli/>`_ (:code:`pip install spython`)
 
-Some sorters require (are can be accelerated) with use of a GPU. To run containerized sorters with GPU capabilities,
+Some sorters require (or can be accelerated) with use of a GPU. To run containerized sorters with GPU capabilities,
 CUDA and `nvidia-container-toolkit <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html>`_
 need to be installed. Only NVIDIA GPUs are supported for now.
 

--- a/doc/modules/sortingcomponents.rst
+++ b/doc/modules/sortingcomponents.rst
@@ -59,7 +59,7 @@ follows:
         **job_kwargs,
     )
 
-The output :code:`peaks` is a numpy array with a length of the number of peaks found and the following dtype:
+The output :code:`peaks` is a NumPy array with a length of the number of peaks found and the following dtype:
 
 .. code-block:: python
 
@@ -112,7 +112,7 @@ These methods are the same as implemented in :py:mod:`spikeinterface.postprocess
 
 
 
-The output :code:`peak_locations` is a 1d numpy array with a dtype that depends on the chosen method.
+The output :code:`peak_locations` is a 1d NumPy array with a dtype that depends on the chosen method.
 
 For instance, the 'monopolar_triangulation' method will have:
 
@@ -122,10 +122,10 @@ For instance, the 'monopolar_triangulation' method will have:
 
 .. note::
 
-   By convention in spikeinterface, when a probe is described in 2d
+   By convention in SpikeInterface, when a probe is described in 2d
      * **'x'** is the width of the probe
      * **'y'** is the depth
-     * **'z'** is the orthogonal to the probe plane
+     * **'z'** is orthogonal to the probe plane
 
 
 Peak selection
@@ -166,7 +166,7 @@ Motion estimation
 Recently, drift estimation has been added to some of the available spike sorters (Kilosort 2.5, 3)
 Especially for Neuropixels-like probes, this is a crucial step.
 
-Several methods have been proposed to correct for drift, but only one is currently implemented in spikeinterface. 
+Several methods have been proposed to correct for drift, but only one is currently implemented in SpikeInterface. 
 See `Decentralized Motion Inference and Registration of Neuropixel Data <https://ieeexplore.ieee.org/document/9414145>`_ 
 for more details.
 
@@ -232,10 +232,10 @@ Here is a short example that depends on the output of "Motion estimation":
 Clustering
 ----------
 
-The clustering step remains the central step of the spike sorting.
+The clustering step remains the central step of spike sorting.
 Historically this step was separted into two distinct parts: feature reduction and clustering.
-In spikeinterface, we decided to regroup these two steps into the same module.
-This allows one to compute feature reduction on-the-fly and avoid long computations and storage of 
+In SpikeInterface, we decided to regroup these two steps into the same module.
+This allows one to compute feature reduction 'on-the-fly' and avoid long computations and storage of 
 large features.
 
 The clustering step takes the recording and detected (and optionally selected) peaks as input and returns 
@@ -268,17 +268,17 @@ Different methods may need different inputs (for instance some of them require p
 Template matching
 -----------------
 
-Template matching is the final step used in many sorters (kilosort, spyking-circus, yass, tridesclous, hdsort...)
+Template matching is the final step used in many sorters (Kilosort, SpyKING-Circus, YASS, Tridesclous, HDsort...)
 
 In this step, from a given catalogue (or dictionary) of templates (or atoms), the algorithms try to *explain* the 
-traces as a linear sum of template plus a residual noise.
+traces as a linear sum of a template plus a residual noise.
 
 At the moment, there are four methods implemented:
 
-  * 'naive': a very naive implemenation used as  a reference for benchmarks
-  * 'tridesclous': the algorithm for template matching implemented in tridesclous
-  * 'circus': the algorithm for template matching implemented in spyking-circus
-  * 'circus-omp': a updated algorithm similar to the spyking-circus one circus but with OMP (orthogonal macthing 
+  * 'naive': a very naive implemenation used as a reference for benchmarks
+  * 'tridesclous': the algorithm for template matching implemented in Tridesclous
+  * 'circus': the algorithm for template matching implemented in SpyKING-Circus
+  * 'circus-omp': a updated algorithm similar to SpyKING-Circus but with OMP (orthogonal macthing 
     pursuit)
 
 Very preliminary benchmarks suggest that:

--- a/doc/modules/widgets.rst
+++ b/doc/modules/widgets.rst
@@ -114,7 +114,7 @@ The :code:`plot_*(..., backend="matplotlib")` functions come with the following 
 
 * :code:`figure`: Matplotlib figure. When None, it is created. Default None
 * :code:`ax`: Single matplotlib axis. When None, it is created. Default None
-* :code:`axes`: Multiple matplotlib axes. When None, they is created. Default None
+* :code:`axes`: Multiple matplotlib axes. When None, they are created. Default None
 * :code:`ncols`: Number of columns to create in subplots.  Default 5
 * :code:`figsize`: Size of matplotlib figure. Default None
 * :code:`figtitle`: The figure title. Default None
@@ -146,7 +146,7 @@ Each function has the following additional arguments:
 
     from spikeinterface.preprocessing import common_reference
 
-    # ipywidgets backend also supports multiple "layers" fro plot_timeseries
+    # ipywidgets backend also supports multiple "layers" for plot_timeseries
     rec_dict = dict(filt=recording, cmr=common_reference(recording))
     w = sw.plot_timeseries(rec_dict, backend="ipywidgets")
 
@@ -158,7 +158,7 @@ Each function has the following additional arguments:
 sortingview
 ^^^^^^^^^^^
 
-The :code:`plot_*(..., backend="sortingview")` generate web-based GUIs, which are also shareable link (provided 
+The :code:`plot_*(..., backend="sortingview")` generate web-based GUIs, which are also shareable with a link (provided 
 that :code:`kachery-cloud` is correctly setup, see :ref:`sorting_view`). 
 The functions have the following additional arguments:
 


### PR DESCRIPTION
As briefly mentioned in #1380 the main goal for this round was to unify capitalization of SpikeInterface and some of the other packages (the various sorters, NVIDIA, CUDA, Docker). I also tried to fix a few more typos I missed in my previous passes. Just let me know if you want to revert any of the capitalizations.