### PR TITLE
Fixed wrong inter_sample_shift for NP1.0 AP channels

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/spikeglx.py
+++ b/src/spikeinterface/extractors/neoextractors/spikeglx.py
@@ -76,14 +76,16 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
 
             if ptype in [21, 24]: # NP2.0
                 num_channels_per_adc = 16
+                num_cycles_in_adc = 16  # TODO: Check this.
                 total_channels = 384
             else: # NP1.0
                 num_channels_per_adc = 12
+                num_cycles_in_adc = 13 if "ap" in self.stream_id else 12
                 total_channels = 384
             
             # sample_shifts is generated from total channels (384) channels
             # when only some channels are saved we need to slice this vector (like we do for the probe)
-            sample_shifts = get_neuropixels_sample_shifts(total_channels, num_channels_per_adc)
+            sample_shifts = get_neuropixels_sample_shifts(total_channels, num_channels_per_adc, num_cycles_in_adc)
             if self.get_num_channels() != total_channels:
                 # need slice because not all channel are saved
                 chans = pi.get_saved_channel_indices_from_spikeglx_meta(meta_filename)

--- a/src/spikeinterface/extractors/neuropixels_utils.py
+++ b/src/spikeinterface/extractors/neuropixels_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def get_neuropixels_sample_shifts(num_channels=384, num_channels_per_adc=12):
+def get_neuropixels_sample_shifts(num_channels=384, num_channels_per_adc=12, num_cycles=None):
     """
     Calculates the relative sampling phase of each channel that results
     from Neuropixels ADC multiplexing.
@@ -22,12 +22,18 @@ def get_neuropixels_sample_shifts(num_channels=384, num_channels_per_adc=12):
         The number of channels per ADC on the probe.
         Neuropixels 1.0 probes have 12 ADCs.
         Neuropixels 2.0 probes have 16 ADCs.
+    num_cycles: int or None, default: None
+        The number of cycles in the ADC on the probe.
+        Neuropixels 1.0 probes have 13 cycles for AP and 12 for LFP.
+        Neuropixels 2.0 probes have 16 cycles?? (TODO: check).
 
     Returns
     -------
     sample_shifts : ndarray
         The relative phase (from 0-1) of each channel
     """
+    if num_cycles is None:
+        num_cycles = num_channels_per_adc
 
     adc_indices = np.floor(np.arange(num_channels) /
                            (num_channels_per_adc * 2)) * 2 + np.mod(np.arange(num_channels), 2)
@@ -35,7 +41,7 @@ def get_neuropixels_sample_shifts(num_channels=384, num_channels_per_adc=12):
     sample_shifts = np.zeros_like(adc_indices)
 
     for a in adc_indices:
-        sample_shifts[adc_indices == a] = np.arange(num_channels_per_adc) / num_channels_per_adc
+        sample_shifts[adc_indices == a] = np.arange(num_channels_per_adc) / num_cycles
 
     return sample_shifts
 


### PR DESCRIPTION
Fixed a bug where the number of cycles per adc is not equal to the number of channels per adc in NP1.0 AP channels (13 vs 12).