### PR TITLE
Fix cosine similarity matrix in `TemplateComparison` 

### DIFF
--- a/src/spikeinterface/comparison/paircomparisons.py
+++ b/src/spikeinterface/comparison/paircomparisons.py
@@ -769,7 +769,7 @@ class TemplateComparison(BasePairComparison, MixinTemplateComparison):
         if self._verbose:
             print("Agreement scores...")
 
-        agreement_scores = compute_template_similarity(self.we1, self.we2, method=self.similarity_method)
+        agreement_scores = compute_template_similarity(self.we1, waveform_extractor_other=self.we2, method=self.similarity_method)
         import pandas as pd
 
         self.agreement_scores = pd.DataFrame(agreement_scores, index=self.unit_ids[0], columns=self.unit_ids[1])

--- a/src/spikeinterface/comparison/paircomparisons.py
+++ b/src/spikeinterface/comparison/paircomparisons.py
@@ -769,7 +769,9 @@ class TemplateComparison(BasePairComparison, MixinTemplateComparison):
         if self._verbose:
             print("Agreement scores...")
 
-        agreement_scores = compute_template_similarity(self.we1, waveform_extractor_other=self.we2, method=self.similarity_method)
+        agreement_scores = compute_template_similarity(
+            self.we1, waveform_extractor_other=self.we2, method=self.similarity_method
+        )
         import pandas as pd
 
         self.agreement_scores = pd.DataFrame(agreement_scores, index=self.unit_ids[0], columns=self.unit_ids[1])


### PR DESCRIPTION
`postprocessing.template_similarity.compute_template_similarity` seems to have changed the way it accepts the second waveform extractor as an argument but `TemplateComparison` was not updated to reflect this. This causes an error when the two waveform extractors have different number of units. There may be other errors like this in the comparison module. 