### PR TITLE
fix NWBFile type hints

### DIFF
--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -37,7 +37,7 @@ def check_fsspec_install():
     assert HAVE_FSSPEC, "To stream NWB data with fsspec, install fsspec: \n\n pip install fsspec aiohttp requests\n\n"
 
 
-def retrieve_electrical_series(nwbfile: NWBFile, electrical_series_name: Optional[str] = None) -> ElectricalSeries:
+def retrieve_electrical_series(nwbfile: "NWBFile", electrical_series_name: Optional[str] = None) -> ElectricalSeries:
     """
     Get an ElectricalSeries object from an NWBFile.
 
@@ -90,7 +90,7 @@ def retrieve_electrical_series(nwbfile: NWBFile, electrical_series_name: Optiona
 
 def read_nwbfile(
     file_path: str, stream_mode: Optional[Literal["ffspec", "ros3"]] = None, stream_cache_path: Optional[str] = None
-) -> NWBFile:
+) -> "NWBFile":
     """
     Read an NWB file and return the NWBFile object.
 

--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -37,7 +37,7 @@ def check_fsspec_install():
     assert HAVE_FSSPEC, "To stream NWB data with fsspec, install fsspec: \n\n pip install fsspec aiohttp requests\n\n"
 
 
-def retrieve_electrical_series(nwbfile: "NWBFile", electrical_series_name: Optional[str] = None) -> ElectricalSeries:
+def retrieve_electrical_series(nwbfile: "NWBFile", electrical_series_name: Optional[str] = None) -> "ElectricalSeries":
     """
     Get an ElectricalSeries object from an NWBFile.
 


### PR DESCRIPTION
A [recent commit](https://github.com/SpikeInterface/spikeinterface/commit/72b0835cd855cb3fac165a362646a7312c0c73f3) nicely added type hints but in the case `NWBFile` and `ElectricalSeries` cannot be imported the script crashes. This PR just wraps these type hints in strings, another approach is to use [this kind of syntax](https://stackoverflow.com/questions/39740632/python-type-hinting-without-cyclic-imports), but I don't think this will work in this case because the module cannot be imported at all. A tricky one to detect because only is exposed if `pynwb.ecephys` is not installed



