### PR TITLE
Return `nn_unit_id` along with `nn_isolation`

### DIFF
--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -468,6 +468,7 @@ def nearest_neighbors_isolation(waveform_extractor: WaveformExtractor, this_unit
         # if no unit is within neighborhood of target unit, then just say isolation is 1 (best possible)
         if not other_units_ids:
             nn_isolation = 1
+            nn_unit_id = np.nan
         # if there are units to compare, then compute isolation with each
         else:
             isolation = np.zeros(len(other_units_ids),)


### PR DESCRIPTION
Hi again,

When computing `nn_isolation`, return the nearest neighbor of each unit used to compute the isolation score
This is useful for sanity checks.
I don't think this should affect the tests.
Best
