### PR TITLE
Propagate `get_times_kwargs` to BaseRecording

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -321,6 +321,32 @@ class BaseRecording(BaseRecordingSnippets):
         """
         return self.has_scaled()
 
+    def get_times_kwargs(self, segment_index=None) -> dict:
+        """
+        Retrieves the timing attributes for a given segment index. As with
+        other recorders this method only needs a segment index in the case
+        of multi-segment recordings.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the following key-value pairs:
+
+            - 'sampling_frequency': The sampling frequency of the RecordingSegment.
+            - 't_start': The start time of the RecordingSegment.
+            - 'time_vector': The time vector of the RecordingSegment.
+
+        Notes
+        -----
+        The keys are always present, but the values may be None.
+        """
+
+        segment_index = self._check_segment_index(segment_index)
+        rs = self._recording_segments[segment_index]
+        time_kwargs = rs.get_times_kwargs()
+
+        return time_kwargs
+
     def get_times(self, segment_index=None):
         """Get time vector for a recording segment.
 
@@ -657,8 +683,23 @@ class BaseRecordingSegment(BaseSegment):
                 time_vector += self.t_start
             return time_vector
 
-    def get_times_kwargs(self):
-        # useful for other internal RecordingSegment
+    def get_times_kwargs(self) -> dict:
+        """
+        Retrieves the timing attributes characterizing a RecordingSegment
+
+        Returns
+        -------
+        dict
+            A dictionary containing the following key-value pairs:
+
+            - 'sampling_frequency': The sampling frequency of the RecordingSegment.
+            - 't_start': The start time of the RecordingSegment.
+            - 'time_vector': The time vector of the RecordingSegment.
+
+        Notes
+        -----
+        The keys are always present, but the values may be None.
+        """
         d = dict(sampling_frequency=self.sampling_frequency, t_start=self.t_start, time_vector=self.time_vector)
         return d
 

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -321,7 +321,7 @@ class BaseRecording(BaseRecordingSnippets):
         """
         return self.has_scaled()
 
-    def get_times_kwargs(self, segment_index=None) -> dict:
+    def get_time_info(self, segment_index=None) -> dict:
         """
         Retrieves the timing attributes for a given segment index. As with
         other recorders this method only needs a segment index in the case

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -700,8 +700,10 @@ class BaseRecordingSegment(BaseSegment):
         -----
         The keys are always present, but the values may be None.
         """
-        d = dict(sampling_frequency=self.sampling_frequency, t_start=self.t_start, time_vector=self.time_vector)
-        return d
+        time_kwargs = dict(
+            sampling_frequency=self.sampling_frequency, t_start=self.t_start, time_vector=self.time_vector
+        )
+        return time_kwargs
 
     def sample_index_to_time(self, sample_ind):
         """


### PR DESCRIPTION
Recording segments have a dictionary characterizing their timing properties:

https://github.com/SpikeInterface/spikeinterface/blob/5369cb0e799a52a1ccb1de6feacf05c41f65dd95/src/spikeinterface/core/baserecording.py#L660-L663

 Recently, we have been working on time alignment in neuroconv. For data ingestion / extraction is very useful to have this information available from the recoder.  This is what this PR does. It creates a new method at the `BaseRecording` level that returns the information witt the usual logic of working directly for single segment and requiring segment specification for multiple segment. 

The idea is that the segments should be an implementation detail and that users should not have to dig into them to extract timing information if so they desire.

I also added more complete docstrings to the segment method.

