### PR TITLE
Update pyproject.toml to include numba in full installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ full = [
     "distinctipy",
     "matplotlib",
     "cuda-python",
+    "numba",
 ]
 
 widgets = [


### PR DESCRIPTION
Hey All,

I believe `numba` should be on the `[full]` section of the pyroject.toml as it is required to calculate the quality metrics after spike sorting [here](https://github.com/SpikeInterface/spikeinterface/blob/9ea8f92f8d14661cdd84f9569dbde24f12383e08/src/spikeinterface/qualitymetrics/misc_metrics.py#L26). Apologies if I have misunderstood!

Cheers,
Joe