### PR TITLE
Refactor detect peak tests

### DIFF
--- a/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from spikeinterface import download_dataset
-from spikeinterface.extractors import MEArecRecordingExtractor
+from spikeinterface.extractors.neoextractors.mearec import MEArecRecordingExtractor, MEArecSortingExtractor
 
 from spikeinterface.sortingcomponents.peak_detection import detect_peaks
 
@@ -20,142 +20,229 @@ else:
 
 try:
     import pyopencl
+
     HAVE_PYOPENCL = True
 except:
     HAVE_PYOPENCL = False
 
 try:
     import torch
+
     HAVE_TORCH = True
 except:
     HAVE_TORCH = False
 
 
-DEBUG = False
-
-
-def test_detect_peaks():
-
-    repo = 'https://gin.g-node.org/NeuralEnsemble/ephy_testing_data'
-    remote_path = 'mearec/mearec_test_10s.h5'
-    local_path = download_dataset(
-        repo=repo, remote_path=remote_path, local_folder=None)
+@pytest.fixture(scope="module")
+def recording():
+    repo = "https://gin.g-node.org/NeuralEnsemble/ephy_testing_data"
+    remote_path = "mearec/mearec_test_10s.h5"
+    local_path = download_dataset(repo=repo, remote_path=remote_path, local_folder=None)
     recording = MEArecRecordingExtractor(local_path)
-    
-    job_kwargs = dict(n_jobs=-1, chunk_size=10000, progress_bar=True, verbose=True)
+    return recording
+
+@pytest.fixture(scope="module")
+def sorting():
+    repo = "https://gin.g-node.org/NeuralEnsemble/ephy_testing_data"
+    remote_path = "mearec/mearec_test_10s.h5"
+    local_path = download_dataset(repo=repo, remote_path=remote_path, local_folder=None)
+    sorting = MEArecSortingExtractor(local_path)
+    return sorting
+
+@pytest.fixture(scope="module")
+def job_kwargs():
+    return dict(n_jobs=-1, chunk_size=10000, progress_bar=True, verbose=True)
+
+# Don't know why this was different normal job_kwargs
+@pytest.fixture(scope="module")
+def torch_job_kwargs(job_kwargs):
     torch_job_kwargs = job_kwargs.copy()
     torch_job_kwargs["n_jobs"] = 2
+    return torch_job_kwargs
 
-    # by_channel
-    by_channel_str = f"By channel:\n"
-    peaks_by_channel_np = detect_peaks(recording, method='by_channel',
-                                       peak_sign='neg', detect_threshold=5, exclude_sweep_ms=0.1,
-                                       **job_kwargs)
-    by_channel_str += f"- numpy - {len(peaks_by_channel_np)}\n"
 
-    if HAVE_TORCH:    
-        peaks_by_channel_torch = detect_peaks(recording, method='by_channel_torch',
-                                              peak_sign='neg', detect_threshold=5, exclude_sweep_ms=0.1,
-                                              **torch_job_kwargs)
-        # due to the different implementations, we allow a small tolerance
-        assert np.isclose(np.array(len(peaks_by_channel_np)), np.array(len(peaks_by_channel_torch)),
-                          rtol=0.1)
-        by_channel_str += f"- torch - {len(peaks_by_channel_torch)}\n"
-    print(by_channel_str)
+def calculate_peaks_spike_recall(peaks, sorting, tolerance_ms=0.4):
+    """
+    Calculate the spike recall of a given peak_detection method.
+    
+    That is, it calculates the number of True positives divided by 
+    the total number of positive examples (i.e. the number of spikes) 
+    within a given tolerance.
+    
+    The tolerance is given in milliseconds and means that the detected peak 
+    time should be less than the tolerance away from the real spike time.
+    """    
+    
+    sample_indices = peaks["sample_ind"]
+    spike_trains = sorting.get_all_spike_trains()[0][0]
 
-    # locally_exclusive
-    locally_exclusive_str = f"Locally exclusive:\n"
-    peaks_local_numba = detect_peaks(recording, method='locally_exclusive',
-                                     peak_sign='neg', detect_threshold=5, exclude_sweep_ms=0.1,
-                                     **job_kwargs)
+    tolerance_number_samples = tolerance_ms * sorting.get_sampling_frequency() / 1000.
+    are_spikes_close_any_peaks = np.any(np.abs(sample_indices - spike_trains[:, np.newaxis]) < tolerance_number_samples, axis=1)
+    
+    return are_spikes_close_any_peaks.mean()
+
+
+def test_detect_peaks_by_channel(recording, sorting, job_kwargs, torch_job_kwargs):
+    peaks_by_channel_np = detect_peaks(
+        recording, method="by_channel", peak_sign="neg", detect_threshold=5, exclude_sweep_ms=0.1, **job_kwargs
+    )
+    method_recall = calculate_peaks_spike_recall(peaks_by_channel_np, sorting)
+    # Test with pytest that method_recall is close to 1
+    pytest.approx(method_recall, 1)
+    
+    if HAVE_TORCH:
+        peaks_by_channel_torch = detect_peaks(
+            recording,
+            method="by_channel_torch",
+            peak_sign="neg",
+            detect_threshold=5,
+            exclude_sweep_ms=0.1,
+            **torch_job_kwargs,
+        )
+
+        # Test that torch and numpy implementation match
+        assert np.isclose(np.array(len(peaks_by_channel_np)), np.array(len(peaks_by_channel_torch)), rtol=0.1)
+        
+        method_recall = calculate_peaks_spike_recall(peaks_by_channel_torch, sorting)
+        # Test with pytest that method_recall is close to 1
+        pytest.approx(method_recall, 1)
+
+def test_detect_peaks_locally_exclusive(recording, sorting, job_kwargs, torch_job_kwargs):
+    peaks_by_channel_np = detect_peaks(
+        recording, method="by_channel", peak_sign="neg", detect_threshold=5, exclude_sweep_ms=0.1, **job_kwargs
+    )
+
+    method_recall = calculate_peaks_spike_recall(peaks_by_channel_np, sorting)
+    # Test with pytest that method_recall is close to 1
+    pytest.approx(method_recall, 1)
+
+    peaks_local_numba = detect_peaks(
+        recording, method="locally_exclusive", peak_sign="neg", detect_threshold=5, exclude_sweep_ms=0.1, **job_kwargs
+    )
     assert len(peaks_by_channel_np) > len(peaks_local_numba)
 
-    locally_exclusive_str += f"- numba - {len(peaks_local_numba)}\n"
+    method_recall = calculate_peaks_spike_recall(peaks_local_numba, sorting)
+    # Test with pytest that method_recall is close to 1
+    pytest.approx(method_recall, 1)
 
     if HAVE_TORCH:
-        peaks_local_torch = detect_peaks(recording, method='locally_exclusive_torch',
-                                         peak_sign='neg', detect_threshold=5, exclude_sweep_ms=0.1,
-                                         **torch_job_kwargs)
-        assert len(peaks_by_channel_torch) > len(peaks_local_torch)
-        # due to the different implementations, we allow a small tolerance
-        assert np.isclose(np.array(len(peaks_local_numba)), np.array(len(peaks_local_torch)),
-                          rtol=0.1)
-        locally_exclusive_str += f"- torch - {len(peaks_local_torch)}\n"
 
-    
-    # locally_exclusive + opencl
+        peaks_local_torch = detect_peaks(
+            recording,
+            method="locally_exclusive_torch",
+            peak_sign="neg",
+            detect_threshold=5,
+            exclude_sweep_ms=0.1,
+            **torch_job_kwargs,
+        )
+        assert np.isclose(np.array(len(peaks_local_numba)), np.array(len(peaks_local_torch)), rtol=0.1)
+        
+        method_recall = calculate_peaks_spike_recall(peaks_local_torch, sorting)
+        # Test with pytest that method_recall is close to 1
+        pytest.approx(method_recall, 1)
+
     if HAVE_PYOPENCL:
-        peaks_local_cl = detect_peaks(recording, method='locally_exclusive_cl',
-                                      peak_sign='neg', detect_threshold=5, exclude_sweep_ms=0.1,
-                                      **job_kwargs)
-        locally_exclusive_str += f"- opencl - {len(peaks_local_cl)}\n"
-        # in this case implementations are exactly the same
+        peaks_local_cl = detect_peaks(
+            recording,
+            method="locally_exclusive_cl",
+            peak_sign="neg",
+            detect_threshold=5,
+            exclude_sweep_ms=0.1,
+            **job_kwargs,
+        )
         assert len(peaks_local_numba) == len(peaks_local_cl)
-    print(locally_exclusive_str)
+        
+        method_recall = calculate_peaks_spike_recall(peaks_local_cl, sorting)
+        # Test with pytest that method_recall is close to 1
+        pytest.approx(method_recall, 1)
 
-    # locally_exclusive + pipeline steps LocalizeCenterOfMass + PeakToPeakFeature
-    print("With peak pipeline")
-    extract_dense_waveforms = ExtractDenseWaveforms(recording, ms_before=1., ms_after=1.,
-                                                    return_output=False)
+# Fixture for pipeline nodes
+@pytest.fixture(scope="module")
+def pipeline_nodes(recording):
+    extract_dense_waveforms = ExtractDenseWaveforms(recording, ms_before=1.0, ms_after=1.0, return_output=False)
 
-    pipeline_nodes = [
+    return [
         extract_dense_waveforms,
-        PeakToPeakFeature(recording,  all_channels=False, parents=[extract_dense_waveforms]),
-        LocalizeCenterOfMass(recording, local_radius_um=50., parents=[extract_dense_waveforms]),
+        PeakToPeakFeature(recording, all_channels=False, parents=[extract_dense_waveforms]),
+        LocalizeCenterOfMass(recording, local_radius_um=50.0, parents=[extract_dense_waveforms]),
     ]
-    peaks, ptp, peak_locations = detect_peaks(recording, method='locally_exclusive',
-                                              peak_sign='neg', detect_threshold=5, exclude_sweep_ms=0.1,
-                                              pipeline_nodes=pipeline_nodes, **job_kwargs)
+
+DEBUG = False
+def test_peak_detection_with_pipeline(recording, pipeline_nodes, job_kwargs, torch_job_kwargs):
+    peaks, ptp, peak_locations = detect_peaks(
+        recording,
+        method="locally_exclusive",
+        peak_sign="neg",
+        detect_threshold=5,
+        exclude_sweep_ms=0.1,
+        pipeline_nodes=pipeline_nodes,
+        **job_kwargs,
+    )
     assert peaks.shape[0] == ptp.shape[0]
     assert peaks.shape[0] == peak_locations.shape[0]
-    assert 'x' in peak_locations.dtype.fields
+    assert "x" in peak_locations.dtype.fields
 
     # same pipeline but saved to npy
-    folder = cache_folder / 'peak_detection_folder'
+    folder = cache_folder / "peak_detection_folder"
     if folder.is_dir():
         shutil.rmtree(folder)
-    peaks2, ptp2, peak_locations2 = detect_peaks(recording, method='locally_exclusive',
-                                                 peak_sign='neg', detect_threshold=5, exclude_sweep_ms=0.1,
-                                                 pipeline_nodes=pipeline_nodes, gather_mode='npy',
-                                                 folder=folder, names=['peaks', 'ptps', 'peak_locations'],
-                                                 **job_kwargs)
-    peak_file = folder / 'peaks.npy'
+    peaks2, ptp2, peak_locations2 = detect_peaks(
+        recording,
+        method="locally_exclusive",
+        peak_sign="neg",
+        detect_threshold=5,
+        exclude_sweep_ms=0.1,
+        pipeline_nodes=pipeline_nodes,
+        gather_mode="npy",
+        folder=folder,
+        names=["peaks", "ptps", "peak_locations"],
+        **job_kwargs,
+    )
+    peak_file = folder / "peaks.npy"
     assert peak_file.is_file()
     peaks3 = np.load(peak_file)
     assert np.array_equal(peaks, peaks2)
     assert np.array_equal(peaks2, peaks3)
 
-    ptp_file = folder / 'ptps.npy'
+    ptp_file = folder / "ptps.npy"
     assert ptp_file.is_file()
     ptp3 = np.load(ptp_file)
     assert np.array_equal(ptp, ptp2)
     assert np.array_equal(ptp2, ptp3)
 
-    peak_location_file = folder / 'peak_locations.npy'
+    peak_location_file = folder / "peak_locations.npy"
     assert peak_location_file.is_file()
     peak_locations3 = np.load(peak_location_file)
     assert np.array_equal(peak_locations, peak_locations2)
     assert np.array_equal(peak_locations2, peak_locations3)
 
-
     if HAVE_TORCH:
-        peaks_torch, ptp_torch, peak_locations_torch = detect_peaks(recording, method='locally_exclusive_torch',
-                                                                    peak_sign='neg', detect_threshold=5,
-                                                                    exclude_sweep_ms=0.1, pipeline_nodes=pipeline_nodes,
-                                                                    **torch_job_kwargs)
+        peaks_torch, ptp_torch, peak_locations_torch = detect_peaks(
+            recording,
+            method="locally_exclusive_torch",
+            peak_sign="neg",
+            detect_threshold=5,
+            exclude_sweep_ms=0.1,
+            pipeline_nodes=pipeline_nodes,
+            **torch_job_kwargs,
+        )
         assert peaks_torch.shape[0] == ptp_torch.shape[0]
         assert peaks_torch.shape[0] == peak_locations_torch.shape[0]
-        assert 'x' in peak_locations_torch.dtype.fields
+        assert "x" in peak_locations_torch.dtype.fields
 
     if HAVE_PYOPENCL:
-        peaks_cl, ptp_cl, peak_locations_cl = detect_peaks(recording, method='locally_exclusive_cl',
-                                                           peak_sign='neg', detect_threshold=5,
-                                                           exclude_sweep_ms=0.1, pipeline_nodes=pipeline_nodes,
-                                                           **job_kwargs)
+        peaks_cl, ptp_cl, peak_locations_cl = detect_peaks(
+            recording,
+            method="locally_exclusive_cl",
+            peak_sign="neg",
+            detect_threshold=5,
+            exclude_sweep_ms=0.1,
+            pipeline_nodes=pipeline_nodes,
+            **job_kwargs,
+        )
         assert peaks_cl.shape[0] == ptp_cl.shape[0]
         assert peaks_cl.shape[0] == peak_locations_cl.shape[0]
-        assert 'x' in peak_locations_cl.dtype.fields
-    
+        assert "x" in peak_locations_cl.dtype.fields
 
     # DEBUG
     if DEBUG:
@@ -163,32 +250,35 @@ def test_detect_peaks():
         import spikeinterface.widgets as sw
         from probeinterface.plotting import plot_probe
 
-        sample_inds, chan_inds, amplitudes = peaks['sample_ind'], peaks['channel_index'], peaks['amplitude']
+        sample_inds, chan_inds, amplitudes = peaks["sample_ind"], peaks["channel_index"], peaks["amplitude"]
         chan_offset = 500
         traces = recording.get_traces()
         traces += np.arange(traces.shape[1])[None, :] * chan_offset
         fig, ax = plt.subplots()
-        ax.plot(traces, color='k')
-        ax.scatter(sample_inds, chan_inds * chan_offset + amplitudes, color='r')
+        ax.plot(traces, color="k")
+        ax.scatter(sample_inds, chan_inds * chan_offset + amplitudes, color="r")
         plt.show()
 
         fig, ax = plt.subplots()
         probe = recording.get_probe()
         plot_probe(probe, ax=ax)
-        ax.scatter(peak_locations['x'], peak_locations['y'], color='k', s=1, alpha=0.5)
+        ax.scatter(peak_locations["x"], peak_locations["y"], color="k", s=1, alpha=0.5)
         # MEArec is "yz" in 2D
         import MEArec
-        recgen = MEArec.load_recordings(recordings=local_path, return_h5_objects=True,
-        check_suffix=False,
-        load=['recordings', 'spiketrains', 'channel_positions'],
-        load_waveforms=False)
-        soma_positions = np.zeros((len(recgen.spiketrains), 3), dtype='float32')
+
+        recgen = MEArec.load_recordings(
+            recordings=local_path,
+            return_h5_objects=True,
+            check_suffix=False,
+            load=["recordings", "spiketrains", "channel_positions"],
+            load_waveforms=False,
+        )
+        soma_positions = np.zeros((len(recgen.spiketrains), 3), dtype="float32")
         for i, st in enumerate(recgen.spiketrains):
-            soma_positions[i, :] = st.annotations['soma_position']
-        ax.scatter(soma_positions[:, 1], soma_positions[:, 2], color='g', s=20, marker='*')
+            soma_positions[i, :] = st.annotations["soma_position"]
+        ax.scatter(soma_positions[:, 1], soma_positions[:, 2], color="g", s=20, marker="*")
         plt.show()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_detect_peaks()
-    


### PR DESCRIPTION
WIth this PR I want to start a re-organization of the peak detection testing battery.  The idea is having recall test for all the methods which they should pass with 100 % for the mearec data. 

I am also doing a refactor to start separting the methods to a more unit-test-like organization. I am envisioning that we can have a unit-test for each specific method that will test the following for the mearec data:
* Recall (this PR).
* No spikes too close in time for the by_channel methods
* No spikes too close in space for `exclusive` methods.

In this PR I am only adding the first point but I am hoping that in the future when we add a new method we can just simply add an extra unit-test where it will be easy to just tests for all the criteria above and possible more.