### PR TITLE
Allow `new_unit_id` to be same id in `CurationSorting.merge`

### DIFF
--- a/src/spikeinterface/curation/curationsorting.py
+++ b/src/spikeinterface/curation/curationsorting.py
@@ -80,7 +80,7 @@ class CurationSorting:
         current_sorting = self._sorting_stages[self._sorting_stages_i]
         if new_unit_id is None:
             new_unit_id = self._get_unused_id()[0]
-        else:
+        elif new_unit_id not in units_to_merge:
             assert new_unit_id not in current_sorting.unit_ids, f"new_unit_id already exists!"
         new_sorting = MergeUnitsSorting(
             parent_sorting=current_sorting,

--- a/src/spikeinterface/curation/tests/test_curationsorting.py
+++ b/src/spikeinterface/curation/tests/test_curationsorting.py
@@ -59,12 +59,14 @@ def test_curation():
     cs = CurationSorting(parent_sort, properties_policy="remove")
     # %%
     cs.merge(["a", "c"])
+    assert cs.sorting.get_num_units() == len(spikestimes[0]) - 1
     split_index = [v["b"] < 6 for v in spikestimes]  # spit class 4 in even and odds
     cs.split("b", split_index)
     after_split = cs.sorting
+    assert cs.sorting.get_num_units() == len(spikestimes[0])
 
     all_units = cs.sorting.get_unit_ids()
-    cs.merge(all_units)
+    cs.merge(all_units, new_unit_id=all_units[0])
     assert len(cs.sorting.get_unit_ids()) == 1, "error merging units"
     cs.undo()
 

--- a/src/spikeinterface/curation/tests/test_curationsorting.py
+++ b/src/spikeinterface/curation/tests/test_curationsorting.py
@@ -60,7 +60,7 @@ def test_curation():
     # %%
     cs.merge(["a", "c"])
     assert cs.sorting.get_num_units() == len(spikestimes[0]) - 1
-    split_index = [v["b"] < 6 for v in spikestimes]  # spit class 4 in even and odds
+    split_index = [v["b"] < 6 for v in spikestimes]  # split class 4 in even and odds
     cs.split("b", split_index)
     after_split = cs.sorting
     assert cs.sorting.get_num_units() == len(spikestimes[0])
@@ -68,6 +68,7 @@ def test_curation():
     all_units = cs.sorting.get_unit_ids()
     cs.merge(all_units, new_unit_id=all_units[0])
     assert len(cs.sorting.get_unit_ids()) == 1, "error merging units"
+    assert cs.sorting.unit_ids[0] = all_units[0]
     cs.undo()
 
     assert cs.sorting is after_split

--- a/src/spikeinterface/curation/tests/test_curationsorting.py
+++ b/src/spikeinterface/curation/tests/test_curationsorting.py
@@ -68,7 +68,7 @@ def test_curation():
     all_units = cs.sorting.get_unit_ids()
     cs.merge(all_units, new_unit_id=all_units[0])
     assert len(cs.sorting.get_unit_ids()) == 1, "error merging units"
-    assert cs.sorting.unit_ids[0] = all_units[0]
+    assert cs.sorting.unit_ids[0] == all_units[0]
     cs.undo()
 
     assert cs.sorting is after_split


### PR DESCRIPTION
Right now it's not possible to do `CurationSorting.merge([1, 2], new_unit_id=1)`, and it should be possible