### PR TITLE
Make binary recording memmap efficient II (using native memmaps)

### DIFF
--- a/src/spikeinterface/core/binaryrecordingextractor.py
+++ b/src/spikeinterface/core/binaryrecordingextractor.py
@@ -189,7 +189,7 @@ class BinaryRecordingSegment(BaseRecordingSegment):
         end_frame: Union[int, None] = None,
         channel_indices: Union[List, None] = None,
     ) -> np.ndarray:
-        length = self.mmemmap_length
+        length = self.memmap_length
         memmap_offset = self.memmap_offset
         memmap_obj = mmap.mmap(self.file.fileno(), length=length, access=mmap.ACCESS_READ, offset=memmap_offset)
 

--- a/src/spikeinterface/core/binaryrecordingextractor.py
+++ b/src/spikeinterface/core/binaryrecordingextractor.py
@@ -162,6 +162,10 @@ class BinaryRecordingSegment(BaseRecordingSegment):
         self.time_axis = time_axis
         self.datfile = datfile
         self.num_samples = (Path(datfile).stat().st_size - file_offset) // (num_chan * np.dtype(dtype).itemsize)
+        if self.time_axis == 0:
+            self.shape = (self.num_samples, self.num_chan)
+        else:
+            self.shape = (self.num_chan, self.num_samples)
 
     def get_num_samples(self) -> int:
         """Returns the number of samples in this signal block
@@ -177,13 +181,10 @@ class BinaryRecordingSegment(BaseRecordingSegment):
         end_frame: Union[int, None] = None,
         channel_indices: Union[List, None] = None,
     ) -> np.ndarray:
-        shape = (self.num_samples, self.num_chan)
-        if self.time_axis != 0:
-            shape = (self.num_chan, self.num_samples)
-
-        data = np.memmap(self.datfile, self.dtype, mode="r", offset=self.file_offset, shape=shape)
-        if self.time_axis != 0:
+        data = np.memmap(self.datfile, self.dtype, mode="r", offset=self.file_offset, shape=self.shape)
+        if self.time_axis == 1:
             data = data.T
+
         traces = data[start_frame:end_frame]
         if channel_indices is not None:
             traces = traces[:, channel_indices]

--- a/src/spikeinterface/core/tests/test_binaryrecordingextractor.py
+++ b/src/spikeinterface/core/tests/test_binaryrecordingextractor.py
@@ -49,6 +49,13 @@ def test_round_trip(tmp_path):
 
     assert np.allclose(recording.get_traces(), binary_recorder.get_traces())
 
+    start_frame = 200
+    end_frame = 500
+    smaller_traces = recording.get_traces(start_frame=start_frame, end_frame=end_frame)
+    binary_smaller_traces = binary_recorder.get_traces(start_frame=start_frame, end_frame=end_frame)
+
+    np.allclose(smaller_traces, binary_smaller_traces)
+
 
 if __name__ == "__main__":
     test_BinaryRecordingExtractor()

--- a/src/spikeinterface/core/tests/test_binaryrecordingextractor.py
+++ b/src/spikeinterface/core/tests/test_binaryrecordingextractor.py
@@ -3,7 +3,8 @@ import numpy as np
 from pathlib import Path
 
 from spikeinterface.core import BinaryRecordingExtractor
-
+from spikeinterface.core.datasets import download_dataset
+from spikeinterface.extractors.neoextractors import MEArecRecordingExtractor
 
 if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "core"
@@ -30,6 +31,23 @@ def test_BinaryRecordingExtractor():
 
     file_paths = [cache_folder / f"test_BinaryRecordingExtractor_{i}.raw" for i in range(num_seg)]
     assert (cache_folder / "test_BinaryRecordingExtractor_copied_0.raw").is_file()
+
+
+def test_round_trip(tmp_path):
+    mearec_path = download_dataset()
+
+    recording = MEArecRecordingExtractor(file_path=mearec_path)
+    file_path = tmp_path / "test_BinaryRecordingExtractor.raw"
+    dtype = recording.get_dtype()
+    BinaryRecordingExtractor.write_recording(recording=recording, dtype=dtype, file_paths=file_path)
+
+    sampling_frequency = recording.get_sampling_frequency()
+    num_chan = recording.get_num_channels()
+    binary_recorder = BinaryRecordingExtractor(
+        file_paths=file_path, sampling_frequency=sampling_frequency, num_chan=num_chan, dtype=dtype
+    )
+
+    assert np.allclose(recording.get_traces(), binary_recorder.get_traces())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Larger change than #1741. Can be merged after or instead of it.

Uses native memmaps instead and adds an extra test.

Similar approach as the one used in https://github.com/SpikeInterface/spikeinterface/pull/1741.