### PR TITLE
Allow to set the recording of `WaveformExtractor`

### DIFF
--- a/src/spikeinterface/core/recording_tools.py
+++ b/src/spikeinterface/core/recording_tools.py
@@ -350,3 +350,32 @@ def check_probe_do_not_overlap(probes):
                 raise Exception(
                     "Probes are overlapping! Retrieve locations of single probes separately"
                 )
+
+
+def get_rec_attributes(recording):
+    """
+    Construct rec_attributes from recording object
+
+    Parameters
+    ----------
+    recording : BaseRecording
+        The recording object
+
+    Returns
+    -------
+    dict
+        The rec_attributes dictionary
+    """
+    properties_to_attrs = deepcopy(recording._properties)
+    if 'contact_vector' in properties_to_attrs:
+        del properties_to_attrs['contact_vector']
+    rec_attributes = dict(
+            channel_ids=recording.channel_ids,
+            sampling_frequency=recording.get_sampling_frequency(),
+            num_channels=recording.get_num_channels(),
+            num_samples=[recording.get_num_samples(seg_index)
+                         for seg_index in range(recording.get_num_segments())],
+            is_filtered=recording.is_filtered(),
+            properties=properties_to_attrs
+        )
+    return rec_attributes

--- a/src/spikeinterface/core/recording_tools.py
+++ b/src/spikeinterface/core/recording_tools.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Literal
 import numpy as np
 

--- a/src/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/src/spikeinterface/core/tests/test_waveform_extractor.py
@@ -483,9 +483,9 @@ def test_compute_sparsity():
 
 
 if __name__ == '__main__':
-    # test_WaveformExtractor()
+    test_WaveformExtractor()
     # test_extract_waveforms()
     # test_sparsity()
     # test_portability()
-    test_recordingless()
+    # test_recordingless()
     # test_compute_sparsity()

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -85,7 +85,7 @@ class WaveformExtractor:
                                            sorting.get_sampling_frequency(), decimal=2)
             if not recording.is_filtered() and not allow_unfiltered:
                 raise Exception('The recording is not filtered, you must filter it using `bandpass_filter()`.'
-                           3     'If the recording is already filtered, you can also do '
+                                'If the recording is already filtered, you can also do '
                                 '`recording.annotate(is_filtered=True).\n'
                                 'If you trully want to extract unfiltered waveforms, use `allow_unfiltered=True`.')
             self._rec_attributes = rec_attributes

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -1,3 +1,4 @@
+import math
 import pickle
 from pathlib import Path
 import shutil
@@ -595,7 +596,7 @@ class WaveformExtractor:
         else:
             if recording.get_num_segments() != self.get_num_segments():
                 raise ValueError(f"Couldn't set the WaveformExtractor recording: num_segments do not match!\n{self.get_num_segments()} != {recording.get_num_segments()}")
-            if abs(recording.sampling_frequency - self.sampling_frequency) > 1e-2:
+            if not math.isclose(recording.sampling_frequency, self.sampling_frequency, abs_tol=1e-2, rel_tol=1e-5):
                 raise ValueError(f"Couldn't set the WaveformExtractor recording: sampling frequency doesn't match!\n{self.sampling_frequency} != {recording.sampling_frequency}")
             try:  # Will fail if called from __init__ because can't check from previous channel_ids.
                 if np.array_equal(self.channel_ids, recording.channel_ids):
@@ -1477,7 +1478,7 @@ def load_waveforms(folder, with_recording: bool = True, sorting: Optional[BaseSo
     ----------
     folder : str or Path
         The folder / zarr folder where the waveform extractor is stored
-    with_recording : bool | BaseRecording, optional
+    with_recording : bool, optional
         If True, the recording is loaded, by default True.
         If False, the WaveformExtractor object in recordingless mode.
     sorting : BaseSorting, optional

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -1469,8 +1469,10 @@ def load_waveforms(folder, with_recording=True, sorting=None):
     ----------
     folder : str or Path
         The folder / zarr folder where the waveform extractor is stored
-    with_recording : bool, optional
+    with_recording : bool | BaseRecording, optional
         If True, the recording is loaded, by default True
+        If False, the WaveformExtractor object in recordless
+        If BaseRecording, the given recording is used
     sorting : BaseSorting, optional
         If passed, the sorting object associated to the waveform extractor, by default None
 

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -16,8 +16,8 @@ from .baserecording import BaseRecording
 from .basesorting import BaseSorting
 from .core_tools import check_json
 from .job_tools import _shared_job_kwargs_doc, split_job_kwargs, fix_job_kwargs
-from .recording_tools import check_probe_do_not_overlap
-from .waveform_tools import extract_waveforms_to_buffers, has_exceeding_spikes, get_rec_attributes
+from .recording_tools import check_probe_do_not_overlap, get_rec_attributes
+from .waveform_tools import extract_waveforms_to_buffers, has_exceeding_spikes
 from .sparsity import ChannelSparsity, compute_sparsity, _sparsity_doc
 
 _possible_template_modes = ('average', 'std', 'median')

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -1470,9 +1470,9 @@ def load_waveforms(folder, with_recording=True, sorting=None):
     folder : str or Path
         The folder / zarr folder where the waveform extractor is stored
     with_recording : bool | BaseRecording, optional
-        If True, the recording is loaded, by default True
-        If False, the WaveformExtractor object in recordless
-        If BaseRecording, the given recording is used
+        If True, the recording is loaded, by default True.
+        If False, the WaveformExtractor object in recordingless mode.
+        If BaseRecording, the given recording is used as the WaveformExtractor.recording
     sorting : BaseSorting, optional
         If passed, the sorting object associated to the waveform extractor, by default None
 

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -10,6 +10,7 @@ from warnings import warn
 import probeinterface
 
 from .base import load_extractor
+from .baserecording import BaseRecording
 from .core_tools import check_json
 from .job_tools import _shared_job_kwargs_doc, split_job_kwargs, fix_job_kwargs
 from .recording_tools import check_probe_do_not_overlap
@@ -84,7 +85,7 @@ class WaveformExtractor:
                                            sorting.get_sampling_frequency(), decimal=2)
             if not recording.is_filtered() and not allow_unfiltered:
                 raise Exception('The recording is not filtered, you must filter it using `bandpass_filter()`.'
-                                'If the recording is already filtered, you can also do '
+                           3     'If the recording is already filtered, you can also do '
                                 '`recording.annotate(is_filtered=True).\n'
                                 'If you trully want to extract unfiltered waveforms, use `allow_unfiltered=True`.')
             self._rec_attributes = rec_attributes
@@ -146,7 +147,10 @@ class WaveformExtractor:
         folder = Path(folder)
         assert folder.is_dir(), f'This waveform folder does not exists {folder}'
 
-        if not with_recording:
+        if isinstance(with_recording, BaseRecording):
+            recording = with_recording
+            rec_attributes = None
+        elif not with_recording:
             # load
             recording = None
             rec_attributes_file = folder / 'recording_info' / 'recording_attributes.json'

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -30,7 +30,7 @@ class WaveformExtractor:
 
     Parameters
     ----------
-    recording: Recording
+    recording: Recording | None
         The recording object
     sorting: Sorting
         The sorting object
@@ -66,7 +66,7 @@ class WaveformExtractor:
 
     """
     extensions = []
-    def __init__(self, recording: BaseRecording, sorting: BaseSorting,
+    def __init__(self, recording: Optional[BaseRecording], sorting: BaseSorting,
                  folder=None, rec_attributes=None, allow_unfiltered=False, sparsity=None):
         self.sorting = sorting
         self._rec_attributes = None
@@ -570,7 +570,18 @@ class WaveformExtractor:
 
     def set_recording(self, recording: Optional[BaseRecording], rec_attributes: Optional[dict] = None, allow_unfiltered: bool = False) -> None:
         """
+        Sets the recording object and attributes for the WaveformExtractor.
 
+        Parameters
+        ----------
+        recording: Recording | None
+            The recording object
+        rec_attributes: None or dict
+            When recording is None then a minimal dict with some attributes
+            is needed.
+        allow_unfiltered: bool
+            If true, will accept unfiltered recording.
+            False by default.
         """
 
         if recording is None:  # Recordless mode.

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -11,6 +11,7 @@ It is a 2-step approach:
 from pathlib import Path
 
 import numpy as np
+from copy import deepcopy
 
 from .job_tools import ChunkRecordingExecutor, ensure_n_jobs, _shared_job_kwargs_doc
 from .core_tools import make_shared_array
@@ -376,3 +377,32 @@ def has_exceeding_spikes(recording, sorting):
             if spike_vector_seg["sample_ind"][-1] > recording.get_num_samples(segment_index=segment_index) - 1:
                 return True
     return False
+
+
+def get_rec_attributes(recording):
+    """
+    Construct rec_attributes from recording object
+
+    Parameters
+    ----------
+    recording : BaseRecording
+        The recording object
+
+    Returns
+    -------
+    dict
+        The rec_attributes dictionary
+    """
+    properties_to_attrs = deepcopy(recording._properties)
+    if 'contact_vector' in properties_to_attrs:
+        del properties_to_attrs['contact_vector']
+    rec_attributes = dict(
+            channel_ids=recording.channel_ids,
+            sampling_frequency=recording.get_sampling_frequency(),
+            num_channels=recording.get_num_channels(),
+            num_samples=[recording.get_num_samples(seg_index)
+                         for seg_index in range(recording.get_num_segments())],
+            is_filtered=recording.is_filtered(),
+            properties=properties_to_attrs
+        )
+    return rec_attributes

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -377,32 +377,3 @@ def has_exceeding_spikes(recording, sorting):
             if spike_vector_seg["sample_index"][-1] > recording.get_num_samples(segment_index=segment_index) - 1:
                 return True
     return False
-
-
-def get_rec_attributes(recording):
-    """
-    Construct rec_attributes from recording object
-
-    Parameters
-    ----------
-    recording : BaseRecording
-        The recording object
-
-    Returns
-    -------
-    dict
-        The rec_attributes dictionary
-    """
-    properties_to_attrs = deepcopy(recording._properties)
-    if 'contact_vector' in properties_to_attrs:
-        del properties_to_attrs['contact_vector']
-    rec_attributes = dict(
-            channel_ids=recording.channel_ids,
-            sampling_frequency=recording.get_sampling_frequency(),
-            num_channels=recording.get_num_channels(),
-            num_samples=[recording.get_num_samples(seg_index)
-                         for seg_index in range(recording.get_num_segments())],
-            is_filtered=recording.is_filtered(),
-            properties=properties_to_attrs
-        )
-    return rec_attributes

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -11,7 +11,6 @@ It is a 2-step approach:
 from pathlib import Path
 
 import numpy as np
-from copy import deepcopy
 
 from .job_tools import ChunkRecordingExecutor, ensure_n_jobs, _shared_job_kwargs_doc
 from .core_tools import make_shared_array


### PR DESCRIPTION
I need to load multiple wvf_extractor with the same `recording` object, to then compute the amplitudes.

For that, I cannot use `with_recording=False`, but if I set it to `True`, then it will load the same recording tens of times (which takes time and RAM).

I'd like the possibility to use `with_recording=recording`.

Thanks :)