### PR TITLE
Use annotations from future (PEP563) to solve type hint references

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ streaming_extractors = [
     "fsspec", 
     "aiohttp",
     "requests",
-    "pynwb",
+    "pynwb>=2.3.0",
 ]
 
 full = [

--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -1,23 +1,25 @@
+from __future__ import annotations
 from pathlib import Path
-from typing import Union, List, Optional, Literal
+from typing import Union, List, Optional, Literal, Dict
 
 import numpy as np
-import h5py
 
 from spikeinterface import get_global_tmp_folder
 from spikeinterface.core import BaseRecording, BaseRecordingSegment, BaseSorting, BaseSortingSegment
 from spikeinterface.core.core_tools import define_function_from_class
 
 try:
-    import pynwb
     from pynwb import NWBHDF5IO, NWBFile
-    from pynwb.ecephys import ElectricalSeries, FilteredEphys, LFP, ElectrodeGroup
-    from hdmf.data_utils import DataChunkIterator
-    from hdmf.backends.hdf5.h5_utils import H5DataIO
-
+    from pynwb.ecephys import ElectricalSeries, ElectrodeGroup
     HAVE_NWB = True
 except ModuleNotFoundError:
     HAVE_NWB = False
+
+try:
+    import h5py
+    HAVE_H5PY = True
+except:
+    HAVE_H5PY = False
 
 try:
     import fsspec


### PR DESCRIPTION
OK, so #1597 turn out too big as there were a lot of imports that were exposed naively. I am passing the small patch to fix the import with pynwb here as that one will probably take longer to reivew. 

Copying PR text verbatim from here:

This PR resolves #1596.

As described in the issue, importing extractors fails when pynwb is not installed. The problem arises from the newly added type-hints, which are currently evaluated at import time.

PR #1593 suggests a solution that employs forward references, where type hints are defined as strings to force deferred evaluation. While this approach works, we can improve upon it.

Starting with Python 3.8, we can use the following statement at the top of a module to defer the evaluation of type annotations until runtime:

```python
from __future__ import annotations
```
More details can be found in PEP 563: https://peps.python.org/pep-0563/

This change allows us to maintain the same notation regardless of whether the module is installed or not, simplifying code navigation.

Moreover, deferring type hints by default is expected to enhance import performance, which aligns with the long-term goals of the library.

Finally, I've added a test to the core that verifies all major modules can be imported with only a core installation, without raising errors. This test would have helped prevent the current issue. Furthermore, the test will be used to monitor import times, helping us track and reduce them in the future.

The tests and the use of run-time imports are now in #1597 