### PR TITLE
Add xml_file_path option to Neuroscope

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/neuroscope.py
+++ b/src/spikeinterface/extractors/neoextractors/neuroscope.py
@@ -43,16 +43,25 @@ class NeuroScopeRecordingExtractor(NeoBaseRecordingExtractor):
     NeoRawIOClass = "NeuroScopeRawIO"
     name = "neuroscope"
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
-        neo_kwargs = self.map_to_neo_kwargs(file_path)
+    def __init__(self, file_path, xml_file_path=None, stream_id=None, stream_name=None, all_annotations=False):
+        neo_kwargs = self.map_to_neo_kwargs(file_path, xml_file_path)
+
         NeoBaseRecordingExtractor.__init__(
             self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
         )
         self._kwargs.update(dict(file_path=str(file_path)))
 
     @classmethod
-    def map_to_neo_kwargs(cls, file_path):
-        neo_kwargs = {"filename": str(file_path)}
+    def map_to_neo_kwargs(cls, file_path, xml_file_path):
+        # For this because of backwards compatibility we have a strange convention
+        # filename is the xml file
+        # binary_file is the binary file in .dat, .lfp, .eeg
+
+        if xml_file_path is not None:
+            neo_kwargs = {"binary_file": Path(file_path), "filename": xml_file_path}
+        else:
+            neo_kwargs = {"filename": file_path}
+
         return neo_kwargs
 
 

--- a/src/spikeinterface/extractors/neoextractors/neuroscope.py
+++ b/src/spikeinterface/extractors/neoextractors/neuroscope.py
@@ -51,16 +51,16 @@ class NeuroScopeRecordingExtractor(NeoBaseRecordingExtractor):
         NeoBaseRecordingExtractor.__init__(
             self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
         )
-        self._kwargs.update(dict(file_path=str(file_path), xml_file_path=str(xml_file_path)))
+        self._kwargs.update(dict(file_path=str(file_path), xml_file_path=xml_file_path))
 
     @classmethod
-    def map_to_neo_kwargs(cls, file_path, xml_file_path):
+    def map_to_neo_kwargs(cls, file_path, xml_file_path=None):
         # For this because of backwards compatibility we have a strange convention
         # filename is the xml file
         # binary_file is the binary file in .dat, .lfp, .eeg
 
         if xml_file_path is not None:
-            neo_kwargs = {"binary_file": Path(file_path), "filename": xml_file_path}
+            neo_kwargs = {"binary_file": file_path, "filename": xml_file_path}
         else:
             neo_kwargs = {"filename": file_path}
 

--- a/src/spikeinterface/extractors/neoextractors/neuroscope.py
+++ b/src/spikeinterface/extractors/neoextractors/neuroscope.py
@@ -30,7 +30,9 @@ class NeuroScopeRecordingExtractor(NeoBaseRecordingExtractor):
     Parameters
     ----------
     file_path: str
-        The file path to load the recordings from.
+        The file path to the binary container usually a .dat, .lfp, .eeg extension.
+    xml_file_path: str, optional
+        The path to the xml file. If None, the xml file is assumed to have the same name as the binary file.
     stream_id: str, optional
         If there are several streams, specify the stream id you want to load.
     stream_name: str, optional
@@ -49,7 +51,7 @@ class NeuroScopeRecordingExtractor(NeoBaseRecordingExtractor):
         NeoBaseRecordingExtractor.__init__(
             self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
         )
-        self._kwargs.update(dict(file_path=str(file_path)))
+        self._kwargs.update(dict(file_path=str(file_path), xml_file_path=str(xml_file_path)))
 
     @classmethod
     def map_to_neo_kwargs(cls, file_path, xml_file_path):

--- a/src/spikeinterface/extractors/tests/common_tests.py
+++ b/src/spikeinterface/extractors/tests/common_tests.py
@@ -29,6 +29,7 @@ class RecordingCommonTestSuite(CommonTestSuite):
 
     def test_open(self):
         for entity in self.entities:
+            kwargs = {}
             if isinstance(entity, tuple):
                 path, kwargs = entity
             elif isinstance(entity, str):
@@ -37,13 +38,6 @@ class RecordingCommonTestSuite(CommonTestSuite):
 
             # test streams and blocks retrieval
             full_path = self.get_full_path(path)
-
-            extractor_name = self.ExtractorClass.name
-            print(f"Extractor name {extractor_name} - path {full_path}")
-            nblocks = get_neo_num_blocks(extractor_name, full_path)
-            stream_names, stream_ids = get_neo_streams(extractor_name, full_path)
-
-            print(f"Num blocks: {nblocks}, Stream names: {stream_names}, Stream IDs: {stream_ids}")
 
             rec = self.ExtractorClass(full_path, **kwargs)
 

--- a/src/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/src/spikeinterface/extractors/tests/test_neoextractors.py
@@ -105,6 +105,7 @@ class NeuroScopeRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     downloads = ["neuroscope"]
     entities = [
         "neuroscope/test1/test1.xml",
+        ("neuroscope/test2/signal1.dat", {"xml_file_path": local_folder / "neuroscope" / "test2" / "recording.xml"}),
     ]
 
 


### PR DESCRIPTION
The neo reader for Neuroscope supports indicating the xml_file_path that is used to extract the metadata. The option, however, has not been propagated to spikeinterface. This PR solves that.