### PR TITLE
Allow to pass `sorting` to `qualitymetrics.compute_refrac_period_violations`

### DIFF
--- a/src/spikeinterface/__init__.py
+++ b/src/spikeinterface/__init__.py
@@ -9,6 +9,7 @@ __version__ = importlib.metadata.version("spikeinterface")
 from .core import *
 
 import warnings
+
 warnings.filterwarnings("ignore", message="distutils Version classes are deprecated")
 warnings.filterwarnings("ignore", message="the imp module is deprecated")
 

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -297,7 +297,9 @@ _default_params["isi_violation"] = dict(isi_threshold_ms=1.5, min_isi_ms=0)
 
 
 def compute_refrac_period_violations(
-    waveform_or_sorting_extractor: Union[BaseSorting, WaveformExtractor], refractory_period_ms: float = 1.0, censored_period_ms: float = 0.0
+    waveform_or_sorting_extractor: Union[BaseSorting, WaveformExtractor],
+    refractory_period_ms: float = 1.0,
+    censored_period_ms: float = 0.0,
 ):
     """Calculates the number of refractory period violations.
 

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -32,13 +32,13 @@ except ModuleNotFoundError as err:
 _default_params = dict()
 
 
-def compute_num_spikes(waveform_extractor, **kwargs):
+def compute_num_spikes(waveform_or_sorting_extractor: Union[BaseSorting, WaveformExtractor], **kwargs):
     """Compute the number of spike across segments.
 
     Parameters
     ----------
-    waveform_extractor : WaveformExtractor
-        The waveform extractor object.
+    waveform_or_sorting_extractor : BaseSorting | WaveformExtractor
+        The waveform or sorting extractor object.
 
     Returns
     -------
@@ -46,7 +46,10 @@ def compute_num_spikes(waveform_extractor, **kwargs):
         The number of spikes, across all segments, for each unit ID.
     """
 
-    sorting = waveform_extractor.sorting
+    if isinstance(waveform_or_sorting_extractor, WaveformExtractor):
+        sorting = waveform_or_sorting_extractor.sorting
+    else:
+        sorting = waveform_or_sorting_extractor
     unit_ids = sorting.unit_ids
     num_segs = sorting.get_num_segments()
 
@@ -349,7 +352,7 @@ def compute_refrac_period_violations(
     num_units = sorting.get_num_units()
     num_segments = sorting.get_num_segments()
     spikes = sorting.get_all_spike_trains(outputs="unit_index")
-    num_spikes = compute_num_spikes(waveform_extractor)
+    num_spikes = compute_num_spikes(sorting)
 
     t_c = int(round(censored_period_ms * fs * 1e-3))
     t_r = int(round(refractory_period_ms * fs * 1e-3))

--- a/src/spikeinterface/qualitymetrics/tests/test_metrics_functions.py
+++ b/src/spikeinterface/qualitymetrics/tests/test_metrics_functions.py
@@ -259,6 +259,7 @@ def test_calculate_rp_violations(simulated_data):
     counts_gt = {0: 2, 1: 4, 2: 10}
     we = setup_dataset(simulated_data)
     rp_contamination, counts = compute_refrac_period_violations(we, 1, 0.0)
+    rp_contamination, counts = compute_refrac_period_violations(we.sorting, 1, 0.0)
 
     print(rp_contamination)
     assert np.allclose(list(rp_contamination_gt.values()), list(rp_contamination.values()), rtol=0.05)


### PR DESCRIPTION
Since the recording is not necessary, allow both `wvf_extractor` and `sorting` objects as input