### PR TITLE
Fixed crash when loading `MergeUnitsSorting`

### DIFF
--- a/doc/modules/core.rst
+++ b/doc/modules/core.rst
@@ -247,7 +247,7 @@ Finally, an existing :py:class:`~spikeinterface.core.WaveformExtractor` can be s
 
 
 **IMPORTANT:** to load a waveform extractor object from disk, it needs to be able to reload the associated
-:code:`sorting` object (the :code:`recording` is optional, using :code:`with_recording=False`). 
+:code:`sorting` object (the :code:`recording` is optional, using :code:`with_recording=False`).
 In order to make a waveform folder portable (e.g. copied to another location or machine), one can do:
 
 .. code-block:: python

--- a/src/spikeinterface/curation/mergeunitssorting.py
+++ b/src/spikeinterface/curation/mergeunitssorting.py
@@ -127,7 +127,7 @@ class MergeUnitsSorting(BaseSorting):
         self._kwargs = dict(
             parent_sorting=parent_sorting,
             units_to_merge=units_to_merge,
-            new_unit_id=new_unit_ids,
+            new_unit_ids=new_unit_ids,
             properties_policy=properties_policy,
             delta_time_ms=delta_time_ms,
         )


### PR DESCRIPTION
Couldn't load `MergeUnitsSorting` from json because of a typo in `kwargs`