### PR TITLE
Adapt `CellExplorerSortingExtractor` to new format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ extractors = [
     "pyedflib>=0.1.30",
     "sonpy;python_version<'3.10'",
     "lxml", # lxml for neuroscope
-    "hdf5storage", # hdf5storage and scipy for cellexplorer
     "scipy",
     # ONE-api and ibllib for streaming IBL
     "ONE-api>=1.19.1",

--- a/src/spikeinterface/extractors/cellexplorersortingextractor.py
+++ b/src/spikeinterface/extractors/cellexplorersortingextractor.py
@@ -11,13 +11,13 @@ class CellExplorerSortingExtractor(BaseSorting):
     """
     Extracts spiking information from .mat files stored in the CellExplorer format.
     Spike times are stored in units of seconds so we transform them to units of samples.
-    
+
     The newer version of the format is described here:
     https://cellexplorer.org/data-structure/
-    
+
     Whereas the old format is described here:
     https://github.com/buzsakilab/buzcode/wiki/Data-Formatting-Standards
-    
+
     Parameters
     ----------
     folder_path: str | Path
@@ -33,84 +33,107 @@ class CellExplorerSortingExtractor(BaseSorting):
     mode = "folder"
     installation_mesg = "To use the CellExplorerSortingExtractor install scipy and h5py"
 
-    def __init__(self, folder_path: str | Path,
-                 sampling_frequency: float | None = None,
-                 session_info_matfile_path: str | Path | None = None):
-        
+    def __init__(
+        self,
+        folder_path: str | Path,
+        sampling_frequency: float | None = None,
+        session_info_matfile_path: str | Path | None = None,
+    ):
         try:
             import h5py
-            import scipy.io 
+            import scipy.io
         except ImportError:
             raise ImportError(self.installation_mesg)
 
-        folder_path = Path(folder_path)
-        session_id = next((path.stem.split(".")[0] for path in folder_path.iterdir() if path.suffix == ".mat"), None)
-        assert session_id is not None, f"No .mat files found in the {folder_path}!"
+        self.folder_path = Path(folder_path)
+        self.session_info_matfile_path = session_info_matfile_path
         
-        spikes_cellinfo_path = folder_path / f"{session_id}.spikes.cellinfo.mat"
-        assert spikes_cellinfo_path.is_file(), f"The spikes.cellinfo.mat file must exist in the {folder_path}!"
+        mat_file_path = next((path for path in self.folder_path.iterdir() if path.suffix == ".mat"), None) 
+        self.session_id = mat_file_path.stem.split(".")[0]
+        assert self.session_id is not None, f"No .mat files found in the {self.folder_path}!"
+
+        spikes_cellinfo_path = self.folder_path / f"{self.session_id}.spikes.cellinfo.mat"
+        assert spikes_cellinfo_path.is_file(), f"The spikes.cellinfo.mat file must exist in the {self.folder_path}!"
 
         try:
             spikes_mat = scipy.io.loadmat(file_name=str(spikes_cellinfo_path), simplify_cells=True)
             self.read_spikes_info_with_scipy = True
-        except NotImplementedError: 
-            spikes_mat = h5py.File(name=spikes_cellinfo_path, mode='r')
-            self.read_spikes_info_with_scipy = False      
-        
-        if sampling_frequency is None:
-            # This is for the new format of spikes.cellinfo.mat files
-            sampling_frequency = spikes_mat["spikes"].get("sr", None) 
-        
-        if sampling_frequency is None:
-            if session_info_matfile_path is None:
-                session_info_matfile_path = folder_path / f"{session_id}.sessionInfo.mat"
-            session_info_matfile_path = Path(session_info_matfile_path)
-            assert session_info_matfile_path.is_file(), f"No {session_id}.sessionInfo.mat file found in the {folder_path}!" 
+        except NotImplementedError:
+            spikes_mat = h5py.File(name=spikes_cellinfo_path, mode="r")
+            self.read_spikes_info_with_scipy = False
 
-            try:
-                session_info_mat = scipy.io.loadmat(file_name=str(session_info_matfile_path), simplify_cells=True)
-                self.read_session_info_with_scipy = True
-            except NotImplementedError:
-                session_info_mat = h5py.File(name=str(session_info_matfile_path), mode="r")
-                self.read_session_info_with_scipy = False
-            
-            rates = session_info_mat["sessionInfo"]["rates"]
-            wideband_in_rates = "wideband" in rates.keys()
-            assert wideband_in_rates, "a 'sessionInfo' should contain a  'wideband' to extract the sampling frequency!"
-    
-            # careful not to confuse it with the lfpsamplingrate; reported in units Hz
-            if self.read_session_info_with_scipy:
-                sampling_frequency = float(rates["wideband"])
-            else:
-                sampling_frequency = float(rates["wideband"][()])
-            
+        if sampling_frequency is None:
+            # First try is for the new format of spikes.cellinfo.mat files where sampling rate is included
+            sampling_frequency = spikes_mat["spikes"].get("sr", None)
+            sampling_frequency = sampling_frequency[()] if sampling_frequency is not None else None 
+        
+        if sampling_frequency is None:
+            sampling_frequency = self._retrieve_sampling_frequency_from_session_info()
+        
+        sampling_frequency = float(sampling_frequency)
+        
         unit_ids_available = "UID" in spikes_mat["spikes"].keys()
         assert unit_ids_available, "The spikes.cellinfo.mat file must contain field 'UID'!"
-        
-        spike_times_available =  "times" in spikes_mat["spikes"].keys()
+
+        spike_times_available = "times" in spikes_mat["spikes"].keys()
         assert spike_times_available, "The spikes.cellinfo.mat file must contain field 'times'!"
-        
+
         if self.read_spikes_info_with_scipy:
             unit_ids = spikes_mat["spikes"]["UID"].tolist()
-            spike_times = spikes_mat["spikes"]["times"]            
+            spike_times = spikes_mat["spikes"]["times"]
         else:
             unit_ids = spikes_mat["spikes"]["UID"][:].squeeze().astype("int").tolist()
             spike_references = spikes_mat["spikes"]["times"][:]  # These are HDF5 references
             spike_times = [spikes_mat[reference[0]][()].squeeze() for reference in spike_references]
-            
+
         # CellExplorer reports spike times in units seconds; SpikeExtractors uses time units of sampling frames
         # Rounding is necessary to prevent data loss from int-casting floating point errors
         spiketrains_dict = {unit_id: spike_times[index] for index, unit_id in enumerate(unit_ids)}
         for unit_id in unit_ids:
             spiketrains_dict[unit_id] = (sampling_frequency * spiketrains_dict[unit_id]).round().astype(np.int64)
-        
+
         BaseSorting.__init__(self, unit_ids=unit_ids, sampling_frequency=sampling_frequency)
         sorting_segment = CellExplorerSortingSegment(spiketrains_dict, unit_ids)
         self.add_sorting_segment(sorting_segment)
 
-        self.extra_requirements.append('scipy')
+        self.extra_requirements.append("scipy")
+        
+        self._kwargs = dict(
+            folder_path=str(self.folder_path.absolute()),
+            sampling_frequency=sampling_frequency,
+            session_info_matfile_path=session_info_matfile_path
+        )
 
-        self._kwargs = dict(folder_path=str(folder_path.absolute()))
+    def _retrieve_sampling_frequency_from_session_info(self) -> float:
+        import h5py
+        import scipy.io
+            
+        if self.session_info_matfile_path is None:
+            self.session_info_matfile_path = self.folder_path / f"{self.session_id}.sessionInfo.mat"
+
+        self.session_info_matfile_path = Path(self.session_info_matfile_path).absolute()
+        assert (
+            self.session_info_matfile_path.is_file()
+        ), f"No {self.session_id}.sessionInfo.mat file found in the {self.folder_path}!"
+        try:
+            session_info_mat = scipy.io.loadmat(file_name=str(self.session_info_matfile_path), simplify_cells=True)
+            self.read_session_info_with_scipy = True
+        except NotImplementedError:
+            session_info_mat = h5py.File(name=str(self.session_info_matfile_path), mode="r")
+            self.read_session_info_with_scipy = False
+
+        rates = session_info_mat["sessionInfo"]["rates"]
+        wideband_in_rates = "wideband" in rates.keys()
+        assert wideband_in_rates, "a 'sessionInfo' should contain a  'wideband' to extract the sampling frequency!"
+
+        # Not to be connfused with the lfpsamplingrate; reported in units Hz also present in rates
+        sampling_frequency = rates["wideband"]
+
+        if not self.read_session_info_with_scipy:
+            sampling_frequency = sampling_frequency[()]
+
+        return sampling_frequency
+
 
 class CellExplorerSortingSegment(BaseSortingSegment):
     def __init__(self, spiketrains_dict, unit_ids):
@@ -118,12 +141,12 @@ class CellExplorerSortingSegment(BaseSortingSegment):
         self._unit_ids = list(unit_ids)
         BaseSortingSegment.__init__(self)
 
-    def get_unit_spike_train(self,
-                             unit_id,
-                             start_frame,
-                             end_frame,
-                             ) -> np.ndarray:
-
+    def get_unit_spike_train(
+        self,
+        unit_id,
+        start_frame,
+        end_frame,
+    ) -> np.ndarray:
         spike_frames = self.spiketrains_dict[unit_id]
         # clip
         if start_frame is not None:
@@ -134,5 +157,5 @@ class CellExplorerSortingSegment(BaseSortingSegment):
 
         return spike_frames
 
-read_cellexplorer = define_function_from_class(source_class=CellExplorerSortingExtractor,
-                                               name="read_cellexplorer")
+
+read_cellexplorer = define_function_from_class(source_class=CellExplorerSortingExtractor, name="read_cellexplorer")

--- a/src/spikeinterface/extractors/cellexplorersortingextractor.py
+++ b/src/spikeinterface/extractors/cellexplorersortingextractor.py
@@ -1,119 +1,120 @@
+from __future__ import annotations
+
 import numpy as np
 from pathlib import Path
-from typing import Union, Optional
 
 from ..core import BaseSorting, BaseSortingSegment
 from ..core.core_tools import define_function_from_class
 
 
-try:
-    import scipy.io 
-    import hdf5storage
-    HAVE_SCIPY_AND_HDF5STORAGE = True
-except ImportError:
-    HAVE_SCIPY_AND_HDF5STORAGE = False
-
-
-PathType = Union[str, Path]
-OptionalPathType = Optional[PathType]  
-
-
 class CellExplorerSortingExtractor(BaseSorting):
     """
     Extracts spiking information from .mat files stored in the CellExplorer format.
-    Spike times are stored in units of seconds.
-
+    Spike times are stored in units of seconds so we transform them to units of samples.
+    
+    The newer version of the format is described here:
+    https://cellexplorer.org/data-structure/
+    
+    Whereas the old format is described here:
+    https://github.com/buzsakilab/buzcode/wiki/Data-Formatting-Standards
+    
     Parameters
     ----------
-    spikes_matfile_path : PathType
-        Path to the sorting_id.spikes.cellinfo.mat file.
+    folder_path: str | Path
+        Path to the folder containing the .mat files from the session.
+    sampling_frequency: float | None, optional
+        The sampling frequency of the data. If None, it will be extracted from the files.
+    session_info_matfile_path: str | Path | None, optional
+        Path to the session info .mat file. If None, it will be inferred from the folder path.
     """
 
     extractor_name = "CellExplorerSortingExtractor"
-    installed = HAVE_SCIPY_AND_HDF5STORAGE
     is_writable = True
-    mode = "file"
-    installation_mesg = "To use the CellExplorerSortingExtractor install scipy and hdf5storage: \n\n pip install scipy  hdf5storage"
+    mode = "folder"
+    installation_mesg = "To use the CellExplorerSortingExtractor install scipy and h5py"
 
-    def __init__(self, spikes_matfile_path: PathType,
-                 session_info_matfile_path: OptionalPathType=None,
-                 sampling_frequency: Optional[float] = None):
-        assert self.installed, self.installation_mesg
-
-        spikes_matfile_path = Path(spikes_matfile_path)
-        assert (
-            spikes_matfile_path.is_file()
-        ), f"The spikes_matfile_path ({spikes_matfile_path}) must exist!"
+    def __init__(self, folder_path: str | Path,
+                 sampling_frequency: float | None = None,
+                 session_info_matfile_path: str | Path | None = None):
         
-        if sampling_frequency is None:
-            folder_path = spikes_matfile_path.parent
-            sorting_id = spikes_matfile_path.name.split(".")[0]
-            if session_info_matfile_path is None:
-                session_info_matfile_path = folder_path / f"{sorting_id}.sessionInfo.mat"
-            session_info_matfile_path = Path(session_info_matfile_path)
-            assert (
-                (session_info_matfile_path).is_file()
-            ), f"No {sorting_id}.sessionInfo.mat file found in the folder!" 
+        try:
+            import h5py
+            import scipy.io 
+        except ImportError:
+            raise ImportError(self.installation_mesg)
 
-            try:
-                session_info_mat = scipy.io.loadmat(file_name=str(session_info_matfile_path))
-                self.read_session_info_with_scipy = True
-            except NotImplementedError:
-                session_info_mat = hdf5storage.loadmat(file_name=str(session_info_matfile_path))
-                self.read_session_info_with_scipy = False
-            
-            assert session_info_mat["sessionInfo"]["rates"][0][0]["wideband"], (
-                "The sesssionInfo.mat file must contain "
-                "a 'sessionInfo' struct with field 'rates' containing field 'wideband' to extract the sampling frequency!"
-            )
-            if self.read_session_info_with_scipy:
-                sampling_frequency = float(
-                    session_info_mat["sessionInfo"]["rates"][0][0]["wideband"][0][0][0][0]
-                )  # careful not to confuse it with the lfpsamplingrate; reported in units Hz
-            else:
-                sampling_frequency = float(
-                    session_info_mat["sessionInfo"]["rates"][0][0]["wideband"][0][0]
-                )  # careful not to confuse it with the lfpsamplingrate; reported in units Hz
+        folder_path = Path(folder_path)
+        session_id = next((path.stem.split(".")[0] for path in folder_path.iterdir() if path.suffix == ".mat"), None)
+        assert session_id is not None, f"No .mat files found in the {folder_path}!"
+        
+        spikes_cellinfo_path = folder_path / f"{session_id}.spikes.cellinfo.mat"
+        assert spikes_cellinfo_path.is_file(), f"The spikes.cellinfo.mat file must exist in the {folder_path}!"
 
         try:
-            spikes_mat = scipy.io.loadmat(file_name=str(spikes_matfile_path))
+            spikes_mat = scipy.io.loadmat(file_name=str(spikes_cellinfo_path), simplify_cells=True)
             self.read_spikes_info_with_scipy = True
         except NotImplementedError: 
-            spikes_mat = hdf5storage.loadmat(file_name=str(spikes_matfile_path))
-            self.read_spikes_info_with_scipy = False
+            spikes_mat = h5py.File(name=spikes_cellinfo_path, mode='r')
+            self.read_spikes_info_with_scipy = False      
+        
+        if sampling_frequency is None:
+            # This is for the new format of spikes.cellinfo.mat files
+            sampling_frequency = spikes_mat["spikes"].get("sr", None) 
+        
+        if sampling_frequency is None:
+            if session_info_matfile_path is None:
+                session_info_matfile_path = folder_path / f"{session_id}.sessionInfo.mat"
+            session_info_matfile_path = Path(session_info_matfile_path)
+            assert session_info_matfile_path.is_file(), f"No {session_id}.sessionInfo.mat file found in the {folder_path}!" 
 
-        assert np.all(
-            np.isin(["UID", "times"], spikes_mat["spikes"].dtype.names)
-        ), "The spikes.cellinfo.mat file must contain a 'spikes' struct with fields 'UID' and 'times'!"
-
+            try:
+                session_info_mat = scipy.io.loadmat(file_name=str(session_info_matfile_path), simplify_cells=True)
+                self.read_session_info_with_scipy = True
+            except NotImplementedError:
+                session_info_mat = h5py.File(name=str(session_info_matfile_path), mode="r")
+                self.read_session_info_with_scipy = False
+            
+            rates = session_info_mat["sessionInfo"]["rates"]
+            wideband_in_rates = "wideband" in rates.keys()
+            assert wideband_in_rates, "a 'sessionInfo' should contain a  'wideband' to extract the sampling frequency!"
+    
+            # careful not to confuse it with the lfpsamplingrate; reported in units Hz
+            if self.read_session_info_with_scipy:
+                sampling_frequency = float(rates["wideband"])
+            else:
+                sampling_frequency = float(rates["wideband"][()])
+            
+        unit_ids_available = "UID" in spikes_mat["spikes"].keys()
+        assert unit_ids_available, "The spikes.cellinfo.mat file must contain field 'UID'!"
+        
+        spike_times_available =  "times" in spikes_mat["spikes"].keys()
+        assert spike_times_available, "The spikes.cellinfo.mat file must contain field 'times'!"
+        
+        if self.read_spikes_info_with_scipy:
+            unit_ids = spikes_mat["spikes"]["UID"].tolist()
+            spike_times = spikes_mat["spikes"]["times"]            
+        else:
+            unit_ids = spikes_mat["spikes"]["UID"][:].squeeze().astype("int").tolist()
+            spike_references = spikes_mat["spikes"]["times"][:]  # These are HDF5 references
+            spike_times = [spikes_mat[reference[0]][()].squeeze() for reference in spike_references]
+            
         # CellExplorer reports spike times in units seconds; SpikeExtractors uses time units of sampling frames
         # Rounding is necessary to prevent data loss from int-casting floating point errors
-        if self.read_spikes_info_with_scipy:
-            unit_ids = np.asarray(spikes_mat["spikes"]["UID"][0][0][0])
-            spiketrains = [
-                (np.array([y[0] for y in x]) * sampling_frequency).round().astype(np.int64)
-                for x in spikes_mat["spikes"]["times"][0][0][0]
-            ]
-        else:
-            unit_ids = np.asarray(spikes_mat["spikes"]["UID"][0][0])
-            spiketrains = [
-                (np.array([y[0] for y in x]) * sampling_frequency).round().astype(np.int64)
-                for x in spikes_mat["spikes"]["times"][0][0]            
-            ]
+        spiketrains_dict = {unit_id: spike_times[index] for index, unit_id in enumerate(unit_ids)}
+        for unit_id in unit_ids:
+            spiketrains_dict[unit_id] = (sampling_frequency * spiketrains_dict[unit_id]).round().astype(np.int64)
         
         BaseSorting.__init__(self, unit_ids=unit_ids, sampling_frequency=sampling_frequency)
-        sorting_segment = CellExplorerSortingSegment(spiketrains, unit_ids)
+        sorting_segment = CellExplorerSortingSegment(spiketrains_dict, unit_ids)
         self.add_sorting_segment(sorting_segment)
 
         self.extra_requirements.append('scipy')
-        self.extra_requirements.append('hdf5storage')
 
-        self._kwargs = dict(spikes_matfile_path=str(spikes_matfile_path.absolute()))
-
+        self._kwargs = dict(folder_path=str(folder_path.absolute()))
 
 class CellExplorerSortingSegment(BaseSortingSegment):
-    def __init__(self, spiketrains, unit_ids):
-        self._spiketrains = spiketrains
+    def __init__(self, spiketrains_dict, unit_ids):
+        self.spiketrains_dict = spiketrains_dict
         self._unit_ids = list(unit_ids)
         BaseSortingSegment.__init__(self)
 
@@ -122,15 +123,16 @@ class CellExplorerSortingSegment(BaseSortingSegment):
                              start_frame,
                              end_frame,
                              ) -> np.ndarray:
-        # must be implemented in subclass
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = np.inf
-        spike_frames = self._spiketrains[self._unit_ids.index(unit_id)]
-        inds = np.where((start_frame <= spike_frames) & (spike_frames < end_frame))
-        return spike_frames[inds]
 
+        spike_frames = self.spiketrains_dict[unit_id]
+        # clip
+        if start_frame is not None:
+            spike_frames = spike_frames[spike_frames >= start_frame]
+
+        if end_frame is not None:
+            spike_frames = spike_frames[spike_frames <= end_frame]
+
+        return spike_frames
 
 read_cellexplorer = define_function_from_class(source_class=CellExplorerSortingExtractor,
                                                name="read_cellexplorer")

--- a/src/spikeinterface/extractors/shybridextractors.py
+++ b/src/spikeinterface/extractors/shybridextractors.py
@@ -1,5 +1,5 @@
-import json
 from pathlib import Path
+import yaml
 
 import numpy as np
 
@@ -8,13 +8,6 @@ from probeinterface import read_prb, write_prb
 from spikeinterface.core import BinaryRecordingExtractor, BaseRecordingSegment, BaseSorting, BaseSortingSegment
 from spikeinterface.core.core_tools import write_binary_recording, define_function_from_class
 
-try:
-    import hybridizer.io as sbio
-    import hybridizer.probes as sbprb
-    import yaml
-    HAVE_SBEX = True
-except ImportError:
-    HAVE_SBEX = False
 
 
 class SHYBRIDRecordingExtractor(BinaryRecordingExtractor):
@@ -33,7 +26,6 @@ class SHYBRIDRecordingExtractor(BinaryRecordingExtractor):
 
     extractor_name = 'SHYBRIDRecording'
     has_default_locations = True
-    installed = HAVE_SBEX  # check at class level if installed or not
     is_writable = True
     mode = 'folder'
     installation_mesg = "To use the SHYBRID extractors, install SHYBRID and pyyaml: " \
@@ -41,8 +33,16 @@ class SHYBRIDRecordingExtractor(BinaryRecordingExtractor):
     name = "shybrid"
 
     def __init__(self, file_path):
+        try:
+            import hybridizer.io as sbio
+            import hybridizer.probes as sbprb
+            HAVE_SBEX = True
+        except ImportError:
+            HAVE_SBEX = False
+
+        
         # load params file related to the given shybrid recording
-        assert self.installed, self.installation_mesg
+        assert HAVE_SBEX, self.installation_mesg
         assert Path(file_path).suffix in [".yml", ".yaml"], "The 'file_path' should be a yaml file!"
         params = sbio.get_params(file_path)['data']
         file_path = Path(file_path)
@@ -92,6 +92,13 @@ class SHYBRIDRecordingExtractor(BinaryRecordingExtractor):
             Type of the saved data. Default float32.
         **write_binary_kwargs: keyword arguments for write_to_binary_dat_format() function
         """
+        try:
+            import hybridizer.io as sbio
+            import hybridizer.probes as sbprb
+            HAVE_SBEX = True
+        except ImportError:
+            HAVE_SBEX = False
+        
         assert HAVE_SBEX, SHYBRIDRecordingExtractor.installation_mesg
         assert recording.get_num_segments() == 1, "SHYBRID can only write single segment recordings"
         save_path = Path(save_path)
@@ -145,13 +152,19 @@ class SHYBRIDSortingExtractor(BaseSorting):
     """
 
     extractor_name = 'SHYBRIDSorting'
-    installed = HAVE_SBEX
     is_writable = True
     installation_mesg = "To use the SHYBRID extractors, install SHYBRID: \n\n pip install shybrid\n\n"
     name = "shybrid"
 
     def __init__(self, file_path, sampling_frequency, delimiter=','):
-        assert self.installed, self.installation_mesg
+        try:
+            import hybridizer.io as sbio
+            import hybridizer.probes as sbprb
+            HAVE_SBEX = True
+        except ImportError:
+            HAVE_SBEX = False
+              
+        assert HAVE_SBEX, self.installation_mesg
         assert Path(file_path).suffix == ".csv", "The 'file_path' should be a csv file!"
 
         if Path(file_path).is_file():
@@ -180,6 +193,13 @@ class SHYBRIDSortingExtractor(BaseSorting):
         save_path : str
             Full path to the desired target folder.
         """
+        try:
+            import hybridizer.io as sbio
+            import hybridizer.probes as sbprb
+            HAVE_SBEX = True
+        except ImportError:
+            HAVE_SBEX = False
+        
         assert HAVE_SBEX, SHYBRIDSortingExtractor.installation_mesg
         assert sorting.get_num_segments() == 1, "SHYBRID can only write single segment sortings"
         save_path = Path(save_path)

--- a/src/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/src/spikeinterface/extractors/tests/test_neoextractors.py
@@ -290,8 +290,8 @@ class CellExplorerSortingTest(SortingCommonTestSuite, unittest.TestCase):
     ExtractorClass = CellExplorerSortingExtractor
     downloads = ['cellexplorer']
     entities = [
-        'cellexplorer/dataset_1/20170311_684um_2088um_170311_134350.spikes.cellinfo.mat',
-        ('cellexplorer/dataset_2/20170504_396um_0um_merge.spikes.cellinfo.mat', 
+        'cellexplorer/dataset_1/',
+        ('cellexplorer/dataset_2/', 
         {'session_info_matfile_path': 
             local_folder / 'cellexplorer/dataset_2/20170504_396um_0um_merge.sessionInfo.mat'})
     ]


### PR DESCRIPTION
Currently we are doing a conversion https://github.com/catalystneuro/buzsaki-lab-to-nwb/issues/55 where we need to adapt this. Basically, there is a new format change where the sampling frequency is in the same files where the spikes are (!). I am adapting here the sorter in consequence.

Plus, I changed the non-standard name of the input so it plays along with the conversion in the repo and delayed the imports to run time. I also managed to eliminate the dependency.