### PR TITLE
Fix wrong path in read the docs 

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,7 +30,7 @@ SpikeInterface is made of several modules to deal with different aspects of the 
 - compute quality metrics to validate and curate spike sorting outputs.
 - visualize recordings and spike sorting outputs.
 - export a report and/or export to Phy.
-- offer a powerful Qt-based viewer in a separate package `spikeinterface-gui <https://https://github.com/SpikeInterface/spikeinterface-gui>`_
+- offer a powerful Qt-based viewer in a separate package `spikeinterface-gui <https://github.com/SpikeInterface/spikeinterface-gui>`_
 - have some powerful sorting components to build your own sorter.
 
 


### PR DESCRIPTION
Adresses this point:

https://github.com/SpikeInterface/spikeinterface/discussions/1062