### PR TITLE
Change v_peak name and thresholder behavior

### DIFF
--- a/src/spikeinterface/postprocessing/unit_localization.py
+++ b/src/spikeinterface/postprocessing/unit_localization.py
@@ -251,11 +251,11 @@ def compute_monopolar_triangulation(waveform_extractor, optimizer='minimize_with
         Return or not the alpha value
     enforce_decrease : bool (default False)
         Enforce spatial decreasingness for PTP vectors
-    feature: string in ['ptp', 'energy', 'v_peak']
+    feature: string in ['ptp', 'energy', 'peak_voltage']
         The available features to consider for estimating the position via
         monopolar triangulation are peak-to-peak amplitudes ('ptp', default), 
         energy ('energy', as L2 norm) or voltages at the center of the waveform
-        ('v_peak')
+        ('peak_voltage')
 
     Returns
     -------
@@ -265,7 +265,7 @@ def compute_monopolar_triangulation(waveform_extractor, optimizer='minimize_with
     '''
     assert optimizer in ('least_square', 'minimize_with_log_penality')
 
-    assert feature in ['ptp', 'energy', 'v_peak'], f'{feature} is not a valid feature'
+    assert feature in ['ptp', 'energy', 'peak_voltage'], f'{feature} is not a valid feature'
     unit_ids = waveform_extractor.sorting.unit_ids
 
     contact_locations = waveform_extractor.get_channel_locations()
@@ -293,7 +293,7 @@ def compute_monopolar_triangulation(waveform_extractor, optimizer='minimize_with
             wf_data = wf.ptp(axis=0)
         elif feature == 'energy':
             wf_data = np.linalg.norm(wf, axis=0)
-        elif feature == 'v_peak':
+        elif feature == 'peak_voltage':
             wf_data = np.abs(wf[nbefore])
 
         #if enforce_decrease:
@@ -321,7 +321,7 @@ def compute_center_of_mass(waveform_extractor, peak_sign='neg', radius_um=75, fe
         Sign of the template to compute best channels ('neg', 'pos', 'both')
     radius_um: float
         Radius to consider in order to estimate the COM
-    feature: str ['ptp', 'mean', 'energy', 'v_peak']
+    feature: str ['ptp', 'mean', 'energy', 'peak_voltage']
         Feature to consider for computation. Default is 'ptp'
 
     Returns
@@ -333,7 +333,7 @@ def compute_center_of_mass(waveform_extractor, peak_sign='neg', radius_um=75, fe
     recording = waveform_extractor.recording
     contact_locations = recording.get_channel_locations()
 
-    assert feature in ['ptp', 'mean', 'energy', 'v_peak'], f'{feature} is not a valid feature'
+    assert feature in ['ptp', 'mean', 'energy', 'peak_voltage'], f'{feature} is not a valid feature'
 
     sparsity = compute_sparsity(waveform_extractor, peak_sign=peak_sign, method='radius', radius_um=radius_um)
     templates = waveform_extractor.get_all_templates(mode='average')
@@ -351,7 +351,7 @@ def compute_center_of_mass(waveform_extractor, peak_sign='neg', radius_um=75, fe
             wf_data = (wf[:, chan_inds]).mean(axis=0)
         elif feature == 'energy':
             wf_data = np.linalg.norm(wf[:, chan_inds], axis=0)
-        elif feature == 'v_peak':
+        elif feature == 'peak_voltage':
             wf_data = wf[waveform_extractor.nbefore, chan_inds]
 
         # center of mass

--- a/src/spikeinterface/sortingcomponents/matching/circus.py
+++ b/src/spikeinterface/sortingcomponents/matching/circus.py
@@ -161,6 +161,8 @@ class CircusOMPPeeler(BaseTemplateMatchingEngine):
     noise_levels: array
         The noise levels, for every channels. If None, they will be automatically
         computed
+    random_chunk_kwargs: dict
+        Parameters for computing noise levels, if not provided (sub optimal)
     -----
     """
 

--- a/src/spikeinterface/sortingcomponents/peak_localization.py
+++ b/src/spikeinterface/sortingcomponents/peak_localization.py
@@ -144,14 +144,14 @@ class LocalizeCenterOfMass(LocalizeBase):
     params_doc = """
     local_radius_um: float
         Radius in um for channel sparsity.
-    feature: str ['ptp', 'mean', 'energy', 'v_peak']
+    feature: str ['ptp', 'mean', 'energy', 'peak_voltage']
         Feature to consider for computation. Default is 'ptp'
     """
     def __init__(self, recording, return_output=True, parents=['extract_waveforms'], local_radius_um=75., feature='ptp'):
         LocalizeBase.__init__(self, recording, return_output=return_output, parents=parents, local_radius_um=local_radius_um)
         self._dtype = np.dtype(dtype_localize_by_method['center_of_mass'])
 
-        assert feature in ['ptp', 'mean', 'energy', 'v_peak'], f'{feature} is not a valid feature'
+        assert feature in ['ptp', 'mean', 'energy', 'peak_voltage'], f'{feature} is not a valid feature'
         self.feature = feature
 
         # Find waveform extractor in the parents
@@ -179,7 +179,7 @@ class LocalizeCenterOfMass(LocalizeBase):
                 wf_data = (waveforms[idx][:, :, chan_inds]).mean(axis=1)
             elif self.feature == 'energy':
                 wf_data = np.linalg.norm(waveforms[idx][:, :, chan_inds], axis=1)
-            elif self.feature == 'v_peak':
+            elif self.feature == 'peak_voltage':
                 wf_data = waveforms[idx][:, self.nbefore, chan_inds]
 
             coms = np.dot(wf_data, local_contact_locations)/(np.sum(wf_data, axis=1)[:,np.newaxis])
@@ -206,11 +206,11 @@ class LocalizeMonopolarTriangulation(PipelineNode):
         Boundary for distance estimation.
     enforce_decrease : bool (default True)
         Enforce spatial decreasingness for PTP vectors
-    feature: string in ['ptp', 'energy', 'v_peak']
+    feature: string in ['ptp', 'energy', 'peak_voltage']
         The available features to consider for estimating the position via
         monopolar triangulation are peak-to-peak amplitudes (ptp, default), 
         energy ('energy', as L2 norm) or voltages at the center of the waveform
-        (v_peak)
+        (peak_voltage)
     """
     def __init__(self, recording, return_output=True, parents=['extract_waveforms'],
                             local_radius_um=75., max_distance_um=150., optimizer='minimize_with_log_penality', 
@@ -219,7 +219,7 @@ class LocalizeMonopolarTriangulation(PipelineNode):
 
         
 
-        assert feature in ['ptp', 'energy', 'v_peak'], f'{feature} is not a valid feature'
+        assert feature in ['ptp', 'energy', 'peak_voltage'], f'{feature} is not a valid feature'
         self.max_distance_um = max_distance_um
         self.optimizer = optimizer
         self.feature = feature
@@ -255,7 +255,7 @@ class LocalizeMonopolarTriangulation(PipelineNode):
                 wf_data = wf.ptp(axis=0)
             elif self.feature == 'energy':
                 wf_data = np.linalg.norm(wf, axis=0)
-            elif self.feature == 'v_peak':
+            elif self.feature == 'peak_voltage':
                 wf_data = np.abs(wf[self.nbefore])
 
             if self.enforce_decrease_radial_parents is not None:

--- a/src/spikeinterface/sortingcomponents/tests/test_peak_localization.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_peak_localization.py
@@ -58,7 +58,7 @@ def test_localize_peaks():
 
     peak_locations = localize_peaks(recording, peaks, method='monopolar_triangulation', 
                                     optimizer='minimize_with_log_penality',
-                                    enforce_decrease=True, feature='v_peak', **job_kwargs)
+                                    enforce_decrease=True, feature='peak_voltage', **job_kwargs)
     assert peaks.size == peak_locations.shape[0]
     list_locations.append(('minimize_with_log_penality_v_peak', peak_locations))
     

--- a/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_waveforms/test_waveform_thresholder.py
@@ -29,6 +29,7 @@ def test_waveform_thresholder_ptp(extract_waveforms, mearec_recording, detected_
     peaks = detected_peaks
 
     tresholded_waveforms_ptp = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='ptp', threshold=3, return_output=True)
+    noise_levels = tresholded_waveforms_ptp.noise_levels
 
     pipeline_nodes = [extract_waveforms, tresholded_waveforms_ptp]
     # Extract projected waveforms and compare
@@ -36,7 +37,8 @@ def test_waveform_thresholder_ptp(extract_waveforms, mearec_recording, detected_
         recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
     )
 
-    assert np.all(tresholded_waveforms.ptp(axis=1) >= 3)
+    data = (tresholded_waveforms.ptp(axis=1) / noise_levels)
+    assert np.all(data[data != 0] > 3)
 
 def test_waveform_thresholder_mean(extract_waveforms, mearec_recording, detected_peaks, chunk_executor_kwargs):
     recording = mearec_recording
@@ -57,6 +59,7 @@ def test_waveform_thresholder_energy(extract_waveforms, mearec_recording, detect
     peaks = detected_peaks
 
     tresholded_waveforms_energy = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='energy', threshold=3, return_output=True)
+    noise_levels = tresholded_waveforms_energy.noise_levels
 
     pipeline_nodes = [extract_waveforms, tresholded_waveforms_energy]
     # Extract projected waveforms and compare
@@ -64,28 +67,16 @@ def test_waveform_thresholder_energy(extract_waveforms, mearec_recording, detect
         recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
     )
 
-    assert np.all(np.linalg.norm(tresholded_waveforms, axis=1) >= 3)
-
-def test_waveform_thresholder_peak(extract_waveforms, mearec_recording, detected_peaks, chunk_executor_kwargs):
-    recording = mearec_recording
-    peaks = detected_peaks
-
-    tresholded_waveforms_peak = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='v_peak', threshold=-5, return_output=True)
-
-    pipeline_nodes = [extract_waveforms, tresholded_waveforms_peak]
-    # Extract projected waveforms and compare
-    waveforms, tresholded_waveforms = run_peak_pipeline(
-        recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
-    )
-
-    assert np.all(tresholded_waveforms[:, extract_waveforms.nbefore, :] >= -5)
+    data = (np.linalg.norm(tresholded_waveforms, axis=1) / noise_levels)
+    assert np.all(data[data != 0] > 3)
 
 def test_waveform_thresholder_operator(extract_waveforms, mearec_recording, detected_peaks, chunk_executor_kwargs):
     recording = mearec_recording
     peaks = detected_peaks
 
     import operator
-    tresholded_waveforms_peak = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='ptp', threshold=3, operator = operator.ge, return_output=True)
+    tresholded_waveforms_peak = WaveformThresholder(recording=recording, parents=[extract_waveforms], feature='peak_voltage', threshold=5, operator = operator.ge, return_output=True)
+    noise_levels = tresholded_waveforms_peak.noise_levels
 
     pipeline_nodes = [extract_waveforms, tresholded_waveforms_peak]
     # Extract projected waveforms and compare
@@ -93,4 +84,5 @@ def test_waveform_thresholder_operator(extract_waveforms, mearec_recording, dete
         recording, peaks, nodes=pipeline_nodes, job_kwargs=chunk_executor_kwargs
     )
 
-    assert np.all(tresholded_waveforms[:, extract_waveforms.nbefore, :] <= 3)
+    data = (tresholded_waveforms[:, extract_waveforms.nbefore, :] / noise_levels)
+    assert np.all(data[data != 0] <= 5)

--- a/src/spikeinterface/sortingcomponents/tools.py
+++ b/src/spikeinterface/sortingcomponents/tools.py
@@ -17,12 +17,15 @@ def make_multi_method_doc(methods, ident='    '):
 
 
 def get_prototype_spike(recording, peaks, job_kwargs, nb_peaks=1000, ms_before=0.5, ms_after=0.5):
-    from spikeinterface.sortingcomponents.peak_pipeline import run_peak_pipeline, ExtractSparseWaveforms
-    sparse_waveforms = ExtractSparseWaveforms(recording, ms_before=ms_before, ms_after=ms_after, 
-                                                      return_output=True, local_radius_um=5)
-    nbefore = sparse_waveforms.nbefore
-    idx = np.sort(np.random.choice(len(peaks), nb_peaks, replace=False))
+    from spikeinterface.sortingcomponents.peak_pipeline import run_node_pipeline, ExtractSparseWaveforms, PeakRetriever
     
-    waveforms = run_peak_pipeline(recording, peaks[idx], [sparse_waveforms], job_kwargs=job_kwargs)
+    idx = np.sort(np.random.choice(len(peaks), nb_peaks, replace=False))
+    peak_retriever = PeakRetriever(recording, peaks[idx])
+
+    sparse_waveforms = ExtractSparseWaveforms(recording, parents=[peak_retriever], 
+        ms_before=ms_before, ms_after=ms_after, return_output=True, local_radius_um=5)
+
+    nbefore = sparse_waveforms.nbefore    
+    waveforms = run_node_pipeline(recording, [peak_retriever, sparse_waveforms], job_kwargs=job_kwargs)
     prototype =  np.median(waveforms[:, :, 0]/(waveforms[:, nbefore, 0][:, np.newaxis]), axis=0)
     return prototype

--- a/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
@@ -6,7 +6,7 @@ import numpy as np
 import operator
 from typing import Literal
 
-from spikeinterface.core import BaseRecording
+from spikeinterface.core import BaseRecording, get_noise_levels
 from spikeinterface.sortingcomponents.peak_pipeline import (
     PipelineNode,
     WaveformsNode,
@@ -21,7 +21,7 @@ class WaveformThresholder(WaveformsNode):
     This node allows you to perform adaptive masking by setting channels to 0
     that have a given feature below a certain threshold. The available features
     to consider are peak-to-peak amplitude ('ptp'), mean amplitude ('mean'),
-    energy ('energy'), and voltage peak ('v_peak').
+    energy ('energy'), and peak voltage ('peak_voltage').
 
     Parameters
     ----------
@@ -31,10 +31,14 @@ class WaveformThresholder(WaveformsNode):
         Whether to return output from this node (default True).
     parents: list of PipelineNodes, optional
         The parent nodes of this node (default None).
-    feature: {'ptp', 'mean', 'energy', 'v_peak'}, optional
+    feature: {'ptp', 'mean', 'energy', 'peak_voltage'}, optional
         The feature to be considered for thresholding (default 'ptp').
     threshold: float, optional
         The threshold value for the selected feature (default 2).
+    noise_levels: array, optional
+        The noise levels to determine the thresholds
+    random_chunk_kwargs: dict
+        Parameters for computing noise levels, if not provided (sub optimal)
     operator: callable, optional
         Comparator to flag values that should be set to 0 (default less or equal)
     """
@@ -42,8 +46,10 @@ class WaveformThresholder(WaveformsNode):
     def __init__(
         self, recording: BaseRecording, return_output: bool = True, 
         parents: Optional[List[PipelineNode]] = None,
-        feature: Literal['ptp', 'mean', 'energy', 'v_peak'] = 'ptp',
+        feature: Literal['ptp', 'mean', 'energy', 'peak_voltage'] = 'ptp',
         threshold: float = 2,
+        noise_levels: Optional[np.array] = None,
+        random_chunk_kwargs: dict = {},
         operator: callable = operator.le
     ):
         waveform_extractor = find_parent_of_type(parents, WaveformsNode)
@@ -52,26 +58,31 @@ class WaveformThresholder(WaveformsNode):
 
         super().__init__(recording, waveform_extractor.ms_before, waveform_extractor.ms_after,
             return_output=return_output, parents=parents)
-        assert feature in ['ptp', 'mean', 'energy', 'v_peak'], f'{feature} is not a valid feature'
+        assert feature in ['ptp', 'mean', 'energy', 'peak_voltage'], f'{feature} is not a valid feature'
 
         self.threshold = threshold
         self.feature = feature
         self.operator = operator
 
+        self.noise_levels = noise_levels
+        if self.noise_levels is None:
+            self.noise_levels = get_noise_levels(self.recording, **random_chunk_kwargs, return_scaled=False)
+
         self._kwargs.update(dict(feature=feature,
                                  threshold=threshold,
-                                 operator=operator))
+                                 operator=operator, 
+                                 noise_levels=self.noise_levels))
         
     def compute(self, traces, peaks, waveforms):
         
         if self.feature == 'ptp':
-            wf_data = waveforms.ptp(axis=1)
+            wf_data = waveforms.ptp(axis=1) / self.noise_levels
         elif self.feature == 'mean':
-            wf_data = waveforms.mean(axis=1)
+            wf_data = waveforms.mean(axis=1) / self.noise_levels
         elif self.feature == 'energy':
-            wf_data = np.linalg.norm(waveforms, axis=1)
-        elif self.feature == 'v_peak':
-            wf_data = waveforms[:, self.nbefore, :]
+            wf_data = np.linalg.norm(waveforms, axis=1) / self.noise_levels
+        elif self.feature == 'peak_voltage':
+            wf_data = waveforms[:, self.nbefore, :] / self.noise_levels
 
         mask = self.operator(wf_data, self.threshold)
         mask = np.broadcast_to(mask[:, np.newaxis, :], waveforms.shape)

--- a/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/waveform_thresholder.py
@@ -32,7 +32,7 @@ class WaveformThresholder(WaveformsNode):
     parents: list of PipelineNodes, optional
         The parent nodes of this node (default None).
     feature: {'ptp', 'mean', 'energy', 'peak_voltage'}, optional
-        The feature to be considered for thresholding (default 'ptp').
+        The feature to be considered for thresholding (default 'ptp'). Features are normalized with the channel noise levels.
     threshold: float, optional
         The threshold value for the selected feature (default 2).
     noise_levels: array, optional


### PR DESCRIPTION
After discussing with Samuel, we've decided to change the name v_peak to something more explicit (peak_voltage). In addition, I've modified an util function for GridLocalization to remove a deprecation warning, and I've also modified the WaveformThresholder object to not assume data are whitened. 

@samuelgarcia @alejoe91 @h-mayorquin Regarding the noise_levels, this would really be helpful if they could be attached to the recording object, in order to avoid duplicated computations all over the places (in sparsities, in thresholder, in matching engines, ...). I know that know they can be attached to waveform_extractor, and this is a good step, but to me these noise levels are really at the recording level