### PR TITLE
Use censored_period when merging units in `scur.merge_units`

### DIFF
--- a/src/spikeinterface/curation/auto_merge.py
+++ b/src/spikeinterface/curation/auto_merge.py
@@ -464,9 +464,9 @@ def check_improve_contaminations_score(
 
         # make a merged sorting and tale one unit (unit_id1 is used)
         unit_id1, unit_id2 = sorting.unit_ids[ind1], sorting.unit_ids[ind2]
-        sorting_merged = MergeUnitsSorting(sorting, [[unit_id1, unit_id2]], new_unit_ids=[unit_id1], delta_time_ms=censored_period_ms).select_units(
-            [unit_id1]
-        )
+        sorting_merged = MergeUnitsSorting(
+            sorting, [[unit_id1, unit_id2]], new_unit_ids=[unit_id1], delta_time_ms=censored_period_ms
+        ).select_units([unit_id1])
         # make a lazy fake WaveformExtractor to compute contamination and firing rate
         we_new = MockWaveformExtractor(recording, sorting_merged)
 

--- a/src/spikeinterface/curation/auto_merge.py
+++ b/src/spikeinterface/curation/auto_merge.py
@@ -18,7 +18,7 @@ def get_potential_auto_merge(
     window_ms=100.0,
     corr_diff_thresh=0.16,
     template_diff_thresh=0.25,
-    censored_period_ms=0.0,
+    censored_period_ms=0.3,
     refractory_period_ms=1.0,
     sigma_smooth_ms=0.6,
     contamination_threshold=0.2,
@@ -464,7 +464,7 @@ def check_improve_contaminations_score(
 
         # make a merged sorting and tale one unit (unit_id1 is used)
         unit_id1, unit_id2 = sorting.unit_ids[ind1], sorting.unit_ids[ind2]
-        sorting_merged = MergeUnitsSorting(sorting, [[unit_id1, unit_id2]], new_unit_ids=[unit_id1]).select_units(
+        sorting_merged = MergeUnitsSorting(sorting, [[unit_id1, unit_id2]], new_unit_ids=[unit_id1], delta_time_ms=censored_period_ms).select_units(
             [unit_id1]
         )
         # make a lazy fake WaveformExtractor to compute contamination and firing rate


### PR DESCRIPTION
Use the given censored period rather than the default 0.4ms when merging units.

Also sets a default censored period != 0