### PR TITLE
Fix bug with `to_dict(recurvise, relative_to)`

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -318,7 +318,7 @@ class BaseExtractor:
             to_dict_kwargs = dict(
                 include_annotations=include_annotations,
                 include_properties=include_properties,
-                relative_to=relative_to,
+                relative_to=None,  # '_make_paths_relative' is already recursive!
                 folder_metadata=folder_metadata,
                 recursive=recursive,
             )

--- a/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
+++ b/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
@@ -62,7 +62,7 @@ def test_center():
 
 def test_zscore():
     seed = 0
-    rec = generate_recording()
+    rec = generate_recording(seed=seed)
     tr = rec.get_traces(segment_index=0)
 
     rec2 = zscore(rec, seed=seed)
@@ -81,7 +81,6 @@ def test_zscore():
     rec_int = scale(rec, dtype="int16", gain=100)
     with pytest.raises(AssertionError):
         rec4 = zscore(rec_int, dtype=None)
-    rec4 = zscore(rec_int, dtype="float32", mode="mean+std", seed=seed)
     rec4 = zscore(rec_int, dtype="int16", int_scale=256, mode="mean+std", seed=seed)
     tr = rec4.get_traces(segment_index=0)
     trace_mean = np.mean(tr, axis=0)


### PR DESCRIPTION
Since `_make_paths_relative` is already recursive, setting `relative_to=` recursively means that for parents, it will be applied twice which can cause a wrong path.

As you can see in the following example (where some prints were added):
```
sorting.select_units([0, 1]).to_dict(relative_to=base_folder, recursive=True)
>>> /export/home1/users/nsr/wyngaard/Documents/lussac2/tests/datasets/cerebellar_cortex/lussac/logs/merge_sortings/CS/merged_sorting.npz -> merge_sortings/CS/merged_sorting.npz  # Correct transformation.
>>> merge_sortings/CS/merged_sorting.npz -> ../../../../../merge_sortings/CS/merged_sorting.npz  # Second transformation breaks the path!
```

Thanks @alejoe91 for helping me debug this!

This PR fixes #1731.