### PR TITLE
Change `channel_ind` for `channel_index` in `peak_dtype` for sortingcomponents 

### DIFF
--- a/src/spikeinterface/core/numpyextractors.py
+++ b/src/spikeinterface/core/numpyextractors.py
@@ -227,7 +227,7 @@ class NumpySorting(BaseSorting):
         sorting
             The NumpySorting object
         """
-        return NumpySorting.from_times_labels(peaks['sample_ind'], peaks['channel_ind'], sampling_frequency)
+        return NumpySorting.from_times_labels(peaks['sample_ind'], peaks['channel_index'], sampling_frequency)
 
 
 class NumpySortingSegment(BaseSortingSegment):

--- a/src/spikeinterface/sortingcomponents/benchmark/benchmark_clustering.py
+++ b/src/spikeinterface/sortingcomponents/benchmark/benchmark_clustering.py
@@ -183,7 +183,7 @@ class BenchmarkClustering:
             if self.verbose:
                 print("Computing gt peaks")
             gt_peaks_ = self.gt_sorting.to_spike_vector()
-            self.gt_peaks = np.zeros(gt_peaks_.size, dtype=[('sample_ind', '<i8'), ('channel_ind', '<i8'), ('segment_ind', '<i8')])
+            self.gt_peaks = np.zeros(gt_peaks_.size, dtype=[('sample_ind', '<i8'), ('channel_index', '<i8'), ('segment_ind', '<i8')])
             self.gt_peaks['sample_ind'] = gt_peaks_['sample_ind']
             self.gt_peaks['segment_ind'] = gt_peaks_['segment_ind']
             max_channels = get_template_extremum_channel(self.waveforms['full_gt'], peak_sign='neg', outputs='index')
@@ -191,7 +191,7 @@ class BenchmarkClustering:
             for unit_ind, unit_id in enumerate(self.waveforms['full_gt'].sorting.unit_ids):
                 mask = gt_peaks_['unit_ind'] == unit_ind
                 max_channel = max_channels[unit_id]
-                self.gt_peaks['channel_ind'][mask] = max_channel
+                self.gt_peaks['channel_index'][mask] = max_channel
 
         self.sliced_gt_peaks = self.gt_peaks[idx]
         self.sliced_gt_positions = self.gt_positions[idx]

--- a/src/spikeinterface/sortingcomponents/benchmark/benchmark_peak_selection.py
+++ b/src/spikeinterface/sortingcomponents/benchmark/benchmark_peak_selection.py
@@ -123,7 +123,7 @@ class BenchmarkPeakSelection:
         self.good_matches = matches['index1']
 
         garbage_matches = ~np.in1d(np.arange(len(times2)), self.good_matches)
-        garbage_channels = self.peaks['channel_ind'][garbage_matches]
+        garbage_channels = self.peaks['channel_index'][garbage_matches]
         garbage_peaks = times2[garbage_matches]
         nb_garbage = len(garbage_peaks)
 
@@ -156,7 +156,7 @@ class BenchmarkPeakSelection:
             if self.verbose:
                 print("Computing gt peaks")
             gt_peaks_ = self.gt_sorting.to_spike_vector()
-            self.gt_peaks = np.zeros(gt_peaks_.size, dtype=[('sample_ind', '<i8'), ('channel_ind', '<i8'), ('segment_ind', '<i8'), ('amplitude', '<f8')])
+            self.gt_peaks = np.zeros(gt_peaks_.size, dtype=[('sample_ind', '<i8'), ('channel_index', '<i8'), ('segment_ind', '<i8'), ('amplitude', '<f8')])
             self.gt_peaks['sample_ind'] = gt_peaks_['sample_ind']
             self.gt_peaks['segment_ind'] = gt_peaks_['segment_ind']
             max_channels = get_template_extremum_channel(self.waveforms['full_gt'], peak_sign='neg', outputs='index')
@@ -165,7 +165,7 @@ class BenchmarkPeakSelection:
             for unit_ind, unit_id in enumerate(self.waveforms['full_gt'].sorting.unit_ids):
                 mask = gt_peaks_['unit_ind'] == unit_ind
                 max_channel = max_channels[unit_id]
-                self.gt_peaks['channel_ind'][mask] = max_channel
+                self.gt_peaks['channel_index'][mask] = max_channel
                 self.gt_peaks['amplitude'][mask] = max_amplitudes[unit_id]
 
         self.sliced_gt_peaks = self.gt_peaks[gt_matches]
@@ -417,13 +417,13 @@ class BenchmarkPeakSelection:
         ax = axs[1, 0]
 
         noise_levels = get_noise_levels(self.recording, return_scaled=False)
-        snrs = self.peaks['amplitude']/noise_levels[self.peaks['channel_ind']]
-        garbage_snrs = self.garbage_peaks['amplitude']/noise_levels[self.garbage_peaks['channel_ind']]
+        snrs = self.peaks['amplitude']/noise_levels[self.peaks['channel_index']]
+        garbage_snrs = self.garbage_peaks['amplitude']/noise_levels[self.garbage_peaks['channel_index']]
         amin, amax = snrs.min(), snrs.max()
         
         ax.hist(snrs, np.linspace(amin, amax, 100), density=True, label='peaks')
         #ax.hist(garbage_snrs, np.linspace(amin, amax, 100), density=True, label='garbage', alpha=0.5)
-        ax.hist(self.sliced_gt_peaks['amplitude']/noise_levels[self.sliced_gt_peaks['channel_ind']], np.linspace(amin, amax, 100), density=True, alpha=0.5, label='matched gt')
+        ax.hist(self.sliced_gt_peaks['amplitude']/noise_levels[self.sliced_gt_peaks['channel_index']], np.linspace(amin, amax, 100), density=True, alpha=0.5, label='matched gt')
         ax.spines['top'].set_visible(False)
         ax.spines['right'].set_visible(False)
         ax.legend()
@@ -517,7 +517,7 @@ class BenchmarkPeakSelection:
         # ax.set_xlabel('time (s)')
         # ax.set_ylabel('density')
 
-        # for channel_ind in       
+        # for channel_index in       
         #     ax.hist(snrs, np.linspace(amin, amax, 100), density=True, label='peaks')
         # ax.spines['top'].set_visible(False)
         # ax.spines['right'].set_visible(False)
@@ -543,8 +543,8 @@ class BenchmarkPeakSelection:
             ymin, ymax = ax.get_ylim()
             ax.plot([detect_threshold, detect_threshold], [ymin, ymax], 'k--')
 
-    def explore_garbage(self, channel_ind, nb_bins=None, dt=None):
-        mask = self.garbage_peaks['channel_ind'] == channel_ind
+    def explore_garbage(self, channel_index, nb_bins=None, dt=None):
+        mask = self.garbage_peaks['channel_index'] == channel_index
         times2 = self.garbage_peaks[mask]['sample_ind']
         times1 = self.gt_sorting.get_all_spike_trains()[0]
         from spikeinterface.comparison.comparisontools import make_matching_events

--- a/src/spikeinterface/sortingcomponents/clustering/circus.py
+++ b/src/spikeinterface/sortingcomponents/clustering/circus.py
@@ -86,7 +86,7 @@ class CircusClustering:
         spikes = np.zeros(peaks.size, dtype=peak_dtype)
         spikes['sample_ind'] = peaks['sample_ind']
         spikes['segment_ind'] = peaks['segment_ind']
-        spikes['unit_ind'] = peaks['channel_ind']
+        spikes['unit_ind'] = peaks['channel_index']
 
         num_chans = recording.get_num_channels()
         sparsity_mask = np.zeros((peaks.size, num_chans), dtype='bool')

--- a/src/spikeinterface/sortingcomponents/clustering/dummy.py
+++ b/src/spikeinterface/sortingcomponents/clustering/dummy.py
@@ -4,7 +4,7 @@ class DummyClustering:
     """
     Stupid clustering.
     peak are clustered from there channel detection
-    So peak['channel_ind'] will be the peak_labels
+    So peak['channel_index'] will be the peak_labels
     """
     _default_params = {
     }
@@ -12,5 +12,5 @@ class DummyClustering:
     @classmethod
     def main_function(cls, recording, peaks, params):
         labels = np.arange(recording.get_num_channels(), dtype='int64')
-        peak_labels = peaks['channel_ind']
+        peak_labels = peaks['channel_index']
         return labels, peak_labels

--- a/src/spikeinterface/sortingcomponents/clustering/sliding_hdbscan.py
+++ b/src/spikeinterface/sortingcomponents/clustering/sliding_hdbscan.py
@@ -105,7 +105,7 @@ class SlidingHdbscanClustering:
         dtype = [('sample_ind', 'int64'), ('unit_ind', 'int64'), ('segment_ind', 'int64')]
         peaks2 = np.zeros(peaks.size, dtype=dtype)
         peaks2['sample_ind'] = peaks['sample_ind']
-        peaks2['unit_ind'] = peaks['channel_ind']
+        peaks2['unit_ind'] = peaks['channel_index']
         peaks2['segment_ind'] = peaks['segment_ind']
         
         fs = recording.get_sampling_frequency()
@@ -144,7 +144,7 @@ class SlidingHdbscanClustering:
         
         
         
-        possible_channel_inds = np.unique(peaks['channel_ind'])
+        possible_channel_inds = np.unique(peaks['channel_index'])
         
         # channel neighborhood
         chan_distances = get_channel_distances(recording)
@@ -163,7 +163,7 @@ class SlidingHdbscanClustering:
         remain_percent = np.zeros(num_chans, dtype='float64')
         total_count = np.zeros(num_chans, dtype='int64')
         for chan_ind in range(num_chans):
-            total_count[chan_ind] = np.sum(peaks['channel_ind'] == chan_ind)
+            total_count[chan_ind] = np.sum(peaks['channel_index'] == chan_ind)
 
         # this force compute compute at forst loop
         prev_local_chan_inds = np.arange(num_chans, dtype='int64')
@@ -175,8 +175,8 @@ class SlidingHdbscanClustering:
             for chan_ind in prev_local_chan_inds:
                 if total_count[chan_ind] == 0:
                     continue
-                #~ inds, = np.nonzero(np.in1d(peaks['channel_ind'], closest_channels[chan_ind]) & (peak_labels==0))
-                inds, = np.nonzero((peaks['channel_ind'] == chan_ind) & (peak_labels==0))
+                #~ inds, = np.nonzero(np.in1d(peaks['channel_index'], closest_channels[chan_ind]) & (peak_labels==0))
+                inds, = np.nonzero((peaks['channel_index'] == chan_ind) & (peak_labels==0))
                 if inds.size <= d['min_spike_on_channel']:
                     chan_amps[chan_ind] = 0.
                 else:
@@ -202,7 +202,7 @@ class SlidingHdbscanClustering:
             wfs = []
             local_peak_ind = []
             for chan_ind in local_chan_inds:
-                sel,  = np.nonzero(peaks['channel_ind'] == chan_ind)
+                sel,  = np.nonzero(peaks['channel_index'] == chan_ind)
                 inds,  = np.nonzero(peak_labels[sel] == 0)
                 local_peak_ind.append(sel[inds])
                 # here a unit is a channel index!!!
@@ -282,7 +282,7 @@ class SlidingHdbscanClustering:
                 final_peak_inds = local_peak_ind[local_labels == best_label]
 
                 # trash outliers from this channel (propably some collision)
-                outlier_inds, = np.nonzero((local_labels == -1) & (peaks[local_peak_ind]['channel_ind'] == local_chan_ind))
+                outlier_inds, = np.nonzero((local_labels == -1) & (peaks[local_peak_ind]['channel_index'] == local_chan_ind))
                 if outlier_inds.size > 0:
                     peak_labels[local_peak_ind[outlier_inds]] = -1
             elif num_cluster == 1:
@@ -292,7 +292,7 @@ class SlidingHdbscanClustering:
                 best_label = None
                 final_peak_inds = np.array([], dtype='int64')
                 # trash all peaks from this channel
-                to_trash_ind,  = np.nonzero(peaks[local_peak_ind]['channel_ind'] == local_chan_ind)
+                to_trash_ind,  = np.nonzero(peaks[local_peak_ind]['channel_index'] == local_chan_ind)
                 peak_labels[local_peak_ind[to_trash_ind]] = -1
                 
             if best_label is not None:
@@ -358,7 +358,7 @@ class SlidingHdbscanClustering:
                 ax.set_title(f'n={local_peak_ind.size} labeled={final_peak_inds.size} chans={local_chan_ind} {local_chan_inds}')
 
                 ax = axs[2]
-                sel, = np.nonzero((peaks['channel_ind'] == local_chan_ind) & (peak_labels == 0))
+                sel, = np.nonzero((peaks['channel_index'] == local_chan_ind) & (peak_labels == 0))
                 count, bins = np.histogram(np.abs(peaks['amplitude'][sel]), bins=200)
                 ax.plot(bins[:-1], count, color='k', alpha=0.5)
 
@@ -385,7 +385,7 @@ class SlidingHdbscanClustering:
         nbefore = int(d['ms_before'] * fs / 1000.)
         nafter = int(d['ms_after'] * fs / 1000.)
         
-        possible_channel_inds = np.unique(peaks['channel_ind'])
+        possible_channel_inds = np.unique(peaks['channel_index'])
         chan_distances = get_channel_distances(recording)
         closest_channels = []
         for c in range(num_chans):
@@ -454,7 +454,7 @@ class SlidingHdbscanClustering:
 def _collect_sparse_waveforms(peaks, wfs_arrays, closest_channels, peak_labels, sparsity_mask, label):
     inds, = np.nonzero(peak_labels == label)
     local_peaks = peaks[inds]
-    label_chan_inds, count = np.unique(local_peaks['channel_ind'], return_counts=True)
+    label_chan_inds, count = np.unique(local_peaks['channel_index'], return_counts=True)
     main_chan = label_chan_inds[np.argmax(count)]
 
     #only main channel sparsity
@@ -467,7 +467,7 @@ def _collect_sparse_waveforms(peaks, wfs_arrays, closest_channels, peak_labels, 
 
     wfs = []
     for chan_ind in label_chan_inds:
-        sel,  = np.nonzero(peaks['channel_ind'] == chan_ind)
+        sel,  = np.nonzero(peaks['channel_index'] == chan_ind)
 
         inds,  = np.nonzero(peak_labels[sel] == label)
         

--- a/src/spikeinterface/sortingcomponents/clustering/sliding_nn.py
+++ b/src/spikeinterface/sortingcomponents/clustering/sliding_nn.py
@@ -115,7 +115,7 @@ class SlidingNNClustering:
         dtype = [('sample_ind', 'int64'), ('unit_ind', 'int64'), ('segment_ind', 'int64')]
         peaks2 = np.zeros(peaks.size, dtype=dtype)
         peaks2['sample_ind'] = peaks['sample_ind']
-        peaks2['unit_ind'] = peaks['channel_ind']
+        peaks2['unit_ind'] = peaks['channel_index']
         peaks2['segment_ind'] = peaks['segment_ind']
         
         fs = recording.get_sampling_frequency()
@@ -505,15 +505,15 @@ def get_chunk_spike_waveforms(
     all_chan_idx = np.zeros((len(peaks_chunk), n_channel_neighbors))
 
     # for each spike in the sample, add it to the
-    for spike_i, (sample_ind, channel_ind, amplitude, segment_ind) in enumerate(
+    for spike_i, (sample_ind, channel_index, amplitude, segment_ind) in enumerate(
         peaks_chunk
     ):
         spike_start = sample_ind + margin_frames - spike_pre_frames - start_frame
         spike_end = sample_ind + margin_frames + spike_post_frames - start_frame
         all_spikes[spike_i] = traces[
-            spike_start:spike_end, channel_neighbors[channel_ind]
+            spike_start:spike_end, channel_neighbors[channel_index]
         ].T
-        all_chan_idx[spike_i] = channel_neighbors[channel_ind]
+        all_chan_idx[spike_i] = channel_neighbors[channel_index]
 
     return all_spikes, all_chan_idx, peaks_in_chunk_idx
 

--- a/src/spikeinterface/sortingcomponents/features_from_peaks.py
+++ b/src/spikeinterface/sortingcomponents/features_from_peaks.py
@@ -116,8 +116,8 @@ class PeakToPeakFeature(PipelineNode):
             all_ptps = np.ptp(waveforms, axis=1)
         else:
             all_ptps = np.zeros(peaks.size)
-            for main_chan in np.unique(peaks['channel_ind']):
-                idx, = np.nonzero(peaks['channel_ind'] == main_chan)
+            for main_chan in np.unique(peaks['channel_index']):
+                idx, = np.nonzero(peaks['channel_index'] == main_chan)
                 chan_inds, = np.nonzero(self.neighbours_mask[main_chan])
                 wfs = waveforms[idx][:, :, chan_inds]
                 all_ptps[idx] = np.max(np.ptp(wfs, axis=1))
@@ -149,8 +149,8 @@ class PeakToPeakLagsFeature(PipelineNode):
             all_lags = all_maxs - all_mins
         else:
             all_lags = np.zeros(peaks.size)
-            for main_chan in np.unique(peaks['channel_ind']):
-                idx, = np.nonzero(peaks['channel_ind'] == main_chan)
+            for main_chan in np.unique(peaks['channel_index']):
+                idx, = np.nonzero(peaks['channel_index'] == main_chan)
                 chan_inds, = np.nonzero(self.neighbours_mask[main_chan])
                 wfs = waveforms[idx][:, :, chan_inds]
                 maxs = np.argmax(wfs, axis=1)
@@ -184,8 +184,8 @@ class RandomProjectionsFeature(PipelineNode):
 
     def compute(self, traces, peaks, waveforms):
         all_projections = np.zeros((peaks.size, self.projections.shape[1]), dtype=self._dtype)
-        for main_chan in np.unique(peaks['channel_ind']):
-            idx, = np.nonzero(peaks['channel_ind'] == main_chan)
+        for main_chan in np.unique(peaks['channel_index']):
+            idx, = np.nonzero(peaks['channel_index'] == main_chan)
             chan_inds, = np.nonzero(self.neighbours_mask[main_chan])
             local_projections = self.projections[chan_inds, :]
             wf_ptp = (waveforms[idx][:, :, chan_inds]).ptp(axis=1)
@@ -220,8 +220,8 @@ class RandomProjectionsEnergyFeature(PipelineNode):
 
     def compute(self, traces, peaks, waveforms):
         all_projections = np.zeros((peaks.size, self.projections.shape[1]), dtype=self._dtype)
-        for main_chan in np.unique(peaks['channel_ind']):
-            idx, = np.nonzero(peaks['channel_ind'] == main_chan)
+        for main_chan in np.unique(peaks['channel_index']):
+            idx, = np.nonzero(peaks['channel_index'] == main_chan)
             chan_inds, = np.nonzero(self.neighbours_mask[main_chan])
             local_projections = self.projections[chan_inds, :]
             energies = np.linalg.norm(waveforms[idx][:, :, chan_inds], axis=1)
@@ -254,8 +254,8 @@ class StdPeakToPeakFeature(PipelineNode):
 
     def compute(self, traces, peaks, waveforms):
         all_ptps = np.zeros(peaks.size)
-        for main_chan in np.unique(peaks['channel_ind']):
-            idx, = np.nonzero(peaks['channel_ind'] == main_chan)
+        for main_chan in np.unique(peaks['channel_index']):
+            idx, = np.nonzero(peaks['channel_index'] == main_chan)
             chan_inds, = np.nonzero(self.neighbours_mask[main_chan])
             wfs = waveforms[idx][:, :, chan_inds]
             all_ptps[idx] = np.std(np.ptp(wfs, axis=1), axis=1)
@@ -280,8 +280,8 @@ class GlobalPeakToPeakFeature(PipelineNode):
 
     def compute(self, traces, peaks, waveforms):
         all_ptps = np.zeros(peaks.size)
-        for main_chan in np.unique(peaks['channel_ind']):
-            idx, = np.nonzero(peaks['channel_ind'] == main_chan)
+        for main_chan in np.unique(peaks['channel_index']):
+            idx, = np.nonzero(peaks['channel_index'] == main_chan)
             chan_inds, = np.nonzero(self.neighbours_mask[main_chan])
             wfs = waveforms[idx][:, :, chan_inds]
             all_ptps[idx] = np.max(wfs, axis=(1, 2)) - np.min(wfs, axis=(1, 2))
@@ -306,8 +306,8 @@ class KurtosisPeakToPeakFeature(PipelineNode):
     def compute(self, traces, peaks, waveforms):
         all_ptps = np.zeros(peaks.size)
         import scipy
-        for main_chan in np.unique(peaks['channel_ind']):
-            idx, = np.nonzero(peaks['channel_ind'] == main_chan)
+        for main_chan in np.unique(peaks['channel_index']):
+            idx, = np.nonzero(peaks['channel_index'] == main_chan)
             chan_inds, = np.nonzero(self.neighbours_mask[main_chan])
             wfs = waveforms[idx][:, :, chan_inds]
             all_ptps[idx] = scipy.stats.kurtosis(np.ptp(wfs, axis=1), axis=1)
@@ -330,8 +330,8 @@ class EnergyFeature(PipelineNode):
 
     def compute(self, traces, peaks, waveforms):
         energy = np.zeros(peaks.size, dtype='float32')
-        for main_chan in np.unique(peaks['channel_ind']):
-            idx, = np.nonzero(peaks['channel_ind'] == main_chan)
+        for main_chan in np.unique(peaks['channel_index']):
+            idx, = np.nonzero(peaks['channel_index'] == main_chan)
             chan_inds, = np.nonzero(self.neighbours_mask[main_chan])
 
             wfs = waveforms[idx][:, :, chan_inds]

--- a/src/spikeinterface/sortingcomponents/matching/circus.py
+++ b/src/spikeinterface/sortingcomponents/matching/circus.py
@@ -22,7 +22,7 @@ potrs, = scipy.linalg.get_lapack_funcs(('potrs',), dtype=np.float32)
 
 nrm2, = scipy.linalg.get_blas_funcs(('nrm2', ), dtype=np.float32)
 
-spike_dtype = [('sample_ind', 'int64'), ('channel_ind', 'int64'), ('cluster_ind', 'int64'),
+spike_dtype = [('sample_ind', 'int64'), ('channel_index', 'int64'), ('cluster_ind', 'int64'),
                ('amplitude', 'float64'), ('segment_ind', 'int64')]
 
 from .main import BaseTemplateMatchingEngine
@@ -475,7 +475,7 @@ class CircusOMPPeeler(BaseTemplateMatchingEngine):
 
         num_spikes = len(valid_indices[0])
         spikes['sample_ind'][:num_spikes] = valid_indices[1] + d['nbefore']
-        spikes['channel_ind'][:num_spikes] = 0
+        spikes['channel_index'][:num_spikes] = 0
         spikes['cluster_ind'][:num_spikes] = valid_indices[0]
         spikes['amplitude'][:num_spikes] = final_amplitudes[valid_indices[0], valid_indices[1]]
         
@@ -871,7 +871,7 @@ class CircusPeeler(BaseTemplateMatchingEngine):
             scalar_products[best_cluster_ind, is_valid_nn[0]:is_valid_nn[1]] = -np.inf
 
             spikes['sample_ind'][num_spikes] = best_peak_sample_ind
-            spikes['channel_ind'][num_spikes] = best_peak_chan_ind
+            spikes['channel_index'][num_spikes] = best_peak_chan_ind
             spikes['cluster_ind'][num_spikes] = best_cluster_ind
             spikes['amplitude'][num_spikes] = best_amplitude
             num_spikes += 1

--- a/src/spikeinterface/sortingcomponents/matching/naive.py
+++ b/src/spikeinterface/sortingcomponents/matching/naive.py
@@ -7,7 +7,7 @@ from spikeinterface.postprocessing import (get_template_channel_sparsity, get_te
 
 from spikeinterface.sortingcomponents.peak_detection import DetectPeakLocallyExclusive
 
-spike_dtype = [('sample_ind', 'int64'), ('channel_ind', 'int64'), ('cluster_ind', 'int64'),
+spike_dtype = [('sample_ind', 'int64'), ('channel_index', 'int64'), ('cluster_ind', 'int64'),
                ('amplitude', 'float64'), ('segment_ind', 'int64')]
 
 
@@ -110,7 +110,7 @@ class NaiveMatching(BaseTemplateMatchingEngine):
 
         spikes = np.zeros(peak_sample_ind.size, dtype=spike_dtype)
         spikes['sample_ind'] = peak_sample_ind
-        spikes['channel_ind'] = peak_chan_ind  # TODO need to put the channel from template
+        spikes['channel_index'] = peak_chan_ind  # TODO need to put the channel from template
         
         # naively take the closest template
         for i in range(peak_sample_ind.size):

--- a/src/spikeinterface/sortingcomponents/matching/tdc.py
+++ b/src/spikeinterface/sortingcomponents/matching/tdc.py
@@ -5,7 +5,7 @@ from spikeinterface.core import (WaveformExtractor, get_noise_levels, get_channe
 
 from spikeinterface.sortingcomponents.peak_detection import DetectPeakLocallyExclusive
 
-spike_dtype = [('sample_ind', 'int64'), ('channel_ind', 'int64'), ('cluster_ind', 'int64'),
+spike_dtype = [('sample_ind', 'int64'), ('channel_index', 'int64'), ('cluster_ind', 'int64'),
                ('amplitude', 'float64'), ('segment_ind', 'int64')]
 
 from .main import BaseTemplateMatchingEngine
@@ -149,8 +149,8 @@ class TridesclousPeeler(BaseTemplateMatchingEngine):
 
         # nearby cluster for each channel
         possible_clusters_by_channel = []
-        for channel_ind in range(distances.shape[0]):
-            cluster_inds, = np.nonzero(near_cluster_mask[channel_ind, :])
+        for channel_index in range(distances.shape[0]):
+            cluster_inds, = np.nonzero(near_cluster_mask[channel_index, :])
             possible_clusters_by_channel.append(cluster_inds)
         
         d['possible_clusters_by_channel'] = possible_clusters_by_channel
@@ -225,7 +225,7 @@ def _tdc_find_spikes(traces, d, level=0):
 
         spikes = np.zeros(peak_sample_ind.size, dtype=spike_dtype)
         spikes['sample_ind'] = peak_sample_ind
-        spikes['channel_ind'] = peak_chan_ind  # TODO need to put the channel from template
+        spikes['channel_index'] = peak_chan_ind  # TODO need to put the channel from template
 
         possible_shifts = d['possible_shifts']
         distances_shift = np.zeros(possible_shifts.size)

--- a/src/spikeinterface/sortingcomponents/matching/wobble.py
+++ b/src/spikeinterface/sortingcomponents/matching/wobble.py
@@ -291,7 +291,7 @@ class WobbleMatch(BaseTemplateMatchingEngine):
     default_params = {
         'waveform_extractor' : None,
     }
-    spike_dtype = [('sample_ind', 'int64'), ('channel_ind', 'int64'), ('cluster_ind', 'int64'),
+    spike_dtype = [('sample_ind', 'int64'), ('channel_index', 'int64'), ('cluster_ind', 'int64'),
                    ('amplitude', 'float64'), ('segment_ind', 'int64')]
 
     @classmethod
@@ -454,7 +454,7 @@ class WobbleMatch(BaseTemplateMatchingEngine):
         spikes = np.zeros(spike_train.shape[0], dtype=cls.spike_dtype)
         spikes['sample_ind'] = spike_train[:, 0]
         spikes['cluster_ind'] = spike_train[:, 1]
-        spikes['channel_ind'] = channel_inds
+        spikes['channel_index'] = channel_inds
         spikes['amplitude'] = amplitudes
 
         return spikes

--- a/src/spikeinterface/sortingcomponents/peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/peak_detection.py
@@ -126,7 +126,7 @@ class PeakDetectorWrapper(PeakDetector):
         peak_amplitude = traces[peak_sample_ind, peak_chan_ind]
         local_peaks = np.zeros(peak_sample_ind.size, dtype=base_peak_dtype)
         local_peaks['sample_ind'] = peak_sample_ind
-        local_peaks['channel_ind'] = peak_chan_ind
+        local_peaks['channel_index'] = peak_chan_ind
         local_peaks['amplitude'] = peak_amplitude
         local_peaks['segment_ind'] = segment_index
 

--- a/src/spikeinterface/sortingcomponents/peak_localization.py
+++ b/src/spikeinterface/sortingcomponents/peak_localization.py
@@ -124,7 +124,7 @@ class LocalizePeakChannel(PipelineNode):
     def compute(self, traces, peaks):
         peak_locations = np.zeros(peaks.size, dtype=self._dtype)
 
-        for index, main_chan in enumerate(peaks['channel_ind']):
+        for index, main_chan in enumerate(peaks['channel_index']):
             locations = self.contact_locations[main_chan, :]
             peak_locations['x'][index] = locations[0]
             peak_locations['y'][index] = locations[1]
@@ -168,8 +168,8 @@ class LocalizeCenterOfMass(LocalizeBase):
     def compute(self, traces, peaks, waveforms):
         peak_locations = np.zeros(peaks.size, dtype=self._dtype)
 
-        for main_chan in np.unique(peaks['channel_ind']):
-            idx, = np.nonzero(peaks['channel_ind'] == main_chan)
+        for main_chan in np.unique(peaks['channel_index']):
+            idx, = np.nonzero(peaks['channel_index'] == main_chan)
             chan_inds, = np.nonzero(self.neighbours_mask[main_chan])
             local_contact_locations = self.contact_locations[chan_inds, :]
 
@@ -246,7 +246,7 @@ class LocalizeMonopolarTriangulation(PipelineNode):
 
         for i, peak in enumerate(peaks):
             sample_ind = peak['sample_ind']
-            chan_mask = self.neighbours_mask[peak['channel_ind'], :]
+            chan_mask = self.neighbours_mask[peak['channel_index'], :]
             chan_inds = np.flatnonzero(chan_mask)
             local_contact_locations = self.contact_locations[chan_inds, :]
 
@@ -259,7 +259,7 @@ class LocalizeMonopolarTriangulation(PipelineNode):
                 wf_data = np.abs(wf[self.nbefore])
 
             if self.enforce_decrease_radial_parents is not None:
-                enforce_decrease_shells_data(wf_data, peak['channel_ind'], self.enforce_decrease_radial_parents, in_place=True)
+                enforce_decrease_shells_data(wf_data, peak['channel_index'], self.enforce_decrease_radial_parents, in_place=True)
 
             peak_locations[i] = solve_monopolar_triangulation(wf_data, local_contact_locations,
                                                               self.max_distance_um, self.optimizer)
@@ -335,8 +335,8 @@ class LocalizeGridConvolution(PipelineNode):
     def compute(self, traces, peaks, waveforms):
         peak_locations = np.zeros(peaks.size, dtype=self._dtype)
 
-        for main_chan in np.unique(peaks['channel_ind']):
-            idx, = np.nonzero(peaks['channel_ind'] == main_chan)
+        for main_chan in np.unique(peaks['channel_index']):
+            idx, = np.nonzero(peaks['channel_index'] == main_chan)
             if 'amplitude' in peaks.dtype.names:
                 amplitudes = peaks['amplitude'][idx]
             else:

--- a/src/spikeinterface/sortingcomponents/peak_pipeline.py
+++ b/src/spikeinterface/sortingcomponents/peak_pipeline.py
@@ -30,7 +30,7 @@ from spikeinterface.core.job_tools import ChunkRecordingExecutor, fix_job_kwargs
 from spikeinterface.core import get_channel_distances
 
 
-base_peak_dtype = [('sample_ind', 'int64'), ('channel_ind', 'int64'),
+base_peak_dtype = [('sample_ind', 'int64'), ('channel_index', 'int64'),
                    ('amplitude', 'float64'), ('segment_ind', 'int64')]
 
 
@@ -271,7 +271,7 @@ class ExtractSparseWaveforms(WaveformsNode):
         sparse_wfs = np.zeros((peaks.shape[0], self.nbefore + self.nafter, self.max_num_chans), dtype=traces.dtype)
 
         for i, peak in enumerate(peaks):
-            (chans,) = np.nonzero(self.neighbours_mask[peak["channel_ind"]])
+            (chans,) = np.nonzero(self.neighbours_mask[peak["channel_index"]])
             sparse_wfs[i, :, : len(chans)] = traces[
                 peak["sample_ind"] - self.nbefore : peak["sample_ind"] + self.nafter, :
             ][:, chans]

--- a/src/spikeinterface/sortingcomponents/peak_selection.py
+++ b/src/spikeinterface/sortingcomponents/peak_selection.py
@@ -99,8 +99,8 @@ def select_peak_indices(peaks, method, seed, **method_kwargs):
         if params['select_per_channel']:
 
             ## This method will randomly select max_peaks_per_channel peaks per channels
-            for channel in np.unique(peaks['channel_ind']):
-                peaks_indices = np.where(peaks['channel_ind'] == channel)[0]
+            for channel in np.unique(peaks['channel_index']):
+                peaks_indices = np.where(peaks['channel_index'] == channel)[0]
                 max_peaks = min(peaks_indices.size, params['n_peaks'])
                 selected_indices += [rng.choice(peaks_indices, size=max_peaks, replace=False)]
         else:
@@ -130,9 +130,9 @@ def select_peak_indices(peaks, method, seed, **method_kwargs):
             assert params['noise_levels'] is not None, "Noise levels should be provided"
 
             if params['select_per_channel']:
-                for channel in np.unique(peaks['channel_ind']):
+                for channel in np.unique(peaks['channel_index']):
 
-                    peaks_indices = np.where(peaks['channel_ind'] == channel)[0]                
+                    peaks_indices = np.where(peaks['channel_index'] == channel)[0]                
                     if params['n_peaks'] > peaks_indices.size:
                         selected_indices += [peaks_indices]
                     else:
@@ -155,7 +155,7 @@ def select_peak_indices(peaks, method, seed, **method_kwargs):
                 if params['n_peaks'] > peaks.size:
                     selected_indices += [np.arange(peaks.size)]
                 else:
-                    snrs = peaks['amplitude'] / params['noise_levels'][peaks['channel_ind']]
+                    snrs = peaks['amplitude'] / params['noise_levels'][peaks['channel_index']]
                     preprocessing = QuantileTransformer(output_distribution='uniform', n_quantiles=min(100, len(snrs)))
                     snrs = preprocessing.fit_transform(snrs[:, np.newaxis])
 

--- a/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -163,7 +163,7 @@ def test_detect_peaks():
         import spikeinterface.widgets as sw
         from probeinterface.plotting import plot_probe
 
-        sample_inds, chan_inds, amplitudes = peaks['sample_ind'], peaks['channel_ind'], peaks['amplitude']
+        sample_inds, chan_inds, amplitudes = peaks['sample_ind'], peaks['channel_index'], peaks['amplitude']
         chan_offset = 500
         traces = recording.get_traces()
         traces += np.arange(traces.shape[1])[None, :] * chan_offset


### PR DESCRIPTION
Let's try to move forward with #1409 which got sidestep because of the changes to main.

This PR deals with the changes for `channel_ind` to `channel_index` and only in the places where the peak structure is used. I will change the others in a PR and the rest of variables with that name more gradually.