### PR TITLE
Make gin-caches great again

### DIFF
--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -73,8 +73,8 @@ jobs:
       - name: Move the downloaded data to the right directory
         if: steps.cache-datasets.outputs.cache-hit != 'true'
         run: |
-          mkdir --parents --verbose ${{ github.workspace }}/spikeinterface_datasets/ephy_testing_data/
-          mv --force ./ephy_testing_data ${{ github.workspace }}/spikeinterface_datasets/
+          mkdir --parents --verbose $HOME/spikeinterface_datasets/ephy_testing_data/
+          mv --force ./ephy_testing_data $HOME/spikeinterface_datasets/
       - name: Show size of the cache to assert data is downloaded
         run: |
           cd ${{ github.workspace }}

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   push:  # When someting is pushed into main this checks if caches need to re-created
     branches:
-      - master
       - main
   schedule:
     - cron: "0 12 * * *"  # Daily at noon UTC

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [synchronize, opened, reopened]
     branches:
-      - master
       - main
 
 concurrency:  # Cancel previous workflows on the same pull request

--- a/.github/workflows/full-test-with-codecov.yml
+++ b/.github/workflows/full-test-with-codecov.yml
@@ -46,7 +46,7 @@ jobs:
           # the key depends on the last comit repo https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git
           HASH_EPHY_DATASET: git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1
         with:
-          path: ${{ github.workspace }}/spikeinterface_datasets
+          path: $HOME/spikeinterface_datasets
           key: ${{ runner.os }}-datasets-${{ steps.vars.outputs.HASH_EPHY_DATASET }}
           restore-keys: |
             ${{ runner.os }}-datasets

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -52,7 +52,7 @@ jobs:
           # the key depends on the last comit repo https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git
           HASH_EPHY_DATASET: git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1
         with:
-          path: ${{ github.workspace }}/spikeinterface_datasets
+          path: $HOME/spikeinterface_datasets
           key: ${{ runner.os }}-datasets-${{ steps.vars.outputs.HASH_EPHY_DATASET }}
           restore-keys: |
             ${{ runner.os }}-datasets

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [synchronize, opened, reopened]
     branches:
-      - master
       - main
       
 concurrency:  # Cancel previous workflows on the same pull request

--- a/.github/workflows/streaming-extractor-test.yml
+++ b/.github/workflows/streaming-extractor-test.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     types: [synchronize, opened, reopened]
     branches:
-      - master
       - main
 concurrency:  # Cancel previous workflows on the same pull request
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
I have noticed that the extractors test are taking too long and that is because they are not using the caches again.

After all the modifications with the CI I have realized that the tests are not using the cached data for the extractors (gin-data). This is a mistake I make where I forgot that the extractor in the tests point with globals to a folder in the home directory. This PR creates the caches in the right directory so that they can be used by the extractors.

I also removed the references to master.