### PR TITLE
Use annotations from future (PEP563) to solve type hint references

### DIFF
--- a/.github/profile_and_test_imports.py
+++ b/.github/profile_and_test_imports.py
@@ -1,0 +1,45 @@
+import subprocess
+import numpy as np
+
+import_statement_list = [
+    "import spikeinterface",
+    "import spikeinterface.core",
+    "import spikeinterface.extractors",
+    "import spikeinterface.qualitymetrics",
+    "import spikeinterface.preprocessing",
+    "import spikeinterface.comparison",
+    "import spikeinterface.postprocessing",
+    "import spikeinterface.sortingcomponents",
+    "import spikeinterface.curation",
+]
+
+markdown_output = "## Import Profiling\n\n| Module | Time (seconds) | Standard Deviation |\n| ------ | -------------- | ------------------ |\n"
+n_samples = 10
+
+for import_statement in import_statement_list:
+    time_taken_list = []
+    for _ in range(n_samples):
+        code = f"""
+                import timeit
+                import_statement = "{import_statement}"
+                time_taken = timeit.timeit(import_statement, number=1)
+                print(time_taken)
+                """
+
+        result = subprocess.run(["python", "-c", code], capture_output=True, text=True)
+
+        if result.returncode != 0:
+            error_message  = (
+                f"Error when running {import_statement} \n"
+                f"Error in subprocess: {result.stderr.strip()}\n"
+            )
+            raise ImportError(error_message)
+
+        time_taken = float(result.stdout.strip())
+        time_taken_list.append(time_taken)
+
+    avg_time_taken = np.mean(time_taken_list)
+    std_dev_time_taken = np.std(time_taken_list)
+    markdown_output += f"| {import_statement} | {avg_time_taken:.2f} | {std_dev_time_taken:.2f} |\n"
+
+print(markdown_output)

--- a/.github/workflows/test_imports.yml
+++ b/.github/workflows/test_imports.yml
@@ -1,0 +1,34 @@
+name: Profile Imports
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+build-and-test:
+    name: Test on ${{ matrix.os }} OS
+    runs-on: ${{ matrix.os }}
+    strategy:
+    fail-fast: false
+    matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install Spikeinterface with only core dependencies
+      run: |
+        git config --global user.email "CI@example.com"
+        git config --global user.name "CI Almighty"
+        python -m pip install -U pip  # Official recommended way 
+        pip install -e .  # This should install core only
+    - name: Profile Imports
+      run: python ./.github/profile_and_test_imports.py
+    - name: Read Report
+      run: |
+        report=$(<report.md)
+        echo "GITHUB_STEP_SUMMARY=${report}" >> $GITHUB_ENV
+    - name: Display Report
+      run: echo "$GITHUB_STEP_SUMMARY"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ streaming_extractors = [
     "fsspec", 
     "aiohttp",
     "requests",
-    "pynwb",
+    "pynwb>=2.3.0",
 ]
 
 full = [

--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
 from pathlib import Path
-from typing import Union, List, Optional, Literal
+from typing import Union, List, Optional, Literal, Dict
 
 import numpy as np
 import h5py
@@ -9,11 +10,8 @@ from spikeinterface.core import BaseRecording, BaseRecordingSegment, BaseSorting
 from spikeinterface.core.core_tools import define_function_from_class
 
 try:
-    import pynwb
     from pynwb import NWBHDF5IO, NWBFile
-    from pynwb.ecephys import ElectricalSeries, FilteredEphys, LFP, ElectrodeGroup
-    from hdmf.data_utils import DataChunkIterator
-    from hdmf.backends.hdf5.h5_utils import H5DataIO
+    from pynwb.ecephys import ElectricalSeries, ElectrodeGroup
 
     HAVE_NWB = True
 except ModuleNotFoundError:


### PR DESCRIPTION
This PR resolves #1596.

As described in the issue, importing extractors fails when pynwb is not installed. The problem arises from the newly added type-hints, which are currently evaluated at import time.

PR #1593 suggests a solution that employs forward references, where type hints are defined as strings to force deferred evaluation. While this approach works, we can improve upon it.

Starting with Python 3.8, we can use the following statement at the top of a module to defer the evaluation of type annotations until runtime:

```python
from __future__ import annotations
```
More details can be found in PEP 563: https://peps.python.org/pep-0563/

This change allows us to maintain the same notation regardless of whether the module is installed or not, simplifying code navigation.

Moreover, deferring type hints by default is expected to enhance import performance, which aligns with the long-term goals of the library.

Finally, I've added a test to the core that verifies all major modules can be imported with only a core installation, without raising errors. This test would have helped prevent the current issue. Furthermore, the test will be used to monitor import times, helping us track and reduce them in the future.
