### PR TITLE
Add silhouette score quality metric

### DIFF
--- a/doc/modules/qualitymetrics/references.rst
+++ b/doc/modules/qualitymetrics/references.rst
@@ -9,6 +9,8 @@ References
 
 .. [Hill] Hill, Daniel N., Samar B. Mehta, and David Kleinfeld. “Quality Metrics to Accompany Spike Sorting of Extracellular Signals.” The Journal of neuroscience 31.24 (2011): 8699–8705. Web.
 
+.. [Hruschka] Hruscha, E.R., de Castro, L.N., Campello R.J.G.B. "Evolutionary algorithms for clustering gene-expression data." Fourth IEEE International Conference on Data Mining (ICDM'04) 2004, pp 403-406.
+
 .. [IBL] International Brain Laboratory. “Spike sorting pipeline for the International Brain Laboratory”. 4 May 2022.
 
 .. [Jackson] Jadin Jackson, Neil Schmitzer-Torbert, K.D. Harris, and A.D. Redish. Quantitative assessment of extracellular multichannel recording quality using measures of cluster separation. Soc Neurosci Abstr, 518, 01 2005.

--- a/doc/modules/qualitymetrics/references.rst
+++ b/doc/modules/qualitymetrics/references.rst
@@ -9,7 +9,7 @@ References
 
 .. [Hill] Hill, Daniel N., Samar B. Mehta, and David Kleinfeld. “Quality Metrics to Accompany Spike Sorting of Extracellular Signals.” The Journal of neuroscience 31.24 (2011): 8699–8705. Web.
 
-.. [Hruschka] Hruscha, E.R., de Castro, L.N., Campello R.J.G.B. "Evolutionary algorithms for clustering gene-expression data." Fourth IEEE International Conference on Data Mining (ICDM'04) 2004, pp 403-406.
+.. [Hruschka] Hruschka, E.R., de Castro, L.N., Campello R.J.G.B. "Evolutionary algorithms for clustering gene-expression data." Fourth IEEE International Conference on Data Mining (ICDM'04) 2004, pp 403-406.
 
 .. [IBL] International Brain Laboratory. “Spike sorting pipeline for the International Brain Laboratory”. 4 May 2022.
 

--- a/doc/modules/qualitymetrics/silhouette_score.rst
+++ b/doc/modules/qualitymetrics/silhouette_score.rst
@@ -1,5 +1,5 @@
-Silhouette score (silhouette_score, simplified_silhouette_score)
-============================================
+Silhouette score (:code:`silhouette`, :code:`silhouette_full`)
+==============================================================
 
 Calculation
 -----------
@@ -8,7 +8,7 @@ Gives the ratio between the cohesiveness of a cluster and its separation from ot
 Values for silhouette score range from -1 to 1. 
 
 For the full method as proposed by [Rouseeuw]_, the pairwise distances between each point 
-and every other point :math:`a(i)` in a cluster :math:`C_i` and then iterating through 
+and every other point :math:`a(i)` in a cluster :math:`C_i` are calculated and then iterating through 
 every other cluster's distances between the points in :math:`C_i` and the points in :math:`C_j` 
 are calculated. The cluster with the minimal mean distance is taken to be :math:`b(i)`. The
 average value of :math:`s(i)` is taken to give the final silhouette score for a cluster with
@@ -46,7 +46,7 @@ SpikeInterface provides access to both implementations of silhouette score.
 
 To reduce complexity the default implementation in SpikeInterface is to use the simplified silhouette score.
 This can be changes by switching the silhouette method to either 'full' (the Rousseeuw implementation) or
-('simplified', 'full') for both methods.
+('simplified', 'full') for both methods when entering the qm_params parameter.
 
 
 Literature

--- a/doc/modules/qualitymetrics/silhouette_score.rst
+++ b/doc/modules/qualitymetrics/silhouette_score.rst
@@ -1,11 +1,21 @@
-Silhouette score (not currently implemented)
+Silhouette score
 ============================================
 
 Calculation
 -----------
 
 Gives the ratio between the cohesiveness of a cluster and its separation from other clusters.
-Values for silhouette score range from -1 to 1.
+Values for silhouette score range from -1 to 1. First the pairwise distances between each
+point and every other point :math:`a(i)` in a cluster :math:`C_i` and then iterating through 
+every other cluster distances between the points in :math:`C_i` and the points in :math:`C_j` 
+are calculated. The cluster with the minimal mean distance is taken to be :math:`b(i)`. The
+average value of :math:`s(i)` is taken to give the final silhouette score for a cluster.
+
+.. math::
+    a(i) = \frac{1}{C_i-1} \sum_{j \in C_i, j \neq i} d(i,j)
+    b(i) = \min {J \neq I} \frac{1}{C_j} \sum_{j \in C_j} d(i, j)
+    s(i) = \frac{a(i)-b(i)}{\max(a(i), b(i))}
+    Silhouette Score = \frac{1}{N} \sum^{N} s(i)
 
 Expectation and use
 -------------------

--- a/doc/modules/qualitymetrics/silhouette_score.rst
+++ b/doc/modules/qualitymetrics/silhouette_score.rst
@@ -5,15 +5,29 @@ Calculation
 -----------
 
 Gives the ratio between the cohesiveness of a cluster and its separation from other clusters.
-Values for silhouette score range from -1 to 1. First the pairwise distances between each
-point and every other point :math:`a(i)` in a cluster :math:`C_i` and then iterating through 
-every other cluster distances between the points in :math:`C_i` and the points in :math:`C_j` 
+Values for silhouette score range from -1 to 1. 
+
+For the full method as proposed by [Rouseeuw]_, the pairwise distances between each point 
+and every other point :math:`a(i)` in a cluster :math:`C_i` and then iterating through 
+every other cluster's distances between the points in :math:`C_i` and the points in :math:`C_j` 
 are calculated. The cluster with the minimal mean distance is taken to be :math:`b(i)`. The
-average value of :math:`s(i)` is taken to give the final silhouette score for a cluster.
+average value of :math:`s(i)` is taken to give the final silhouette score for a cluster with
+the following equations:
 
 .. math::
     a(i) = \frac{1}{C_i-1} \sum_{j \in C_i, j \neq i} d(i,j)
     b(i) = \min {J \neq I} \frac{1}{C_j} \sum_{j \in C_j} d(i, j)
+    s(i) = \frac{a(i)-b(i)}{\max(a(i), b(i))}
+    Silhouette Score = \frac{1}{N} \sum^{N} s(i)
+
+In order to improve computational complexity an alternative approach was proposed by [Hruschka]_
+in which rather than pairwise point calculations, centroids of clusters are used. Thus :math:`a(i)`
+is determined by distances from each point :math:`i` to the centroid of :math:`C_I` given as 
+:math:`mu_{C_I}`, which means the calculations are simplified as follows:
+
+.. math::
+    a(i) = d(i, \mu_{C_I})
+    b(i) = \min {C_J \neq C_I}  d(i, \mu_{C_J})
     s(i) = \frac{a(i)-b(i)}{\max(a(i), b(i))}
     Silhouette Score = \frac{1}{N} \sum^{N} s(i)
 
@@ -22,9 +36,15 @@ Expectation and use
 
 A good clustering with well separated and compact clusters will have a silhouette score close to 1.
 A low silhouette score (close to -1) indicates a poorly isolated cluster (both type I and type II error).
+SpikeInterface provides access to both implementations of silhouette score.
+
+To reduce complexity the default implementation in SpikeInterface is to use the simplified silhouette score.
+This can be changes by switching the silhouette method to either 'full' (the Rousseeuw implementation) or
+('simplified', 'full') for both methods.
 
 
 Literature
 ----------
 
-Introduced by [Rousseeuw]_.
+Full method introduced by [Rousseeuw]_.
+Simplified method introduced by [Hruschka]_.

--- a/doc/modules/qualitymetrics/silhouette_score.rst
+++ b/doc/modules/qualitymetrics/silhouette_score.rst
@@ -1,4 +1,4 @@
-Silhouette score
+Silhouette score (silhouette_score, simplified_silhouette_score)
 ============================================
 
 Calculation
@@ -16,8 +16,11 @@ the following equations:
 
 .. math::
     a(i) = \frac{1}{C_i-1} \sum_{j \in C_i, j \neq i} d(i,j)
+    
     b(i) = \min {J \neq I} \frac{1}{C_j} \sum_{j \in C_j} d(i, j)
+    
     s(i) = \frac{a(i)-b(i)}{\max(a(i), b(i))}
+    
     Silhouette Score = \frac{1}{N} \sum^{N} s(i)
 
 In order to improve computational complexity an alternative approach was proposed by [Hruschka]_
@@ -27,8 +30,11 @@ is determined by distances from each point :math:`i` to the centroid of :math:`C
 
 .. math::
     a(i) = d(i, \mu_{C_I})
+    
     b(i) = \min {C_J \neq C_I}  d(i, \mu_{C_J})
+    
     s(i) = \frac{a(i)-b(i)}{\max(a(i), b(i))}
+    
     Silhouette Score = \frac{1}{N} \sum^{N} s(i)
 
 Expectation and use

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -28,7 +28,7 @@ from ..postprocessing import WaveformPrincipalComponent
 
 
 _possible_pc_metric_names = ['isolation_distance', 'l_ratio', 'd_prime',
-                             'nearest_neighbor', 'nn_isolation', 'nn_noise_overlap', 'silhouette_score', 'simplified_silhouette_score']
+                             'nearest_neighbor', 'nn_isolation', 'nn_noise_overlap', 'silhouette']
 
 
 _default_params = dict(
@@ -53,7 +53,10 @@ _default_params = dict(
         n_components=10,
         radius_um=100,
         peak_sign='neg'
-    )
+    ),
+    silhouette=dict(
+        method='simplified'
+  )
 )
 
 
@@ -730,7 +733,8 @@ def simplified_silhouette_score(all_pcs, all_labels, this_unit_id):
 
 def silhouette_score(all_pcs, all_labels, this_unit_id):
     """Calculates the silhouette score which is a marker of cluster quality ranging from
-    -1 (bad clustering) to 1 (good clustering).
+    -1 (bad clustering) to 1 (good clustering). Distances are all calculated as pairwise
+    comparisons of all data points.
     Parameters
     ----------
     all_pcs : 2d array
@@ -899,18 +903,19 @@ def pca_metrics_one_unit(pcs_flat, labels, metric_names, unit_id,
             nn_noise_overlap = np.nan
         pc_metrics['nn_noise_overlap'] = nn_noise_overlap
         
-    if 'silhouette_score' in metric_names:
-        try:
-            unit_silhouette_score = silhouette_score(pcs_flat, labels, unit_id)
-        except:
-            unit_silhouette_score = np.nan
-        pc_metrics['silhouette_score'] = unit_silhouette_score
-        
-    if 'simplified_silhouette_score' in metric_names:
-        try:
-            unit_silhouette_score = simplified_silhouette_score(pcs_flat, labels, unit_id)
-        except:
-            unit_silhouette_score = np.nan
-        pc_metrics['simplified_silhouette_score'] = unit_silhouette_score
-
+    if 'silhouette' in metric_names:
+        silhouette_method = qm_params['silhouette']['method']
+        if 'simplified' in silhouette_method:
+            try:
+                unit_silhouette_score = simplified_silhouette_score(pcs_flat, labels, unit_id)
+            except:
+                unit_silhouette_score = np.nan
+            pc_metrics['silhouette'] = unit_silhouette_score
+        if 'full' in silhouette_method:
+            try:
+                unit_silhouette_score = silhouette_score(pcs_flat, labels, unit_id)
+            except:
+                unit_silhouette_score = np.nan
+            pc_metrics['silhouette_full'] = unit_silhouette_socre
+  
     return pc_metrics

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -899,14 +899,14 @@ def pca_metrics_one_unit(pcs_flat, labels, metric_names, unit_id,
             nn_noise_overlap = np.nan
         pc_metrics['nn_noise_overlap'] = nn_noise_overlap
         
-    if 'silhouette_score' in metrics_names:
+    if 'silhouette_score' in metric_names:
         try:
             unit_silhouette_score = silhouette_score(pcs_flat, labels, unit_id)
         except:
             unit_silhouette_score = np.nan
         pc_metrics['silhouette_score'] = unit_silhouette_score
         
-    if 'simplified_silhouette_score' in metrics_name:
+    if 'simplified_silhouette_score' in metric_names:
         try:
             unit_silhouette_score = simplified_silhouette_score(pcs_flat, labels, unit_id)
         except:

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -55,7 +55,7 @@ _default_params = dict(
         peak_sign='neg'
     ),
     silhouette=dict(
-        method='simplified'
+        method=('simplified',)
   )
 )
 
@@ -682,6 +682,8 @@ def nearest_neighbors_noise_overlap(waveform_extractor: WaveformExtractor, this_
                                                   n_neighbors)
 
         return nn_noise_overlap
+      
+      
 def simplified_silhouette_score(all_pcs, all_labels, this_unit_id):
     """Calculates the simplified silhouette score for each cluster. The value ranges
     from -1 (bad clustering) to 1 (good clustering). The simplified silhoutte score
@@ -731,6 +733,7 @@ def simplified_silhouette_score(all_pcs, all_labels, this_unit_id):
     unit_silhouette_score = np.mean(sil_distances)
     return unit_silhouette_score
 
+  
 def silhouette_score(all_pcs, all_labels, this_unit_id):
     """Calculates the silhouette score which is a marker of cluster quality ranging from
     -1 (bad clustering) to 1 (good clustering). Distances are all calculated as pairwise

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -684,15 +684,16 @@ def simplified_silhouette_score(all_pcs, all_labels, this_unit_id):
     # find centroid of other cluster and measure distances to that rather than pairwise
     # if less than current minimum distance update
     for label in np.unique(all_labels):
-        pcs_for_other_cluster = all_pcs[all_labels == label, :]
-        centroid_for_other_cluster = np.expand_dims(
-            np.mean(pcs_for_other_cluster, 0), 0
-        )
-        distances_for_other_cluster = scipy.spatial.distance.cdist(
+        if label != this_unit_id
+            pcs_for_other_cluster = all_pcs[all_labels == label, :]
+            centroid_for_other_cluster = np.expand_dims(np.mean(pcs_for_other_cluster, 0), 0)
+            distances_for_other_cluster = scipy.spatial.distance.cdist(
             centroid_for_other_cluster, pcs_for_this_unit
-        )
-        if np.mean(distances_for_other_cluster) < distance:
-            distances_for_minimum_cluster = distances_for_other_cluster
+            )
+            mean_distance_for_other_cluster = np.mean(distances_for_other_cluster)
+            if mean_distance_for_other_cluster < distance:
+                distance = mean_distance_for_other_cluster
+                distances_for_minimum_cluster = distances_for_other_cluster
 
     sil_distances = (
         distances_for_minimum_cluster - distances_for_this_unit
@@ -730,12 +731,15 @@ def silhouette_score(all_pcs, all_labels, this_unit_id):
     # iterate through all other clusters and do pairwise distance comparisons
     # if current cluster distances < current mimimum update
     for label in np.unique(all_labels):
-        pcs_for_other_cluster = all_pcs[all_labels == label, :]
-        distances_for_other_cluster = scipy.spatial.distance.cdist(
+        if label != this_unit_id: 
+            pcs_for_other_cluster = all_pcs[all_labels == label, :]
+            distances_for_other_cluster = scipy.spatial.distance.cdist(
             pcs_for_other_cluster, pcs_for_this_unit
-        )
-        if np.mean(distances_for_other_cluster) < distance:
-            distances_for_minimum_cluster = distances_for_other_cluster
+            )
+            mean_distance_for_other_cluster = np.mean(distances_for_other_cluster)
+            if mean_distance_for_other_cluster < distance:
+                distance = mean_distance_for_other_cluster
+                distances_for_minimum_cluster = distances_for_other_cluster
 
     sil_distances = (
         distances_for_minimum_cluster - distances_for_this_unit

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -28,7 +28,7 @@ from ..postprocessing import WaveformPrincipalComponent
 
 
 _possible_pc_metric_names = ['isolation_distance', 'l_ratio', 'd_prime',
-                             'nearest_neighbor', 'nn_isolation', 'nn_noise_overlap']
+                             'nearest_neighbor', 'nn_isolation', 'nn_noise_overlap', 'silhouette_score', 'simplified_silhouette_score']
 
 
 _default_params = dict(
@@ -653,6 +653,96 @@ def nearest_neighbors_noise_overlap(waveform_extractor: WaveformExtractor, this_
                                                   n_neighbors)
 
         return nn_noise_overlap
+def simplified_silhouette_score(all_pcs, all_labels, this_unit_id):
+    """Calculates the simplified silhouette score for each cluster. The value ranges
+    from -1 (bad clustering) to 1 (good clustering). The simplified silhoutte score
+    utilizes the centroids for distance calculations rather than pairwise calculations.
+    Parameters
+    ----------
+    all_pcs : 2d array
+        The PCs for all spikes, organized as [num_spikes, PCs].
+    all_labels : 1d array
+        The cluster labels for all spikes. Must have length of number of spikes.
+    this_unit_id : int
+        The ID for the unit to calculate this metric for.
+    Returns
+    -------
+    unit_silhouette_score : float
+        Simplified Silhouette Score for this unit
+    References
+    ------------
+    Based on simplified silhouette score suggested by [Hruschka]_
+    """
+
+    pcs_for_this_unit = all_pcs[all_labels == this_unit_id, :]
+    centroid_for_this_unit = np.expand_dims(np.mean(pcs_for_this_unit, 0), 0)
+    distances_for_this_unit = scipy.spatial.distance.cdist(
+        centroid_for_this_unit, pcs_for_this_unit
+    )
+    distance = np.inf
+
+    # find centroid of other cluster and measure distances to that rather than pairwise
+    # if less than current minimum distance update
+    for label in np.unique(all_labels):
+        pcs_for_other_cluster = all_pcs[all_labels == label, :]
+        centroid_for_other_cluster = np.expand_dims(
+            np.mean(pcs_for_other_cluster, 0), 0
+        )
+        distances_for_other_cluster = scipy.spatial.distance.cdist(
+            centroid_for_other_cluster, pcs_for_this_unit
+        )
+        if np.mean(distances_for_other_cluster) < distance:
+            distances_for_minimum_cluster = distances_for_other_cluster
+
+    sil_distances = (
+        distances_for_minimum_cluster - distances_for_this_unit
+    ) / np.maximum(distances_for_minimum_cluster , distances_for_this_unit)
+
+    unit_silhouette_score = np.mean(sil_distances)
+    return unit_silhouette_score
+
+def silhouette_score(all_pcs, all_labels, this_unit_id):
+    """Calculates the silhouette score which is a marker of cluster quality ranging from
+    -1 (bad clustering) to 1 (good clustering).
+    Parameters
+    ----------
+    all_pcs : 2d array
+        The PCs for all spikes, organized as [num_spikes, PCs].
+    all_labels : 1d array
+        The cluster labels for all spikes. Must have length of number of spikes.
+    this_unit_id : int
+        The ID for the unit to calculate this metric for.
+    Returns
+    -------
+    unit_silhouette_score : float
+        Silhouette Score for this unit
+    References
+    ------------
+    Based on [Rousseeuw]_
+    """
+
+    pcs_for_this_unit = all_pcs[all_labels == this_unit_id, :]
+    distances_for_this_unit = scipy.spatial.distance.cdist(
+        pcs_for_this_unit, pcs_for_this_unit
+    )
+    distance = np.inf
+
+    # iterate through all other clusters and do pairwise distance comparisons
+    # if current cluster distances < current mimimum update
+    for label in np.unique(all_labels):
+        pcs_for_other_cluster = all_pcs[all_labels == label, :]
+        distances_for_other_cluster = scipy.spatial.distance.cdist(
+            pcs_for_other_cluster, pcs_for_this_unit
+        )
+        if np.mean(distances_for_other_cluster) < distance:
+            distances_for_minimum_cluster = distances_for_other_cluster
+
+    sil_distances = (
+        distances_for_minimum_cluster - distances_for_this_unit
+    ) / np.maximum(distances_for_minimum_cluster , distances_for_this_unit)
+
+    unit_silhouette_score = np.mean(sil_distances)
+    return unit_silhouette_score
 
 
 def _subtract_clip_component(clip1, component):
@@ -770,5 +860,19 @@ def pca_metrics_one_unit(pcs_flat, labels, metric_names, unit_id,
         except:
             nn_noise_overlap = np.nan
         pc_metrics['nn_noise_overlap'] = nn_noise_overlap
+        
+    if 'silhouette_score' in metrics_names:
+        try:
+            unit_silhouette_score = silhouette_score(pcs_flat, labels, unit_id)
+        except:
+            unit_silhouette_score = np.nan
+        pc_metrics['silhouette_score'] = unit_silhouette_score
+        
+    if 'simplified_silhouette_score' in metrics_name:
+        try:
+            unit_silhouette_score = simplified_silhouette_score(pcs_flat, labels, unit_id)
+        except:
+            unit_silhouette_score = np.nan
+        pc_metrics['simplified_silhouette_score'] = unit_silhouette_score
 
     return pc_metrics

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -684,7 +684,7 @@ def simplified_silhouette_score(all_pcs, all_labels, this_unit_id):
     # find centroid of other cluster and measure distances to that rather than pairwise
     # if less than current minimum distance update
     for label in np.unique(all_labels):
-        if label != this_unit_id
+        if label != this_unit_id:
             pcs_for_other_cluster = all_pcs[all_labels == label, :]
             centroid_for_other_cluster = np.expand_dims(np.mean(pcs_for_other_cluster, 0), 0)
             distances_for_other_cluster = scipy.spatial.distance.cdist(

--- a/src/spikeinterface/qualitymetrics/quality_metric_list.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_list.py
@@ -19,7 +19,9 @@ from .pca_metrics import (
     lda_metrics,
     nearest_neighbors_metrics,
     nearest_neighbors_isolation,
-    nearest_neighbors_noise_overlap
+    nearest_neighbors_noise_overlap,
+    silhouette_score,
+    simplified_silhouette_score
 )
 
 from .pca_metrics import _possible_pc_metric_names

--- a/src/spikeinterface/qualitymetrics/tests/test_metrics_functions.py
+++ b/src/spikeinterface/qualitymetrics/tests/test_metrics_functions.py
@@ -10,10 +10,10 @@ from spikeinterface.qualitymetrics.utils import create_ground_truth_pc_distribut
 from spikeinterface.qualitymetrics import calculate_pc_metrics
 from spikeinterface.postprocessing import compute_principal_components, compute_spike_locations, compute_spike_amplitudes
 
-from spikeinterface.qualitymetrics import (mahalanobis_metrics, lda_metrics, nearest_neighbors_metrics, 
-        compute_amplitude_cutoffs, compute_presence_ratios, compute_isi_violations, compute_firing_rates, 
-        compute_num_spikes, compute_snrs, compute_refrac_period_violations, compute_sliding_rp_violations,
-        compute_drift_metrics, compute_amplitude_medians)
+from spikeinterface.qualitymetrics import (mahalanobis_metrics, lda_metrics, nearest_neighbors_metrics,
+        silhouette_score, simplified_silhouette_score, compute_amplitude_cutoffs, compute_presence_ratios, 
+        compute_isi_violations, compute_firing_rates, compute_num_spikes, compute_snrs, compute_refrac_period_violations, 
+        compute_sliding_rp_violations, compute_drift_metrics, compute_amplitude_medians)
 
 
 if hasattr(pytest, "global_test_folder"):
@@ -102,6 +102,27 @@ def test_nearest_neighbors_metrics():
 
     assert hit_rate1 < hit_rate2
     assert miss_rate1 > miss_rate2
+        
+        
+def test_silhouette_score_metrics():
+    all_pcs1, all_labels1 = create_ground_truth_pc_distributions([1, -1], [1000, 1000])
+    all_pcs2, all_labels2 = create_ground_truth_pc_distributions([1, -2],
+                                                                 [1000, 1000])  # increase distance between clusters
+
+    sil_score1 = silhouette_score(all_pcs1, all_labels1, 0)
+    sil_score2 = silhouette_score(all_pcs2, all_labels2, 0)
+
+    assert sil_score1 < sil_score2
+
+def test_simplified_silhouette_score_metrics():
+    all_pcs1, all_labels1 = create_ground_truth_pc_distributions([1, -1], [1000, 1000])
+    all_pcs2, all_labels2 = create_ground_truth_pc_distributions([1, -2],
+                                                                 [1000, 1000])  # increase distance between clusters
+
+    sim_sil_score1 = simplified_silhouette_score(all_pcs1, all_labels1, 0)
+    sim_sil_score2 = simplified_silhouette_score(all_pcs2, all_labels2, 0)
+
+    assert sim_sil_score1 < sim_sil_score2
 
 @pytest.fixture
 def simulated_data():


### PR DESCRIPTION
First Tom's PR #1499 will need to be merged before this can be done, so I can update to get rid of the merge conflicts. So I'll leave this as a draft until that's done.

Working on the docs I saw that silhouette score had not been implemented. So I implemented it two different ways and was hoping for feedback (if you guys want it implemented in SI--otherwise I can delete it). First is the simplified silhouette score proposal here: https://ieeexplore.ieee.org/document/1410321, which uses centroids rather than pairwise point calculations
Pros:
It is computationally and space-wise o(kn) rather than o(kn2). 
Cons:
Literature is less developed (and was proposed for genomics purposes) and technically doesn't use all info available

And the original silhouette score as proposed by Rousseeuw.
Pros:
It uses all information provided by doing point by point calculations. ML literature uses it.
Cons:
Computationally and space it is o(kn2) which can quickly lead to memory overflow for large datasets.

I figure only one would be implemented, so I'll just delete the one not wanted for the qualitymetrics.