### PR TITLE
Add pure noise generation to generator recording

### DIFF
--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -389,7 +389,7 @@ from typing import Union, Optional, List, Literal
 class GeneratorRecording(BaseRecording):
     def __init__(
         self,
-        durations: List[int],
+        durations: List[float],
         sampling_frequency: float,
         num_channels: int,
         dtype: Optional[Union[np.dtype, str]] = "float32",
@@ -531,12 +531,14 @@ class GeneratorRecordingSegment(BaseRecordingSegment):
         
         return traces
 
-def generate_lazy_recording(full_traces_size_GiB: float, seed=None) -> GeneratorRecording:
+def generate_lazy_recording(
+    full_traces_size_GiB: float, seed: Optional[int] = None, mode: Literal["pure_noise", "deterministic"] = "pure_noise"
+) -> GeneratorRecording:
     """
     Generate a large lazy recording.
     This is a convenience wrapper around the GeneratorRecording class where only
     the size in GiB (NOT GB!) is specified.
-    
+
     It is generated with 1024 channels and a sampling frequency of 1 Hz. The duration is manipulted to
     produced the desired size.
 
@@ -551,20 +553,27 @@ def generate_lazy_recording(full_traces_size_GiB: float, seed=None) -> Generator
     GeneratorRecording
         A lazy random recording with the specified size.
     """
-    
+
     dtype = np.dtype("float32")
-    sampling_frequency = 30_000.0 # Hz 
-    num_channels = 1024    
-    
-    GiB_to_bytes = 1024** 3
-    full_traces_size_bytes = int(full_traces_size_GiB * GiB_to_bytes) 
+    sampling_frequency = 30_000.0  # Hz
+    num_channels = 1024
+
+    GiB_to_bytes = 1024**3
+    full_traces_size_bytes = int(full_traces_size_GiB * GiB_to_bytes)
     num_samples = int(full_traces_size_bytes / (num_channels * dtype.itemsize))
     durations = [num_samples / sampling_frequency]
 
-    recording = GeneratorRecording(durations=durations, sampling_frequency=sampling_frequency, 
-                        num_channels=num_channels, dtype=dtype, seed=seed)
+    recording = GeneratorRecording(
+        durations=durations,
+        sampling_frequency=sampling_frequency,
+        num_channels=num_channels,
+        dtype=dtype,
+        seed=seed,
+        mode=mode,
+    )
 
     return recording
+
 
 
 if __name__ == '__main__':

--- a/src/spikeinterface/core/tests/test_generate.py
+++ b/src/spikeinterface/core/tests/test_generate.py
@@ -34,6 +34,8 @@ def measure_memory_allocation(measure_in_process: bool = True) -> float:
 
 @pytest.mark.parametrize("mode", mode_list)
 def test_lazy_random_recording(mode):
+    # Test that get_traces does not consume more memory than allocated. 
+    
     bytes_to_MiB_factor = 1024**2
     relative_tolerance = 0.05  # relative tolerance of 5 per cent
 
@@ -83,8 +85,8 @@ def test_lazy_random_recording(mode):
 def test_generate_lazy_recording(mode):
     # Test that get_traces does not consume more memory than allocated. 
     bytes_to_MiB_factor = 1024**2
-    full_traces_size_GiB = 3.0
-    relative_tolerance = 0.01  # Tolerance of 1 % is used for large memory consumption
+    full_traces_size_GiB = 1.0
+    relative_tolerance = 0.05  # relative tolerance of 5 per cent
 
     initial_memory_MiB = measure_memory_allocation() / bytes_to_MiB_factor
 
@@ -176,14 +178,20 @@ def test_generator_recording_consistency(mode):
 
 
 @pytest.mark.parametrize("mode", mode_list)
-def test_generator_recording_consistency_across_traces(mode):
+@pytest.mark.parametrize("start_frame, end_frame, extra_samples", [
+    (0, 1000, 10),
+    (0, 2000, 20),
+    (1000, 2000, 5),
+    (250, 750, 15),
+])
+def test_generator_recording_consistency_across_traces(mode, start_frame, end_frame, extra_samples):
     # Test that the generated traces behave like true arrays. Calling a larger array and then slicing it should
     # give the same result as calling a smaller array.
     sampling_frequency = 30000  # Hz
     durations = [1.0]
     dtype = np.dtype("float32")
     num_channels = 384
-    seed = 0
+    seed = start_frame + end_frame + extra_samples # To make sure that the seed is different for each test
 
     lazy_recording = GeneratorRecording(
         durations=durations,
@@ -194,10 +202,8 @@ def test_generator_recording_consistency_across_traces(mode):
         mode=mode,
     )
 
-    extra_samples = 10
-    start_frame = 0
-    end_frame = 1000
     traces = lazy_recording.get_traces(start_frame=start_frame, end_frame=end_frame)
-    lager_traces = lazy_recording.get_traces(start_frame=start_frame, end_frame=end_frame + extra_samples)
-    equivalent_trace_from_larger_traces = lager_traces[:end_frame - start_frame, :]
+    end_frame_larger_array = end_frame + extra_samples
+    larger_traces = lazy_recording.get_traces(start_frame=start_frame, end_frame=end_frame_larger_array)
+    equivalent_trace_from_larger_traces = larger_traces[:-extra_samples, :]  # Remove the extra samples
     assert np.allclose(traces, equivalent_trace_from_larger_traces)

--- a/src/spikeinterface/core/tests/test_generate.py
+++ b/src/spikeinterface/core/tests/test_generate.py
@@ -104,3 +104,65 @@ def test_generate_lazy_recording_under_giga():
     
     recording = generate_lazy_recording(full_traces_size_GiB=0.5)
     assert recording.get_memory_size() == "512.00 MiB"
+
+def test_generate_recording_correct_sizes():
+    sampling_frequency = 30000  # Hz
+    durations = [1.0]
+    dtype = np.dtype("float32")
+    num_channels = 384
+    seed = 0
+
+
+    lazy_recording = GeneratorRecording(
+        durations=durations, sampling_frequency=sampling_frequency, num_channels=num_channels, dtype=dtype, seed=seed
+    )
+    
+    
+    num_frames = lazy_recording.get_num_frames(segment_index=0)
+    assert num_frames == sampling_frequency * durations[0]
+    
+    traces = lazy_recording.get_traces(start_frame=0, end_frame=None)
+
+    assert traces.shape[0] == num_frames
+
+def test_generator_recording_consistency():
+    sampling_frequency = 30000  # Hz
+    durations = [1.0]
+    dtype = np.dtype("float32")
+    num_channels = 384
+    seed = 0
+
+
+    lazy_recording = GeneratorRecording(
+        durations=durations, sampling_frequency=sampling_frequency, num_channels=num_channels, dtype=dtype, seed=seed
+    )
+
+    traces = lazy_recording.get_traces(start_frame=0, end_frame=None)
+    assert np.allclose(lazy_recording.get_traces(), traces)
+    
+    start_frame = 25
+    end_frame = 80
+    traces = lazy_recording.get_traces(start_frame=start_frame, end_frame=end_frame)
+    same_traces = lazy_recording.get_traces(start_frame=start_frame, end_frame=end_frame)
+    assert np.allclose(traces, same_traces)
+
+
+def test_generator_recording_consistency_across_traces():
+    
+    sampling_frequency = 30000  # Hz
+    durations = [1.0]
+    dtype = np.dtype("float32")
+    num_channels = 384
+    seed = 0
+
+
+    lazy_recording = GeneratorRecording(
+        durations=durations, sampling_frequency=sampling_frequency, num_channels=num_channels, dtype=dtype, seed=seed
+    )
+    
+    extra_samples = 10
+    start_frame = 0
+    end_frame = 1000
+    traces = lazy_recording.get_traces(start_frame=start_frame, end_frame=end_frame)
+    lager_traces = lazy_recording.get_traces(start_frame=start_frame, end_frame=end_frame + extra_samples)
+    assert np.allclose(traces, lager_traces[:end_frame, :]) 

--- a/src/spikeinterface/core/tests/test_generate.py
+++ b/src/spikeinterface/core/tests/test_generate.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from spikeinterface.core.generate import GeneratorRecording, generate_lazy_recording
 
-mode_list = ["deterministic", "pure_noise"]
+mode_list = GeneratorRecording.available_modes
 
 
 def measure_memory_allocation(measure_in_process: bool = True) -> float:

--- a/src/spikeinterface/core/tests/test_generate.py
+++ b/src/spikeinterface/core/tests/test_generate.py
@@ -121,9 +121,9 @@ def test_generate_recording_correct_sizes():
     num_frames = lazy_recording.get_num_frames(segment_index=0)
     assert num_frames == sampling_frequency * durations[0]
     
-    traces = lazy_recording.get_traces(start_frame=0, end_frame=None)
+    traces = lazy_recording.get_traces()
 
-    assert traces.shape[0] == num_frames
+    assert traces.shape == (num_frames, num_channels)
 
 def test_generator_recording_consistency():
     sampling_frequency = 30000  # Hz

--- a/src/spikeinterface/core/tests/test_generate.py
+++ b/src/spikeinterface/core/tests/test_generate.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from spikeinterface.core.generate import GeneratorRecording, generate_lazy_recording
 
-mode_list = ["random", "pure_noise"]
+mode_list = ["deterministic", "pure_noise"]
 
 
 def measure_memory_allocation(measure_in_process: bool = True) -> float:


### PR DESCRIPTION
Following on #1413. This adds the capabilities of generating pure noise with the recording above.

I also added tests for the two modalities to assure that the generator behaves as an array in the expected way:
* Running get_traces twice gets the sames results.
* Running get_traces and then slicing is the same as running get_traces in the smaller slice.