### PR TITLE
Warning that `setup.py` is legacy

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -57,7 +57,7 @@ as :code:`spikeinterface` strongly relies on these packages to interface with va
 
     git clone https://github.com/SpikeInterface/spikeinterface.git
     cd spikeinterface
-    python setup.py install (or develop)
+    pip install -e .
     cd ..
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
 import setuptools
+import warnings
+
+warnings.warn("Using `python setup.py` is legacy! See https://spikeinterface.readthedocs.io/en/latest/installation.html for installation")
 
 if __name__ == "__main__":
     setuptools.setup() 


### PR DESCRIPTION
Warn the user when using `setup.py` for installation as it is now the legacy way of installing SpikeInterface.