### PR TITLE
Fix torch detector for case when non peaks are found

### DIFF
--- a/src/spikeinterface/sortingcomponents/peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/peak_detection.py
@@ -123,6 +123,9 @@ class PeakDetectorWrapper(PeakDetector):
     def compute(self, traces, start_frame, end_frame, segment_index, max_margin):
         
         peak_sample_ind, peak_chan_ind = self.detect_peaks(traces, *self.args)
+        if peak_sample_ind.size == 0 or peak_chan_ind.size == 0:
+            return (np.zeros(0, dtype=base_peak_dtype), )
+        
         peak_amplitude = traces[peak_sample_ind, peak_chan_ind]
         local_peaks = np.zeros(peak_sample_ind.size, dtype=base_peak_dtype)
         local_peaks['sample_index'] = peak_sample_ind
@@ -457,6 +460,8 @@ if HAVE_TORCH:
         MAXCOPY = 8
 
         num_samples, num_channels = traces.shape
+        dtype = torch.float32
+        empty_return_value = (torch.tensor([], dtype=dtype) , torch.tensor([], dtype=dtype))
 
         # -- torch argrelmin
         if peak_sign == "neg":
@@ -491,7 +496,7 @@ if HAVE_TORCH:
         max_amps_at_inds = max_amps.view(-1)[window_max_inds]
         crossings = torch.nonzero(max_amps_at_inds > 1).squeeze()
         if not crossings.numel():
-            return np.array([]), np.array([]), np.array([])
+            return empty_return_value
 
         # -- unravel the spike index
         # (right now the indices are into flattened recording)
@@ -505,7 +510,7 @@ if HAVE_TORCH:
             (0 < sample_inds) & (sample_inds < traces.shape[0] - 1)
         ).squeeze()
         if not sample_inds.numel():
-            return np.array([]), np.array([]), np.array([])
+            return empty_return_value
         sample_inds = sample_inds[valid_inds]
         chan_inds = chan_inds[valid_inds]
         amplitudes = amplitudes[valid_inds]
@@ -545,7 +550,7 @@ if HAVE_TORCH:
                 amplitudes >= max_amps[sample_inds, chan_inds] - 1e-8
             ).squeeze()
             if not dedup.numel():
-                return np.array([]), np.array([]), np.array([])
+                return empty_return_value
             sample_inds = sample_inds[dedup]
             chan_inds = chan_inds[dedup]
             amplitudes = amplitudes[dedup]

--- a/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -12,9 +12,6 @@ from spikeinterface.sortingcomponents.peak_pipeline import ExtractDenseWaveforms
 from spikeinterface.sortingcomponents.peak_localization import LocalizeCenterOfMass
 from spikeinterface.sortingcomponents.features_from_peaks import PeakToPeakFeature
 
-from spikeinterface.sortingcomponents.peak_detection import DetectPeakByChannel, DetectPeakByChannelTorch, DetectPeakLocallyExclusive, DetectPeakLocallyExclusiveTorch
-from spikeinterface.sortingcomponents.peak_pipeline import run_node_pipeline
-
 
 if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "sortingcomponents"
@@ -59,7 +56,7 @@ def spike_trains(sorting):
 
 @pytest.fixture(scope="module")
 def job_kwargs():
-    return dict(n_jobs=-1, chunk_size=10000, progress_bar=True, verbose=True, mp_context="spawn")
+    return dict(n_jobs=-1, chunk_size=10000, progress_bar=True, verbose=True)
 
 # Don't know why this was different normal job_kwargs
 @pytest.fixture(scope="module")
@@ -68,73 +65,7 @@ def torch_job_kwargs(job_kwargs):
     torch_job_kwargs["n_jobs"] = 2
     return torch_job_kwargs
 
-def test_peak_sign_consistency(recording, job_kwargs):
-    detection_class = DetectPeakByChannel
-    
-    peak_sign = "neg"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "pos"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "both"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
-    
-def test_peak_sign_consistency_torch(recording, job_kwargs):
-    detection_class = DetectPeakByChannelTorch
-    
-    peak_sign = "neg"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "pos"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "both"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
-    
-def test_peak_sign_consistency_exclusive_numba(recording, job_kwargs):
-    detection_class = DetectPeakLocallyExclusive
-    
-    peak_sign = "neg"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "pos"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "both"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
 
-def test_peak_sign_consistency_exclusive_torch(recording, job_kwargs):
-    detection_class = DetectPeakLocallyExclusiveTorch
-    
-    peak_sign = "neg"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "pos"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "both"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
 
 def test_detect_peaks_by_channel(recording, spike_trains, job_kwargs, torch_job_kwargs):
     peaks_by_channel_np = detect_peaks(

--- a/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -12,6 +12,9 @@ from spikeinterface.sortingcomponents.peak_pipeline import ExtractDenseWaveforms
 from spikeinterface.sortingcomponents.peak_localization import LocalizeCenterOfMass
 from spikeinterface.sortingcomponents.features_from_peaks import PeakToPeakFeature
 
+from spikeinterface.sortingcomponents.peak_detection import DetectPeakByChannel, DetectPeakByChannelTorch, DetectPeakLocallyExclusive, DetectPeakLocallyExclusiveTorch
+from spikeinterface.sortingcomponents.peak_pipeline import run_node_pipeline
+
 
 if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "sortingcomponents"
@@ -56,7 +59,7 @@ def spike_trains(sorting):
 
 @pytest.fixture(scope="module")
 def job_kwargs():
-    return dict(n_jobs=-1, chunk_size=10000, progress_bar=True, verbose=True)
+    return dict(n_jobs=-1, chunk_size=10000, progress_bar=True, verbose=True, mp_context="spawn")
 
 # Don't know why this was different normal job_kwargs
 @pytest.fixture(scope="module")
@@ -65,7 +68,73 @@ def torch_job_kwargs(job_kwargs):
     torch_job_kwargs["n_jobs"] = 2
     return torch_job_kwargs
 
+def test_peak_sign_consistency(recording, job_kwargs):
+    detection_class = DetectPeakByChannel
+    
+    peak_sign = "neg"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "pos"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "both"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
+    
+def test_peak_sign_consistency_torch(recording, job_kwargs):
+    detection_class = DetectPeakByChannelTorch
+    
+    peak_sign = "neg"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "pos"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "both"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
+    
+def test_peak_sign_consistency_exclusive_numba(recording, job_kwargs):
+    detection_class = DetectPeakLocallyExclusive
+    
+    peak_sign = "neg"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "pos"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "both"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
 
+def test_peak_sign_consistency_exclusive_torch(recording, job_kwargs):
+    detection_class = DetectPeakLocallyExclusiveTorch
+    
+    peak_sign = "neg"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "pos"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "both"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
 
 def test_detect_peaks_by_channel(recording, spike_trains, job_kwargs, torch_job_kwargs):
     peaks_by_channel_np = detect_peaks(


### PR DESCRIPTION
I am hunting a bug in torch but this should be changed anyway so I am pushing it now. This fixes a bug where Torch returns numpy arrays (it should be tensors) when no peaks are found at any stage of the peak detection pipeline. It also, adds logic to the `PeakDetectorWrapper` to handle this issue.
