### PR TITLE
Fix MultiSortingComparison._populate_spiketrains to prevent overwriting agreement sorting spiketrains

### DIFF
--- a/src/spikeinterface/comparison/multicomparisons.py
+++ b/src/spikeinterface/comparison/multicomparisons.py
@@ -94,8 +94,8 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
                 # Append correct spike train
                 if len(sorter_unit_ids.keys()) == 1:
                     sorting = self.object_list[self.name_list.index(list(sorter_unit_ids.keys())[0])]
-                    unit_id = list(sorter_unit_ids.values())[0]
-                    spike_train = sorting.get_unit_spike_train(unit_id, seg_index)
+                    this_sorting_unit_id = list(sorter_unit_ids.values())[0]
+                    spike_train = sorting.get_unit_spike_train(this_sorting_unit_id, seg_index)
                 else:
                     max_edge = edges[int(np.argmax([d['weight']
                                         for u, v, d in edges]))]


### PR DESCRIPTION
Reuse of the variable name `unit_id` in the method `_populate_spiketrains` was leading to incorrect `get_agreement_sorting` outputs which are described in issue  https://github.com/SpikeInterface/spikeinterface/issues/1547. Changing `unit_id` to `this_sorting_unit_id` in the appropriate locations should fix this. https://github.com/SpikeInterface/spikeinterface/blob/1bd169fc19673c60b7335d51ff38f758fd1fcc78/src/spikeinterface/comparison/multicomparisons.py#L97-L98

In the plots below, blue are spiketimes identified by KiloSort2, orange are from MountainSort4, and green are supposed to be the intersection of these spiketrains.

Before the fix:
![image](https://user-images.githubusercontent.com/34801760/233191112-d96d3c5e-77b9-4dc1-8ca9-92db201e9aa4.png)

After the fix:
![image](https://user-images.githubusercontent.com/34801760/233191820-6deef81d-293b-4a01-8098-fbb112009b10.png)
