### PR TITLE
Fixes `to_dict(recursive)` that isn't recursive

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -320,7 +320,7 @@ class BaseExtractor:
                 include_properties=include_properties,
                 relative_to=relative_to,
                 folder_metadata=folder_metadata,
-                recursive=recursive
+                recursive=recursive,
             )
 
             new_kwargs = dict()

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -320,6 +320,7 @@ class BaseExtractor:
                 include_properties=include_properties,
                 relative_to=relative_to,
                 folder_metadata=folder_metadata,
+                recursive=recursive
             )
 
             new_kwargs = dict()


### PR DESCRIPTION
The `recursive` parameter isn't given to the children, and thus doesn't apply after the first parent.