### PR TITLE
Richer Recording representations

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -72,10 +72,10 @@ class BaseRecording(BaseRecordingSnippets):
             list_to_string = lambda lst: '[' + ', '.join(str(x) for x in lst) + ']'
             txt += (
                 f"\n"
-                f"Segments: "
-                f"Samples {list_to_string(samples_per_segment_formated)} - "
-                f"Durations {list_to_string(durations_per_segment_formated)} - "
-                f"Memory {list_to_string(memory_per_segment_formated)}"
+                f"Segments:"
+                f"\nSamples   {list_to_string(samples_per_segment_formated)}"
+                f"\nDurations {list_to_string(durations_per_segment_formated)}"
+                f"\nMemory    {list_to_string(memory_per_segment_formated)}"
             )        
             
         if 'file_paths' in self._kwargs:

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -60,9 +60,16 @@ class BaseRecording(BaseRecordingSnippets):
             f"{num_segments} segments - "
             f"{total_samples:,} samples - "
             f"{convert_seconds_to_string(total_duration)} - "
-            f"{dtype} type - "
+            f"{dtype} dtype - "
             f"{convert_bytes_to_str(total_memory_size)}"
         )
+        
+        # Split if too long
+        if len(txt) > 100:
+            split_index = txt.rfind("-", 0, 100)  # Find the last "-" before character 100
+            if split_index != -1:
+                prefix_spaces = len(extractor_name) + 2  # Length of extractor_name plus ": "
+                txt = txt[:split_index] + "\n" + " " * prefix_spaces + txt[split_index+1:].lstrip()
 
         if num_segments > 1:
             samples_per_segment_formated = [f"{samples:,}" for samples in samples_per_segment]

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -859,41 +859,32 @@ def convert_seconds_to_string(seconds: float, long_notation: bool = True) -> str
     seconds : float
         The duration in seconds.
     long_notation : bool, optional, default: True
-        Whether to display the time in parentheses with other units. If set to True, the function will
-        display a more detailed representation of the duration, including other units (such as minutes,
-        hours, or days) in parentheses alongside the primary seconds representation.
+        Whether to display the time with additional units (such as milliseconds, minutes,
+        hours, or days). If set to True, the function will display a more detailed
+        representation of the duration, including other units alongside the primary
+        seconds representation.
 
     Returns
     -------
     str
-        A string representing the duration in seconds with other units in parentheses, if applicable and
+        A string representing the duration, with additional units included if
         requested by the `long_notation` parameter.
-
-    Examples
-    --------
-    >>> seconds_to_string(45)
-    '45.000s'
-    >>> seconds_to_string(45, long_notation=True)
-    '45.000s (45.0s)'
-    >>> seconds_to_string(90)
-    '90.00s'
-    >>> seconds_to_string(90, long_notation=True)
-    '90.00s (1 minutes)'
-    >>> seconds_to_string(7200)
-    '7200s'
-    >>> seconds_to_string(7200, long_notation=True)
-    '7200s (2 hours)'
     """
-    if seconds < 0.5:
-        return f"{seconds:.3f}s" if not long_notation else f"{seconds:.3f}s ({seconds * 1000:.0f} ms)"
-    elif seconds < 60:
-        return f"{seconds:.2f}s"
-    elif seconds < 3600:
-        minutes = seconds // 60
-        return f"{seconds:.1f}s" if not long_notation else f"{seconds:.0f}s ({minutes:.0f} minutes)"
-    elif seconds < 86400 * 2:  # Crazy long recording
-        hours = seconds // 3600
-        return f"{seconds:.0f}s" if not long_notation else f"{seconds:.0f}s ({hours:.0f} hours)"
-    else:
-        days = seconds // 86400
-        return f"{seconds:.0f}s" if not long_notation else f"{seconds:.0f}s ({days:.0f} days)"
+    base_str = f"{seconds:,.2f}s"
+    
+    if long_notation:
+        if seconds < 1.0:
+            base_str += f" ({seconds * 1000:,.2f} ms)"
+        elif seconds < 60:
+            pass # seconds is already the primary representation
+        elif seconds < 3600:
+            minutes = seconds // 60
+            base_str += f" ({minutes:,.2f} minutes)"
+        elif seconds < 86400 * 2:  # 2 days
+            hours = seconds // 3600
+            base_str += f" ({hours:,.2f} hours)"
+        else:
+            days = seconds // 86400
+            base_str += f" ({days:,.2f} days)"
+
+    return base_str

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -848,3 +848,52 @@ def convert_bytes_to_str(byte_value:int ) -> str:
         byte_value /= 1024
         i += 1
     return f"{byte_value:.2f} {suffixes[i]}"
+
+
+def convert_seconds_to_string(seconds: float, long_notation: bool = True) -> str:
+    """
+    Convert seconds to a human-readable string representation.
+
+    Parameters
+    ----------
+    seconds : float
+        The duration in seconds.
+    long_notation : bool, optional, default: True
+        Whether to display the time in parentheses with other units. If set to True, the function will
+        display a more detailed representation of the duration, including other units (such as minutes,
+        hours, or days) in parentheses alongside the primary seconds representation.
+
+    Returns
+    -------
+    str
+        A string representing the duration in seconds with other units in parentheses, if applicable and
+        requested by the `long_notation` parameter.
+
+    Examples
+    --------
+    >>> seconds_to_string(45)
+    '45.000s'
+    >>> seconds_to_string(45, long_notation=True)
+    '45.000s (45.0s)'
+    >>> seconds_to_string(90)
+    '90.00s'
+    >>> seconds_to_string(90, long_notation=True)
+    '90.00s (1 minutes)'
+    >>> seconds_to_string(7200)
+    '7200s'
+    >>> seconds_to_string(7200, long_notation=True)
+    '7200s (2 hours)'
+    """
+    if seconds < 0.5:
+        return f"{seconds:.3f}s" if not long_notation else f"{seconds:.3f}s ({seconds * 1000:.0f} ms)"
+    elif seconds < 60:
+        return f"{seconds:.2f}s"
+    elif seconds < 3600:
+        minutes = seconds // 60
+        return f"{seconds:.1f}s" if not long_notation else f"{seconds:.0f}s ({minutes:.0f} minutes)"
+    elif seconds < 86400 * 2:  # Crazy long recording
+        hours = seconds // 3600
+        return f"{seconds:.0f}s" if not long_notation else f"{seconds:.0f}s ({hours:.0f} hours)"
+    else:
+        days = seconds // 86400
+        return f"{seconds:.0f}s" if not long_notation else f"{seconds:.0f}s ({days:.0f} days)"


### PR DESCRIPTION
While working with the memmap issue I found myself wanting that the Recorders displayed more information on my notebook. Things like the number of samples in a better notation would have been nice. This is compunded for recoders with multiple segments where I needed to use the getter methods to find out what I wanted to known (i.e. `sefl.get_num_samples()`)

Here is a PR that expands the representations to include number of samples and adds a second line with a breakdown of the qualities of each segment. When the recording object is monsegment it displays nothing as it was the case with the old representation.

Two other minor human readability improvements:
1) This shows the numbers with coma separated power of 10**3. That is, it shows 1,000,000 instead of 1000000, 1,000 instead of 1000 and so on and so forth.
2) When the time is higher than minutes, hours or days it shows that number in parenthesis but shows nothing if the number is around seconds

Here are some examples:
```python
from spikeinterface.core.generate import GeneratorRecording

print("Recording with two segments, note the comas in between the numbers and the different durations per segment")
print(GeneratorRecording(durations=[10, 5], sampling_frequency=30_000, num_channels=10))
print("\nRecording with one segment should be as before")
print(GeneratorRecording(durations=[10], sampling_frequency=30_000, num_channels=10))
print("\nRecording with larger durations should show how time is represented when larger than minutes")
print(GeneratorRecording(durations=[70, 3900], sampling_frequency=30_000, num_channels=10))
print("\nTimes from a variety of scales")
print(GeneratorRecording(durations=[0.020, 0.500, 3.0, 150], sampling_frequency=30_000, num_channels=10))
print("\nMore variation of times")
print(GeneratorRecording(durations=[6_235, 90_000, 153_252_15], sampling_frequency=30_000, num_channels=10))
print("\nMearec to show how it looks when file_path is provided")
from spikeinterface.core.datasets import download_dataset
from spikeinterface.extractors.neoextractors.mearec import read_mearec

local_path = download_dataset(remote_path="mearec/mearec_test_10s.h5")
recording, sorting = read_mearec(local_path)
print(recording)
```

Output:
```python
Recording with two segments, note the comas in between the numbers and the different durations per segment
GeneratorRecording: 10 channels - 30.0kHz - 2 segments - 450,000 samples - 15.00s - float32 dtype 
                    17.17 MiB
Segments:
Samples   [300,000, 150,000]
Durations [10.00s, 5.00s]
Memory    [11.44 MiB, 5.72 MiB]

Recording with one segment should be as before
GeneratorRecording: 10 channels - 30.0kHz - 1 segments - 300,000 samples - 10.00s - float32 dtype 
                    11.44 MiB

Recording with larger durations should show how time is represented when larger than minutes
GeneratorRecording: 10 channels - 30.0kHz - 2 segments - 119,100,000 samples 
                    3,970.00s (1.00 hours) - float32 dtype - 4.44 GiB
Segments:
Samples   [2,100,000, 117,000,000]
Durations [70.00s (1.00 minutes), 3,900.00s (1.00 hours)]
Memory    [80.11 MiB, 4.36 GiB]

Times from a variety of scales
GeneratorRecording: 10 channels - 30.0kHz - 4 segments - 4,605,600 samples 
                    153.52s (2.00 minutes) - float32 dtype - 175.69 MiB
Segments:
Samples   [600, 15,000, 90,000, 4,500,000]
Durations [0.02s (20.00 ms), 0.50s (500.00 ms), 3.00s, 150.00s (2.00 minutes)]
Memory    [23.44 KiB, 585.94 KiB, 3.43 MiB, 171.66 MiB]

More variation of times
GeneratorRecording: 10 channels - 30.0kHz - 3 segments - 462,643,500,000 samples 
                    15,421,450.00s (178.00 days) - float32 dtype - 16.83 TiB
Segments:
Samples   [187,050,000, 2,700,000,000, 459,756,450,000]
Durations [6,235.00s (1.00 hours), 90,000.00s (25.00 hours), 15,325,215.00s (177.00 days)]
Memory    [6.97 GiB, 100.58 GiB, 16.73 TiB]

Mearec to show how it looks when file_path is provided
MEArecRecordingExtractor: 32 channels - 32.0kHz - 1 segments - 320,000 samples - 10.00s 
                          float32 dtype - 39.06 MiB
Mearec to show how it looks when file_path is provided
MEArecRecordingExtractor: 32 channels - 32.0kHz - 1 segments - 320,000 samples - 10.00s 
                          float32 dtype - 39.06 MiB
  file_path: [/home/heberto/spikeinterface_datasets/ephy_testing_data/mearec/mearec_test_10s.h5](https://file+.vscode-resource.vscode-cdn.net/home/heberto/spikeinterface_datasets/ephy_testing_data/mearec/mearec_test_10s.h5)
```





