### PR TITLE
Add recursive=True when caching objects before container

### DIFF
--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -377,7 +377,7 @@ def run_sorter_container(
     output_folder.mkdir(parents=True, exist_ok=True)
 
     # find input folder of recording for folder bind
-    rec_dict = recording.to_dict()
+    rec_dict = recording.to_dict(recursive=True)
     recording_input_folders = find_recording_folders(rec_dict)
 
     if platform.system() == "Windows":


### PR DESCRIPTION
Related to #1695

In #1674 we set the default behavior of `to_dict()` not to recursively serialize sub-parents. This is totally fine locally, but when running in a container we need the full dictionary to be serialized in order to properly find the volumes to map.

The issue is not totally solved, still WIP