### PR TITLE
Remove zero pad samples from write_binary_recorder

### DIFF
--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -271,6 +271,7 @@ def write_binary_recording(
         dtype = recording.get_dtype()
     else:
         dtype = np.dtype(dtype)
+
     if auto_cast_uint:
         cast_unsigned = determine_cast_unsigned(recording, dtype)
     else:
@@ -284,11 +285,10 @@ def write_binary_recording(
 
         file_path = file_paths[segment_index]
         num_channels = recording.get_num_channels()
-        offset = byte_offset * dtype.itemsize * num_channels
         shape = (num_frames, num_channels)
-        rec_memmap = np.memmap(str(file_path), dtype=dtype, mode="w+", offset=offset, shape=shape)
+        rec_memmap = np.memmap(str(file_path), dtype=dtype, mode="w+", offset=byte_offset, shape=shape)
         rec_memmaps.append(rec_memmap)
-        rec_memmaps_dict.append(dict(filename=str(file_path), dtype=dtype, mode="r+", offset=offset, shape=shape))
+        rec_memmaps_dict.append(dict(filename=str(file_path), dtype=dtype, mode="r+", offset=byte_offset, shape=shape))
 
     # use executor (loop or workers)
     func = _write_binary_chunk

--- a/src/spikeinterface/sorters/external/kilosortbase.py
+++ b/src/spikeinterface/sorters/external/kilosortbase.py
@@ -10,6 +10,7 @@ from ..utils import ShellScript, get_matlab_shell_name, get_bash_path
 from ..basesorter import get_job_kwargs
 from spikeinterface.extractors import KiloSortSortingExtractor
 from spikeinterface.core import write_binary_recording
+from spikeinterface.preprocessing.zero_channel_pad import TracePaddedRecording
 
 
 class KilosortBase:
@@ -128,8 +129,8 @@ class KilosortBase:
             and not skip_kilosort_preprocessing
         ):
             # no copy
-            d = recording.get_binary_description()
-            binary_file_path = Path(d["file_paths"][0])
+            binary_description = recording.get_binary_description()
+            binary_file_path = Path(binary_description["file_paths"][0])
         else:
             # local copy needed
             binary_file_path = sorter_output_folder / "recording.dat"
@@ -139,15 +140,20 @@ class KilosortBase:
                 nt = params["NT"]
                 num_samples = recording.get_num_samples()
                 pad = nt - num_samples % nt
-                zero_pad_samples = [0, pad]
-            else:
-                zero_pad_samples = None
 
+                padding_start = 0
+                padding_end = pad
+                padded_recording = TracePaddedRecording(
+                    recording=recording,
+                    padding_start=padding_start,
+                    padding_end=padding_end,
+                )
+            else:
+                padded_recording = recording
             write_binary_recording(
-                recording,
+                recording=padded_recording,
                 file_paths=[binary_file_path],
                 dtype="int16",
-                zero_pad_samples=zero_pad_samples,
                 **get_job_kwargs(params, verbose),
             )
 


### PR DESCRIPTION
This is necessary for #1602, it removes the `zero_pad_samples` as this can be done with preprocessing after #1706. 

Adjuste the code in kilosort base that was using this option.

