### PR TITLE
Handle empty units in quality metrics

### DIFF
--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -292,10 +292,10 @@ class BaseSorting(BaseExtractor):
         BaseSorting
             Sorting object with non-empty units
         """
-        non_empty_units = self.get_non_empty_units()
+        non_empty_units = self.get_non_empty_unit_ids()
         return self.select_units(non_empty_units)
 
-    def get_non_empty_units(self):
+    def get_non_empty_unit_ids(self):
         non_empty_units = []
         for segment_index in range(self.get_num_segments()):
             for unit in self.get_unit_ids():
@@ -304,9 +304,9 @@ class BaseSorting(BaseExtractor):
         non_empty_units = np.unique(non_empty_units)
         return non_empty_units
 
-    def get_empty_units(self):
+    def get_empty_unit_ids(self):
         unit_ids = self.get_unit_ids()
-        empty_units = unit_ids[~np.isin(unit_ids, self.get_non_empty_units())]
+        empty_units = unit_ids[~np.isin(unit_ids, self.get_non_empty_unit_ids())]
         return empty_units
 
     def frame_slice(self, start_frame, end_frame, check_spike_frames=True):

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -292,13 +292,22 @@ class BaseSorting(BaseExtractor):
         BaseSorting
             Sorting object with non-empty units
         """
-        units_to_keep = []
+        non_empty_units = self.get_non_empty_units()
+        return self.select_units(non_empty_units)
+
+    def get_non_empty_units(self):
+        non_empty_units = []
         for segment_index in range(self.get_num_segments()):
             for unit in self.get_unit_ids():
                 if len(self.get_unit_spike_train(unit, segment_index=segment_index)) > 0:
-                    units_to_keep.append(unit)
-        units_to_keep = np.unique(units_to_keep)
-        return self.select_units(units_to_keep)
+                    non_empty_units.append(unit)
+        non_empty_units = np.unique(non_empty_units)
+        return non_empty_units
+
+    def get_empty_units(self):
+        unit_ids = self.get_unit_ids()
+        empty_units = unit_ids[~np.isin(unit_ids, self.get_non_empty_units())]
+        return empty_units
 
     def frame_slice(self, start_frame, end_frame, check_spike_frames=True):
         from spikeinterface import FrameSliceSorting

--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -28,7 +28,12 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
     name = "phykilosort"
 
     def __init__(
-        self, folder_path, exclude_cluster_groups=None, keep_good_only=False, load_all_cluster_properties=True
+        self,
+        folder_path,
+        exclude_cluster_groups=None,
+        keep_good_only=False,
+        remove_empty_units=False,
+        load_all_cluster_properties=True,
     ):
         try:
             import pandas as pd
@@ -52,7 +57,7 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
         spike_clusters = np.atleast_1d(spike_clusters.squeeze())
 
         clust_id = np.unique(spike_clusters)
-        unit_ids = list(clust_id)
+        unique_unit_ids = list(clust_id)
         params = read_python(str(phy_folder / "params.py"))
         sampling_frequency = params["sample_rate"]
 
@@ -87,8 +92,8 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
 
         # in case no tsv/csv files are found populate cluster info with minimal info
         if cluster_info is None:
-            cluster_info = pd.DataFrame({"cluster_id": unit_ids})
-            cluster_info["group"] = ["unsorted"] * len(unit_ids)
+            cluster_info = pd.DataFrame({"cluster_id": unique_unit_ids})
+            cluster_info["group"] = ["unsorted"] * len(unique_unit_ids)
 
         if exclude_cluster_groups is not None:
             if isinstance(exclude_cluster_groups, str):
@@ -105,6 +110,9 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
             assert "id" in cluster_info.columns, "Couldn't find cluster ids in the tsv files!"
             cluster_info.loc[:, "cluster_id"] = cluster_info["id"].values
             del cluster_info["id"]
+
+        if remove_empty_units:
+            cluster_info = cluster_info.query(f"cluster_id in {unique_unit_ids}")
 
         # update spike clusters and times values
         bad_clusters = [clust for clust in clust_id if clust not in cluster_info["cluster_id"].values]
@@ -220,6 +228,8 @@ class KiloSortSortingExtractor(BasePhyKilosortSortingExtractor):
     keep_good_only : bool, default: True
         Whether to only keep good units.
         If True, only Kilosort-labeled 'good' units are returned.
+    remove_empty_units : bool, default: True
+        If True, empty units are removed from the sorting extractor.
 
     Returns
     -------
@@ -230,9 +240,13 @@ class KiloSortSortingExtractor(BasePhyKilosortSortingExtractor):
     extractor_name = "KiloSortSorting"
     name = "kilosort"
 
-    def __init__(self, folder_path, keep_good_only=False):
+    def __init__(self, folder_path, keep_good_only=False, remove_empty_units=True):
         BasePhyKilosortSortingExtractor.__init__(
-            self, folder_path, exclude_cluster_groups=None, keep_good_only=keep_good_only
+            self,
+            folder_path,
+            exclude_cluster_groups=None,
+            keep_good_only=keep_good_only,
+            remove_empty_units=remove_empty_units,
         )
 
         self._kwargs = {"folder_path": str(Path(folder_path).absolute()), "keep_good_only": keep_good_only}

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -282,7 +282,11 @@ def compute_isi_violations(waveform_extractor, isi_threshold_ms=1.5, min_isi_ms=
 
         for segment_index in range(num_segs):
             spike_train = sorting.get_unit_spike_train(unit_id=unit_id, segment_index=segment_index)
-            spike_trains.append(spike_train / fs)
+            if np.any(spike_train):
+                spike_trains.append(spike_train / fs)
+
+        if not np.any(spike_trains):
+            continue
 
         ratio, _, count = isi_violations(spike_trains, total_duration_s, isi_threshold_s, min_isi_s)
 
@@ -429,7 +433,11 @@ def compute_sliding_rp_violations(
 
         for segment_index in range(num_segs):
             spike_train = sorting.get_unit_spike_train(unit_id=unit_id, segment_index=segment_index)
-            spike_train_list.append(spike_train)
+            if np.any(spike_train):
+                spike_train_list.append(spike_train)
+
+        if not np.any(spike_train_list):
+            continue
 
         unit_n_spikes = np.sum([len(train) for train in spike_train_list])
         if unit_n_spikes <= min_spikes:

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -278,17 +278,17 @@ def compute_isi_violations(waveform_extractor, isi_threshold_ms=1.5, min_isi_ms=
 
     # all units converted to seconds
     for unit_id in unit_ids:
-        spike_trains = []
+        spike_train_list = []
 
         for segment_index in range(num_segs):
             spike_train = sorting.get_unit_spike_train(unit_id=unit_id, segment_index=segment_index)
             if np.any(spike_train):
-                spike_trains.append(spike_train / fs)
+                spike_train_list.append(spike_train / fs)
 
-        if not any([np.any(train) for train in spike_trains]):
+        if not any([np.any(train) for train in spike_train_list]):
             continue
 
-        ratio, _, count = isi_violations(spike_trains, total_duration_s, isi_threshold_s, min_isi_s)
+        ratio, _, count = isi_violations(spike_train_list, total_duration_s, isi_threshold_s, min_isi_s)
 
         isi_violations_ratio[unit_id] = ratio
         isi_violations_count[unit_id] = count

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -285,7 +285,7 @@ def compute_isi_violations(waveform_extractor, isi_threshold_ms=1.5, min_isi_ms=
             if np.any(spike_train):
                 spike_trains.append(spike_train / fs)
 
-        if not np.any(spike_trains):
+        if not any([np.any(train) for train in spike_trains]):
             continue
 
         ratio, _, count = isi_violations(spike_trains, total_duration_s, isi_threshold_s, min_isi_s)
@@ -436,7 +436,7 @@ def compute_sliding_rp_violations(
             if np.any(spike_train):
                 spike_train_list.append(spike_train)
 
-        if not np.any(spike_train_list):
+        if not any([np.any(train) for train in spike_train_list]):
             continue
 
         unit_n_spikes = np.sum([len(train) for train in spike_train_list])

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -31,13 +31,15 @@ except ModuleNotFoundError as err:
 _default_params = dict()
 
 
-def compute_num_spikes(waveform_extractor, **kwargs):
+def compute_num_spikes(waveform_extractor, unit_ids=None, **kwargs):
     """Compute the number of spike across segments.
 
     Parameters
     ----------
     waveform_extractor : WaveformExtractor
         The waveform extractor object.
+    unit_ids : list or None
+        The list of unit ids to compute the number of spikes. If None, all units are used.
 
     Returns
     -------
@@ -46,7 +48,8 @@ def compute_num_spikes(waveform_extractor, **kwargs):
     """
 
     sorting = waveform_extractor.sorting
-    unit_ids = sorting.unit_ids
+    if unit_ids is None:
+        unit_ids = sorting.unit_ids
     num_segs = sorting.get_num_segments()
 
     num_spikes = {}
@@ -60,13 +63,15 @@ def compute_num_spikes(waveform_extractor, **kwargs):
     return num_spikes
 
 
-def compute_firing_rates(waveform_extractor):
+def compute_firing_rates(waveform_extractor, unit_ids=None, **kwargs):
     """Compute the firing rate across segments.
 
     Parameters
     ----------
     waveform_extractor : WaveformExtractor
         The waveform extractor object.
+    unit_ids : list or None
+        The list of unit ids to compute the firing rate. If None, all units are used.
 
     Returns
     -------
@@ -75,7 +80,8 @@ def compute_firing_rates(waveform_extractor):
     """
 
     sorting = waveform_extractor.sorting
-    unit_ids = sorting.unit_ids
+    if unit_ids is None:
+        unit_ids = sorting.unit_ids
     total_duration = waveform_extractor.get_total_duration()
 
     firing_rates = {}
@@ -85,13 +91,15 @@ def compute_firing_rates(waveform_extractor):
     return firing_rates
 
 
-def compute_presence_ratios(waveform_extractor, bin_duration_s=60.0, mean_fr_ratio_thresh=0.0):
+def compute_presence_ratios(waveform_extractor, unit_ids=None, bin_duration_s=60.0, mean_fr_ratio_thresh=0.0, **kwargs):
     """Calculate the presence ratio, the fraction of time the unit is firing above a certain threshold.
 
     Parameters
     ----------
     waveform_extractor : WaveformExtractor
         The waveform extractor object.
+    unit_ids : list or None
+        The list of unit ids to compute the presence ratio. If None, all units are used.
     bin_duration_s : float, default: 60
         The duration of each bin in seconds. If the duration is less than this value,
         presence_ratio is set to NaN
@@ -110,7 +118,8 @@ def compute_presence_ratios(waveform_extractor, bin_duration_s=60.0, mean_fr_rat
     To do so, spike trains across segments are concatenated to mimic a continuous segment.
     """
     sorting = waveform_extractor.sorting
-    unit_ids = sorting.unit_ids
+    if unit_ids is None:
+        unit_ids = sorting.unit_ids
     num_segs = sorting.get_num_segments()
 
     seg_lengths = [waveform_extractor.get_num_samples(i) for i in range(num_segs)]
@@ -133,7 +142,7 @@ def compute_presence_ratios(waveform_extractor, bin_duration_s=60.0, mean_fr_rat
         warnings.warn(
             f"Bin duration of {bin_duration_s}s is larger than recording duration. " f"Presence ratios are set to NaN."
         )
-        presence_ratios = {unit_id: np.nan for unit_id in sorting.unit_ids}
+        presence_ratios = {unit_id: np.nan for unit_id in unit_ids}
     else:
         for unit_id in unit_ids:
             spike_train = []
@@ -163,7 +172,11 @@ _default_params["presence_ratio"] = dict(
 
 
 def compute_snrs(
-    waveform_extractor, peak_sign: str = "neg", peak_mode: str = "extremum", random_chunk_kwargs_dict=None
+    waveform_extractor,
+    unit_ids=None,
+    peak_sign: str = "neg",
+    peak_mode: str = "extremum",
+    random_chunk_kwargs_dict=None,
 ):
     """Compute signal to noise ratio.
 
@@ -171,6 +184,8 @@ def compute_snrs(
     ----------
     waveform_extractor : WaveformExtractor
         The waveform extractor object.
+    unit_ids : list or None
+        The list of unit ids to compute the SNR. If None, all units are used.
     peak_sign : {'neg', 'pos', 'both'}
         The sign of the template to compute best channels.
     peak_mode: {'extremum', 'at_index'}
@@ -199,7 +214,8 @@ def compute_snrs(
     assert peak_mode in ("extremum", "at_index")
 
     sorting = waveform_extractor.sorting
-    unit_ids = sorting.unit_ids
+    if unit_ids is None:
+        unit_ids = sorting.unit_ids
     channel_ids = waveform_extractor.channel_ids
 
     extremum_channels_ids = get_template_extremum_channel(waveform_extractor, peak_sign=peak_sign, mode=peak_mode)
@@ -221,7 +237,7 @@ def compute_snrs(
 _default_params["snr"] = dict(peak_sign="neg", peak_mode="extremum", random_chunk_kwargs_dict=None)
 
 
-def compute_isi_violations(waveform_extractor, isi_threshold_ms=1.5, min_isi_ms=0):
+def compute_isi_violations(waveform_extractor, unit_ids=None, isi_threshold_ms=1.5, min_isi_ms=0):
     """Calculate Inter-Spike Interval (ISI) violations.
 
     It computes several metrics related to isi violations:
@@ -233,6 +249,8 @@ def compute_isi_violations(waveform_extractor, isi_threshold_ms=1.5, min_isi_ms=
     ----------
     waveform_extractor : WaveformExtractor
         The waveform extractor object
+    unit_ids : list or None
+        List of unit ids to compute the ISI violations. If None, all units are used.
     isi_threshold_ms : float, default: 1.5
         Threshold for classifying adjacent spikes as an ISI violation, in ms.
         This is the biophysical refractory period (default=1.5).
@@ -264,7 +282,8 @@ def compute_isi_violations(waveform_extractor, isi_threshold_ms=1.5, min_isi_ms=
     res = namedtuple("isi_violation", ["isi_violations_ratio", "isi_violations_count"])
 
     sorting = waveform_extractor.sorting
-    unit_ids = sorting.unit_ids
+    if unit_ids is None:
+        unit_ids = sorting.unit_ids
     num_segs = sorting.get_num_segments()
 
     total_duration_s = waveform_extractor.get_total_duration()
@@ -282,10 +301,10 @@ def compute_isi_violations(waveform_extractor, isi_threshold_ms=1.5, min_isi_ms=
 
         for segment_index in range(num_segs):
             spike_train = sorting.get_unit_spike_train(unit_id=unit_id, segment_index=segment_index)
-            if np.any(spike_train):
+            if len(spike_train) > 0:
                 spike_train_list.append(spike_train / fs)
 
-        if not any([np.any(train) for train in spike_train_list]):
+        if not any([len(train) > 0 for train in spike_train_list]):
             continue
 
         ratio, _, count = isi_violations(spike_train_list, total_duration_s, isi_threshold_s, min_isi_s)
@@ -300,7 +319,7 @@ _default_params["isi_violation"] = dict(isi_threshold_ms=1.5, min_isi_ms=0)
 
 
 def compute_refrac_period_violations(
-    waveform_extractor, refractory_period_ms: float = 1.0, censored_period_ms: float = 0.0
+    waveform_extractor, unit_ids=None, refractory_period_ms: float = 1.0, censored_period_ms: float = 0.0
 ):
     """Calculates the number of refractory period violations.
 
@@ -313,6 +332,8 @@ def compute_refrac_period_violations(
     ----------
     waveform_extractor : WaveformExtractor
         The waveform extractor object
+    unit_ids : list or None
+        List of unit ids to compute the refractory period violations. If None, all units are used.
     refractory_period_ms : float, default: 1.0
         The period (in ms) where no 2 good spikes can occur.
     censored_period_ùs : float, default: 0.0
@@ -347,6 +368,8 @@ def compute_refrac_period_violations(
     num_units = len(sorting.unit_ids)
     num_segments = sorting.get_num_segments()
     spikes = sorting.get_all_spike_trains(outputs="unit_index")
+    if unit_ids is None:
+        unit_ids = sorting.unit_ids
     num_spikes = compute_num_spikes(waveform_extractor)
 
     t_c = int(round(censored_period_ms * fs * 1e-3))
@@ -363,7 +386,7 @@ def compute_refrac_period_violations(
     nb_violations = {}
     rp_contamination = {}
 
-    for i, unit_id in enumerate(sorting.unit_ids):
+    for i, unit_id in enumerate(unit_ids):
         nb_violations[unit_id] = n_v = nb_rp_violations[i]
         N = num_spikes[unit_id]
         if N == 0:
@@ -380,6 +403,7 @@ _default_params["rp_violation"] = dict(refractory_period_ms=1.0, censored_period
 
 def compute_sliding_rp_violations(
     waveform_extractor,
+    unit_ids=None,
     min_spikes=0,
     bin_size_ms=0.25,
     window_size_s=1,
@@ -395,6 +419,8 @@ def compute_sliding_rp_violations(
     ----------
     waveform_extractor : WaveformExtractor
         The waveform extractor object.
+    unit_ids : list or None
+        List of unit ids to compute the sliding RP violations. If None, all units are used.
     min_spikes : int, default 0
         Contamination  is set to np.nan if the unit has less than this many
         spikes across all segments.
@@ -421,7 +447,8 @@ def compute_sliding_rp_violations(
     """
     duration = waveform_extractor.get_total_duration()
     sorting = waveform_extractor.sorting
-    unit_ids = sorting.unit_ids
+    if unit_ids is None:
+        unit_ids = sorting.unit_ids
     num_segs = sorting.get_num_segments()
     fs = waveform_extractor.sampling_frequency
 
@@ -470,6 +497,7 @@ _default_params["sliding_rp_violation"] = dict(
 
 def compute_amplitude_cutoffs(
     waveform_extractor,
+    unit_ids=None,
     peak_sign="neg",
     num_histogram_bins=500,
     histogram_smoothing_value=3,
@@ -481,6 +509,8 @@ def compute_amplitude_cutoffs(
     ----------
     waveform_extractor : WaveformExtractor
         The waveform extractor object.
+    unit_ids : list or None
+        List of unit ids to compute the amplitude cutoffs. If None, all units are used.
     peak_sign : {'neg', 'pos', 'both'}
         The sign of the peaks.
     num_histogram_bins : int, default: 100
@@ -513,7 +543,8 @@ def compute_amplitude_cutoffs(
 
     """
     sorting = waveform_extractor.sorting
-    unit_ids = sorting.unit_ids
+    if unit_ids is None:
+        unit_ids = sorting.unit_ids
 
     before = waveform_extractor.nbefore
     extremum_channels_ids = get_template_extremum_channel(waveform_extractor, peak_sign=peak_sign)
@@ -566,13 +597,15 @@ _default_params["amplitude_cutoff"] = dict(
 )
 
 
-def compute_amplitude_medians(waveform_extractor, peak_sign="neg"):
+def compute_amplitude_medians(waveform_extractor, unit_ids=None, peak_sign="neg"):
     """Compute median of the amplitude distributions (in absolute value).
 
     Parameters
     ----------
     waveform_extractor : WaveformExtractor
         The waveform extractor object.
+    unit_ids : list or None
+        List of unit ids to compute the amplitude medians. If None, all units are used.
     peak_sign : {'neg', 'pos', 'both'}
         The sign of the peaks.
 
@@ -588,7 +621,8 @@ def compute_amplitude_medians(waveform_extractor, peak_sign="neg"):
     https://github.com/int-brain-lab/ibllib/blob/master/brainbox/metrics/single_units.py
     """
     sorting = waveform_extractor.sorting
-    unit_ids = sorting.unit_ids
+    if unit_ids is None:
+        unit_ids = sorting.unit_ids
 
     before = waveform_extractor.nbefore
 
@@ -624,6 +658,7 @@ _default_params["amplitude_median"] = dict(peak_sign="neg")
 
 def compute_drift_metrics(
     waveform_extractor,
+    unit_ids=None,
     interval_s=60,
     min_spikes_per_interval=100,
     direction="y",
@@ -648,6 +683,8 @@ def compute_drift_metrics(
     ----------
     waveform_extractor : WaveformExtractor
         The waveform extractor object.
+    unit_ids : list or None
+        List of unit ids to compute the drift metrics. If None, all units are used.
     interval_s : int, optional
         Interval length is seconds for computing spike depth, by default 60
     min_spikes_per_interval : int, optional
@@ -681,6 +718,9 @@ def compute_drift_metrics(
     there are large displacements in between segments, the resulting metric values will be very high.
     """
     res = namedtuple("drift_metrics", ["drift_ptp", "drift_std", "drift_mad"])
+    sorting = waveform_extractor.sorting
+    if unit_ids is None:
+        unit_ids = sorting.unit_ids
 
     if waveform_extractor.is_extension("spike_locations"):
         locs_calculator = waveform_extractor.load_extension("spike_locations")
@@ -692,14 +732,12 @@ def compute_drift_metrics(
             "Use the `postprocessing.compute_spike_locations()` function. "
             "Drift metrics will be set to NaN"
         )
-        empty_dict = {unit_id: np.nan for unit_id in waveform_extractor.unit_ids}
+        empty_dict = {unit_id: np.nan for unit_id in unit_ids}
         if return_positions:
             return res(empty_dict, empty_dict, empty_dict), np.nan
         else:
             return res(empty_dict, empty_dict, empty_dict)
 
-    sorting = waveform_extractor.sorting
-    unit_ids = waveform_extractor.unit_ids
     interval_samples = int(interval_s * waveform_extractor.sampling_frequency)
     assert direction in spike_locations.dtype.names, (
         f"Direction {direction} is invalid. Available directions: " f"{spike_locations.dtype.names}"
@@ -710,7 +748,7 @@ def compute_drift_metrics(
             "The recording is too short given the specified 'interval_s' and "
             "'min_num_bins'. Drift metrics will be set to NaN"
         )
-        empty_dict = {unit_id: np.nan for unit_id in waveform_extractor.unit_ids}
+        empty_dict = {unit_id: np.nan for unit_id in unit_ids}
         if return_positions:
             return res(empty_dict, empty_dict, empty_dict), np.nan
         else:

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -64,7 +64,7 @@ def get_quality_pca_metric_list():
 
 
 def calculate_pc_metrics(
-    pca, metric_names=None, sparsity=None, qm_params=None, seed=None, n_jobs=1, progress_bar=False
+    pca, unit_ids=None, metric_names=None, sparsity=None, qm_params=None, seed=None, n_jobs=1, progress_bar=False
 ):
     """Calculate principal component derived metrics.
 
@@ -72,6 +72,8 @@ def calculate_pc_metrics(
     ----------
     pca : WaveformPrincipalComponent
         Waveform object with principal components computed.
+    unit_ids : list of int or None
+        List of unit ids to compute metrics for.
     metric_names : list of str, optional
         The list of PC metrics to compute.
         If not provided, defaults to all PC metrics.
@@ -102,7 +104,8 @@ def calculate_pc_metrics(
     we = pca.waveform_extractor
     extremum_channels = get_template_extremum_channel(we)
 
-    unit_ids = we.unit_ids
+    if unit_ids is None:
+        unit_ids = we.unit_ids
     channel_ids = we.channel_ids
 
     # create output dict of dict  pc_metrics['metric_name'][unit_id]
@@ -117,8 +120,8 @@ def calculate_pc_metrics(
 
     # Compute nspikes and firing rate outside of main loop for speed
     if any([n in metric_names for n in ["nn_isolation", "nn_noise_overlap"]]):
-        n_spikes_all_units = compute_num_spikes(we)
-        fr_all_units = compute_firing_rates(we)
+        n_spikes_all_units = compute_num_spikes(we, unit_ids=unit_ids)
+        fr_all_units = compute_firing_rates(we, unit_ids=unit_ids)
     else:
         n_spikes_all_units = None
         fr_all_units = None

--- a/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -1,5 +1,5 @@
 """Classes and functions for computing multiple quality metrics."""
-
+import warnings
 from copy import deepcopy
 
 import numpy as np
@@ -91,6 +91,7 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
         progress_bar = job_kwargs["progress_bar"]
 
         unit_ids = self.sorting.unit_ids
+        self._warn_on_empty_units()
         import pandas as pd
 
         metrics = pd.DataFrame(index=unit_ids)
@@ -138,6 +139,14 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
                 metrics[col] = pd.Series(values)
 
         self._extension_data["metrics"] = metrics
+
+    def _warn_on_empty_units(self):
+        empty_units = self.sorting.get_empty_units()
+        if np.any(empty_units):
+            warnings.warn(
+                f"Units {empty_units} are empty. Quality metrcs will be non-interpretable "
+                f"for these units.\n To remove empty units, use `sorting.remove_empty_units()`."
+            )
 
     def get_data(self):
         """

--- a/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -92,7 +92,7 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
 
         unit_ids = self.sorting.unit_ids
         non_empty_unit_ids = self.sorting.get_non_empty_unit_ids()
-        empty_unit_ids = self.sorting.get_empty_unit_ids()
+        empty_unit_ids = unit_ids[~np.isin(unit_ids, non_empty_unit_ids)]
         if len(empty_unit_ids) > 0:
             warnings.warn(
                 f"Units {empty_unit_ids} are empty. Quality metrcs will be set to NaN "

--- a/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -91,7 +91,14 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
         progress_bar = job_kwargs["progress_bar"]
 
         unit_ids = self.sorting.unit_ids
-        self._warn_on_empty_units()
+        non_empty_unit_ids = self.sorting.get_non_empty_unit_ids()
+        empty_unit_ids = self.sorting.get_empty_unit_ids()
+        if len(empty_unit_ids > 0):
+            warnings.warn(
+                f"Units {empty_unit_ids} are empty. Quality metrcs will be set to NaN "
+                f"for these units.\n To remove empty units, use `sorting.remove_empty_units()`."
+            )
+
         import pandas as pd
 
         metrics = pd.DataFrame(index=unit_ids)
@@ -108,17 +115,17 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
             func = _misc_metric_name_to_func[metric_name]
 
             params = qm_params[metric_name] if metric_name in qm_params else {}
-            res = func(self.waveform_extractor, **params)
+            res = func(self.waveform_extractor, unit_ids=non_empty_unit_ids, **params)
             # QM with uninstall dependencies might return None
             if res is not None:
                 if isinstance(res, dict):
                     # res is a dict convert to series
-                    metrics[metric_name] = pd.Series(res)
+                    metrics.loc[non_empty_unit_ids, metric_name] = pd.Series(res)
                 else:
                     # res is a namedtuple with several dict
                     # so several columns
                     for i, col in enumerate(res._fields):
-                        metrics[col] = pd.Series(res[i])
+                        metrics.loc[non_empty_unit_ids, col] = pd.Series(res[i])
 
         # metrics based on PCs
         pc_metric_names = [k for k in metric_names if k in _possible_pc_metric_names]
@@ -128,6 +135,7 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
             pc_extension = self.waveform_extractor.load_extension("principal_components")
             pc_metrics = calculate_pc_metrics(
                 pc_extension,
+                unit_ids=non_empty_unit_ids,
                 metric_names=pc_metric_names,
                 sparsity=sparsity,
                 progress_bar=progress_bar,
@@ -136,17 +144,13 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
                 seed=seed,
             )
             for col, values in pc_metrics.items():
-                metrics[col] = pd.Series(values)
+                metrics.loc[non_empty_unit_ids, col] = pd.Series(values)
+
+        # add NaN for empty units
+        if len(empty_unit_ids) > 0:
+            metrics.loc[empty_unit_ids] = np.nan
 
         self._extension_data["metrics"] = metrics
-
-    def _warn_on_empty_units(self):
-        empty_units = self.sorting.get_empty_units()
-        if np.any(empty_units):
-            warnings.warn(
-                f"Units {empty_units} are empty. Quality metrcs will be non-interpretable "
-                f"for these units.\n To remove empty units, use `sorting.remove_empty_units()`."
-            )
 
     def get_data(self):
         """

--- a/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -93,7 +93,7 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
         unit_ids = self.sorting.unit_ids
         non_empty_unit_ids = self.sorting.get_non_empty_unit_ids()
         empty_unit_ids = self.sorting.get_empty_unit_ids()
-        if len(empty_unit_ids > 0):
+        if len(empty_unit_ids) > 0:
             warnings.warn(
                 f"Units {empty_unit_ids} are empty. Quality metrcs will be set to NaN "
                 f"for these units.\n To remove empty units, use `sorting.remove_empty_units()`."

--- a/src/spikeinterface/qualitymetrics/tests/test_metrics_functions.py
+++ b/src/spikeinterface/qualitymetrics/tests/test_metrics_functions.py
@@ -238,7 +238,7 @@ def test_calculate_isi_violations(simulated_data):
     isi_viol_gt = {0: 0.0998002996004994, 1: 0.7904857139469347, 2: 1.929898371551754}
     counts_gt = {0: 2, 1: 4, 2: 10}
     we = setup_dataset(simulated_data)
-    isi_viol, counts = compute_isi_violations(we, 1, 0.0)
+    isi_viol, counts = compute_isi_violations(we, isi_threshold_ms=1, min_isi_ms=0.0)
 
     print(isi_viol)
     assert np.allclose(list(isi_viol_gt.values()), list(isi_viol.values()), rtol=0.05)
@@ -258,7 +258,7 @@ def test_calculate_rp_violations(simulated_data):
     rp_contamination_gt = {0: 0.10534956502609294, 1: 1.0, 2: 1.0}
     counts_gt = {0: 2, 1: 4, 2: 10}
     we = setup_dataset(simulated_data)
-    rp_contamination, counts = compute_refrac_period_violations(we, 1, 0.0)
+    rp_contamination, counts = compute_refrac_period_violations(we, refractory_period_ms=1, censored_period_ms=0.0)
 
     print(rp_contamination)
     assert np.allclose(list(rp_contamination_gt.values()), list(rp_contamination.values()), rtol=0.05)
@@ -266,7 +266,7 @@ def test_calculate_rp_violations(simulated_data):
 
     sorting = NumpySorting.from_dict({0: np.array([28, 150], dtype=np.int16), 1: np.array([], dtype=np.int16)}, 30000)
     we.sorting = sorting
-    rp_contamination, counts = compute_refrac_period_violations(we, 1, 0.0)
+    rp_contamination, counts = compute_refrac_period_violations(we, refractory_period_ms=1, censored_period_ms=0.0)
     assert np.isnan(rp_contamination[1])
 
 


### PR DESCRIPTION
This PR closes #1760 by handling the empty-unit case in quality metrics's `compute_sliding_rp_violations` and `compute_isi_violations`. 

It also shows a warning if empty units exist when running `compute_quality_metrics` to indicate the values for these units are un-interpretable.

To ease this, two new conveience functions `get_non_empty_units` and `get_empty_units` are introduced on basesorter.

Happy to make any required changes!
