### PR TITLE
Force_dense mode for waveforms and templates

### DIFF
--- a/src/spikeinterface/core/tests/test_waveform_extractor.py
+++ b/src/spikeinterface/core/tests/test_waveform_extractor.py
@@ -83,7 +83,10 @@ def test_WaveformExtractor():
             wfs_array = we.get_waveforms(0, lazy=False)
             assert isinstance(wfs_array, np.ndarray)
 
-            
+            ## Test force dense mode
+            wfs = we.get_waveforms(0, force_dense=True)
+            assert wfs.shape[2] == num_channels
+
             template = we.get_template(0)
             if sparsity is None:
                 assert template.shape == (num_samples, num_channels)
@@ -91,6 +94,9 @@ def test_WaveformExtractor():
                 assert template.shape == (num_samples, num_sparse_channels)
             templates = we.get_all_templates()
             assert templates.shape == (num_units, num_samples, num_channels)
+
+            template = we.get_template(0, force_dense=True)
+            assert template.shape == (num_samples, num_channels)
 
             if sparsity is not None:
                 assert np.all(templates[:, :, 1] == 0)


### PR DESCRIPTION
This solves #1595, with the addition of a force_dense flag in both get_waveforms and get_templates. 