### PR TITLE
Allow PhyExtractor to handle splits from Phy

### DIFF
--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -123,7 +123,7 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
             for i, (phy_id, si_id) in enumerate(
                 zip(cluster_info["cluster_id"].values, cluster_info["si_unit_id"].values)
             ):
-                if np.isnan(si_id) or np.count_nonzero(cluster_info["si_unit_id"].values==si_id)!=1:
+                if np.isnan(si_id) or np.count_nonzero(cluster_info["si_unit_id"].values == si_id) != 1:
                     max_si_unit_id += 1
                     new_si_id = int(max_si_unit_id)
                 else:

--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -123,7 +123,7 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
             for i, (phy_id, si_id) in enumerate(
                 zip(cluster_info["cluster_id"].values, cluster_info["si_unit_id"].values)
             ):
-                if np.count_nonzero(cluster_info["si_unit_id"].values==si_id)!=1:
+                if np.isnan(si_id) or np.count_nonzero(cluster_info["si_unit_id"].values==si_id)!=1:
                     max_si_unit_id += 1
                     new_si_id = int(max_si_unit_id)
                 else:

--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -123,7 +123,7 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
             for i, (phy_id, si_id) in enumerate(
                 zip(cluster_info["cluster_id"].values, cluster_info["si_unit_id"].values)
             ):
-                if np.isnan(si_id):
+                if np.count_nonzero(cluster_info["si_unit_id"].values==si_id)!=1:
                     max_si_unit_id += 1
                     new_si_id = int(max_si_unit_id)
                 else:


### PR DESCRIPTION
**Problem** 

As seen in #1690 splitting in Phy leads to some problems for SI. Phy has two main actions merges which delete two rows of the `cluster_info` tsv/csv and creates a new row (which should) create a nan for the `si_unit_id`. In the case of splits however it takes one row in the tsv and copies it to two new rows with every column except `cluster_id` and `n_spikes` being the same value as the previous single row. Thus the `si_unit_id` is also duplicated in the case of splits.  This issue will only occur after the user has done any SI work because the only way the `si_unit_id` can be duplicated is if it already exists. So performing sorting/Phy outside of SI and doing splitting wouldn't cause this issue if trying to extract an old dataset.

**Potential Solution**

I've put one potential solution in this pull request. Originally I was thinking of a more complicated logic to handle duplicates and reuse numbers. But the issue with that more complicated logic is that it may still miss edge cases (If-elif-else would likely miss something). For example I know some Phy users who split a cluster multiple times to remove stimulation artifacts, which means rather than simple duplicates there could actually be `n` occurrences of the same `si_unit_id`. I've also tested merging and splitting repeatedly on Phy and the memcache can misbehave in extreme conditions so the merging and splitting results are not 100% consistent. So the simple solution of this PR is to check for `nan` which should indicate a merge (almost all the time) and check for duplicates (anything that is not 1) which should indicate (a) split(s). And if either of these conditions occur just use a new `si_unit_id` number. Simple logic, easier to debug if a new edge case appears in the future and behaves similarly to how Phy itself behaves so if users want to use Phy they won't need to change their intuition too much. If it is easier to read I could also make 
```python
if np.isnan(x)
elif np.count_nonzero(x)
else
```
instead, but I figured the shortcircuiting `or` would be fine since really the implication is in the case of a merge or a split.
