### PR TITLE
Add docs requirements and build read-the-docs documentation faster

### DIFF
--- a/doc/development/development.rst
+++ b/doc/development/development.rst
@@ -4,8 +4,6 @@ Development
 How to contribute
 -----------------
 
-I WANT TO TEST THAT THE DOCUMENTATION IS CALLING THE RIGHT BRANCH!
-
 There are various ways to contribute to SpikeInterface as a user or developer. Some tasks you can help us with include:
 
 * Developing a new extractor for a different file format.

--- a/doc/development/development.rst
+++ b/doc/development/development.rst
@@ -4,6 +4,8 @@ Development
 How to contribute
 -----------------
 
+I WANT TO TEST THAT THE DOCUMENTATION IS CALLING THE RIGHT BRANCH!
+
 There are various ways to contribute to SpikeInterface as a user or developer. Some tasks you can help us with include:
 
 * Developing a new extractor for a different file format.

--- a/doc/install_sorters.rst
+++ b/doc/install_sorters.rst
@@ -191,7 +191,7 @@ Mountainsort5
       pip install mountainsort5
 
 SpyKING CIRCUS
-^^^^^^^^^^^^^
+^^^^^^^^^^^^^^
 
 * Python, requires MPICH
 * Url: https://spyking-circus.readthedocs.io

--- a/docs_rtd.yml
+++ b/docs_rtd.yml
@@ -1,0 +1,9 @@
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.10
+  - pip
+  - datalad
+  - pip:
+    - -e ./spikeinterface[docs]

--- a/docs_rtd.yml
+++ b/docs_rtd.yml
@@ -6,4 +6,4 @@ dependencies:
   - pip
   - datalad
   - pip:
-    - -e ./spikeinterface[docs]
+    - -e .[docs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,8 +144,9 @@ test = [
 ]
 
 docs = [
+    "Sphinx==5.1.1",
+    "sphinx_rtd_theme==1.0.0",
     "sphinx-gallery",
-    "sphinx_rtd_theme",
     "numpydoc",
     "MEArec",   # For examples
     "datalad==0.16.2",  # Download mearec data in examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,12 +148,15 @@ docs = [
     "sphinx_rtd_theme==1.0.0",
     "sphinx-gallery",
     "numpydoc",
-    "MEArec",   # For examples
-    "datalad==0.16.2",  # Download mearec data in examples
+
+    # for notebooks in the gallery
+    "MEArec",   # Use as an example
+    "datalad==0.16.2",  # Download mearec data in examples, needs to be installed with conda because of git-annex
     "pandas", # Don't know where this is needed
     "hdbscan",   # For sorters, probably spikingcircus
     "numba", # For sorters, probably spikingcircus
-    "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",  # Until next release
+    "probeinterface @ git+https://github.com/SpikeInterface/probeinterface.git",  # We always build from the latest version
+    "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",  # We always build from the latest version
 
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,10 +147,11 @@ docs = [
     "sphinx-gallery",
     "sphinx_rtd_theme",
     "numpydoc",
-    "MEArec",
-    "datalad==0.16.2",
-    "pandas", # Don't know why yet
-    "hdbscan",   # For sorters I think
+    "MEArec",   # For examples
+    "datalad==0.16.2",  # Download mearec data in examples
+    "pandas", # Don't know where this is needed
+    "hdbscan",   # For sorters, probably spikingcircus
+    "numba", # For sorters, probably spikingcircus
     "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",  # Until next release
 
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,10 @@ docs = [
     "numpydoc",
     "MEArec",
     "datalad==0.16.2",
+    "pandas", # Don't know why yet
+    "hdbscan",   # For sorters I think
+    "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",  # Until next release
+
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ docs = [
     "pandas", # Don't know where this is needed
     "hdbscan",   # For sorters, probably spikingcircus
     "numba", # For sorters, probably spikingcircus
+    # for release we need pypi, so this needs to be commented
     "probeinterface @ git+https://github.com/SpikeInterface/probeinterface.git",  # We always build from the latest version
     "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",  # We always build from the latest version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,13 @@ test = [
     "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",
 ]
 
+docs = [
+    "sphinx-gallery",
+    "sphinx_rtd_theme",
+    "numpydoc",
+    "MEArec",
+    "datalad==0.16.2",
+]
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ docs = [
 
     # for notebooks in the gallery
     "MEArec",   # Use as an example
-    "datalad==0.16.2",  # Download mearec data in examples, needs to be installed with conda because of git-annex
+    "datalad==0.16.2",  # Download mearec data, not sure if needed as is installed with conda as well because of git-annex
     "pandas", # Don't know where this is needed
     "hdbscan",   # For sorters, probably spikingcircus
     "numba", # For sorters, probably spikingcircus

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,17 +1,10 @@
 version: 2
 
 build:
-    image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "mambaforge-4.10"
+
 
 conda:
-  environment: environment_rtd.yml
-
-# python:
-#   install:
-#     - method: pip
-#       path: .
-
-# python:
-#   version: 3.8
-#   install:
-#     - requirements: requirements_rtd.txt
+  environment: docs_rtd.yml


### PR DESCRIPTION
Couple of things that were encountered during the last release.

- Building documentation too slow, both conda and pytorch responsible I think.
- No specific requirements (as in the setup requirements) for the docs.

The big problem is that we need to use conda because of datalad. I am trying to make this better by using mamba. This complicates stuff as I don't know how to hack the read the docs configuration file to use the local branch through conda. Trying a couple of things but will probably need another pair of eyes in the documentation to see that nothing breaks.

I wish that we had the mearec files to the repo so we could get rid of datalad in a bunch of scenarios as the duo git-annex / datalad are a pain and mostly not needed outsides of testing suite for recording.