### PR TITLE
Sign consistency test in peak detection

### DIFF
--- a/src/spikeinterface/sortingcomponents/peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/peak_detection.py
@@ -490,8 +490,8 @@ if HAVE_TORCH:
         window_max_indices = unique_indices[indices.view(-1)[unique_indices] == unique_indices]
 
         # voltage threshold
-        max_ampltidues_at_iitudes = max_amplitudes.view(-1)[window_max_indices]
-        crossings = torch.nonzero(max_ampltidues_at_iitudes > 1).squeeze()
+        max_ampltidues_at_indices = max_amplitudes.view(-1)[window_max_indices]
+        crossings = torch.nonzero(max_ampltidues_at_indices > 1).squeeze()
         if not crossings.numel():
             return empty_return_value
 
@@ -500,7 +500,7 @@ if HAVE_TORCH:
         peak_indices = window_max_indices[crossings]
         sample_indices = torch.div(peak_indices, num_channels, rounding_mode="floor")
         channel_indices = peak_indices % num_channels
-        amplitudes = max_ampltidues_at_iitudes[crossings]
+        amplitudes = max_ampltidues_at_indices[crossings]
 
         # we need this due to the padding in convolution
         valid_indices = torch.nonzero(

--- a/src/spikeinterface/sortingcomponents/peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/peak_detection.py
@@ -490,8 +490,8 @@ if HAVE_TORCH:
         window_max_indices = unique_indices[indices.view(-1)[unique_indices] == unique_indices]
 
         # voltage threshold
-        max_ampltidues_at_indices = max_amplitudes.view(-1)[window_max_indices]
-        crossings = torch.nonzero(max_ampltidues_at_indices > 1).squeeze()
+        max_amplitudes_at_indices = max_amplitudes.view(-1)[window_max_indices]
+        crossings = torch.nonzero(max_amplitudes_at_indices > 1).squeeze()
         if not crossings.numel():
             return empty_return_value
 
@@ -500,7 +500,7 @@ if HAVE_TORCH:
         peak_indices = window_max_indices[crossings]
         sample_indices = torch.div(peak_indices, num_channels, rounding_mode="floor")
         channel_indices = peak_indices % num_channels
-        amplitudes = max_ampltidues_at_indices[crossings]
+        amplitudes = max_amplitudes_at_indices[crossings]
 
         # we need this due to the padding in convolution
         valid_indices = torch.nonzero(

--- a/src/spikeinterface/sortingcomponents/peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/peak_detection.py
@@ -123,6 +123,9 @@ class PeakDetectorWrapper(PeakDetector):
     def compute(self, traces, start_frame, end_frame, segment_index, max_margin):
         
         peak_sample_ind, peak_chan_ind = self.detect_peaks(traces, *self.args)
+        if peak_sample_ind.size == 0 or peak_chan_ind.size == 0:
+            return (np.zeros(0, dtype=base_peak_dtype), )
+        
         peak_amplitude = traces[peak_sample_ind, peak_chan_ind]
         local_peaks = np.zeros(peak_sample_ind.size, dtype=base_peak_dtype)
         local_peaks['sample_index'] = peak_sample_ind
@@ -457,6 +460,8 @@ if HAVE_TORCH:
         MAXCOPY = 8
 
         num_samples, num_channels = traces.shape
+        dtype = torch.float32
+        empty_return_value = (torch.tensor([], dtype=dtype) , torch.tensor([], dtype=dtype))
 
         # -- torch argrelmin
         if peak_sign == "neg":
@@ -491,7 +496,7 @@ if HAVE_TORCH:
         max_amps_at_inds = max_amps.view(-1)[window_max_inds]
         crossings = torch.nonzero(max_amps_at_inds > 1).squeeze()
         if not crossings.numel():
-            return np.array([]), np.array([]), np.array([])
+            return empty_return_value
 
         # -- unravel the spike index
         # (right now the indices are into flattened recording)
@@ -505,7 +510,7 @@ if HAVE_TORCH:
             (0 < sample_inds) & (sample_inds < traces.shape[0] - 1)
         ).squeeze()
         if not sample_inds.numel():
-            return np.array([]), np.array([]), np.array([])
+            return empty_return_value
         sample_inds = sample_inds[valid_inds]
         chan_inds = chan_inds[valid_inds]
         amplitudes = amplitudes[valid_inds]
@@ -545,7 +550,7 @@ if HAVE_TORCH:
                 amplitudes >= max_amps[sample_inds, chan_inds] - 1e-8
             ).squeeze()
             if not dedup.numel():
-                return np.array([]), np.array([]), np.array([])
+                return empty_return_value
             sample_inds = sample_inds[dedup]
             chan_inds = chan_inds[dedup]
             amplitudes = amplitudes[dedup]

--- a/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -12,9 +12,6 @@ from spikeinterface.sortingcomponents.peak_pipeline import ExtractDenseWaveforms
 from spikeinterface.sortingcomponents.peak_localization import LocalizeCenterOfMass
 from spikeinterface.sortingcomponents.features_from_peaks import PeakToPeakFeature
 
-from spikeinterface.sortingcomponents.peak_detection import DetectPeakByChannel, DetectPeakByChannelTorch, DetectPeakLocallyExclusive, DetectPeakLocallyExclusiveTorch
-from spikeinterface.sortingcomponents.peak_pipeline import run_node_pipeline
-
 
 if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "sortingcomponents"
@@ -59,7 +56,7 @@ def spike_trains(sorting):
 
 @pytest.fixture(scope="module")
 def job_kwargs():
-    return dict(n_jobs=-1, chunk_size=10000, progress_bar=True, verbose=True, mp_context="spawn")
+    return dict(n_jobs=-1, chunk_size=10000, progress_bar=True, verbose=True)
 
 # Don't know why this was different normal job_kwargs
 @pytest.fixture(scope="module")
@@ -68,73 +65,7 @@ def torch_job_kwargs(job_kwargs):
     torch_job_kwargs["n_jobs"] = 2
     return torch_job_kwargs
 
-def test_peak_sign_consistency(recording, job_kwargs):
-    detection_class = DetectPeakByChannel
-    
-    peak_sign = "neg"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "pos"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "both"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
-    
-def test_peak_sign_consistency_torch(recording, job_kwargs):
-    detection_class = DetectPeakByChannelTorch
-    
-    peak_sign = "neg"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "pos"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "both"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
-    
-def test_peak_sign_consistency_exclusive_numba(recording, job_kwargs):
-    detection_class = DetectPeakLocallyExclusive
-    
-    peak_sign = "neg"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "pos"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "both"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
 
-def test_peak_sign_consistency_exclusive_torch(recording, job_kwargs):
-    detection_class = DetectPeakLocallyExclusiveTorch
-    
-    peak_sign = "neg"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "pos"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    peak_sign = "both"
-    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
-    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
-    
-    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
 
 def test_detect_peaks_by_channel(recording, spike_trains, job_kwargs, torch_job_kwargs):
     peaks_by_channel_np = detect_peaks(

--- a/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -142,8 +142,8 @@ def test_peak_sign_consistency(recording, job_kwargs, detection_class):
     peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
     all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
     
-    difference_in_size = all_peaks.size - (positive_peaks.size + negative_peaks.size)
-    assert abs(difference_in_size) <= 1
+    
+    assert negative_peaks.size + positive_peaks.size == all_peaks.size
                 
 def test_peak_detection_with_pipeline(recording, job_kwargs, torch_job_kwargs):
     

--- a/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -143,7 +143,14 @@ def test_peak_sign_consistency(recording, job_kwargs, detection_class):
     all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
     
     
-    assert negative_peaks.size + positive_peaks.size == all_peaks.size
+    # To account for exclusion of positive peaks that are to close to negative peaks.
+    # This should be excluded by the detection method when is exclusive so using peak_sign="both" should
+    # Generate less peaks in this case
+    assert (negative_peaks.size + positive_peaks.size) >= all_peaks.size
+    
+    # Original case that prompted this test
+    if negative_peaks.size > 0 or positive_peaks.size > 0:
+        assert all_peaks.size > 0
                 
 def test_peak_detection_with_pipeline(recording, job_kwargs, torch_job_kwargs):
     

--- a/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -143,7 +143,7 @@ def test_peak_sign_consistency(recording, job_kwargs, detection_class):
     all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
     
     difference_in_size = all_peaks.size - (positive_peaks.size + negative_peaks.size)
-    assert difference_in_size <= 1
+    assert abs(difference_in_size) <= 1
                 
 def test_peak_detection_with_pipeline(recording, job_kwargs, torch_job_kwargs):
     

--- a/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -142,7 +142,8 @@ def test_peak_sign_consistency(recording, job_kwargs, detection_class):
     peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
     all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
     
-    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)        
+    difference_in_size = all_peaks.size - (positive_peaks.size + negative_peaks.size)
+    assert difference_in_size <= 1
                 
 def test_peak_detection_with_pipeline(recording, job_kwargs, torch_job_kwargs):
     

--- a/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -12,6 +12,9 @@ from spikeinterface.sortingcomponents.peak_pipeline import ExtractDenseWaveforms
 from spikeinterface.sortingcomponents.peak_localization import LocalizeCenterOfMass
 from spikeinterface.sortingcomponents.features_from_peaks import PeakToPeakFeature
 
+from spikeinterface.sortingcomponents.peak_detection import DetectPeakByChannel, DetectPeakByChannelTorch, DetectPeakLocallyExclusive, DetectPeakLocallyExclusiveTorch
+from spikeinterface.sortingcomponents.peak_pipeline import run_node_pipeline
+
 
 if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "sortingcomponents"
@@ -56,7 +59,7 @@ def spike_trains(sorting):
 
 @pytest.fixture(scope="module")
 def job_kwargs():
-    return dict(n_jobs=-1, chunk_size=10000, progress_bar=True, verbose=True)
+    return dict(n_jobs=-1, chunk_size=10000, progress_bar=True, verbose=True, mp_context="spawn")
 
 # Don't know why this was different normal job_kwargs
 @pytest.fixture(scope="module")
@@ -64,7 +67,6 @@ def torch_job_kwargs(job_kwargs):
     torch_job_kwargs = job_kwargs.copy()
     torch_job_kwargs["n_jobs"] = 2
     return torch_job_kwargs
-
 
 
 def test_detect_peaks_by_channel(recording, spike_trains, job_kwargs, torch_job_kwargs):
@@ -119,6 +121,29 @@ def test_detect_peaks_locally_exclusive(recording, spike_trains, job_kwargs, tor
         )
         assert len(peaks_local_numba) == len(peaks_local_cl)
         
+detection_classes = [
+    DetectPeakByChannel,
+    DetectPeakByChannelTorch,
+    DetectPeakLocallyExclusive,
+    DetectPeakLocallyExclusiveTorch
+]
+@pytest.mark.parametrize("detection_class", detection_classes)
+def test_peak_sign_consistency(recording, job_kwargs, detection_class):
+    
+    peak_sign = "neg"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "pos"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "both"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)        
+                
 def test_peak_detection_with_pipeline(recording, job_kwargs, torch_job_kwargs):
     
     extract_dense_waveforms = ExtractDenseWaveforms(recording, ms_before=1.0, ms_after=1.0, return_output=False)

--- a/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -12,6 +12,9 @@ from spikeinterface.sortingcomponents.peak_pipeline import ExtractDenseWaveforms
 from spikeinterface.sortingcomponents.peak_localization import LocalizeCenterOfMass
 from spikeinterface.sortingcomponents.features_from_peaks import PeakToPeakFeature
 
+from spikeinterface.sortingcomponents.peak_detection import DetectPeakByChannel, DetectPeakByChannelTorch, DetectPeakLocallyExclusive, DetectPeakLocallyExclusiveTorch
+from spikeinterface.sortingcomponents.peak_pipeline import run_node_pipeline
+
 
 if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "sortingcomponents"
@@ -56,7 +59,7 @@ def spike_trains(sorting):
 
 @pytest.fixture(scope="module")
 def job_kwargs():
-    return dict(n_jobs=-1, chunk_size=10000, progress_bar=True, verbose=True)
+    return dict(n_jobs=-1, chunk_size=10000, progress_bar=True, verbose=True, mp_context="spawn")
 
 # Don't know why this was different normal job_kwargs
 @pytest.fixture(scope="module")
@@ -65,7 +68,73 @@ def torch_job_kwargs(job_kwargs):
     torch_job_kwargs["n_jobs"] = 2
     return torch_job_kwargs
 
+def test_peak_sign_consistency(recording, job_kwargs):
+    detection_class = DetectPeakByChannel
+    
+    peak_sign = "neg"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "pos"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "both"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
+    
+def test_peak_sign_consistency_torch(recording, job_kwargs):
+    detection_class = DetectPeakByChannelTorch
+    
+    peak_sign = "neg"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "pos"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "both"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
+    
+def test_peak_sign_consistency_exclusive_numba(recording, job_kwargs):
+    detection_class = DetectPeakLocallyExclusive
+    
+    peak_sign = "neg"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "pos"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "both"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
 
+def test_peak_sign_consistency_exclusive_torch(recording, job_kwargs):
+    detection_class = DetectPeakLocallyExclusiveTorch
+    
+    peak_sign = "neg"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    negative_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "pos"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    positive_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    peak_sign = "both"
+    peak_detection_node = detection_class(recording=recording, peak_sign=peak_sign)
+    all_peaks = run_node_pipeline(recording=recording, nodes=[peak_detection_node], job_kwargs=job_kwargs)
+    
+    assert len(negative_peaks) + len(positive_peaks) == len(all_peaks)
 
 def test_detect_peaks_by_channel(recording, spike_trains, job_kwargs, torch_job_kwargs):
     peaks_by_channel_np = detect_peaks(


### PR DESCRIPTION
This tests indicates the error for peak detection methods that use torch. Somehow when peak_sign is equal both for this method torch comes empty handed. That is, no peaks are detected and hence the tests fail.

The tests is simple. Itcalculates peaks with positive sign, peaks with negative sign and then all peaks. It asserts that total should be the sume of positive and negative.