### PR TITLE
Extend load_extractor to load zarr and fix zarr annotations

### DIFF
--- a/src/spikeinterface/core/tests/test_baserecording.py
+++ b/src/spikeinterface/core/tests/test_baserecording.py
@@ -257,11 +257,14 @@ def test_BaseRecording():
     compressor = get_default_zarr_compressor()
     rec_zarr = rec2.save(format="zarr", folder=cache_folder / "recording",
                          compressor=compressor)
+    rec_zarr_loaded = load_extractor(cache_folder / "recording.zarr")
     check_recordings_equal(rec2, rec_zarr, return_scaled=False)
+    check_recordings_equal(rec_zarr, rec_zarr_loaded, return_scaled=False)
 
     rec_zarr2 = rec2.save(format="zarr", folder=cache_folder / "recording_channel_chunk",
                           compressor=compressor, channel_chunk_size=2)
-    check_recordings_equal(rec2, rec_zarr2, return_scaled=False)
+    rec_zarr2_loaded = load_extractor(cache_folder / "recording_channel_chunk.zarr")
+    check_recordings_equal(rec_zarr2, rec_zarr2_loaded, return_scaled=False)
 
     # test cast unsigned
     rec_u = rec_uint16.save(format="zarr", folder=cache_folder / "rec_u")


### PR DESCRIPTION
With this PR one can do:
```
recording = si.load_extractor("recording.zarr")
```

Plus, when using the `save(format="zarr")` function the output is reloaded with `read_zarr()` function, so that it gets all properties and annotations right.