### PR TITLE
Fixed `num_chan` warning and propagate to remaining instances

### DIFF
--- a/src/spikeinterface/core/binaryfolder.py
+++ b/src/spikeinterface/core/binaryfolder.py
@@ -50,6 +50,9 @@ class BinaryFolderRecording(BinaryRecordingExtractor):
 
         self._kwargs = dict(folder_path=str(folder_path.absolute()))
         self._bin_kwargs = d["kwargs"]
+        if "num_channels" not in self._bin_kwargs:
+            assert "num_chan" in self._bin_kwargs, "Cannot find num_channels or num_chan in binary.json"
+            self._bin_kwargs["num_channels"] = self._bin_kwargs["num_chan"]
 
     def is_binary_compatible(self):
         return True
@@ -58,7 +61,7 @@ class BinaryFolderRecording(BinaryRecordingExtractor):
         d = dict(
             file_paths=self._bin_kwargs["file_paths"],
             dtype=np.dtype(self._bin_kwargs["dtype"]),
-            num_channels=self._bin_kwargs["num_chan"],
+            num_channels=self._bin_kwargs["num_channels"],
             time_axis=self._bin_kwargs["time_axis"],
             file_offset=self._bin_kwargs["file_offset"],
         )

--- a/src/spikeinterface/core/binaryfolder.py
+++ b/src/spikeinterface/core/binaryfolder.py
@@ -53,9 +53,6 @@ class BinaryFolderRecording(BinaryRecordingExtractor):
         self._bin_kwargs = d["kwargs"]
         if "num_channels" not in self._bin_kwargs:
             assert "num_chan" in self._bin_kwargs, "Cannot find num_channels or num_chan in binary.json"
-            warnings.warn(
-                f"`num_chan` contained in folder {folder_path} is deprecated: it will not be redeable starting with version 0.100."
-            )
             self._bin_kwargs["num_channels"] = self._bin_kwargs["num_chan"]
 
     def is_binary_compatible(self):

--- a/src/spikeinterface/core/binaryfolder.py
+++ b/src/spikeinterface/core/binaryfolder.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import json
-import warnings
 
 import numpy as np
 

--- a/src/spikeinterface/core/binaryfolder.py
+++ b/src/spikeinterface/core/binaryfolder.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import warnings
 
 import numpy as np
 
@@ -52,6 +53,7 @@ class BinaryFolderRecording(BinaryRecordingExtractor):
         self._bin_kwargs = d["kwargs"]
         if "num_channels" not in self._bin_kwargs:
             assert "num_chan" in self._bin_kwargs, "Cannot find num_channels or num_chan in binary.json"
+            warnings.warn(f"`num_chan` contained in folder {folder_path} is deprecated: it will not be redeable starting with version 0.100.")
             self._bin_kwargs["num_channels"] = self._bin_kwargs["num_chan"]
 
     def is_binary_compatible(self):

--- a/src/spikeinterface/core/binaryfolder.py
+++ b/src/spikeinterface/core/binaryfolder.py
@@ -53,7 +53,9 @@ class BinaryFolderRecording(BinaryRecordingExtractor):
         self._bin_kwargs = d["kwargs"]
         if "num_channels" not in self._bin_kwargs:
             assert "num_chan" in self._bin_kwargs, "Cannot find num_channels or num_chan in binary.json"
-            warnings.warn(f"`num_chan` contained in folder {folder_path} is deprecated: it will not be redeable starting with version 0.100.")
+            warnings.warn(
+                f"`num_chan` contained in folder {folder_path} is deprecated: it will not be redeable starting with version 0.100."
+            )
             self._bin_kwargs["num_channels"] = self._bin_kwargs["num_chan"]
 
     def is_binary_compatible(self):

--- a/src/spikeinterface/core/binaryrecordingextractor.py
+++ b/src/spikeinterface/core/binaryrecordingextractor.py
@@ -121,7 +121,7 @@ class BinaryRecordingExtractor(BaseRecording):
             "sampling_frequency": sampling_frequency,
             "t_starts": t_starts,
             "num_channels": num_channels,
-            "num_chan": num_channels,  # TODO: This should be here at least till version 0.100.0
+            "num_chan": num_chan,  # TODO: This should be here at least till version 0.100.0
             "dtype": dtype.str,
             "channel_ids": channel_ids,
             "time_axis": time_axis,

--- a/src/spikeinterface/core/binaryrecordingextractor.py
+++ b/src/spikeinterface/core/binaryrecordingextractor.py
@@ -121,7 +121,6 @@ class BinaryRecordingExtractor(BaseRecording):
             "sampling_frequency": sampling_frequency,
             "t_starts": t_starts,
             "num_channels": num_channels,
-            "num_chan": num_chan,  # TODO: This should be here at least till version 0.100.0
             "dtype": dtype.str,
             "channel_ids": channel_ids,
             "time_axis": time_axis,

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -160,7 +160,7 @@ def add_suffix(file_path, possible_suffix):
     return file_path
 
 
-def read_binary_recording(file, num_chan, dtype, time_axis=0, offset=0):
+def read_binary_recording(file, num_channels, dtype, time_axis=0, offset=0):
     """
     Read binary .bin or .dat file.
 
@@ -168,7 +168,7 @@ def read_binary_recording(file, num_chan, dtype, time_axis=0, offset=0):
     ----------
     file: str
         File name
-    num_chan: int
+    num_channels: int
         Number of channels
     dtype: dtype
         dtype of the file
@@ -179,13 +179,13 @@ def read_binary_recording(file, num_chan, dtype, time_axis=0, offset=0):
         number of offset bytes
 
     """
-    num_chan = int(num_chan)
+    num_channels = int(num_channels)
     with Path(file).open() as f:
-        nsamples = (os.fstat(f.fileno()).st_size - offset) // (num_chan * np.dtype(dtype).itemsize)
+        nsamples = (os.fstat(f.fileno()).st_size - offset) // (num_channels * np.dtype(dtype).itemsize)
     if time_axis == 0:
-        samples = np.memmap(file, np.dtype(dtype), mode="r", offset=offset, shape=(nsamples, num_chan))
+        samples = np.memmap(file, np.dtype(dtype), mode="r", offset=offset, shape=(nsamples, num_channels))
     else:
-        samples = np.memmap(file, np.dtype(dtype), mode="r", offset=offset, shape=(num_chan, nsamples)).T
+        samples = np.memmap(file, np.dtype(dtype), mode="r", offset=offset, shape=(num_channels, nsamples)).T
     return samples
 
 

--- a/src/spikeinterface/extractors/mdaextractors.py
+++ b/src/spikeinterface/extractors/mdaextractors.py
@@ -112,7 +112,7 @@ class MdaRecordingExtractor(BaseRecording):
         save_path.mkdir(parents=True, exist_ok=True)
         save_file_path = save_path / raw_fname
         parent_dir = save_path
-        num_chan = recording.get_num_channels()
+        num_channels = recording.get_num_channels()
         num_frames = recording.get_num_frames(0)
 
         geom = recording.get_channel_locations()
@@ -125,7 +125,7 @@ class MdaRecordingExtractor(BaseRecording):
         if dtype == "int":
             dtype = "int16"
 
-        header = MdaHeader(dt0=dtype, dims0=(num_chan, num_frames))
+        header = MdaHeader(dt0=dtype, dims0=(num_channels, num_frames))
         header_size = header.header_size
 
         write_binary_recording(

--- a/src/spikeinterface/sorters/external/tridesclous.py
+++ b/src/spikeinterface/sorters/external/tridesclous.py
@@ -95,13 +95,13 @@ class TridesclousSorter(BaseSorter):
             d = recording.get_binary_description()
             file_paths = d["file_paths"]
             dtype = str(d["dtype"])
-            num_chan = d["num_channels"]
+            num_channels = d["num_channels"]
             file_offset = d["file_offset"]
         else:
             if verbose:
                 print("Local copy of recording")
             # save binary file (chunk by chunk) into a new file
-            num_chan = recording.get_num_channels()
+            num_channels = recording.get_num_channels()
             dtype = recording.get_dtype().str
             file_paths = [str(sorter_output_folder / f"raw_signals_{i}.raw") for i in range(num_seg)]
             write_binary_recording(recording, file_paths=file_paths, dtype=dtype, **get_job_kwargs(params, verbose))
@@ -115,7 +115,7 @@ class TridesclousSorter(BaseSorter):
             filenames=file_paths,
             dtype=dtype,
             sample_rate=float(sr),
-            total_channel=int(num_chan),
+            total_channel=int(num_channels),
             offset=int(file_offset),
         )
         tdc_dataio.set_probe_file(str(prb_file))


### PR DESCRIPTION
kwargs in `BinaryRecordingExtractor` were causing warnings to be thrown when loading from dict.