### PR TITLE
Exclude end_frame in PhyKilosort get_unit_spike_train

### DIFF
--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -172,7 +172,9 @@ class PhySortingSegment(BaseSortingSegment):
 
     def get_unit_spike_train(self, unit_id, start_frame, end_frame):
         start = 0 if start_frame is None else np.searchsorted(self._all_spikes, start_frame, side="left")
-        end = len(self._all_spikes) if end_frame is None else np.searchsorted(self._all_spikes, end_frame, side="right")
+        end = (
+            len(self._all_spikes) if end_frame is None else np.searchsorted(self._all_spikes, end_frame, side="left")
+        )  # Exclude end frame
 
         spike_times = self._all_spikes[start:end][self._all_clusters[start:end] == unit_id]
         return np.atleast_1d(spike_times.copy().squeeze())


### PR DESCRIPTION
This excludes end_frame in get_unit_spike_train.

This changes the extractor's behavior...!
But is required for a consistent definition of spike_train values (ie: frame of the parent extractor, and therefore exclusive) and in practice: to avoid IndexErrors when using frame_slice sortings.