### PR TITLE
Add tests for json encoding of nested numpy scalars 

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -281,7 +281,7 @@ class BaseExtractor:
             other._preferred_mp_context = self._preferred_mp_context
 
     def to_dict(self, include_annotations=False, include_properties=False,
-                relative_to=None, folder_metadata=None):
+                relative_to=None, folder_metadata=None) -> dict:
         """
         Make a nested serialized dictionary out of the extractor. The dictionary produced can be used to re-initialize 
         an extractor using load_extractor_from_dict(dump_dict)

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Union, Optional
 import importlib
 import warnings
 import weakref
@@ -348,7 +349,7 @@ class BaseExtractor:
         return dump_dict
 
     @staticmethod
-    def from_dict(d, base_folder=None):
+    def from_dict(dictionary: dict, base_folder: Optional[Union[Path, str]] = None) -> "BaseExtractor":
         """
         Instantiate extractor from dictionary
 
@@ -364,14 +365,14 @@ class BaseExtractor:
         extractor: RecordingExtractor or SortingExtractor
             The loaded extractor object
         """
-        if d['relative_paths']:
+        if dictionary['relative_paths']:
             assert base_folder is not None, 'When  relative_paths=True, need to provide base_folder'
-            d = _make_paths_absolute(d, base_folder)
-        extractor = _load_extractor_from_dict(d)
-        folder_metadata = d.get('folder_metadata', None)
+            dictionary = _make_paths_absolute(dictionary, base_folder)
+        extractor = _load_extractor_from_dict(dictionary)
+        folder_metadata = dictionary.get('folder_metadata', None)
         if folder_metadata is not None:
             folder_metadata = Path(folder_metadata)
-            if d['relative_paths']:
+            if dictionary['relative_paths']:
                 folder_metadata = base_folder / folder_metadata
             extractor.load_metadata_from_folder(folder_metadata)
         return extractor
@@ -480,7 +481,7 @@ class BaseExtractor:
                                  relative_to=relative_to,
                                  folder_metadata=folder_metadata)
         file_path = self._get_file_path(file_path, ['.json'])
-        
+    
         try:
             file_path.write_text(
                 json.dumps(dump_dict, indent=4, cls=SIJsonEncoder),
@@ -529,6 +530,7 @@ class BaseExtractor:
                     return bottom_value_to_log
         
             raise Exception(f'Error while dumping to json {str(e)}. \n \n \n  Dump dict : {log_value_types_of_dict(dump_dict)}')
+
 
     def dump_to_pickle(self, file_path=None, include_properties=True,
                        relative_to=None, folder_metadata=None):
@@ -853,7 +855,7 @@ class BaseExtractor:
         return cached
 
 
-def _make_paths_relative(d, relative):
+def _make_paths_relative(d, relative) -> dict:
     relative = str(Path(relative).absolute())
     func = lambda p: os.path.relpath(str(p), start=relative)
     return recursive_path_modifier(d,  func, target='path', copy=True)

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -489,28 +489,45 @@ class BaseExtractor:
         except TypeError as e:
             accepted_type = [str, int, float, bool or None]
             def log_value_types_of_dict(dictionary):
-                result = {}
-                for key, value in dictionary.items():
-                    key_type = type(key)
-                    if key_type in accepted_type:
-                        key_to_log = key
-                    else:
-                        key_to_log = (key, "possible_trouble", type(key).__name__ )
-                    if isinstance(value, dict): # Other dicts
-                        result[key_to_log] = log_value_types_of_dict(value)
-                    elif isinstance(value, (list, tuple)): # Iterables
-                        result[key_to_log] = [(element, log_value_types_of_dict(element)) for element in value]                
-                    elif isinstance(value, BaseExtractor): # Expand extractors
-                        extractor = value
-                        result[key_to_log] = (extractor, log_value_types_of_dict(extractor.to_dict()))
-                    else:  # Base case
-                        value_type = type(value)
-                        if value_type in accepted_type:
-                            value_to_log = value
+                
+                if isinstance(dictionary, dict):
+                    result = {}
+                
+                    for key, value in dictionary.items():
+                        key_type = type(key)
+                        if key_type in accepted_type:
+                            key_to_log = key
                         else:
-                            value_to_log = (value, "possible_trouble", value_type.__name__)
-                        result[key_to_log] = value_to_log
-                return result
+                            key_to_log = (key, "possible_trouble", type(key).__name__ )
+                        if isinstance(value, dict): # Other dicts
+                            result[key_to_log] = log_value_types_of_dict(value)
+                        elif isinstance(value, (list, tuple)): # Iterables
+                            result[key_to_log] = [log_value_types_of_dict(element) for element in value]                
+                        elif isinstance(value, BaseExtractor): # Expand extractors
+                            extractor = value
+                            result[key_to_log] = (extractor, log_value_types_of_dict(extractor.to_dict()))
+                        else:  # Base case
+                            value_type = type(value)
+                            if value_type in accepted_type:
+                                value_to_log = value
+                            else:
+                                value_to_log = (value, "possible_trouble", value_type.__name__)
+                            result[key_to_log] = value_to_log
+                            
+                    return result
+                
+                elif isinstance(dictionary, (list, tuple)):
+                    return [log_value_types_of_dict(element) for element in dictionary]
+
+                else:
+                    bottom_value = dictionary
+                    bottom_value_type = type(bottom_value)
+                    if bottom_value_type in accepted_type:
+                        bottom_value_to_log = bottom_value
+                    else:
+                        bottom_value_to_log = (bottom_value, "possible_trouble", bottom_value_type.__name__)
+                    return bottom_value_to_log
+        
             raise Exception(f'Error while dumping to json {str(e)}. \n \n \n  Dump dict : {log_value_types_of_dict(dump_dict)}')
 
     def dump_to_pickle(self, file_path=None, include_properties=True,

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -481,10 +481,37 @@ class BaseExtractor:
                                  folder_metadata=folder_metadata)
         file_path = self._get_file_path(file_path, ['.json'])
         
-        file_path.write_text(
-            json.dumps(dump_dict, indent=4, cls=SIJsonEncoder),
-            encoding='utf8',
-        )
+        try:
+            file_path.write_text(
+                json.dumps(dump_dict, indent=4, cls=SIJsonEncoder),
+                encoding='utf8',
+            )
+        except TypeError as e:
+            accepted_type = [str, int, float, bool or None]
+            def log_value_types_of_dict(dictionary):
+                result = {}
+                for key, value in dictionary.items():
+                    key_type = type(key)
+                    if key_type in accepted_type:
+                        key_to_log = key
+                    else:
+                        key_to_log = (key, "possible_trouble", type(key).__name__ )
+                    if isinstance(value, dict): # Other dicts
+                        result[key_to_log] = log_value_types_of_dict(value)
+                    elif isinstance(value, (list, tuple)): # Iterables
+                        result[key_to_log] = [(element, log_value_types_of_dict(element)) for element in value]                
+                    elif isinstance(value, BaseExtractor): # Expand extractors
+                        extractor = value
+                        result[key_to_log] = (extractor, log_value_types_of_dict(extractor.to_dict()))
+                    else:  # Base case
+                        value_type = type(value)
+                        if value_type in accepted_type:
+                            value_to_log = value
+                        else:
+                            value_to_log = (value, "possible_trouble", value_type.__name__)
+                        result[key_to_log] = value_to_log
+                return result
+            raise Exception(f'Error while dumping to json {str(e)}. \n \n \n  Dump dict : {log_value_types_of_dict(dump_dict)}')
 
     def dump_to_pickle(self, file_path=None, include_properties=True,
                        relative_to=None, folder_metadata=None):

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -482,55 +482,11 @@ class BaseExtractor:
                                  folder_metadata=folder_metadata)
         file_path = self._get_file_path(file_path, ['.json'])
     
-        try:
-            file_path.write_text(
-                json.dumps(dump_dict, indent=4, cls=SIJsonEncoder),
-                encoding='utf8',
-            )
-        except TypeError as e:
-            accepted_type = [str, int, float, bool or None]
-            def log_value_types_of_dict(dictionary):
-                
-                if isinstance(dictionary, dict):
-                    result = {}
-                
-                    for key, value in dictionary.items():
-                        key_type = type(key)
-                        if key_type in accepted_type:
-                            key_to_log = key
-                        else:
-                            key_to_log = (key, "possible_trouble", type(key).__name__ )
-                        if isinstance(value, dict): # Other dicts
-                            result[key_to_log] = log_value_types_of_dict(value)
-                        elif isinstance(value, (list, tuple)): # Iterables
-                            result[key_to_log] = [log_value_types_of_dict(element) for element in value]                
-                        elif isinstance(value, BaseExtractor): # Expand extractors
-                            extractor = value
-                            result[key_to_log] = (extractor, log_value_types_of_dict(extractor.to_dict()))
-                        else:  # Base case
-                            value_type = type(value)
-                            if value_type in accepted_type:
-                                value_to_log = value
-                            else:
-                                value_to_log = (value, "possible_trouble", value_type.__name__)
-                            result[key_to_log] = value_to_log
-                            
-                    return result
-                
-                elif isinstance(dictionary, (list, tuple)):
-                    return [log_value_types_of_dict(element) for element in dictionary]
-
-                else:
-                    bottom_value = dictionary
-                    bottom_value_type = type(bottom_value)
-                    if bottom_value_type in accepted_type:
-                        bottom_value_to_log = bottom_value
-                    else:
-                        bottom_value_to_log = (bottom_value, "possible_trouble", bottom_value_type.__name__)
-                    return bottom_value_to_log
-        
-            raise Exception(f'Error while dumping to json {str(e)}. \n \n \n  Dump dict : {log_value_types_of_dict(dump_dict)}')
-
+        file_path.write_text(
+            json.dumps(dump_dict, indent=4, cls=SIJsonEncoder),
+            encoding='utf8',
+        )
+    
 
     def dump_to_pickle(self, file_path=None, include_properties=True,
                        relative_to=None, folder_metadata=None):

--- a/src/spikeinterface/core/tests/test_jsonification.py
+++ b/src/spikeinterface/core/tests/test_jsonification.py
@@ -146,28 +146,32 @@ class DummyExtractor(BaseExtractor):
 
 
 @pytest.fixture(scope="module")
-def dictionary_with_numpy_scalars(numpy_array_integer, numpy_array_float, numpy_array_bool):
+def dictionary_with_numpy_scalar_keys(numpy_array_integer, numpy_array_float, numpy_array_bool):
+    numpy_integer_scalar = numpy_array_integer[0]
+    numpy_float_scalar = numpy_array_float[0]
+    numpy_boolean_scalar = numpy_array_bool[1]
+    
     dictionary = {
-        numpy_integer_scalar: "first_string",
-        numpy_float_scalar: "second_string",
-        numpy_boolean_scalar: "third_string",
+        numpy_integer_scalar: "value_of_numpy_integer_scalar",
+        numpy_float_scalar: "value_of_numpy_float_scalar",
+        numpy_boolean_scalar: "value_of_boolean_scalar",
     }
 
     return dictionary
 
 
 @pytest.fixture(scope="module")
-def nested_extractor(dictionary_with_numpy_scalars):
-    inner_extractor = DummyExtractor(attribute=dictionary_with_numpy_scalars)
+def nested_extractor(dictionary_with_numpy_scalar_keys):
+    inner_extractor = DummyExtractor(attribute=dictionary_with_numpy_scalar_keys)
     extractor = DummyExtractor(attribute="a random attribute", other_extractor=inner_extractor)
 
     return extractor
 
 
 @pytest.fixture(scope="module")
-def nested_extractor_list(dictionary_with_numpy_scalars):
-    inner_extractor1 = DummyExtractor(attribute=dictionary_with_numpy_scalars)
-    inner_extractor2 = DummyExtractor(attribute=dictionary_with_numpy_scalars)
+def nested_extractor_list(dictionary_with_numpy_scalar_keys):
+    inner_extractor1 = DummyExtractor(attribute=dictionary_with_numpy_scalar_keys)
+    inner_extractor2 = DummyExtractor(attribute=dictionary_with_numpy_scalar_keys)
 
     extractor = DummyExtractor(attribute="a random attribute", extractor_list=[inner_extractor1, inner_extractor2])
 
@@ -175,9 +179,9 @@ def nested_extractor_list(dictionary_with_numpy_scalars):
 
 
 @pytest.fixture(scope="module")
-def nested_extractor_dict(dictionary_with_numpy_scalars):
-    inner_extractor1 = DummyExtractor(attribute=dictionary_with_numpy_scalars)
-    inner_extractor2 = DummyExtractor(attribute=dictionary_with_numpy_scalars)
+def nested_extractor_dict(dictionary_with_numpy_scalar_keys):
+    inner_extractor1 = DummyExtractor(attribute=dictionary_with_numpy_scalar_keys)
+    inner_extractor2 = DummyExtractor(attribute=dictionary_with_numpy_scalar_keys)
 
     extractor = DummyExtractor(
         attribute="a random attribute",

--- a/src/spikeinterface/core/tests/test_jsonification.py
+++ b/src/spikeinterface/core/tests/test_jsonification.py
@@ -34,6 +34,19 @@ def numpy_array_float():
 def numpy_array_bool(numpy_array_float):
     return numpy_array_float > 0.5
 
+@pytest.fixture(scope="module")
+def dictionary_with_numpy_scalar_keys(numpy_array_integer, numpy_array_float, numpy_array_bool):
+    numpy_integer_scalar = numpy_array_integer[0]
+    numpy_float_scalar = numpy_array_float[0]
+    numpy_boolean_scalar = numpy_array_bool[1]
+    
+    dictionary = {
+        numpy_integer_scalar: "value_of_numpy_integer_scalar",
+        numpy_float_scalar: "value_of_numpy_float_scalar",
+        numpy_boolean_scalar: "value_of_boolean_scalar",
+    }
+
+    return dictionary
 
 def test_numpy_array_encoding(numpy_array_integer, numpy_array_float, numpy_array_bool):
     json.dumps(numpy_array_integer, cls=SIJsonEncoder)
@@ -67,17 +80,8 @@ def test_encoding_numpy_scalars_values(numpy_array_integer, numpy_array_float, n
     json.dumps(dict_with_numpy_scalar_values, cls=SIJsonEncoder)
 
 
-def test_encoding_numpy_scalars_keys(numpy_array_integer, numpy_array_float, numpy_array_bool):
-    numpy_integer_scalar = numpy_array_integer[0]
-    numpy_float_scalar = numpy_array_float[0]
-    numpy_boolean_scalar = numpy_array_bool[1]
-
-    dict_with_numpy_scalar_keys = {
-        numpy_integer_scalar: "first_string",
-        numpy_float_scalar: "second_string",
-        numpy_boolean_scalar: "third_string",
-    }
-    json.dumps(dict_with_numpy_scalar_keys, cls=SIJsonEncoder)
+def test_encoding_numpy_scalars_keys(dictionary_with_numpy_scalar_keys):
+    json.dumps(dictionary_with_numpy_scalar_keys, cls=SIJsonEncoder)
 
 
 def test_encoding_numpy_scalars_keys_nested(numpy_array_integer, numpy_array_float, numpy_array_bool):
@@ -113,7 +117,7 @@ def test_numpy_dtype_encoding():
 
 
 def test_numpy_dtype_alises_encoding():
-    # People tend to use as a dtype instead of the proper classes
+    # People tend to use this a dtype instead of the proper classes
     json.dumps(np.int32, cls=SIJsonEncoder)
     json.dumps(np.float32, cls=SIJsonEncoder)
     json.dumps(np.bool_, cls=SIJsonEncoder)  # Note that np.bool was deperecated in numpy 1.20.0
@@ -146,21 +150,6 @@ class DummyExtractor(BaseExtractor):
 
 
 @pytest.fixture(scope="module")
-def dictionary_with_numpy_scalar_keys(numpy_array_integer, numpy_array_float, numpy_array_bool):
-    numpy_integer_scalar = numpy_array_integer[0]
-    numpy_float_scalar = numpy_array_float[0]
-    numpy_boolean_scalar = numpy_array_bool[1]
-    
-    dictionary = {
-        numpy_integer_scalar: "value_of_numpy_integer_scalar",
-        numpy_float_scalar: "value_of_numpy_float_scalar",
-        numpy_boolean_scalar: "value_of_boolean_scalar",
-    }
-
-    return dictionary
-
-
-@pytest.fixture(scope="module")
 def nested_extractor(dictionary_with_numpy_scalar_keys):
     inner_extractor = DummyExtractor(attribute=dictionary_with_numpy_scalar_keys)
     extractor = DummyExtractor(attribute="a random attribute", other_extractor=inner_extractor)
@@ -190,12 +179,14 @@ def nested_extractor_dict(dictionary_with_numpy_scalar_keys):
 
     return extractor
 
+
 def test_encoding_numpy_scalars_within_nested_extractors(nested_extractor):
     json.dumps(nested_extractor, cls=SIJsonEncoder)
 
 
 def test_encoding_numpy_scalars_within_nested_extractors_list(nested_extractor_list):
     json.dumps(nested_extractor_list, cls=SIJsonEncoder)
+
 
 def test_encoding_numpy_scalars_within_nested_extractors_dict(nested_extractor_dict):
     json.dumps(nested_extractor_dict, cls=SIJsonEncoder)


### PR DESCRIPTION
Temporary branch for debugging error #1525 and possible #1526.

Edit I: OK. I am waiting for @DradeAW to confirm if this solves issue #1525 but I think it should. 
I added tests to cover the error which was generated by our encoder not going into extractors instances that are nested in other extractors and removing the numpy scalars from them. 

I added the tests, I saw that they were failing and the modified the code so they pass. Once @DradeAW confirms that this works I will remove the log and this will be ready to merge.

Edit II: OK, this is ready now. 