### PR TITLE
Fix pickle loading

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -948,7 +948,7 @@ def load_extractor(file_or_folder_or_dict, base_folder=None) -> BaseExtractor:
 
 
 def load_extractor_from_dict(d, base_folder=None) -> BaseExtractor:
-    print("Use load_extractor(..) instead")
+    warnings.warn("Use load_extractor(..) instead")
     return BaseExtractor.from_dict(d, base_folder=base_folder)
 
 

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -868,12 +868,12 @@ def _load_extractor_from_dict(dic) -> BaseExtractor:
     new_kwargs = dict()
     transform_dict_to_extractor = lambda x: _load_extractor_from_dict(x) if is_dict_extractor(x) else x
     for name, value in dic["kwargs"].items():
-        if isinstance(value, dict) and is_dict_extractor(value):
+        if isinstance(value, dict):
             new_kwargs[name] = {k: transform_dict_to_extractor(v) for k, v in value.items()}
         elif isinstance(value, list):
             new_kwargs[name] = [transform_dict_to_extractor(e) for e in value]
         else:
-            new_kwargs[name] = value
+            new_kwargs[name] = transform_dict_to_extractor(value)
 
     class_name = dic["class"]
     extractor_class = _get_class_from_string(class_name)

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -868,12 +868,14 @@ def _load_extractor_from_dict(dic) -> BaseExtractor:
     new_kwargs = dict()
     transform_dict_to_extractor = lambda x: _load_extractor_from_dict(x) if is_dict_extractor(x) else x
     for name, value in dic["kwargs"].items():
-        if isinstance(value, dict):
+        if is_dict_extractor(value):
+            new_kwargs[name] = _load_extractor_from_dict(value)
+        elif isinstance(value, dict):
             new_kwargs[name] = {k: transform_dict_to_extractor(v) for k, v in value.items()}
         elif isinstance(value, list):
             new_kwargs[name] = [transform_dict_to_extractor(e) for e in value]
         else:
-            new_kwargs[name] = transform_dict_to_extractor(value)
+            new_kwargs[name] = value
 
     class_name = dic["class"]
     extractor_class = _get_class_from_string(class_name)

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -404,6 +404,7 @@ class BaseExtractor:
         Clones an existing extractor into a new instance.
         """
         d = self.to_dict(include_annotations=True, include_properties=True)
+        d = deepcopy(d)
         clone = BaseExtractor.from_dict(d)
         return clone
 


### PR DESCRIPTION
This was a rabit hole.

OK, so this is the solution that is performing the best now:

```
results for branch fix_loading_pickle [This branch]
Time elapsed for saving: 0.0029435157775878906
Time elapsed for loading: 0.03637957572937012
Memory used by loading: 1.03125 MiB
Peak memory usage: 684.25390625 MiB
```

What was making loading and the [benchmark](https://gist.github.com/h-mayorquin/72f492275767fa9f2cb77a0b117eea67) very slow for loading was the deep copy.

As discussed on the other PR https://github.com/SpikeInterface/spikeinterface/pull/1622#issuecomment-1562000001 the other approaches are terrible in their loading and memory footprint performance. This approach is just better overall, saving, loading and memory usage. 

