### PR TITLE
Sorter relative path

### DIFF
--- a/src/spikeinterface/sorters/basesorter.py
+++ b/src/spikeinterface/sorters/basesorter.py
@@ -237,9 +237,7 @@ class BaseSorter:
         t0 = time.perf_counter()
 
         try:
-            SorterClass._run_from_folder(
-                sorter_output_folder, sorter_params, verbose, relative_to=relative_to
-            )
+            SorterClass._run_from_folder(sorter_output_folder, sorter_params, verbose, relative_to=relative_to)
             t1 = time.perf_counter()
             run_time = float(t1 - t0)
             has_error = False

--- a/src/spikeinterface/sorters/basesorter.py
+++ b/src/spikeinterface/sorters/basesorter.py
@@ -59,10 +59,11 @@ class BaseSorter:
         verbose=False,
         remove_existing_folder=False,
         delete_output_folder=False,
-        recording_relative_path=None
+        recording_relative_path=None,
     ):
-        output_folder = self.initialize_folder(recording, output_folder, verbose, remove_existing_folder,
-                                               recording_relative_path=recording_relative_path)
+        output_folder = self.initialize_folder(
+            recording, output_folder, verbose, remove_existing_folder, recording_relative_path=recording_relative_path
+        )
 
         self.recording = recording
         self.verbose = verbose
@@ -236,8 +237,9 @@ class BaseSorter:
         t0 = time.perf_counter()
 
         try:
-            SorterClass._run_from_folder(sorter_output_folder, sorter_params, verbose,
-                                         recording_relative_path=recording_relative_path)
+            SorterClass._run_from_folder(
+                sorter_output_folder, sorter_params, verbose, recording_relative_path=recording_relative_path
+            )
             t1 = time.perf_counter()
             run_time = float(t1 - t0)
             has_error = False
@@ -303,8 +305,7 @@ class BaseSorter:
             sorting = cls._get_result_from_folder(output_folder)
 
         # register recording to Sorting object
-        recording = load_extractor(output_folder / "spikeinterface_recording.json",
-                                   base_folder=recording_relative_path)
+        recording = load_extractor(output_folder / "spikeinterface_recording.json", base_folder=recording_relative_path)
         if recording is not None:
             # can be None when not dumpable
             sorting.register_recording(recording)

--- a/src/spikeinterface/sorters/external/combinato.py
+++ b/src/spikeinterface/sorters/external/combinato.py
@@ -146,7 +146,7 @@ class CombinatoSorter(BaseSorter):
             )
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         p = params.copy()
         p["threshold_factor"] = p.pop("detect_threshold")
         sign_thr = p.pop("detect_sign")

--- a/src/spikeinterface/sorters/external/combinato.py
+++ b/src/spikeinterface/sorters/external/combinato.py
@@ -146,7 +146,7 @@ class CombinatoSorter(BaseSorter):
             )
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         p = params.copy()
         p["threshold_factor"] = p.pop("detect_threshold")
         sign_thr = p.pop("detect_sign")

--- a/src/spikeinterface/sorters/external/hdsort.py
+++ b/src/spikeinterface/sorters/external/hdsort.py
@@ -205,7 +205,7 @@ class HDSortSorter(BaseSorter):
         shutil.copy(str(source_dir / "hdsort_master.m"), str(sorter_output_folder))
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         if cls.check_compiled():
             shell_cmd = f"""
                 #!/bin/bash

--- a/src/spikeinterface/sorters/external/hdsort.py
+++ b/src/spikeinterface/sorters/external/hdsort.py
@@ -205,7 +205,7 @@ class HDSortSorter(BaseSorter):
         shutil.copy(str(source_dir / "hdsort_master.m"), str(sorter_output_folder))
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         if cls.check_compiled():
             shell_cmd = f"""
                 #!/bin/bash

--- a/src/spikeinterface/sorters/external/herdingspikes.py
+++ b/src/spikeinterface/sorters/external/herdingspikes.py
@@ -136,7 +136,7 @@ class HerdingspikesSorter(BaseSorter):
         pass
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         import herdingspikes as hs
         from spikeinterface.preprocessing import bandpass_filter, normalize_by_quantile
 
@@ -148,7 +148,7 @@ class HerdingspikesSorter(BaseSorter):
             new_api = False
 
         recording = load_extractor(
-            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=recording_relative_path
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=relative_to
         )
 
         p = params

--- a/src/spikeinterface/sorters/external/herdingspikes.py
+++ b/src/spikeinterface/sorters/external/herdingspikes.py
@@ -147,8 +147,9 @@ class HerdingspikesSorter(BaseSorter):
         else:
             new_api = False
 
-        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json",
-                                   base_folder=recording_relative_path)
+        recording = load_extractor(
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=recording_relative_path
+        )
 
         p = params
 

--- a/src/spikeinterface/sorters/external/herdingspikes.py
+++ b/src/spikeinterface/sorters/external/herdingspikes.py
@@ -136,7 +136,7 @@ class HerdingspikesSorter(BaseSorter):
         pass
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         import herdingspikes as hs
         from spikeinterface.preprocessing import bandpass_filter, normalize_by_quantile
 
@@ -147,7 +147,8 @@ class HerdingspikesSorter(BaseSorter):
         else:
             new_api = False
 
-        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json")
+        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json",
+                                   base_folder=recording_relative_path)
 
         p = params
 

--- a/src/spikeinterface/sorters/external/ironclust.py
+++ b/src/spikeinterface/sorters/external/ironclust.py
@@ -194,7 +194,7 @@ class IronClustSorter(BaseSorter):
             f.write("{}".format(samplerate))
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         dataset_dir = (sorter_output_folder / "ironclust_dataset").absolute()
         source_dir = (Path(__file__).parent).absolute()
 

--- a/src/spikeinterface/sorters/external/ironclust.py
+++ b/src/spikeinterface/sorters/external/ironclust.py
@@ -194,7 +194,7 @@ class IronClustSorter(BaseSorter):
             f.write("{}".format(samplerate))
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         dataset_dir = (sorter_output_folder / "ironclust_dataset").absolute()
         source_dir = (Path(__file__).parent).absolute()
 

--- a/src/spikeinterface/sorters/external/klusta.py
+++ b/src/spikeinterface/sorters/external/klusta.py
@@ -137,7 +137,7 @@ class KlustaSorter(BaseSorter):
             f.writelines(klusta_config)
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         if "win" in sys.platform and sys.platform != "darwin":
             shell_cmd = """
                         klusta --overwrite {klusta_config}

--- a/src/spikeinterface/sorters/external/klusta.py
+++ b/src/spikeinterface/sorters/external/klusta.py
@@ -137,7 +137,7 @@ class KlustaSorter(BaseSorter):
             f.writelines(klusta_config)
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         if "win" in sys.platform and sys.platform != "darwin":
             shell_cmd = """
                         klusta --overwrite {klusta_config}

--- a/src/spikeinterface/sorters/external/mountainsort4.py
+++ b/src/spikeinterface/sorters/external/mountainsort4.py
@@ -86,10 +86,11 @@ class Mountainsort4Sorter(BaseSorter):
         pass
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         import mountainsort4
 
-        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json")
+        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json",
+                                   base_folder=recording_relative_path)
 
         # alias to params
         p = params

--- a/src/spikeinterface/sorters/external/mountainsort4.py
+++ b/src/spikeinterface/sorters/external/mountainsort4.py
@@ -89,8 +89,9 @@ class Mountainsort4Sorter(BaseSorter):
     def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         import mountainsort4
 
-        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json",
-                                   base_folder=recording_relative_path)
+        recording = load_extractor(
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=recording_relative_path
+        )
 
         # alias to params
         p = params

--- a/src/spikeinterface/sorters/external/mountainsort4.py
+++ b/src/spikeinterface/sorters/external/mountainsort4.py
@@ -86,11 +86,11 @@ class Mountainsort4Sorter(BaseSorter):
         pass
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         import mountainsort4
 
         recording = load_extractor(
-            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=recording_relative_path
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=relative_to
         )
 
         # alias to params

--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -115,8 +115,9 @@ class Mountainsort5Sorter(BaseSorter):
     def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         import mountainsort5 as ms5
 
-        recording: BaseRecording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json",
-                                                  base_folder=recording_relative_path)
+        recording: BaseRecording = load_extractor(
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=recording_relative_path
+        )
 
         # alias to params
         p = params

--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -112,10 +112,11 @@ class Mountainsort5Sorter(BaseSorter):
         pass
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         import mountainsort5 as ms5
 
-        recording: BaseRecording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json")
+        recording: BaseRecording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json",
+                                                  base_folder=recording_relative_path)
 
         # alias to params
         p = params

--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -112,11 +112,11 @@ class Mountainsort5Sorter(BaseSorter):
         pass
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         import mountainsort5 as ms5
 
         recording: BaseRecording = load_extractor(
-            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=recording_relative_path
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=relative_to
         )
 
         # alias to params

--- a/src/spikeinterface/sorters/external/pykilosort.py
+++ b/src/spikeinterface/sorters/external/pykilosort.py
@@ -148,8 +148,9 @@ class PyKilosortSorter(BaseSorter):
 
     @classmethod
     def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
-        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json",
-                                   base_folder=recording_relative_path)
+        recording = load_extractor(
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=recording_relative_path
+        )
 
         if not recording.binary_compatible_with(time_axis=0, file_paths_lenght=1):
             # saved by setup recording

--- a/src/spikeinterface/sorters/external/pykilosort.py
+++ b/src/spikeinterface/sorters/external/pykilosort.py
@@ -147,8 +147,9 @@ class PyKilosortSorter(BaseSorter):
             )
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
-        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json")
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json",
+                                   base_folder=recording_relative_path)
 
         if not recording.binary_compatible_with(time_axis=0, file_paths_lenght=1):
             # saved by setup recording

--- a/src/spikeinterface/sorters/external/pykilosort.py
+++ b/src/spikeinterface/sorters/external/pykilosort.py
@@ -147,9 +147,9 @@ class PyKilosortSorter(BaseSorter):
             )
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         recording = load_extractor(
-            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=recording_relative_path
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=relative_to
         )
 
         if not recording.binary_compatible_with(time_axis=0, file_paths_lenght=1):

--- a/src/spikeinterface/sorters/external/spyking_circus.py
+++ b/src/spikeinterface/sorters/external/spyking_circus.py
@@ -147,7 +147,7 @@ class SpykingcircusSorter(BaseSorter):
             f.writelines(circus_config)
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         sorter_name = cls.sorter_name
 
         num_workers = params["num_workers"]

--- a/src/spikeinterface/sorters/external/spyking_circus.py
+++ b/src/spikeinterface/sorters/external/spyking_circus.py
@@ -147,7 +147,7 @@ class SpykingcircusSorter(BaseSorter):
             f.writelines(circus_config)
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         sorter_name = cls.sorter_name
 
         num_workers = params["num_workers"]

--- a/src/spikeinterface/sorters/external/tridesclous.py
+++ b/src/spikeinterface/sorters/external/tridesclous.py
@@ -123,7 +123,7 @@ class TridesclousSorter(BaseSorter):
             print(tdc_dataio)
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         import tridesclous as tdc
 
         tdc_dataio = tdc.DataIO(dirname=str(sorter_output_folder))

--- a/src/spikeinterface/sorters/external/tridesclous.py
+++ b/src/spikeinterface/sorters/external/tridesclous.py
@@ -123,7 +123,7 @@ class TridesclousSorter(BaseSorter):
             print(tdc_dataio)
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         import tridesclous as tdc
 
         tdc_dataio = tdc.DataIO(dirname=str(sorter_output_folder))

--- a/src/spikeinterface/sorters/external/waveclus.py
+++ b/src/spikeinterface/sorters/external/waveclus.py
@@ -182,7 +182,7 @@ class WaveClusSorter(BaseSorter):
             )
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         sorter_output_folder = sorter_output_folder.absolute()
 
         cls._generate_par_file(params, sorter_output_folder)

--- a/src/spikeinterface/sorters/external/waveclus.py
+++ b/src/spikeinterface/sorters/external/waveclus.py
@@ -182,7 +182,7 @@ class WaveClusSorter(BaseSorter):
             )
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         sorter_output_folder = sorter_output_folder.absolute()
 
         cls._generate_par_file(params, sorter_output_folder)

--- a/src/spikeinterface/sorters/external/waveclus_snippets.py
+++ b/src/spikeinterface/sorters/external/waveclus_snippets.py
@@ -122,7 +122,7 @@ class WaveClusSnippetsSorter(BaseSorter):
             print("Num. channels = {}, Num. snippets = {}".format(num_channels, num_snippets))
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         sorter_output_folder = sorter_output_folder.absolute()
 
         cls._generate_par_file(params, sorter_output_folder)

--- a/src/spikeinterface/sorters/external/waveclus_snippets.py
+++ b/src/spikeinterface/sorters/external/waveclus_snippets.py
@@ -122,7 +122,7 @@ class WaveClusSnippetsSorter(BaseSorter):
             print("Num. channels = {}, Num. snippets = {}".format(num_channels, num_snippets))
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         sorter_output_folder = sorter_output_folder.absolute()
 
         cls._generate_par_file(params, sorter_output_folder)

--- a/src/spikeinterface/sorters/external/yass.py
+++ b/src/spikeinterface/sorters/external/yass.py
@@ -194,7 +194,7 @@ class YassSorter(BaseSorter):
             yaml.dump(merge_params, file)
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         """ """
         config_file = sorter_output_folder.absolute() / "config.yaml"
         if "win" in sys.platform and sys.platform != "darwin":

--- a/src/spikeinterface/sorters/external/yass.py
+++ b/src/spikeinterface/sorters/external/yass.py
@@ -194,7 +194,7 @@ class YassSorter(BaseSorter):
             yaml.dump(merge_params, file)
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         """ """
         config_file = sorter_output_folder.absolute() / "config.yaml"
         if "win" in sys.platform and sys.platform != "darwin":

--- a/src/spikeinterface/sorters/internal/spyking_circus2.py
+++ b/src/spikeinterface/sorters/internal/spyking_circus2.py
@@ -40,7 +40,7 @@ class Spykingcircus2Sorter(ComponentsBasedSorter):
         return "2.0"
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         assert HAVE_HDBSCAN, "spykingcircus2 needs hdbscan to be installed"
 
         # this is importanted only on demand because numba import are too heavy
@@ -55,7 +55,7 @@ class Spykingcircus2Sorter(ComponentsBasedSorter):
         job_kwargs["progress_bar"] = verbose
 
         recording = load_extractor(
-            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=recording_relative_path
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=relative_to
         )
         sampling_rate = recording.get_sampling_frequency()
         num_channels = recording.get_num_channels()

--- a/src/spikeinterface/sorters/internal/spyking_circus2.py
+++ b/src/spikeinterface/sorters/internal/spyking_circus2.py
@@ -54,8 +54,9 @@ class Spykingcircus2Sorter(ComponentsBasedSorter):
         job_kwargs["verbose"] = verbose
         job_kwargs["progress_bar"] = verbose
 
-        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json",
-                                   base_folder=recording_relative_path)
+        recording = load_extractor(
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=recording_relative_path
+        )
         sampling_rate = recording.get_sampling_frequency()
         num_channels = recording.get_num_channels()
 

--- a/src/spikeinterface/sorters/internal/spyking_circus2.py
+++ b/src/spikeinterface/sorters/internal/spyking_circus2.py
@@ -40,7 +40,7 @@ class Spykingcircus2Sorter(ComponentsBasedSorter):
         return "2.0"
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         assert HAVE_HDBSCAN, "spykingcircus2 needs hdbscan to be installed"
 
         # this is importanted only on demand because numba import are too heavy
@@ -54,7 +54,8 @@ class Spykingcircus2Sorter(ComponentsBasedSorter):
         job_kwargs["verbose"] = verbose
         job_kwargs["progress_bar"] = verbose
 
-        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json")
+        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json",
+                                   base_folder=recording_relative_path)
         sampling_rate = recording.get_sampling_frequency()
         num_channels = recording.get_num_channels()
 

--- a/src/spikeinterface/sorters/internal/tridesclous2.py
+++ b/src/spikeinterface/sorters/internal/tridesclous2.py
@@ -49,8 +49,9 @@ class Tridesclous2Sorter(ComponentsBasedSorter):
 
         import hdbscan
 
-        recording_raw = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json",
-                                       base_folder=recording_relative_path)
+        recording_raw = load_extractor(
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=recording_relative_path
+        )
 
         num_chans = recording_raw.get_num_channels()
         sampling_frequency = recording_raw.get_sampling_frequency()

--- a/src/spikeinterface/sorters/internal/tridesclous2.py
+++ b/src/spikeinterface/sorters/internal/tridesclous2.py
@@ -35,7 +35,7 @@ class Tridesclous2Sorter(ComponentsBasedSorter):
         return "2.0"
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
         job_kwargs = params["job_kwargs"].copy()
         job_kwargs = fix_job_kwargs(job_kwargs)
         job_kwargs["progress_bar"] = verbose
@@ -49,7 +49,8 @@ class Tridesclous2Sorter(ComponentsBasedSorter):
 
         import hdbscan
 
-        recording_raw = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json")
+        recording_raw = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json",
+                                       base_folder=recording_relative_path)
 
         num_chans = recording_raw.get_num_channels()
         sampling_frequency = recording_raw.get_sampling_frequency()

--- a/src/spikeinterface/sorters/internal/tridesclous2.py
+++ b/src/spikeinterface/sorters/internal/tridesclous2.py
@@ -35,7 +35,7 @@ class Tridesclous2Sorter(ComponentsBasedSorter):
         return "2.0"
 
     @classmethod
-    def _run_from_folder(cls, sorter_output_folder, params, verbose, recording_relative_path=None):
+    def _run_from_folder(cls, sorter_output_folder, params, verbose, relative_to=None):
         job_kwargs = params["job_kwargs"].copy()
         job_kwargs = fix_job_kwargs(job_kwargs)
         job_kwargs["progress_bar"] = verbose
@@ -50,7 +50,7 @@ class Tridesclous2Sorter(ComponentsBasedSorter):
         import hdbscan
 
         recording_raw = load_extractor(
-            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=recording_relative_path
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=relative_to
         )
 
         num_chans = recording_raw.get_num_channels()

--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -162,8 +162,9 @@ def run_sorter_local(
     SorterClass = sorter_dict[sorter_name]
 
     # only classmethod call not instance (stateless at instance level but state is in folder)
-    output_folder = SorterClass.initialize_folder(recording, output_folder, verbose, remove_existing_folder,
-                                                  recording_relative_path=recording_relative_path)
+    output_folder = SorterClass.initialize_folder(
+        recording, output_folder, verbose, remove_existing_folder, recording_relative_path=recording_relative_path
+    )
     SorterClass.set_params_to_folder(recording, output_folder, sorter_params, verbose)
     SorterClass.setup_recording(recording, output_folder, verbose=verbose)
     SorterClass.run_from_folder(output_folder, raise_error, verbose, recording_relative_path=recording_relative_path)

--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -153,7 +153,7 @@ def run_sorter_local(
     verbose=False,
     raise_error=True,
     with_output=True,
-    recording_relative_path=None,
+    relative_to=None,
     **sorter_params,
 ):
     if isinstance(recording, list):
@@ -163,13 +163,13 @@ def run_sorter_local(
 
     # only classmethod call not instance (stateless at instance level but state is in folder)
     output_folder = SorterClass.initialize_folder(
-        recording, output_folder, verbose, remove_existing_folder, recording_relative_path=recording_relative_path
+        recording, output_folder, verbose, remove_existing_folder, relative_to=relative_to
     )
     SorterClass.set_params_to_folder(recording, output_folder, sorter_params, verbose)
     SorterClass.setup_recording(recording, output_folder, verbose=verbose)
-    SorterClass.run_from_folder(output_folder, raise_error, verbose, recording_relative_path=recording_relative_path)
+    SorterClass.run_from_folder(output_folder, raise_error, verbose, relative_to=relative_to)
     if with_output:
-        sorting = SorterClass.get_result_from_folder(output_folder, recording_relative_path=recording_relative_path)
+        sorting = SorterClass.get_result_from_folder(output_folder, relative_to=relative_to)
     else:
         sorting = None
     sorter_output_folder = output_folder / "sorter_output"

--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -153,6 +153,7 @@ def run_sorter_local(
     verbose=False,
     raise_error=True,
     with_output=True,
+    recording_relative_path=None,
     **sorter_params,
 ):
     if isinstance(recording, list):
@@ -161,12 +162,13 @@ def run_sorter_local(
     SorterClass = sorter_dict[sorter_name]
 
     # only classmethod call not instance (stateless at instance level but state is in folder)
-    output_folder = SorterClass.initialize_folder(recording, output_folder, verbose, remove_existing_folder)
+    output_folder = SorterClass.initialize_folder(recording, output_folder, verbose, remove_existing_folder,
+                                                  recording_relative_path=recording_relative_path)
     SorterClass.set_params_to_folder(recording, output_folder, sorter_params, verbose)
     SorterClass.setup_recording(recording, output_folder, verbose=verbose)
-    SorterClass.run_from_folder(output_folder, raise_error, verbose)
+    SorterClass.run_from_folder(output_folder, raise_error, verbose, recording_relative_path=recording_relative_path)
     if with_output:
-        sorting = SorterClass.get_result_from_folder(output_folder)
+        sorting = SorterClass.get_result_from_folder(output_folder, recording_relative_path=recording_relative_path)
     else:
         sorting = None
     sorter_output_folder = output_folder / "sorter_output"


### PR DESCRIPTION
This set of changes exposes functionality to make sorting runs using a relative path for the recording, by exposing these options

* `relative_to` option for `BaseExtractor.dump_to_json`
* `base_folder` option in `spikeinterface.core.base.load_extractor`

The keyword `recording_relative_path` is added to a few signatures in `BaseSorter`.
Logic here is to use `relative_to` for recording JSON dump in `initialize_folder`, and then `base_folder` for JSON load in `run_from_folder` and `get_results_from_folder`.

The bulk of the diffs propagate the options overloads of `BaseSorter._run_from_folder`.
Finally, I added the option to the `spikeinterface.sorters.runsorter.run_sorter_local` method. Did not get into the container space, as I felt that can be more delicate.