### PR TITLE
Added helpful error message if `cuda` missing

### DIFF
--- a/src/spikeinterface/sorters/utils/misc.py
+++ b/src/spikeinterface/sorters/utils/misc.py
@@ -62,7 +62,11 @@ def has_nvidia():
     """
     Checks if the machine has nvidia capability.
     """
-    from cuda import cuda
+    
+    try:
+        from cuda import cuda
+    except ModuleNotFoundError as err:
+        raise Exception("This container requires cuda, but the package is not installed. You can install it with:\npip install cuda-python") from err
         
     try:
         cu_result_init,  = cuda.cuInit(0)

--- a/src/spikeinterface/sorters/utils/misc.py
+++ b/src/spikeinterface/sorters/utils/misc.py
@@ -66,7 +66,7 @@ def has_nvidia():
     try:
         from cuda import cuda
     except ModuleNotFoundError as err:
-        raise Exception("This container requires cuda, but the package is not installed. You can install it with:\npip install cuda-python") from err
+        raise Exception("This sorter requires cuda, but the package is not installed. You can install it with:\npip install cuda-python") from err
         
     try:
         cu_result_init,  = cuda.cuInit(0)

--- a/src/spikeinterface/sorters/utils/misc.py
+++ b/src/spikeinterface/sorters/utils/misc.py
@@ -66,7 +66,7 @@ def has_nvidia():
     try:
         from cuda import cuda
     except ModuleNotFoundError as err:
-        raise Exception("This sorter requires cuda, but the package is not installed. You can install it with:\npip install cuda-python") from err
+        raise Exception("This sorter requires cuda, but the package 'cuda-python' is not installed. You can install it with:\npip install cuda-python") from err
         
     try:
         cu_result_init,  = cuda.cuInit(0)


### PR DESCRIPTION
Added an helpful error message for the user in case he tries to run a sorter dockerized without `cuda-python` installed in the environment.