### PR TITLE
Make NWB imports lazy

### DIFF
--- a/src/spikeinterface/extractors/iblstreamingrecording.py
+++ b/src/spikeinterface/extractors/iblstreamingrecording.py
@@ -9,14 +9,6 @@ import probeinterface as pi
 from spikeinterface.core import BaseRecording, BaseRecordingSegment
 from spikeinterface.core.core_tools import define_function_from_class
 
-try:
-    import brainbox
-    from one.api import ONE
-
-    HAVE_BRAINBOX_ONE = True
-except ModuleNotFoundError:
-    HAVE_BRAINBOX_ONE = False
-
 
 class IblStreamingRecordingExtractor(BaseRecording):
     """
@@ -57,7 +49,6 @@ class IblStreamingRecordingExtractor(BaseRecording):
 
     extractor_name = "IblStreamingRecording"
     has_default_locations = True
-    installed = HAVE_BRAINBOX_ONE
     mode = "folder"
     installation_mesg = "To use the IblStreamingRecordingSegment, install ONE-api and ibllib: \n\n pip install ONE-api\npip install ibllib\n"
     name = "ibl_streaming_recording"
@@ -85,7 +76,10 @@ class IblStreamingRecordingExtractor(BaseRecording):
         stream_names : list of str
             List of stream names as expected by the `stream_name` argument for the class initialization.
         """
-        assert HAVE_BRAINBOX_ONE, cls.installation_mesg
+        try:
+            from one.api import ONE
+        except ImportError:
+            raise ImportError(IblStreamingRecordingExtractor.installation_mesg)
 
         cache_folder = Path(cache_folder) if cache_folder is not None else cache_folder
         one = ONE(
@@ -119,10 +113,12 @@ class IblStreamingRecordingExtractor(BaseRecording):
         cache_folder: Optional[Union[Path, str]] = None,
         remove_cached: bool = True,
     ):
-        assert HAVE_BRAINBOX_ONE, self.installation_mesg
+        try:
+            from brainbox.io.spikeglx import Streamer
+            from one.api import ONE
+        except ImportError:
+            raise ImportError(self.installation_mesg)
 
-        from brainbox.io.spikeglx import Streamer
-        from one.api import ONE
         from neo.rawio.spikeglxrawio import read_meta_file, extract_stream_info
 
         cache_folder = Path(cache_folder) if cache_folder is not None else cache_folder

--- a/src/spikeinterface/extractors/matlabhelpers.py
+++ b/src/spikeinterface/extractors/matlabhelpers.py
@@ -3,40 +3,20 @@ from collections import deque
 
 import numpy as np
 
-try:
-    import h5py
-
-    HAVE_H5PY = True
-except ImportError:
-    HAVE_H5PY = False
-
-try:
-    from scipy.io.matlab import loadmat, savemat
-
-    HAVE_LOADMAT = True
-except ImportError:
-    HAVE_LOADMAT = False
-
-try:
-    import hdf5storage
-
-    HAVE_HDF5STORAGE = True
-except ImportError:
-    HAVE_HDF5STORAGE = False
-
-HAVE_MAT = HAVE_H5PY & HAVE_LOADMAT
-
 
 class MatlabHelper:
     extractor_name = "MATSortingExtractor"
-    installed = HAVE_MAT  # check at class level if installed or not
     mode = "file"
     installation_mesg = (
         "To use the MATSortingExtractor install h5py and scipy: " "\n\n pip install h5py scipy\n\n"
     )  # error message when not installed
 
     def __init__(self, file_path):
-        assert HAVE_MAT, self.installation_mesg
+        try:
+            import h5py
+            from scipy.io.matlab import loadmat, savemat
+        except ImportError:
+            raise ImportError(self.installation_mesg)
 
         file_path = Path(file_path) if isinstance(file_path, str) else file_path
         if not isinstance(file_path, Path):
@@ -78,10 +58,18 @@ class MatlabHelper:
 
     @classmethod
     def write_dict_to_mat(cls, mat_file_path, dict_to_write, version="7.3"):  # field must be a dict
-        assert HAVE_HDF5STORAGE, (
+        hdf5storage_import_error = (
             "To use the MATSortingExtractor write_dict_to_mat function install hdf5storage: "
             "\n\n pip install hdf5storage\n\n"
         )
+
+        try:
+            import hdf5storage
+        except ImportError:
+            raise ImportError(hdf5storage_import_error)
+
+        from scipy.io.matlab import loadmat, savemat
+
         if version == "7.3":
             hdf5storage.write(dict_to_write, "/", mat_file_path, matlab_compatible=True, options="w")
         elif version < "7.3" and version > "4":

--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -8,37 +8,13 @@ from spikeinterface import get_global_tmp_folder
 from spikeinterface.core import BaseRecording, BaseRecordingSegment, BaseSorting, BaseSortingSegment
 from spikeinterface.core.core_tools import define_function_from_class
 
-try:
-    from pynwb import NWBHDF5IO, NWBFile
-    from pynwb.ecephys import ElectricalSeries, ElectrodeGroup
 
-    HAVE_NWB = True
-except ModuleNotFoundError:
-    HAVE_NWB = False
-
-try:
-    import h5py
-
-    HAVE_H5PY = True
-except:
-    HAVE_H5PY = False
-
-try:
-    import fsspec
-
-    HAVE_FSSPEC = True
-except ModuleNotFoundError:
-    HAVE_FSSPEC = False
-
-PathType = Union[str, Path, None]
-
-
-def check_nwb_install():
-    assert HAVE_NWB, NwbRecordingExtractor.installation_mesg
-
-
-def check_fsspec_install():
-    assert HAVE_FSSPEC, "To stream NWB data with fsspec, install fsspec: \n\n pip install fsspec aiohttp requests\n\n"
+def import_lazily():
+    "Makes annotations / typing available lazily"
+    global NWBFile, ElectricalSeries, NWBHDF5IO
+    from pynwb import NWBFile
+    from pynwb.ecephys import ElectricalSeries
+    from pynwb import NWBHDF5IO
 
 
 def retrieve_electrical_series(nwbfile: NWBFile, electrical_series_name: Optional[str] = None) -> ElectricalSeries:
@@ -66,6 +42,8 @@ def retrieve_electrical_series(nwbfile: NWBFile, electrical_series_name: Optiona
     AssertionError
         If the specified electrical_series_name is not present in the NWBFile.
     """
+    from pynwb.ecephys import ElectricalSeries
+
     if electrical_series_name is not None:
         # TODO note that this case does not handle repetitions of the same name
         electrical_series_dict: Dict[str, ElectricalSeries] = {
@@ -91,7 +69,9 @@ def retrieve_electrical_series(nwbfile: NWBFile, electrical_series_name: Optiona
 
 
 def read_nwbfile(
-    file_path: str, stream_mode: Optional[Literal["ffspec", "ros3"]] = None, stream_cache_path: Optional[str] = None
+    file_path: str | Path,
+    stream_mode: Literal["ffspec", "ros3"] | None = None,
+    stream_cache_path: str | Path | None = None,
 ) -> NWBFile:
     """
     Read an NWB file and return the NWBFile object.
@@ -125,8 +105,12 @@ def read_nwbfile(
     >>> nwbfile = read_nwbfile("data.nwb", stream_mode="ros3")
     """
     file_path = str(file_path)
+    from pynwb import NWBHDF5IO, NWBFile
+
     if stream_mode == "fsspec":
         import fsspec
+        import h5py
+
         from fsspec.implementations.cached import CachingFileSystem
 
         stream_cache_path = stream_cache_path if stream_cache_path is not None else str(get_global_tmp_folder())
@@ -135,10 +119,12 @@ def read_nwbfile(
             cache_storage=str(stream_cache_path),
         )
         cached_file = caching_file_system.open(path=file_path, mode="rb")
-        file_path = h5py.File(cached_file)
-        io = NWBHDF5IO(file=file_path, mode="r", load_namespaces=True)
+        file = h5py.File(cached_file)
+        io = NWBHDF5IO(file=file, mode="r", load_namespaces=True)
 
     elif stream_mode == "ros3":
+        import h5py
+
         drivers = h5py.registered_drivers()
         assertion_msg = "ROS3 support not enbabled, use: install -c conda-forge h5py>=3.2 to enable streaming"
         assert "ros3" in drivers, assertion_msg
@@ -198,7 +184,6 @@ class NwbRecordingExtractor(BaseRecording):
 
     extractor_name = "NwbRecording"
     has_default_locations = True
-    installed = HAVE_NWB  # check at class level if installed or not
     is_writable = True
     mode = "file"
     installation_mesg = "To use the Nwb extractors, install pynwb: \n\n pip install pynwb\n\n"
@@ -206,14 +191,19 @@ class NwbRecordingExtractor(BaseRecording):
 
     def __init__(
         self,
-        file_path: PathType,
+        file_path: str | Path,
         electrical_series_name: str = None,
         load_time_vector: bool = False,
         samples_for_rate_estimation: int = 100000,
         stream_mode: Optional[Literal["fsspec", "ros3"]] = None,
-        stream_cache_path: PathType = None,
+        stream_cache_path: str | Path | None = None,
     ):
-        check_nwb_install()
+        try:
+            from pynwb import NWBHDF5IO, NWBFile
+            from pynwb.ecephys import ElectrodeGroup
+        except ImportError:
+            raise ImportError(self.installation_mesg)
+
         self.stream_mode = stream_mode
         self.stream_cache_path = stream_cache_path
         self._electrical_series_name = electrical_series_name
@@ -455,28 +445,31 @@ class NwbSortingExtractor(BaseSorting):
     """
 
     extractor_name = "NwbSorting"
-    installed = HAVE_NWB  # check at class level if installed or not
     mode = "file"
     installation_mesg = "To use the Nwb extractors, install pynwb: \n\n pip install pynwb\n\n"
     name = "nwb"
 
     def __init__(
         self,
-        file_path: PathType,
-        electrical_series_name: str = None,
-        sampling_frequency: float = None,
+        file_path: str | Path,
+        electrical_series_name: str | None = None,
+        sampling_frequency: float | None = None,
         samples_for_rate_estimation: int = 100000,
-        stream_mode: str = None,
-        stream_cache_path: PathType = None,
+        stream_mode: str | None = None,
+        stream_cache_path: str | Path | None = None,
     ):
-        check_nwb_install()
+        try:
+            from pynwb import NWBHDF5IO, NWBFile
+            from pynwb.ecephys import ElectrodeGroup
+        except ImportError:
+            raise ImportError(self.installation_mesg)
+
         self.stream_mode = stream_mode
         self.stream_cache_path = stream_cache_path
         self._electrical_series_name = electrical_series_name
 
         self.file_path = file_path
         if stream_mode == "fsspec":
-            check_fsspec_install()
             import fsspec
             from fsspec.implementations.cached import CachingFileSystem
             import h5py
@@ -487,8 +480,8 @@ class NwbSortingExtractor(BaseSorting):
                 cache_storage=self.stream_cache_path,
             )
             self._file_path = self.cfs.open(str(file_path), "rb")
-            f = h5py.File(self._file_path)
-            self.io = NWBHDF5IO(file=f, mode="r", load_namespaces=True)
+            file = h5py.File(self._file_path)
+            self.io = NWBHDF5IO(file=file, mode="r", load_namespaces=True)
 
         elif stream_mode == "ros3":
             self._file_path = str(file_path)

--- a/src/spikeinterface/extractors/tridesclousextractors.py
+++ b/src/spikeinterface/extractors/tridesclousextractors.py
@@ -3,13 +3,6 @@ from pathlib import Path
 from spikeinterface.core import BaseSorting, BaseSortingSegment
 from spikeinterface.core.core_tools import define_function_from_class
 
-try:
-    import tridesclous as tdc
-
-    HAVE_TDC = True
-except ImportError:
-    HAVE_TDC = False
-
 
 class TridesclousSortingExtractor(BaseSorting):
     """Load Tridesclous format data as a sorting extractor.
@@ -28,12 +21,16 @@ class TridesclousSortingExtractor(BaseSorting):
     """
 
     extractor_name = "TridesclousSortingExtractor"
-    installed = HAVE_TDC
     mode = "folder"
     installation_mesg = "To use the TridesclousSortingExtractor install tridesclous: \n\n pip install tridesclous\n\n"  # error message when not installed
     name = "tridesclous"
 
     def __init__(self, folder_path, chan_grp=None):
+        try:
+            import tridesclous as tdc
+        except ImportError:
+            raise ImportError(self.installation_mesg)
+
         assert self.installed, self.installation_mesg
         tdc_folder = Path(folder_path)
 


### PR DESCRIPTION
I was profiling something and discussing with @alejoe91 today and we realize that the following imports are not lazy:

* Tridesclous
* Pynwb
* one.api import ONE

I am making them lazy here.