### PR TITLE
Add mountainsort5 sorter

### DIFF
--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -138,7 +138,7 @@ Now you can start filling out the required methods:
     def _run_from_folder(cls, output_folder, params, verbose):
 
         # Fill code to run your spike sorter based on the files created in the _setup_recording()
-        # You can run CLI commands (e.g. klusta, spykingcircus, tridesclous), pure Python code (e.g. Mountainsort4,
+        # You can run CLI commands (e.g. klusta, spykingcircus, tridesclous), pure Python code (e.g. Mountainsort5,
         # Herding Spikes), or even MATLAB code (e.g. Kilosort, Kilosort2, Ironclust)
 
     @classmethod

--- a/doc/how_to/get_started.rst
+++ b/doc/how_to/get_started.rst
@@ -232,8 +232,8 @@ installed
 
 .. parsed-literal::
 
-    Available sorters ['combinato', 'hdsort', 'herdingspikes', 'ironclust', 'kilosort', 'kilosort2', 'kilosort2_5', 'kilosort3', 'klusta', 'mountainsort4', 'pykilosort', 'spykingcircus', 'spykingcircus2', 'tridesclous', 'tridesclous2', 'waveclus', 'waveclus_snippets', 'yass']
-    Installed sorters ['herdingspikes', 'kilosort2_5', 'mountainsort4', 'pykilosort', 'spykingcircus2', 'tridesclous', 'tridesclous2']
+    Available sorters ['combinato', 'hdsort', 'herdingspikes', 'ironclust', 'kilosort', 'kilosort2', 'kilosort2_5', 'kilosort3', 'klusta', 'mountainsort4', 'mountainsort5', 'pykilosort', 'spykingcircus', 'spykingcircus2', 'tridesclous', 'tridesclous2', 'waveclus', 'waveclus_snippets', 'yass']
+    Installed sorters ['herdingspikes', 'kilosort2_5', 'mountainsort4', 'mountainsort5', 'pykilosort', 'spykingcircus2', 'tridesclous', 'tridesclous2']
 
 
 The ``ss.installed_sorters()`` will list the sorters installed in the

--- a/doc/install_sorters.rst
+++ b/doc/install_sorters.rst
@@ -180,6 +180,15 @@ Mountainsort4
 
       pip install mountainsort4
 
+Mountainsort5
+^^^^^^^^^^^^^
+
+* Python
+* Url: https://github.com/magland/mountainsort5
+* Authors: 	Jeremy Magland
+* Installation::
+
+      pip install mountainsort5
 
 SpyKING CIRCUS
 ^^^^^^^^^^^^^

--- a/doc/install_sorters.rst
+++ b/doc/install_sorters.rst
@@ -184,7 +184,7 @@ Mountainsort5
 ^^^^^^^^^^^^^
 
 * Python
-* Url: https://github.com/magland/mountainsort5
+* Url: https://github.com/flatironinstitute/mountainsort5
 * Authors: 	Jeremy Magland
 * Installation::
 

--- a/doc/modules/sorters.rst
+++ b/doc/modules/sorters.rst
@@ -404,6 +404,7 @@ Here is the list of external sorters accessible using the run_sorter wrapper:
 * **PyKilosort** :code:`run_sorter('pykilosort')`
 * **Klusta** :code:`run_sorter('klusta')`
 * **Mountainsort4** :code:`run_sorter('mountainsort4')`
+* **Mountainsort5** :code:`run_sorter('mountainsort5')`
 * **SpyKING Circus** :code:`run_sorter('spykingcircus')`
 * **Tridesclous** :code:`run_sorter('tridesclous')`
 * **Wave clus** :code:`run_sorter('waveclus')`
@@ -441,6 +442,7 @@ which outputs,
   ['herdingspikes',
    'klusta',
    'mountainsort4',
+   'mountainsort5',
    'spykingcircus',
    'tridesclous']
 

--- a/installation_tips/full_spikeinterface_environment_mac.yml
+++ b/installation_tips/full_spikeinterface_environment_mac.yml
@@ -39,4 +39,4 @@ dependencies:
     - tridesclous>=1.6.6.1
     # - phy==2.0b5
     - mountainsort4>=1.0.0
-    - mountainsort5>=0.1.2
+    - mountainsort5>=0.1.4

--- a/installation_tips/full_spikeinterface_environment_mac.yml
+++ b/installation_tips/full_spikeinterface_environment_mac.yml
@@ -39,3 +39,4 @@ dependencies:
     - tridesclous>=1.6.6.1
     # - phy==2.0b5
     - mountainsort4>=1.0.0
+    - mountainsort5>=0.1.2

--- a/src/spikeinterface/sorters/external/mountainsort4.py
+++ b/src/spikeinterface/sorters/external/mountainsort4.py
@@ -105,7 +105,7 @@ class Mountainsort4Sorter(BaseSorter):
         if p['whiten']:
             if verbose:
                 print('whitening')
-            recording = whiten(recording=recording)
+            recording = whiten(recording=recording, dtype='float32')
 
         print('Mountainsort4 use the OLD spikeextractors mapped with NewToOldRecording')
         old_api_recording = NewToOldRecording(recording)

--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -80,11 +80,13 @@ class Mountainsort5Sorter(BaseSorter):
             HAVE_MS5 = True
         except ImportError:
             HAVE_MS5 = False
-        
-        vv = parse(mountainsort5.__version__)
-        if vv < parse("0.1") or vv >= parse("0.2"):
-            print(f'WARNING: This version of SpikeInterface expects Mountainsort5 version 0.1.x. You have version {mountainsort5.__version__}')
-            HAVE_MS5 = False
+
+        if HAVE_MS5:
+            vv = parse(mountainsort5.__version__)
+            if vv < parse("0.1") or vv >= parse("0.2"):
+                print(f'WARNING: This version of SpikeInterface expects Mountainsort5 version 0.1.x. '
+                      f'You have version {mountainsort5.__version__}')
+                HAVE_MS5 = False
         return HAVE_MS5
 
     @staticmethod

--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -69,7 +69,7 @@ class Mountainsort5Sorter(BaseSorter):
        >>> pip install mountainsort5
 
     More information on mountainsort5 at:
-      * https://github.com/magland/mountainsort5
+      * https://github.com/flatironinstitute/mountainsort5
     """
 
     @classmethod
@@ -78,6 +78,11 @@ class Mountainsort5Sorter(BaseSorter):
             import mountainsort5
             HAVE_MS5 = True
         except ImportError:
+            HAVE_MS5 = False
+        import semantic_version
+        vv = semantic_version.Version.coerce(mountainsort5.__version__)
+        if vv.major != 0 or vv.minor != 1:
+            print(f'WARNING: This version of SpikeInterface expects Mountainsort5 version 0.1.x. You have version {mountainsort5.__version__}')
             HAVE_MS5 = False
         return HAVE_MS5
 

--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -28,7 +28,6 @@ class Mountainsort5Sorter(BaseSorter):
         'snippet_T2': 20,
         'npca_per_branch': 12,
         'snippet_mask_radius': 250,
-        'pairwise_merge_step': True,
         'scheme1_detect_channel_radius': 150,
         'scheme2_phase1_detect_channel_radius': 200,
         'scheme2_detect_channel_radius': 50,
@@ -51,7 +50,6 @@ class Mountainsort5Sorter(BaseSorter):
         'snippet_T2': 'Number of samples after the peak to include in the snippet',
         'npca_per_branch': 'Number of PCA features to compute at each stage of branch clustering',
         'snippet_mask_radius': 'Radius of the mask to apply to the extracted snippets',
-        'pairwise_merge_step': 'Whether to perform the pairwise merge step',
         'scheme1_detect_channel_radius': 'Channel radius for excluding events that are too close in time in scheme 1',
         'scheme2_phase1_detect_channel_radius': 'Channel radius for excluding events that are too close in time during phase 1 of scheme 2',
         'scheme2_detect_channel_radius': 'Channel radius for excluding events that are too close in time during phase 2 of scheme 2',
@@ -129,8 +127,7 @@ class Mountainsort5Sorter(BaseSorter):
             snippet_T1=p['snippet_T1'],
             snippet_T2=p['snippet_T2'],
             snippet_mask_radius=p['snippet_mask_radius'],
-            npca_per_branch=p['npca_per_branch'],
-            pairwise_merge_step=p['pairwise_merge_step']
+            npca_per_branch=p['npca_per_branch']
         )
 
         scheme2_sorting_parameters = ms5.Scheme2SortingParameters(
@@ -140,7 +137,6 @@ class Mountainsort5Sorter(BaseSorter):
             phase1_detect_time_radius_msec=p['detect_time_radius_msec'],
             detect_time_radius_msec=p['detect_time_radius_msec'],
             phase1_npca_per_branch=p['npca_per_branch'],
-            phase1_pairwise_merge_step=p['pairwise_merge_step'],
             detect_sign=p['detect_sign'],
             detect_threshold=p['detect_threshold'],
             snippet_T1=p['snippet_T1'],

--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -11,6 +11,7 @@ from spikeinterface.core import load_extractor
 
 from spikeinterface.extractors import NpzSortingExtractor, NumpySorting
 
+from packaging.version import parse
 
 class Mountainsort5Sorter(BaseSorter):
     """Mountainsort5 Sorter object."""
@@ -79,9 +80,9 @@ class Mountainsort5Sorter(BaseSorter):
             HAVE_MS5 = True
         except ImportError:
             HAVE_MS5 = False
-        import semantic_version
-        vv = semantic_version.Version.coerce(mountainsort5.__version__)
-        if vv.major != 0 or vv.minor != 1:
+        
+        vv = parse(mountainsort5.__version__)
+        if vv < parse("0.1") or vv >= parse("0.2"):
             print(f'WARNING: This version of SpikeInterface expects Mountainsort5 version 0.1.x. You have version {mountainsort5.__version__}')
             HAVE_MS5 = False
         return HAVE_MS5

--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -1,0 +1,184 @@
+from pathlib import Path
+from tempfile import tempdir
+from packaging.version import parse
+
+from spikeinterface.preprocessing import bandpass_filter, whiten
+
+from spikeinterface.core.baserecording import BaseRecording
+from ..basesorter import BaseSorter
+from spikeinterface.core.old_api_utils import NewToOldRecording
+from spikeinterface.core import load_extractor
+
+from spikeinterface.extractors import NpzSortingExtractor, NumpySorting
+
+
+class Mountainsort5Sorter(BaseSorter):
+    """Mountainsort5 Sorter object."""
+
+    sorter_name = 'mountainsort5'
+    requires_locations = False
+    compatible_with_parallel = {'loky': False, 'multiprocessing': False, 'threading': False}
+
+    _default_params = {
+        'scheme': '2', # '1', '2', '3'
+        'detect_threshold': 5.5, # this is the recommended detection threshold
+        'detect_sign': -1,
+        'detect_time_radius_msec': 0.5,
+        'snippet_T1': 20,
+        'snippet_T2': 20,
+        'npca_per_branch': 12,
+        'snippet_mask_radius': 250,
+        'pairwise_merge_step': True,
+        'scheme1_detect_channel_radius': 150,
+        'scheme2_phase1_detect_channel_radius': 200,
+        'scheme2_detect_channel_radius': 50,
+        'scheme2_max_num_snippets_per_training_batch': 200,
+        'scheme2_training_duration_sec': 60 * 5,
+        'scheme2_training_recording_sampling_mode': 'uniform',
+        'scheme3_block_duration_sec': 60 * 30,
+        'freq_min': 300,
+        'freq_max': 6000,
+        'filter': True,
+        'whiten': True  # Important to do whitening
+    }
+
+    _params_description = {
+        'scheme': "Which sorting scheme to use: '1, '2', or '3'",
+        'detect_threshold': 'Detection threshold - recommend to use the default',
+        'detect_sign': 'Use -1 for detecting negative peaks, 1 for positive, 0 for both',
+        'detect_time_radius_msec': 'Determines the minimum allowable time interval between detected spikes in the same spatial region',
+        'snippet_T1': 'Number of samples before the peak to include in the snippet',
+        'snippet_T2': 'Number of samples after the peak to include in the snippet',
+        'npca_per_branch': 'Number of PCA features to compute at each stage of branch clustering',
+        'snippet_mask_radius': 'Radius of the mask to apply to the extracted snippets',
+        'pairwise_merge_step': 'Whether to perform the pairwise merge step',
+        'scheme1_detect_channel_radius': 'Channel radius for excluding events that are too close in time in scheme 1',
+        'scheme2_phase1_detect_channel_radius': 'Channel radius for excluding events that are too close in time during phase 1 of scheme 2',
+        'scheme2_detect_channel_radius': 'Channel radius for excluding events that are too close in time during phase 2 of scheme 2',
+        'scheme2_max_num_snippets_per_training_batch': 'Maximum number of snippets to use in each batch for training during phase 2 of scheme 2',
+        'scheme2_training_duration_sec': 'Duration of training data to use in scheme 2',
+        'scheme2_training_recording_sampling_mode': 'initial or uniform',
+        'scheme3_block_duration_sec': 'Duration of each block in scheme 3',
+        'freq_min': "High-pass filter cutoff frequency",
+        'freq_max': "Low-pass filter cutoff frequency",
+        'filter': "Enable or disable filter",
+        'whiten': "Enable or disable whitening"
+    }
+
+    sorter_description = "MountainSort5 uses Isosplit clustering. It is an updated version of MountainSort4. See https://doi.org/10.1016/j.neuron.2017.08.030"
+
+    installation_mesg = """\nTo use Mountainsort5 run:\n
+       >>> pip install mountainsort5
+
+    More information on mountainsort5 at:
+      * https://github.com/magland/mountainsort5
+    """
+
+    @classmethod
+    def is_installed(cls):
+        try:
+            import mountainsort5
+            HAVE_MS5 = True
+        except ImportError:
+            HAVE_MS5 = False
+        return HAVE_MS5
+
+    @staticmethod
+    def get_sorter_version():
+        import mountainsort5
+        if hasattr(mountainsort5, '__version__'):
+            return mountainsort5.__version__
+        return 'unknown'
+
+    @classmethod
+    def _check_apply_filter_in_params(cls, params):
+        return params['filter']
+
+    @classmethod
+    def _setup_recording(cls, recording, sorter_output_folder, params, verbose):
+        pass
+
+    @classmethod
+    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+        import mountainsort5 as ms5
+
+        recording: BaseRecording = load_extractor(sorter_output_folder.parent / 'spikeinterface_recording.json')
+
+        # alias to params
+        p = params
+
+        # Bandpass filter
+        if p['filter'] and p['freq_min'] is not None and p['freq_max'] is not None:
+            if verbose:
+                print('filtering')
+            recording = bandpass_filter(recording=recording, freq_min=p['freq_min'], freq_max=p['freq_max'])
+
+        # Whiten
+        if p['whiten']:
+            if verbose:
+                print('whitening')
+            recording = whiten(recording=recording, dtype='float32')
+        else:
+            print('WARNING: Not whitening (MountainSort5 expects whitened data)')
+        
+        scheme1_sorting_parameters = ms5.Scheme1SortingParameters(
+            detect_threshold=p['detect_threshold'],
+            detect_channel_radius=p['scheme1_detect_channel_radius'],
+            detect_time_radius_msec=p['detect_time_radius_msec'],
+            detect_sign=p['detect_sign'],
+            snippet_T1=p['snippet_T1'],
+            snippet_T2=p['snippet_T2'],
+            snippet_mask_radius=p['snippet_mask_radius'],
+            npca_per_branch=p['npca_per_branch'],
+            pairwise_merge_step=p['pairwise_merge_step']
+        )
+
+        scheme2_sorting_parameters = ms5.Scheme2SortingParameters(
+            phase1_detect_channel_radius=p['scheme2_phase1_detect_channel_radius'],
+            detect_channel_radius=p['scheme2_detect_channel_radius'],
+            phase1_detect_threshold=p['detect_threshold'],
+            phase1_detect_time_radius_msec=p['detect_time_radius_msec'],
+            detect_time_radius_msec=p['detect_time_radius_msec'],
+            phase1_npca_per_branch=p['npca_per_branch'],
+            phase1_pairwise_merge_step=p['pairwise_merge_step'],
+            detect_sign=p['detect_sign'],
+            detect_threshold=p['detect_threshold'],
+            snippet_T1=p['snippet_T1'],
+            snippet_T2=p['snippet_T2'],
+            snippet_mask_radius=p['snippet_mask_radius'],
+            max_num_snippets_per_training_batch=p['scheme2_max_num_snippets_per_training_batch'],
+            classifier_npca=None,
+            training_duration_sec=p['scheme2_training_duration_sec'],
+            training_recording_sampling_mode=p['scheme2_training_recording_sampling_mode'],
+        )
+
+        scheme3_sorting_parameters = ms5.Scheme3SortingParameters(
+            block_sorting_parameters=scheme2_sorting_parameters,
+            block_duration_sec=p['scheme3_block_duration_sec']
+        )
+        
+        scheme = p['scheme']
+        if scheme == '1':
+            sorting = ms5.sorting_scheme1(
+                recording=recording,
+                sorting_parameters=scheme1_sorting_parameters
+            )
+        elif p['scheme'] == '2':
+            sorting = ms5.sorting_scheme2(
+                recording=recording,
+                sorting_parameters=scheme2_sorting_parameters
+            )
+        elif p['scheme'] == '3':
+            sorting = ms5.sorting_scheme3(
+                recording=recording,
+                sorting_parameters=scheme3_sorting_parameters
+            )
+        
+        NpzSortingExtractor.write_sorting(sorting, str(sorter_output_folder / 'firings.npz'))
+
+    @classmethod
+    def _get_result_from_folder(cls, sorter_output_folder):
+        sorter_output_folder = Path(sorter_output_folder)
+        result_fname = sorter_output_folder / 'firings.npz'
+        sorting = NpzSortingExtractor(result_fname)
+        return sorting

--- a/src/spikeinterface/sorters/external/tests/test_singularity_containers.py
+++ b/src/spikeinterface/sorters/external/tests/test_singularity_containers.py
@@ -66,6 +66,12 @@ def test_mountainsort4(run_kwargs):
     print(sorting)
 
 
+def test_mountainsort5(run_kwargs):
+    sorting = ss.run_sorter("mountainsort5", output_folder=cache_folder / "mountainsort5", **run_kwargs)
+    print("resulting sorting")
+    print(sorting)
+
+
 def test_tridesclous(run_kwargs):
     sorting = ss.run_sorter("tridesclous", output_folder=cache_folder / "tridesclous", **run_kwargs)
     print("resulting sorting")

--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -25,6 +25,7 @@ SORTER_DOCKER_MAP = dict(
     herdingspikes='herdingspikes',
     klusta='klusta',
     mountainsort4='mountainsort4',
+    mountainsort5='mountainsort5',
     pykilosort='pykilosort',
     spykingcircus='spyking-circus',
     spykingcircus2='spyking-circus2',
@@ -662,6 +663,13 @@ def run_mountainsort4(*args, **kwargs):
 
 
 run_mountainsort4.__doc__ = _common_run_doc.format('mountainsort4')
+
+
+def run_mountainsort5(*args, **kwargs):
+    return run_sorter('mountainsort5', *args, **kwargs)
+
+
+run_mountainsort5.__doc__ = _common_run_doc.format('mountainsort5')
 
 
 def run_ironclust(*args, **kwargs):

--- a/src/spikeinterface/sorters/sorterlist.py
+++ b/src/spikeinterface/sorters/sorterlist.py
@@ -9,6 +9,7 @@ from .external.kilosort3 import Kilosort3Sorter
 from .external.pykilosort import PyKilosortSorter
 from .external.klusta import KlustaSorter
 from .external.mountainsort4 import Mountainsort4Sorter
+from .external.mountainsort5 import Mountainsort5Sorter
 from .external.spyking_circus import SpykingcircusSorter
 from .external.tridesclous import TridesclousSorter
 from .external.waveclus import WaveClusSorter
@@ -32,6 +33,7 @@ sorter_full_list = [
     PyKilosortSorter,
     KlustaSorter,
     Mountainsort4Sorter,
+    Mountainsort5Sorter,
     SpykingcircusSorter,
     TridesclousSorter,
     WaveClusSorter,


### PR DESCRIPTION
Adding a new version of mountainsort spike sorter. See https://github.com/magland/mountainsort5

The structure of the sorting parameters is a bit more complicated than for mountainsort4 because the algorithm is available in three different schemes (scheme1, scheme2, scheme3) -- see the above link. Each scheme has its own set of parameters. So for the SpikeInterface wrapper, I flattened the structure... see mountainsort5.py. Depending on which scheme is selected, different parameters will take effect (and others will be ignored).

