### PR TITLE
Make plot_amplitudes independent of recording

### DIFF
--- a/src/spikeinterface/widgets/amplitudes.py
+++ b/src/spikeinterface/widgets/amplitudes.py
@@ -69,9 +69,7 @@ class AmplitudesWidget(BaseWidget):
         else:
             segment_index = 0
         amplitudes_segment = amplitudes[segment_index]
-        total_duration = (
-            waveform_extractor.recording.get_num_samples(segment_index) / waveform_extractor.sampling_frequency
-        )
+        total_duration = waveform_extractor.get_num_samples(segment_index) / waveform_extractor.sampling_frequency
 
         spiketrains_segment = {}
         for i, unit_id in enumerate(sorting.unit_ids):


### PR DESCRIPTION
Small fix to make `plot_amplitudes` work in recordingless mode