### PR TITLE
Make to_phy write templates.npy with datatype np.float64 as required by phy

### DIFF
--- a/src/spikeinterface/exporters/to_phy.py
+++ b/src/spikeinterface/exporters/to_phy.py
@@ -168,7 +168,7 @@ def export_to_phy(
     # shape (num_units, num_samples, max_num_channels)
     max_num_channels = max(len(chan_inds) for chan_inds in sparse_dict.values())
     num_samples = waveform_extractor.nbefore + waveform_extractor.nafter
-    templates = np.zeros((len(unit_ids), num_samples, max_num_channels), dtype=waveform_extractor.dtype)
+    templates = np.zeros((len(unit_ids), num_samples, max_num_channels), dtype="float64")
     # here we pad template inds with -1 if len of sparse channels is unequal
     templates_ind = -np.ones((len(unit_ids), max_num_channels), dtype="int64")
     for unit_ind, unit_id in enumerate(unit_ids):


### PR DESCRIPTION
This might fix #1627. But I'm basing this on the error trace since the user didn't respond for confirmation.

Based on the phylib library `templates.npy` needs to have a dtype of `np.float32` or `np.float64`.  See link below.
https://github.com/cortex-lab/phylib/blob/2b567cd2e2c382bd5e8926e9abd9a2f9353bfd76/phylib/io/model.py#L701C58-L701C58

Currently `templates.npy` have a dtype dependent on the `WaveformExtractor` which is not required to be `float32` or `float64` so it is possible templates won't load during Phy curation due to wrong dtype.

**Possible Strategy**
Hard coding `np.float64` makes sure templates will also work with `phylib` and is similar to the strategy used right below with `templates_ind`. (L173 in the diff)
https://github.com/SpikeInterface/spikeinterface/blob/2b82cccd4609ad88b81a0a0118f2a844c27c4f56/src/spikeinterface/exporters/to_phy.py#L173C5-L173C79

**Alternative Strategy**
Or, it could default to `np.float32`, but these are pretty small files. My examples are on the order of 100KB-20MB. So shrinking dtype for memory/storage probably not too much of a concern (compared to `pc_feat_ind.npy` which can run into the GB range).

Alternatively a check could be made which checks if the dtype is a float64 and if it is will use the `np.float64` dtype and if it is not then it just uses `np.float32`. I don't think templates would change much between 32 and 64 to be best represented, but just in case I wanted to leave this as a different option.
```python
if waveform_extractor.dtype ==np.float64:
    phy_dtype = np.float64
else:
    phy_dtype = np.float32
```