### PR TITLE
Make recording JSON relative_to output_folder default for BaseSorter

### DIFF
--- a/src/spikeinterface/sorters/basesorter.py
+++ b/src/spikeinterface/sorters/basesorter.py
@@ -141,7 +141,7 @@ class BaseSorter:
 
         rec_file = output_folder / "spikeinterface_recording.json"
         if recording.is_dumpable:
-            recording.dump_to_json(rec_file)
+            recording.dump_to_json(rec_file, relative_to=output_folder)
         else:
             d = {"warning": "The recording is not dumpable"}
             rec_file.write_text(json.dumps(d, indent=4), encoding="utf8")
@@ -221,9 +221,6 @@ class BaseSorter:
 
         SorterClass = sorter_dict[sorter_name]
 
-        # not needed normally
-        #  recording = load_extractor(output_folder / 'spikeinterface_recording.json')
-
         now = datetime.datetime.now()
         log = {
             "sorter_name": str(SorterClass.sorter_name),
@@ -300,7 +297,7 @@ class BaseSorter:
             sorting = cls._get_result_from_folder(output_folder)
 
         # register recording to Sorting object
-        recording = load_extractor(output_folder / "spikeinterface_recording.json")
+        recording = load_extractor(output_folder / "spikeinterface_recording.json", base_folder=output_folder)
         if recording is not None:
             # can be None when not dumpable
             sorting.register_recording(recording)

--- a/src/spikeinterface/sorters/external/herdingspikes.py
+++ b/src/spikeinterface/sorters/external/herdingspikes.py
@@ -147,7 +147,9 @@ class HerdingspikesSorter(BaseSorter):
         else:
             new_api = False
 
-        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json")
+        recording = load_extractor(
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=sorter_output_folder.parent
+        )
 
         p = params
 

--- a/src/spikeinterface/sorters/external/mountainsort4.py
+++ b/src/spikeinterface/sorters/external/mountainsort4.py
@@ -89,7 +89,9 @@ class Mountainsort4Sorter(BaseSorter):
     def _run_from_folder(cls, sorter_output_folder, params, verbose):
         import mountainsort4
 
-        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json")
+        recording = load_extractor(
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=sorter_output_folder.parent
+        )
 
         # alias to params
         p = params

--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -115,7 +115,9 @@ class Mountainsort5Sorter(BaseSorter):
     def _run_from_folder(cls, sorter_output_folder, params, verbose):
         import mountainsort5 as ms5
 
-        recording: BaseRecording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json")
+        recording: BaseRecording = load_extractor(
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=sorter_output_folder.parent
+        )
 
         # alias to params
         p = params

--- a/src/spikeinterface/sorters/external/pykilosort.py
+++ b/src/spikeinterface/sorters/external/pykilosort.py
@@ -148,7 +148,9 @@ class PyKilosortSorter(BaseSorter):
 
     @classmethod
     def _run_from_folder(cls, sorter_output_folder, params, verbose):
-        recording = load_extractor(sorter_output_folder.parent / "spikeinterface_recording.json")
+        recording = load_extractor(
+            sorter_output_folder.parent / "spikeinterface_recording.json", base_folder=sorter_output_folder.parent
+        )
 
         if not recording.binary_compatible_with(time_axis=0, file_paths_lenght=1):
             # saved by setup recording

--- a/src/spikeinterface/sorters/external/yass.py
+++ b/src/spikeinterface/sorters/external/yass.py
@@ -6,8 +6,6 @@ import sys
 from ..basesorter import BaseSorter, get_job_kwargs
 from ..utils import ShellScript
 
-from spikeinterface.core import load_extractor
-
 from spikeinterface.core import write_binary_recording
 from spikeinterface.extractors import YassSortingExtractor
 


### PR DESCRIPTION
This PR fixes #1739 and with a simpler approach than #1737 

Basically, we always save the `spikeinterface_recording.json` relative to the `output_folder`. This way, we don't have to change any signature in the class!