### PR TITLE
Fix failing noise test on windows

### DIFF
--- a/src/spikeinterface/core/recording_tools.py
+++ b/src/spikeinterface/core/recording_tools.py
@@ -1,4 +1,6 @@
 from typing import Literal
+import warnings
+
 import numpy as np
 
 
@@ -12,7 +14,7 @@ def get_random_data_chunks(
     margin_frames=0,
 ):
     """
-    Exctract random chunks across segments
+    Extract random chunks across segments
 
     This is used for instance in get_noise_levels() to estimate noise on traces.
 
@@ -38,36 +40,64 @@ def get_random_data_chunks(
     # TODO: if segment have differents length make another sampling that dependant on the length of the segment
     # Should be done by changing kwargs with total_num_chunks=XXX and total_duration=YYYY
     # And randomize the number of chunk per segment weighted by segment duration
-
+    
     # check chunk size
-    for segment_index in range(recording.get_num_segments()):
-        assert chunk_size < recording.get_num_samples(segment_index), (
-            f"chunk_size is greater than the number "
-            f"of samples for segment index {segment_index}. "
-            f"Use a smaller chunk_size!"
-        )
+    num_segments = recording.get_num_segments()
+    for segment_index in range(num_segments):
+        if chunk_size > recording.get_num_frames(segment_index) - 2 * margin_frames:
+            error_message = (
+                f"chunk_size is greater than the number "
+                f"of samples for segment index {segment_index}. "
+                f"Use a smaller chunk_size!"
+            )
+            raise ValueError(error_message)
 
+    rng = np.random.default_rng(seed)
     chunk_list = []
-    for segment_index in range(recording.get_num_segments()):
-        length = recording.get_num_frames(segment_index)
-
-        random_starts = np.random.RandomState(seed=seed).randint(
-            margin_frames,
-            length - chunk_size - margin_frames,
-            size=num_chunks_per_segment,
-        )
-        for start_frame in random_starts:
-            chunk = recording.get_traces(
+    low = margin_frames
+    size=num_chunks_per_segment
+    for segment_index in range(num_segments):
+        num_frames = recording.get_num_frames(segment_index)
+        high = num_frames - chunk_size - margin_frames
+        random_starts = rng.integers(low=low, high=high, size=size)
+        segment_trace_chunk = [
+            recording.get_traces(
                 start_frame=start_frame,
-                end_frame=start_frame + chunk_size,
+                end_frame=(start_frame + chunk_size),
                 segment_index=segment_index,
                 return_scaled=return_scaled,
             )
-            chunk_list.append(chunk)
+            for start_frame in random_starts
+        ]
+
+        chunk_list.extend(segment_trace_chunk)
+    
     if concatenated:
         return np.concatenate(chunk_list, axis=0)
     else:
         return chunk_list
+
+def get_noise_levels(recording: 'BaseRecording', return_scaled: bool = True, method: Literal['mad', 'std'] = "mad", **random_chunk_kwargs):
+    """
+    Estimate signal std for each channel using median absolute deviation (MAD) and std.
+
+    Internally it samples some chunk across segment.
+    And then, it use MAD estimator (more robust than STD)
+
+    """
+    random_chunks = get_random_data_chunks(
+        recording, return_scaled=return_scaled, **random_chunk_kwargs
+    )
+    
+    if method == "mad":
+        med = np.median(random_chunks, axis=0, keepdims=True)
+        # hard-coded so that core doesn't depend on scipy
+        noise_levels = (
+            np.median(np.abs(random_chunks - med), axis=0) / 0.6744897501960817
+        )
+    elif method == "std":
+        noise_levels = np.std(random_chunks, axis=0)
+    return noise_levels
 
 
 def get_channel_distances(recording):
@@ -117,30 +147,6 @@ def get_closest_channels(recording, channel_ids=None, num_channels=None):
         dists.append(distances[order][1 : num_channels + 1])
 
     return np.array(closest_channels_inds), np.array(dists)
-
-
-def get_noise_levels(recording: 'BaseRecording', return_scaled: bool = True, method: Literal['mad', 'std'] = "mad", **random_chunk_kwargs):
-    """
-    Estimate noise for each channel using MAD methods.
-    You can use standard deviation with `method='std'`
-
-    Internally it samples some chunk across segment.
-    And then, it use MAD estimator (more robust than STD)
-
-    """
-    random_chunks = get_random_data_chunks(
-        recording, return_scaled=return_scaled, **random_chunk_kwargs
-    )
-    
-    if method == "mad":
-        med = np.median(random_chunks, axis=0, keepdims=True)
-        # hard-coded so that core doesn't depend on scipy
-        noise_levels = (
-            np.median(np.abs(random_chunks - med), axis=0) / 0.6744897501960817
-        )
-    elif method == "std":
-        noise_levels = np.std(random_chunks, axis=0)
-    return noise_levels
 
 
 def get_chunk_with_margin(

--- a/src/spikeinterface/core/tests/test_recording_tools.py
+++ b/src/spikeinterface/core/tests/test_recording_tools.py
@@ -32,13 +32,23 @@ def test_get_noise_levels():
 
     noise_levels = get_noise_levels(rec, return_scaled=True, method="std")
 
+def test_get_noise_levels_output():
+
     # Generate a recording following a gaussian distribution to check the result of get_noise.
     std = 6.0
-    traces = np.random.normal(loc=10.0, scale=std, size=(1_000_000, 2))
-    recording = NumpyRecording(traces, 30000)
+    seed = 0 
+    rng = np.random.default_rng(seed=seed)
+    num_channels = 2
+    num_samples = 10_000
+    sampling_frequency = 30_000.0
+    traces = rng.normal(loc=10.0, scale=std, size=(num_samples, num_channels))
+    recording = NumpyRecording(traces_list=traces, sampling_frequency=sampling_frequency)
 
-    assert np.allclose(get_noise_levels(recording, return_scaled=False), [std, std], rtol=1e-2, atol=1e-3)
-    assert np.allclose(get_noise_levels(recording, method="std", return_scaled=False), [std, std], rtol=1e-2, atol=1e-3)
+    std_estimated_with_mad = get_noise_levels(recording, method="mad", return_scaled=False, chunk_size=1_000)
+    assert np.allclose(std_estimated_with_mad, [std, std], rtol=1e-2, atol=1e-3)
+    
+    std_estimated_with_std = get_noise_levels(recording, method="std", return_scaled=False, chunk_size=1_000)
+    assert np.allclose(std_estimated_with_std, [std, std], rtol=1e-2, atol=1e-3)
 
 
 


### PR DESCRIPTION
The tests added in #1548 are failing on windows. I think this is because of an overly restrictive assertion here:
https://github.com/SpikeInterface/spikeinterface/blob/9ea8f92f8d14661cdd84f9569dbde24f12383e08/src/spikeinterface/core/tests/test_recording_tools.py#L40

As the trick we do with MAD is an estimation of the real std.  

However, this is not clear because the previous test was not deterministic. I have added determinism to the test and did some refactoring for cleaning. If the error persists in windows I will lower the tolerance.

EDIT: The test works as expected once determinism is added. This is ready to go.