### PR TITLE
Added typing to `export_to_phy`

### DIFF
--- a/src/spikeinterface/exporters/to_phy.py
+++ b/src/spikeinterface/exporters/to_phy.py
@@ -1,11 +1,13 @@
 from pathlib import Path
+from typing import Literal, Optional, Union
 
 import numpy as np
+import numpy.typing as npt
 import shutil
 import warnings
 
 import spikeinterface
-from spikeinterface.core import write_binary_recording, BinaryRecordingExtractor, ChannelSparsity
+from spikeinterface.core import write_binary_recording, BinaryRecordingExtractor, ChannelSparsity, WaveformExtractor
 from spikeinterface.core.job_tools import _shared_job_kwargs_doc, fix_job_kwargs
 from spikeinterface.postprocessing import (
     compute_spike_amplitudes,
@@ -15,17 +17,17 @@ from spikeinterface.postprocessing import (
 
 
 def export_to_phy(
-    waveform_extractor,
-    output_folder,
-    compute_pc_features=True,
-    compute_amplitudes=True,
-    sparsity=None,
-    copy_binary=True,
-    remove_if_exists=False,
-    peak_sign="neg",
-    template_mode="median",
-    dtype=None,
-    verbose=True,
+    waveform_extractor: WaveformExtractor,
+    output_folder: Union[str, Path],
+    compute_pc_features: bool = True,
+    compute_amplitudes: bool = True,
+    sparsity: Optional[ChannelSparsity] = None,
+    copy_binary: bool = True,
+    remove_if_exists: bool = False,
+    peak_sign: Literal["both", "neg", "pos"] = "neg",
+    template_mode: str = "median",
+    dtype: Optional[npt.DTypeLike] = None,
+    verbose: bool = True,
     **job_kwargs,
 ):
     """
@@ -35,7 +37,7 @@ def export_to_phy(
     ----------
     waveform_extractor: a WaveformExtractor or None
         If WaveformExtractor is provide then the compute is faster otherwise
-    output_folder: str
+    output_folder: str | Path
         The output folder where the phy template-gui files are saved
     compute_pc_features: bool
         If True (default), pc features are computed

--- a/src/spikeinterface/exporters/to_phy.py
+++ b/src/spikeinterface/exporters/to_phy.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Literal, Optional
+from __future__ import annotations
 
 import numpy as np
 import numpy.typing as npt
@@ -18,7 +19,7 @@ from spikeinterface.postprocessing import (
 
 def export_to_phy(
     waveform_extractor: WaveformExtractor,
-    output_folder: Union[str, Path],
+    output_folder: str | Path,
     compute_pc_features: bool = True,
     compute_amplitudes: bool = True,
     sparsity: Optional[ChannelSparsity] = None,

--- a/src/spikeinterface/exporters/to_phy.py
+++ b/src/spikeinterface/exporters/to_phy.py
@@ -1,6 +1,6 @@
+from __future__ import annotations
 from pathlib import Path
 from typing import Literal, Optional
-from __future__ import annotations
 
 import numpy as np
 import numpy.typing as npt


### PR DESCRIPTION
Fixes annoying warning from my IDE telling me that `output_folder` needs to be a `str`, not `Path`