### PR TITLE
Optional check_spike_frames in sorting.frame_slice

### DIFF
--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -300,10 +300,12 @@ class BaseSorting(BaseExtractor):
         units_to_keep = np.unique(units_to_keep)
         return self.select_units(units_to_keep)
 
-    def frame_slice(self, start_frame, end_frame):
+    def frame_slice(self, start_frame, end_frame, check_spike_frames=True):
         from spikeinterface import FrameSliceSorting
 
-        sub_sorting = FrameSliceSorting(self, start_frame=start_frame, end_frame=end_frame)
+        sub_sorting = FrameSliceSorting(
+            self, start_frame=start_frame, end_frame=end_frame, check_spike_frames=check_spike_frames
+        )
         return sub_sorting
 
     def get_all_spike_trains(self, outputs="unit_id"):

--- a/src/spikeinterface/core/frameslicesorting.py
+++ b/src/spikeinterface/core/frameslicesorting.py
@@ -33,7 +33,7 @@ class FrameSliceSorting(BaseSorting):
             - The maximum spike frame + 1, if no recording is assigned
     """
 
-    def __init__(self, parent_sorting, start_frame=None, end_frame=None):
+    def __init__(self, parent_sorting, start_frame=None, end_frame=None, check_spike_frames=True):
         unit_ids = parent_sorting.get_unit_ids()
 
         assert parent_sorting.get_num_segments() == 1, "FrameSliceSorting work only with one segment"
@@ -53,7 +53,7 @@ class FrameSliceSorting(BaseSorting):
             assert (
                 start_frame <= parent_n_samples
             ), "`start_frame` should be smaller than the sortings total number of samples."
-            if has_exceeding_spikes(parent_sorting._recording, parent_sorting):
+            if check_spike_frames and has_exceeding_spikes(parent_sorting._recording, parent_sorting):
                 raise ValueError(
                     "The sorting object has spikes exceeding the recording duration. You have to remove those spikes "
                     "with the `spikeinterface.curation.remove_excess_spikes()` function"
@@ -86,7 +86,12 @@ class FrameSliceSorting(BaseSorting):
             self.register_recording(parent_sorting._recording.frame_slice(start_frame=start_frame, end_frame=end_frame))
 
         # update dump dict
-        self._kwargs = {"parent_sorting": parent_sorting, "start_frame": int(start_frame), "end_frame": int(end_frame)}
+        self._kwargs = {
+            "parent_sorting": parent_sorting,
+            "start_frame": int(start_frame),
+            "end_frame": int(end_frame),
+            "check_spike_frames": check_spike_frames,
+        }
 
 
 class FrameSliceSortingSegment(BaseSortingSegment):


### PR DESCRIPTION
Hi,

I made the call for `has_exceeding_spikes` optional in sorting slicing.

The reason is that it may be redundant with the check performed in `sorting.register_recording`.
Because the check is optional during registration, it's not sufficient to just check whether a recording was assigned...

This is maybe a too specific? but it is a real bottleneck when slicing/concatenating multiple epochs of the same sorting.
Best