### PR TITLE
Hide Y axis when plot_timeseries without channel labels

### DIFF
--- a/spikeinterface/widgets/matplotlib/timeseries.py
+++ b/spikeinterface/widgets/matplotlib/timeseries.py
@@ -36,6 +36,9 @@ class TimeseriesPlotter(MplPlotter):
                 ax.set_yticks(np.arange(n) * dp.vspacing)
                 channel_labels = np.array([str(chan_id) for chan_id in dp.channel_ids])
                 ax.set_yticklabels(channel_labels)
+            else:
+                ax.get_yaxis().set_visible(False)
+
             ax.set_xlim(*dp.time_range)
             ax.set_ylim(-dp.vspacing, dp.vspacing * n)
             ax.get_xaxis().set_major_locator(MaxNLocator(prune='both'))
@@ -60,5 +63,7 @@ class TimeseriesPlotter(MplPlotter):
                 ax.set_yticks(np.linspace(min_y, max_y, n) + (max_y - min_y) / n * 0.5)
                 channel_labels = np.array([str(chan_id) for chan_id in dp.channel_ids])
                 ax.set_yticklabels(channel_labels)
+            else:
+                ax.get_yaxis().set_visible(False)
 
 TimeseriesPlotter.register(TimeseriesWidget)


### PR DESCRIPTION
Just a small suggestion, when first using plot_timeseries (matplotlib backend) I was a little confused by the y-axis numbers and their relationship to channels, until I saw the `show_channel_ids=True` option.

If I understand correctly, the y-axis values on the plots are arbitrary if channel ids are not shown. If so, it just be nice to just hide them as proposed in this PR (images below)

before PR (map):

![image](https://user-images.githubusercontent.com/55797454/229573496-4e0433ca-f68e-4b36-a4f8-baf0f02dd62d.png)


after PR (map):

![image](https://user-images.githubusercontent.com/55797454/229573007-cc5db5e7-9c07-4b87-ad8e-d9d930e4185e.png)


before PR (line):

![image](https://user-images.githubusercontent.com/55797454/229573418-050e52a4-2c7d-46e3-be6f-a9917761c7de.png)


after PR (line):

![image](https://user-images.githubusercontent.com/55797454/229573285-6c611090-3222-4b56-bf72-42b0e08030cf.png)

