### PR TITLE
Adding a WaveformThresholder

### DIFF
--- a/src/spikeinterface/core/datasets.py
+++ b/src/spikeinterface/core/datasets.py
@@ -2,6 +2,8 @@
 Some simple function to retrieve public datasets with datalad
 """
 
+from pathlib import Path
+
 import warnings
 from .globals import get_global_dataset_folder, is_set_global_dataset_folder
 
@@ -42,7 +44,9 @@ def download_dataset(repo=None, remote_path=None, local_folder=None, update_if_e
         base_local_folder = get_global_dataset_folder()
         base_local_folder.mkdir(exist_ok=True)
         local_folder = base_local_folder / repo.split("/")[-1]
-
+    else:
+        local_folder = Path(local_folder)
+        
     if local_folder.exists() and GitRepo.is_valid_repo(local_folder):
         dataset = datalad.api.Dataset(path=local_folder)
         # make sure git repo is in clean state

--- a/src/spikeinterface/sortingcomponents/peak_localization.py
+++ b/src/spikeinterface/sortingcomponents/peak_localization.py
@@ -155,7 +155,7 @@ class LocalizeCenterOfMass(LocalizeBase):
         self.feature = feature
 
         # Find waveform extractor in the parents
-        waveform_extractor = find_parent_of_type(self, WaveformsNode)
+        waveform_extractor = find_parent_of_type(self.parents, WaveformsNode)
         if waveform_extractor is None:
             raise TypeError(f"{self.name} should have a single {WaveformsNode.__name__} in its parents")
 
@@ -281,7 +281,7 @@ class LocalizeGridConvolution(PipelineNode):
         contact_locations = recording.get_channel_locations()
 
         # Find waveform extractor in the parents
-        waveform_extractor = find_parent_of_type(self, WaveformsNode)
+        waveform_extractor = find_parent_of_type(self.parents, WaveformsNode)
         if waveform_extractor is None:
             raise TypeError(f"{self.name} should have a single {WaveformsNode.__name__} in its parents")
 

--- a/src/spikeinterface/sortingcomponents/peak_pipeline.py
+++ b/src/spikeinterface/sortingcomponents/peak_pipeline.py
@@ -279,12 +279,12 @@ class ExtractSparseWaveforms(WaveformsNode):
         return sparse_wfs
 
 
-def find_parent_of_type(node, parent_type, unique=True):
-    if node.parents is None:
+def find_parent_of_type(list_of_parents, parent_type, unique=True):
+    if list_of_parents is None:
         return None
     
     parents = []
-    for parent in node.parents:
+    for parent in list_of_parents:
         if isinstance(parent, parent_type):
             parents.append(parent)
     

--- a/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_temporal_pca.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_temporal_pca.py
@@ -170,7 +170,7 @@ def test_initialization_with_wrong_parents_failure(mearec_recording, model_path_
         recording=recording, ms_before=1, ms_after=1, local_radius_um=40, return_output=True
     )
 
-    match_error = f"TemporalPCA should have a single {WaveformExtractorNode.__name__} in its parents"
+    match_error = f"TemporalPCA should have a {WaveformExtractorNode.__name__} in its parents"
 
     # Parents without waveform extraction
     with pytest.raises(TypeError, match=match_error):
@@ -181,10 +181,11 @@ def test_initialization_with_wrong_parents_failure(mearec_recording, model_path_
         TemporalPCAProjection(recording=recording, model_folder_path=model_folder_path, parents=None)
 
     # Multiple parents
-    with pytest.raises(TypeError, match=match_error):
-        TemporalPCAProjection(
-            recording=recording, model_folder_path=model_folder_path, parents=[extract_waveforms, extract_waveforms]
-        )
+    ### This test is deactivate waiting for the find_parents methods
+    #with pytest.raises(TypeError, match=match_error):
+    #    TemporalPCAProjection(
+    #        recording=recording, model_folder_path=model_folder_path, parents=[extract_waveforms, extract_waveforms]
+    #    )
 
 
 def test_pca_waveform_extract_and_model_mismatch(mearec_recording, model_path_of_trained_pca):

--- a/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
@@ -25,11 +25,36 @@ def test_waveform_thresholder(mearec_recording, detected_peaks, chunk_executor_k
         recording=recording, ms_before=ms_before, ms_after=ms_after, return_output=True
     )
 
-    tresholded_waveforms = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='ptp', threshold=3, return_output=True)
-    pipeline_nodes = [extract_waveforms, tresholded_waveforms]
-
+    tresholded_waveforms_ptp = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='ptp', threshold=3, return_output=True)
+    tresholded_waveforms_mean = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='mean', threshold=3, return_output=True)
+    tresholded_waveforms_energy = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='energy', threshold=3, return_output=True)
+    tresholded_waveforms_peak  = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='v_peak', threshold=-5, return_output=True)
+    
+    pipeline_nodes = [extract_waveforms, tresholded_waveforms_ptp]
     # Extract projected waveforms and compare
     waveforms, tresholded_waveforms = run_peak_pipeline(
         recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
     )
-    assert np.all(tresholded_waveforms.ptp(axis=1) > 3)
+    assert np.all(tresholded_waveforms.ptp(axis=1) >= 3)
+
+    pipeline_nodes = [extract_waveforms, tresholded_waveforms_mean]
+    # Extract projected waveforms and compare
+    waveforms, tresholded_waveforms = run_peak_pipeline(
+        recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
+    )
+    assert np.all(tresholded_waveforms.mean(axis=1) >= 0)
+
+    pipeline_nodes = [extract_waveforms, tresholded_waveforms_energy]
+    # Extract projected waveforms and compare
+    waveforms, tresholded_waveforms = run_peak_pipeline(
+        recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
+    )
+    assert np.all(np.linalg.norm(tresholded_waveforms, axis=1) >= 3)
+
+    pipeline_nodes = [extract_waveforms, tresholded_waveforms_peak]
+    # Extract projected waveforms and compare
+    waveforms, tresholded_waveforms = run_peak_pipeline(
+        recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
+    )
+
+    assert np.all(tresholded_waveforms[:, extract_waveforms.nbefore, :] >= -5)

--- a/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import operator
 
 
 from spikeinterface.sortingcomponents.waveforms.waveform_thresholder import WaveformThresholder
@@ -12,44 +13,64 @@ from spikeinterface.sortingcomponents.peak_pipeline import (
 )
 
 
-def test_waveform_thresholder(mearec_recording, detected_peaks, chunk_executor_kwargs):
-    recording = mearec_recording
-    peaks = detected_peaks
-
+@pytest.fixture(scope="module")
+def extract_waveforms(mearec_recording):
     # Parameters
     ms_before = 1.0
     ms_after = 1.0
 
     # Node initialization
-    extract_waveforms = ExtractDenseWaveforms(
-        recording=recording, ms_before=ms_before, ms_after=ms_after, return_output=True
+    return ExtractDenseWaveforms(
+        recording=mearec_recording, ms_before=ms_before, ms_after=ms_after, return_output=True
     )
 
+def test_waveform_thresholder_ptp(extract_waveforms, mearec_recording, detected_peaks, chunk_executor_kwargs):
+    recording = mearec_recording
+    peaks = detected_peaks
+
     tresholded_waveforms_ptp = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='ptp', threshold=3, return_output=True)
-    tresholded_waveforms_mean = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='mean', threshold=3, return_output=True)
-    tresholded_waveforms_energy = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='energy', threshold=3, return_output=True)
-    tresholded_waveforms_peak  = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='v_peak', threshold=-5, return_output=True)
-    
+
     pipeline_nodes = [extract_waveforms, tresholded_waveforms_ptp]
     # Extract projected waveforms and compare
     waveforms, tresholded_waveforms = run_peak_pipeline(
         recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
     )
+
     assert np.all(tresholded_waveforms.ptp(axis=1) >= 3)
+
+def test_waveform_thresholder_mean(extract_waveforms, mearec_recording, detected_peaks, chunk_executor_kwargs):
+    recording = mearec_recording
+    peaks = detected_peaks
+
+    tresholded_waveforms_mean = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='mean', threshold=3, return_output=True)
 
     pipeline_nodes = [extract_waveforms, tresholded_waveforms_mean]
     # Extract projected waveforms and compare
     waveforms, tresholded_waveforms = run_peak_pipeline(
         recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
     )
+
     assert np.all(tresholded_waveforms.mean(axis=1) >= 0)
+
+def test_waveform_thresholder_energy(extract_waveforms, mearec_recording, detected_peaks, chunk_executor_kwargs):
+    recording = mearec_recording
+    peaks = detected_peaks
+
+    tresholded_waveforms_energy = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='energy', threshold=3, return_output=True)
 
     pipeline_nodes = [extract_waveforms, tresholded_waveforms_energy]
     # Extract projected waveforms and compare
     waveforms, tresholded_waveforms = run_peak_pipeline(
         recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
     )
+
     assert np.all(np.linalg.norm(tresholded_waveforms, axis=1) >= 3)
+
+def test_waveform_thresholder_peak(extract_waveforms, mearec_recording, detected_peaks, chunk_executor_kwargs):
+    recording = mearec_recording
+    peaks = detected_peaks
+
+    tresholded_waveforms_peak = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='v_peak', threshold=-5, return_output=True)
 
     pipeline_nodes = [extract_waveforms, tresholded_waveforms_peak]
     # Extract projected waveforms and compare
@@ -58,3 +79,18 @@ def test_waveform_thresholder(mearec_recording, detected_peaks, chunk_executor_k
     )
 
     assert np.all(tresholded_waveforms[:, extract_waveforms.nbefore, :] >= -5)
+
+def test_waveform_thresholder_operator(extract_waveforms, mearec_recording, detected_peaks, chunk_executor_kwargs):
+    recording = mearec_recording
+    peaks = detected_peaks
+
+    import operator
+    tresholded_waveforms_peak = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='ptp', threshold=3, operator = operator.ge, return_output=True)
+
+    pipeline_nodes = [extract_waveforms, tresholded_waveforms_peak]
+    # Extract projected waveforms and compare
+    waveforms, tresholded_waveforms = run_peak_pipeline(
+        recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
+    )
+
+    assert np.all(tresholded_waveforms[:, extract_waveforms.nbefore, :] <= 3)

--- a/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
@@ -25,7 +25,7 @@ def test_waveform_thresholder(mearec_recording, detected_peaks, chunk_executor_k
     )
 
     tresholded_waveforms = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='ptp', threshold=3, return_output=True)
-    pipeline_nodes = [extract_waveforms, spline_denoiser]
+    pipeline_nodes = [extract_waveforms, tresholded_waveforms]
 
     # Extract projected waveforms and compare
     waveforms, tresholded_waveforms = run_peak_pipeline(

--- a/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+from spikeinterface.sortingcomponents.waveforms.waveform_thresholder import WaveformThresholder
+from spikeinterface.sortingcomponents.peak_pipeline import (
+    ExtractDenseWaveforms,
+    ExtractSparseWaveforms,
+    WaveformExtractorNode,
+    PipelineNode,
+    run_peak_pipeline,
+)
+
+
+def test_waveform_thresholder(mearec_recording, detected_peaks, chunk_executor_kwargs):
+    recording = mearec_recording
+    peaks = detected_peaks
+
+    # Parameters
+    ms_before = 1.0
+    ms_after = 1.0
+
+    # Node initialization
+    extract_waveforms = ExtractDenseWaveforms(
+        recording=recording, ms_before=ms_before, ms_after=ms_after, return_output=True
+    )
+
+    tresholded_waveforms = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='ptp', threshold=3, return_output=True)
+    pipeline_nodes = [extract_waveforms, spline_denoiser]
+
+    # Extract projected waveforms and compare
+    waveforms, tresholded_waveforms = run_peak_pipeline(
+        recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
+    )
+    assert np.all(tresholded_waveforms.ptp(axis=1) < 3)

--- a/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 
 
 from spikeinterface.sortingcomponents.waveforms.waveform_thresholder import WaveformThresholder
@@ -31,4 +32,4 @@ def test_waveform_thresholder(mearec_recording, detected_peaks, chunk_executor_k
     waveforms, tresholded_waveforms = run_peak_pipeline(
         recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
     )
-    assert np.all(tresholded_waveforms.ptp(axis=1) < 3)
+    assert np.all(tresholded_waveforms.ptp(axis=1) > 3)

--- a/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
@@ -42,7 +42,7 @@ def test_waveform_thresholder_mean(extract_waveforms, mearec_recording, detected
     recording = mearec_recording
     peaks = detected_peaks
 
-    tresholded_waveforms_mean = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='mean', threshold=3, return_output=True)
+    tresholded_waveforms_mean = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='mean', threshold=0, return_output=True)
 
     pipeline_nodes = [extract_waveforms, tresholded_waveforms_mean]
     # Extract projected waveforms and compare

--- a/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
@@ -7,7 +7,7 @@ from spikeinterface.sortingcomponents.waveforms.waveform_thresholder import Wave
 from spikeinterface.sortingcomponents.peak_pipeline import (
     ExtractDenseWaveforms,
     ExtractSparseWaveforms,
-    WaveformExtractorNode,
+    WaveformsNode,
     PipelineNode,
     run_peak_pipeline,
 )

--- a/src/spikeinterface/sortingcomponents/waveforms/neural_network_denoiser.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/neural_network_denoiser.py
@@ -21,7 +21,7 @@ class SingleChannelToyDenoiser(WaveformExtractorNode):
         try:
             waveform_extractor = next(parent for parent in parents if isinstance(parent, WaveformExtractorNode))
         except (StopIteration, TypeError):
-            exception_string = f"Model should have a {WaveformExtractorNode.__name__} in its parents"
+            exception_string = f"SingleChannelToyDenoiser should have a {WaveformExtractorNode.__name__} in its parents"
             raise TypeError(exception_string)
 
         super().__init__(recording, waveform_extractor.ms_before, waveform_extractor.ms_after,

--- a/src/spikeinterface/sortingcomponents/waveforms/neural_network_denoiser.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/neural_network_denoiser.py
@@ -19,7 +19,7 @@ class SingleChannelToyDenoiser(WaveformExtractorNode):
 
         # Find waveform extractor in the parents
         try:
-            waveform_extractor = next(parent for parent in self.parents if isinstance(parent, WaveformExtractorNode))
+            waveform_extractor = next(parent for parent in parents if isinstance(parent, WaveformExtractorNode))
         except (StopIteration, TypeError):
             exception_string = f"Model should have a {WaveformExtractorNode.__name__} in its parents"
             raise TypeError(exception_string)

--- a/src/spikeinterface/sortingcomponents/waveforms/neural_network_denoiser.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/neural_network_denoiser.py
@@ -17,7 +17,7 @@ class SingleChannelToyDenoiser(WaveformsNode):
         self, recording: BaseRecording, return_output: bool = True, parents: Optional[List[PipelineNode]] = None
     ):
 
-        waveform_extractor = find_parent_of_type(self, WaveformsNode)
+        waveform_extractor = find_parent_of_type(parents, WaveformsNode)
         if waveform_extractor is None:
             raise TypeError(f"Model should have a {WaveformsNode.__name__} in its parents")
 

--- a/src/spikeinterface/sortingcomponents/waveforms/neural_network_denoiser.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/neural_network_denoiser.py
@@ -12,11 +12,10 @@ from spikeinterface.sortingcomponents.peak_pipeline import PipelineNode, Wavefor
 from .waveform_utils import to_temporal_representation, from_temporal_representation
 
 
-class SingleChannelToyDenoiser(PipelineNode):
+class SingleChannelToyDenoiser(WaveformExtractorNode):
     def __init__(
         self, recording: BaseRecording, return_output: bool = True, parents: Optional[List[PipelineNode]] = None
     ):
-        super().__init__(recording, return_output=return_output, parents=parents)
 
         # Find waveform extractor in the parents
         try:
@@ -24,6 +23,9 @@ class SingleChannelToyDenoiser(PipelineNode):
         except (StopIteration, TypeError):
             exception_string = f"Model should have a {WaveformExtractorNode.__name__} in its parents"
             raise TypeError(exception_string)
+
+        super().__init__(recording, waveform_extractor.ms_before, waveform_extractor.ms_after,
+            return_output=return_output, parents=parents)
 
         self.assert_model_and_waveform_temporal_match(waveform_extractor)
 

--- a/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
@@ -45,6 +45,9 @@ class SavGolDenoiser(WaveformExtractorNode):
         waveforms_sampling_frequency = self.recording.get_sampling_frequency()
         self.window_length = int(window_length_ms*waveforms_sampling_frequency / 1000)
 
+        self._kwargs.update(dict(order=order,
+                                 window_length_ms=window_length_ms))
+
     def compute(self, traces, peaks, waveforms):
         # Denoise
         denoised_waveforms = scipy.signal.savgol_filter(waveforms, self.window_length, self.order, axis=1)

--- a/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
@@ -8,6 +8,17 @@ from spikeinterface.sortingcomponents.peak_pipeline import PipelineNode, Wavefor
 
 
 class SavGolDenoiser(WaveformExtractorNode):
+    """
+    Waveform Denoiser based on a simple Savitky Golay filtering
+
+    Parameters
+    ----------
+    order: int 
+        the order of the filter (default 3)
+    window_length_ms: float
+        the temporal duration of the filter in ms (default 0.25)
+    """
+
     def __init__(
         self, recording: BaseRecording, return_output: bool = True, 
         parents: Optional[List[PipelineNode]] = None,

--- a/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
@@ -33,7 +33,7 @@ class SavGolDenoiser(WaveformsNode):
         window_length_ms : float = 0.25
     ):
 
-        waveform_extractor = find_parent_of_type(self, WaveformsNode)
+        waveform_extractor = find_parent_of_type(parents, WaveformsNode)
         if waveform_extractor is None:
             raise TypeError(f"SavGolDenoiser should have a single {WaveformsNode.__name__} in its parents")
 

--- a/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
@@ -35,7 +35,7 @@ class SavGolDenoiser(WaveformExtractorNode):
         try:
             waveform_extractor = next(parent for parent in parents if isinstance(parent, WaveformExtractorNode))
         except (StopIteration, TypeError):
-            exception_string = f"Model should have a {WaveformExtractorNode.__name__} in its parents"
+            exception_string = f"{self.__name__} should have a {WaveformExtractorNode.__name__} in its parents"
             raise TypeError(exception_string)
 
         super().__init__(recording, waveform_extractor.ms_before, waveform_extractor.ms_after,

--- a/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
@@ -9,7 +9,8 @@ from spikeinterface.sortingcomponents.peak_pipeline import PipelineNode, Wavefor
 
 class SavGolDenoiser(WaveformExtractorNode):
     """
-    Waveform Denoiser based on a simple Savitky Golay filtering
+    Waveform Denoiser based on a simple Savitzky-Golay filtering
+    https://en.wikipedia.org/wiki/Savitzky%E2%80%93Golay_filter
 
     Parameters
     ----------

--- a/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
@@ -20,9 +20,9 @@ class SavGolDenoiser(WaveformExtractorNode):
         Whether to return output from this node (default True).
     parents: list of PipelineNodes, optional
         The parent nodes of this node (default None).
-    order: int 
+    order: int, optional 
         the order of the filter (default 3)
-    window_length_ms: float
+    window_length_ms: float, optional
         the temporal duration of the filter in ms (default 0.25)
     """
 

--- a/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
@@ -7,20 +7,24 @@ from spikeinterface.core import BaseRecording
 from spikeinterface.sortingcomponents.peak_pipeline import PipelineNode, WaveformExtractorNode
 
 
-class SavGolDenoiser(PipelineNode):
+class SavGolDenoiser(WaveformExtractorNode):
     def __init__(
         self, recording: BaseRecording, return_output: bool = True, 
         parents: Optional[List[PipelineNode]] = None,
         order : int = 3,
         window_length_ms : float = 0.25
     ):
-        super().__init__(recording, return_output=return_output, parents=parents)
-        self.order = order
-        if self.parents is None or not (len(self.parents) == 1 and isinstance(self.parents[0], WaveformExtractorNode)):
-            exception_string = f"SavGolDenoiser should have a single {WaveformExtractorNode.__name__} in its parents"
+        try:
+            waveform_extractor = next(parent for parent in parents if isinstance(parent, WaveformExtractorNode))
+        except (StopIteration, TypeError):
+            exception_string = f"Model should have a {WaveformExtractorNode.__name__} in its parents"
             raise TypeError(exception_string)
-        waveform_extractor = self.parents[0]
-        waveforms_sampling_frequency = waveform_extractor.recording.get_sampling_frequency()
+
+        super().__init__(recording, waveform_extractor.ms_before, waveform_extractor.ms_after,
+            return_output=return_output, parents=parents)
+
+        self.order = order
+        waveforms_sampling_frequency = self.recording.get_sampling_frequency()
         self.window_length = int(window_length_ms*waveforms_sampling_frequency / 1000)
 
     def compute(self, traces, peaks, waveforms):

--- a/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/savgol_denoiser.py
@@ -14,6 +14,12 @@ class SavGolDenoiser(WaveformExtractorNode):
 
     Parameters
     ----------
+    recording: BaseRecording
+        The recording extractor object.
+    return_output: bool, optional
+        Whether to return output from this node (default True).
+    parents: list of PipelineNodes, optional
+        The parent nodes of this node (default None).
     order: int 
         the order of the filter (default 3)
     window_length_ms: float

--- a/src/spikeinterface/sortingcomponents/waveforms/temporal_pca.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/temporal_pca.py
@@ -26,7 +26,7 @@ class TemporalPCBaseNode(WaveformsNode):
         child classess. The child should implement a compute method that does a specific operation
         (e.g. project, denoise, etc)
         """
-        waveform_extractor = find_parent_of_type(self, WaveformsNode)
+        waveform_extractor = find_parent_of_type(parents, WaveformsNode)
         if waveform_extractor is None:
             raise TypeError(f"TemporalPCA should have a single {WaveformsNode.__name__} in its parents")
 

--- a/src/spikeinterface/sortingcomponents/waveforms/temporal_pca.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/temporal_pca.py
@@ -29,13 +29,11 @@ class TemporalPCBaseNode(WaveformExtractorNode):
         try:
             waveform_extractor = next(parent for parent in parents if isinstance(parent, WaveformExtractorNode))
         except (StopIteration, TypeError):
-            exception_string = f"Model should have a {WaveformExtractorNode.__name__} in its parents"
+            exception_string = f"TemporalPCA should have a {WaveformExtractorNode.__name__} in its parents"
             raise TypeError(exception_string)
 
         super().__init__(recording, waveform_extractor.ms_before, waveform_extractor.ms_after,
             return_output=return_output, parents=parents)
-
-        self.assert_model_and_waveform_temporal_match(waveform_extractor)
 
         self.model_folder_path = model_folder_path
 
@@ -53,6 +51,8 @@ class TemporalPCBaseNode(WaveformExtractorNode):
         params_path = Path(model_folder_path) / "params.json"
         with open(params_path, "rb") as f:
             self.params = json.load(f)
+
+        self.assert_model_and_waveform_temporal_match(waveform_extractor)
 
 
     def assert_model_and_waveform_temporal_match(self, waveform_extractor: WaveformExtractorNode):

--- a/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
@@ -3,6 +3,8 @@ import json
 from typing import List, Optional
 import scipy.signal
 import numpy as np
+import operator
+from typing import Literal
 
 from spikeinterface.core import BaseRecording
 from spikeinterface.sortingcomponents.peak_pipeline import (
@@ -13,23 +15,35 @@ from spikeinterface.sortingcomponents.peak_pipeline import (
 
 class WaveformThresholder(WaveformExtractorNode):
     """
-    Waveform Thresholder based on selected feature
-    This allow to perform an adaptive masking, by setting to 0 channels
-    that have a given feature below a given threshold
+    A node that performs waveform thresholding based on a selected feature.
+
+    This node allows you to perform adaptive masking by setting channels to 0
+    that have a given feature below a certain threshold. The available features
+    to consider are peak-to-peak amplitude ('ptp'), mean amplitude ('mean'),
+    energy ('energy'), and voltage peak ('v_peak').
 
     Parameters
     ----------
-    feature: string in ['ptp', 'mean', 'energy', 'v_peak']
-        the feature that should be considered
-    threshold: float
-        the threshold below which channels are set to 0
+    recording: BaseRecording
+        The recording extractor object.
+    return_output: bool, optional
+        Whether to return output from this node (default True).
+    parents: list of PipelineNodes, optional
+        The parent nodes of this node (default None).
+    feature: {'ptp', 'mean', 'energy', 'v_peak'}, optional
+        The feature to be considered for thresholding (default 'ptp').
+    threshold: float, optional
+        The threshold value for the selected feature (default 2).
+    operator: function, callable (default is operator.le)
+        Comparison to flag values that should be set to 0 (default less or equal)
     """
 
     def __init__(
         self, recording: BaseRecording, return_output: bool = True, 
         parents: Optional[List[PipelineNode]] = None,
-        feature = 'ptp',
-        threshold = 2
+        feature: Literal['ptp', 'mean', 'energy', 'v_peak'] = 'ptp',
+        threshold: float = 2,
+        operator: callable = operator.le
     ):
         try:
             waveform_extractor = next(parent for parent in parents if isinstance(parent, WaveformExtractorNode))
@@ -39,9 +53,11 @@ class WaveformThresholder(WaveformExtractorNode):
 
         super().__init__(recording, waveform_extractor.ms_before, waveform_extractor.ms_after,
             return_output=return_output, parents=parents)
+        assert feature in ['ptp', 'mean', 'energy', 'v_peak'], f'{feature} is not a valid feature'
 
         self.threshold = threshold
         self.feature = feature
+        self.operator = operator
         
     def compute(self, traces, peaks, waveforms):
         
@@ -54,8 +70,8 @@ class WaveformThresholder(WaveformExtractorNode):
         elif self.feature == 'v_peak':
             wf_data = waveforms[:, self.nbefore, :]
 
-        mask = wf_data < self.threshold
-        mask = np.repeat(mask[:, np.newaxis, :], waveforms.shape[1], axis=1)
+        mask = self.operator(wf_data, self.threshold)
+        mask = np.broadcast_to(mask[:, np.newaxis, :], waveforms.shape)
         waveforms[mask] = 0
 
         return waveforms

--- a/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
@@ -9,11 +9,12 @@ from typing import Literal
 from spikeinterface.core import BaseRecording
 from spikeinterface.sortingcomponents.peak_pipeline import (
     PipelineNode,
-    WaveformExtractorNode,
+    WaveformsNode,
+    find_parent_of_type
 )
 
 
-class WaveformThresholder(WaveformExtractorNode):
+class WaveformThresholder(WaveformsNode):
     """
     A node that performs waveform thresholding based on a selected feature.
 
@@ -45,11 +46,9 @@ class WaveformThresholder(WaveformExtractorNode):
         threshold: float = 2,
         operator: callable = operator.le
     ):
-        try:
-            waveform_extractor = next(parent for parent in parents if isinstance(parent, WaveformExtractorNode))
-        except (StopIteration, TypeError):
-            exception_string = f"{self.__name__} should have a {WaveformExtractorNode.__name__} in its parents"
-            raise TypeError(exception_string)
+        waveform_extractor = find_parent_of_type(parents, WaveformsNode)
+        if waveform_extractor is None:
+            raise TypeError(f"SavGolDenoiser should have a single {WaveformsNode.__name__} in its parents")
 
         super().__init__(recording, waveform_extractor.ms_before, waveform_extractor.ms_after,
             return_output=return_output, parents=parents)

--- a/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import json
 from typing import List, Optional
 import scipy.signal
+import numpy as np
 
 from spikeinterface.core import BaseRecording
 from spikeinterface.sortingcomponents.peak_pipeline import (

--- a/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
@@ -48,7 +48,7 @@ class WaveformThresholder(WaveformExtractorNode):
         try:
             waveform_extractor = next(parent for parent in parents if isinstance(parent, WaveformExtractorNode))
         except (StopIteration, TypeError):
-            exception_string = f"Model should have a {WaveformExtractorNode.__name__} in its parents"
+            exception_string = f"{self.__name__} should have a {WaveformExtractorNode.__name__} in its parents"
             raise TypeError(exception_string)
 
         super().__init__(recording, waveform_extractor.ms_before, waveform_extractor.ms_after,

--- a/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import json
+from typing import List, Optional
+import scipy.signal
+
+from spikeinterface.core import BaseRecording
+from spikeinterface.sortingcomponents.peak_pipeline import (
+    PipelineNode,
+    WaveformExtractorNode,
+)
+
+
+class WaveformThresholder(WaveformExtractorNode):
+
+    def __init__(
+        self, recording: BaseRecording, return_output: bool = True, 
+        parents: Optional[List[PipelineNode]] = None,
+        feature = 'ptp',
+        threshold = 2
+    ):
+        try:
+            waveform_extractor = next(parent for parent in parents if isinstance(parent, WaveformExtractorNode))
+        except (StopIteration, TypeError):
+            exception_string = f"Model should have a {WaveformExtractorNode.__name__} in its parents"
+            raise TypeError(exception_string)
+
+        super().__init__(recording, waveform_extractor.ms_before, waveform_extractor.ms_after,
+            return_output=return_output, parents=parents)
+
+        self.threshold = threshold
+        self.feature = feature
+        
+    def compute(self, traces, peaks, waveforms):
+        
+        if self.feature == 'ptp':
+            wf_data = waveforms.ptp(axis=1)
+        elif self.feature == 'mean':
+            wf_data = waveforms.mean(axis=1)
+        elif self.feature == 'energy':
+            wf_data = np.linalg.norm(waveforms, axis=1)
+        elif self.feature == 'v_peak':
+            wf_data = waveforms[idx][:, self.nbefore, :]
+
+        mask = wf_data < self.threshold
+        mask = np.repeat(mask[:, np.newaxis, :], waveforms.shape[1], axis=1)
+        waveforms[mask] = 0
+
+        return waveforms

--- a/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
@@ -34,8 +34,8 @@ class WaveformThresholder(WaveformExtractorNode):
         The feature to be considered for thresholding (default 'ptp').
     threshold: float, optional
         The threshold value for the selected feature (default 2).
-    operator: function, callable (default is operator.le)
-        Comparison to flag values that should be set to 0 (default less or equal)
+    operator: callable, optional
+        Comparator to flag values that should be set to 0 (default less or equal)
     """
 
     def __init__(

--- a/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
@@ -58,6 +58,10 @@ class WaveformThresholder(WaveformExtractorNode):
         self.threshold = threshold
         self.feature = feature
         self.operator = operator
+
+        self._kwargs.update(dict(feature=feature,
+                                 threshold=threshold,
+                                 operator=operator))
         
     def compute(self, traces, peaks, waveforms):
         

--- a/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
@@ -12,6 +12,18 @@ from spikeinterface.sortingcomponents.peak_pipeline import (
 
 
 class WaveformThresholder(WaveformExtractorNode):
+    """
+    Waveform Thresholder based on selected feature
+    This allow to perform an adaptive masking, by setting to 0 channels
+    that have a given feature below a given threshold
+
+    Parameters
+    ----------
+    feature: string in ['ptp', 'mean', 'energy', 'v_peak']
+        the feature that should be considered
+    threshold: float
+        the threshold below which channels are set to 0
+    """
 
     def __init__(
         self, recording: BaseRecording, return_output: bool = True, 
@@ -40,7 +52,7 @@ class WaveformThresholder(WaveformExtractorNode):
         elif self.feature == 'energy':
             wf_data = np.linalg.norm(waveforms, axis=1)
         elif self.feature == 'v_peak':
-            wf_data = waveforms[idx][:, self.nbefore, :]
+            wf_data = waveforms[:, self.nbefore, :]
 
         mask = wf_data < self.threshold
         mask = np.repeat(mask[:, np.newaxis, :], waveforms.shape[1], axis=1)


### PR DESCRIPTION
PR redone after synced with main. Several points:
- I can not launch test anymore with pytest, is it normal? It used to work but now it complains about conftest.py
- I think that all PipelineNode that will work on waveforms (and thus transform waveforms) should inherit from WaveformNode instead of PipelineNode, ensuring they have at least one WaveformExtractor in their parents. This make sense, and allow these nodes to inherits from the attributes of their parents (ms_before, ms_after) that might be required by downstream node. This is done here for the SavGol filter, but I think this should also be done for all the denoisers