### PR TITLE
Pass tmp_folder as parameter for `compute_principal_components`

### DIFF
--- a/src/spikeinterface/postprocessing/principal_component.py
+++ b/src/spikeinterface/postprocessing/principal_component.py
@@ -43,7 +43,9 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
                 txt += " - sparse"
         return txt
 
-    def _set_params(self, n_components=5, mode="by_channel_local", whiten=True, dtype="float32", sparsity=None, tmp_folder=None):
+    def _set_params(
+        self, n_components=5, mode="by_channel_local", whiten=True, dtype="float32", sparsity=None, tmp_folder=None
+    ):
         assert mode in _possible_modes, "Invalid mode!"
 
         if self.waveform_extractor.is_sparse():
@@ -367,7 +369,7 @@ class WaveformPrincipalComponent(BaseWaveformExtractorExtension):
         if tmp_folder is None:
             tmp_folder = "tmp"
         tmp_folder = Path(tmp_folder)
-        
+
         for chan_ind, chan_id in enumerate(channel_ids):
             pca_model = pca_models[chan_ind]
             if n_jobs > 1:
@@ -699,7 +701,7 @@ def compute_principal_components(
     progress_bar: bool
         If True, a progress bar is shown - default False
     tmp_folder: str
-        You need to specify a tmp_folder, if mode=='by_channel_local' and if you run several compute_principal_components at the same time.         
+        You need to specify a tmp_folder, if mode=='by_channel_local' and if you run several compute_principal_components at the same time.
         Otherwise, let None.
     Returns
     -------
@@ -725,7 +727,9 @@ def compute_principal_components(
         pc = waveform_extractor.load_extension(WaveformPrincipalComponent.extension_name)
     else:
         pc = WaveformPrincipalComponent.create(waveform_extractor)
-        pc.set_params(n_components=n_components, mode=mode, whiten=whiten, dtype=dtype, sparsity=sparsity, tmp_folder=tmp_folder)
+        pc.set_params(
+            n_components=n_components, mode=mode, whiten=whiten, dtype=dtype, sparsity=sparsity, tmp_folder=tmp_folder
+        )
         pc.run(**job_kwargs)
 
     return pc

--- a/src/spikeinterface/postprocessing/principal_component.py
+++ b/src/spikeinterface/postprocessing/principal_component.py
@@ -689,20 +689,23 @@ def compute_principal_components(
         - 'by_channel_local': a local PCA is fitted for each channel (projection by channel)
         - 'by_channel_global': a global PCA is fitted for all channels (projection by channel)
         - 'concatenated': channels are concatenated and a global PCA is fitted
+        default 'by_channel_local'
     sparsity: ChannelSparsity or None
         The sparsity to apply to waveforms.
-        If waveform_extractor is already sparse, the default sparsity will be used.
+        If waveform_extractor is already sparse, the default sparsity will be used - default None
     whiten: bool
-        If True, waveforms are pre-whitened
+        If True, waveforms are pre-whitened - default True
     dtype: dtype
-        Dtype of the pc scores (default float32)
+        Dtype of the pc scores - default float32
     n_jobs: int
         Number of jobs used to fit the PCA model (if mode is 'by_channel_local') - default 1
     progress_bar: bool
         If True, a progress bar is shown - default False
     tmp_folder: str
-        You need to specify a tmp_folder, if mode=='by_channel_local' and if you run several compute_principal_components at the same time.
-        Otherwise, let None.
+        The temporary folder to use for parallel computation. If you run several `compute_principal_components`
+        functions in parallel with mode 'by_channel_local', you need to specify a different `tmp_folder` for each call,
+        to avoid overwriting to the same folder - default None
+
     Returns
     -------
     pc: WaveformPrincipalComponent


### PR DESCRIPTION
Hello,
Here is a proposal to fix #1757. I added the possibilty to specify a tmp_folder in the parameter of the PrincipalComponent object. By default is None. 
It works for me, on my local Linux.
Cheers
Maxime
