### PR TITLE
Fixed IndexError when interpolating artifacts

### DIFF
--- a/src/spikeinterface/preprocessing/remove_artifacts.py
+++ b/src/spikeinterface/preprocessing/remove_artifacts.py
@@ -290,8 +290,8 @@ class RemoveArtifactsRecordingSegment(BasePreprocessorSegment):
                         idxs = np.arange(idx - 3, idx + 1)
                     else:
                         idxs = np.arange(idx - 2, idx + 3)
-                    if np.min(idx) < 0:
-                        idx = idx[idx >= 0]
+                    if np.min(idxs) < 0:
+                        idxs = idxs[idxs >= 0]
                     median_vals = np.median(traces[idxs, :], axis=0, keepdims=True)
                     pre_vals.append(median_vals)
                 post_vals = []
@@ -300,8 +300,8 @@ class RemoveArtifactsRecordingSegment(BasePreprocessorSegment):
                         idxs = np.arange(idx, idx + 4)
                     else:
                         idxs = np.arange(idx - 2, idx + 3)
-                    if np.max(idx) >= traces.shape[0]:
-                        idx = idx[idx < traces.shape[0]]
+                    if np.max(idxs) >= traces.shape[0]:
+                        idxs = idxs[idxs < traces.shape[0]]
                     median_vals = np.median(traces[idxs, :], axis=0, keepdims=True)
                     post_vals.append(median_vals)
 


### PR DESCRIPTION
When removing artifacts, an IndexError error occurs if the start/end of the artifact occurs near the boundaries of the current data block. This pull request fixes the code that was supposed to account for the boundaries.

File ".../spikeinterface/core/core_tools.py", line 209, in _write_binary_chunk
    traces = recording.get_traces(start_frame=start_frame, end_frame=end_frame, segment_index=segment_index,
  File ".../spikeinterface/core/baserecording.py", line 160, in get_traces
    traces = rs.get_traces(start_frame=start_frame, end_frame=end_frame, channel_indices=channel_indices)
  File ".../spikeinterface/preprocessing/remove_artifacts.py", line 306, in get_traces
    median_vals = np.median(traces[idxs, :], axis=0, keepdims=True)
  File ".../numpy/core/memmap.py", line 334, in __getitem__
    res = super().__getitem__(index)
IndexError: index 90000 is out of bounds for axis 0 with size 90000