### PR TITLE
Proposal to separate timestamp extraction and frames extraction logic in neo sorting extractors

### DIFF
--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -439,7 +439,7 @@ class BaseSortingSegment(BaseSegment):
             unit_id=unit_id,
             start_frame=start_frame,
             end_frame=end_frame,
-        )
+        ).astype("int64", copy=False)
 
         if parent_sorting.has_recording():
             times = parent_sorting.get_times(segment_index=segment_index)

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -432,7 +432,7 @@ class BaseSortingSegment(BaseSegment):
 
     def get_unit_spike_times(self, unit_id, start_frame: Optional[int] = None, end_frame: Optional[int] = None):
         parent_sorting = self.parent_extractor
-        sorting_segments = parent_sorting._sorting_sorting_
+        sorting_segments = parent_sorting._sorting_segments
         segment_index = next(index for index, segment in enumerate(sorting_segments) if segment == self)
         sampling_frequency = parent_sorting.get_sampling_frequency()
         spike_frames = self.get_unit_spike_train(

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -431,18 +431,18 @@ class BaseSortingSegment(BaseSegment):
         raise NotImplementedError
 
     def get_unit_spike_times(self, unit_id, start_frame: Optional[int] = None, end_frame: Optional[int] = None):
-        parent_extractor = self.parent_extractor
-        segments = parent_extractor._recording_segments
-        segment_index = next(index for index, segment in enumerate(segments) if segment == self)
-        sampling_frequency = parent_extractor.get_sampling_frequency()
+        parent_sorting = self.parent_extractor
+        sorting_segments = parent_sorting._sorting_sorting_
+        segment_index = next(index for index, segment in enumerate(sorting_segments) if segment == self)
+        sampling_frequency = parent_sorting.get_sampling_frequency()
         spike_frames = self.get_unit_spike_train(
             unit_id=unit_id,
             start_frame=start_frame,
             end_frame=end_frame,
         )
 
-        if parent_extractor.has_recording():
-            times = parent_extractor.get_times(segment_index=segment_index)
+        if parent_sorting.has_recording():
+            times = parent_sorting.get_times(segment_index=segment_index)
             return times[spike_frames]
         else:
             t_start = self._t_start if self._t_start is not None else 0

--- a/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -589,6 +589,8 @@ class NeoSortingSegment(BaseSortingSegment):
         return unit_ids_list.index(unit_id)
 
     def get_unit_spike_train(self, unit_id, start_frame, end_frame):
+        """This method is necessary in every segment extractor."""
+
         spike_channel_index = self.map_from_unit_id_to_spike_channel_index(unit_id)
         spike_timestamps = self.neo_reader.get_spike_timestamps(
             block_index=self.block_index,
@@ -612,6 +614,35 @@ class NeoSortingSegment(BaseSortingSegment):
             spike_frames = spike_frames[spike_frames <= end_frame]
 
         return spike_frames
+
+    def get_unit_spike_times(self, unit_id, start_frame, end_frame):
+        """Useful for avoiding unecessary back and forth conversions between frames and times"""
+        spike_channel_index = self.map_from_unit_id_to_spike_channel_index[unit_id]
+
+        spike_timestamps = self.neo_reader.get_spike_timestamps(
+            block_index=self.block_index,
+            seg_index=self.segment_index,
+            spike_channel_index=spike_channel_index,
+        )
+
+        # Rescale to seconds
+        spike_timestamps = self.neo_reader.rescale_spike_timestamp(spike_timestamps, dtype="float64")
+
+        if self.neo_returns_frames:
+            spike_frames = spike_timestamps
+            t_start = 0 if self._t_start is None else self._t_start
+            spike_timestamps = t_start + spike_frames / self._sampling_frequency
+
+        # clip
+        if start_frame is not None:
+            start_time = start_frame / self._sampling_frequency
+            spike_timestamps = spike_timestamps[spike_timestamps >= start_time]
+
+        if end_frame is not None:
+            end_time = end_frame / self._sampling_frequency
+            spike_timestamps = spike_timestamps[spike_timestamps <= end_time]
+
+        return spike_timestamps
 
 
 _neo_event_dtype = np.dtype([("time", "float64"), ("duration", "float64"), ("label", "<U100")])

--- a/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -625,13 +625,13 @@ class NeoSortingSegment(BaseSortingSegment):
             spike_channel_index=spike_channel_index,
         )
 
-        # Rescale to seconds
-        # spike_timestamps = self.neo_reader.rescale_spike_timestamp(spike_timestamps, dtype="float64")
-
         if self.neo_returns_frames:
             spike_frames = spike_timestamps
             t_start = 0 if self._t_start is None else self._t_start
             spike_timestamps = t_start + spike_frames / self._sampling_frequency
+        else:
+            # Rescale to seconds
+            spike_timestamps = self.neo_reader.rescale_spike_timestamp(spike_timestamps, dtype="float64")
 
         # clip
         if start_frame is not None:

--- a/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -617,7 +617,7 @@ class NeoSortingSegment(BaseSortingSegment):
 
     def get_unit_spike_times(self, unit_id, start_frame, end_frame):
         """Useful for avoiding unecessary back and forth conversions between frames and times"""
-        spike_channel_index = self.map_from_unit_id_to_spike_channel_index[unit_id]
+        spike_channel_index = self.map_from_unit_id_to_spike_channel_index(unit_id)
 
         spike_timestamps = self.neo_reader.get_spike_timestamps(
             block_index=self.block_index,
@@ -626,7 +626,7 @@ class NeoSortingSegment(BaseSortingSegment):
         )
 
         # Rescale to seconds
-        spike_timestamps = self.neo_reader.rescale_spike_timestamp(spike_timestamps, dtype="float64")
+        # spike_timestamps = self.neo_reader.rescale_spike_timestamp(spike_timestamps, dtype="float64")
 
         if self.neo_returns_frames:
             spike_frames = spike_timestamps


### PR DESCRIPTION
Cleaner diff than #1812.

While I was discussing with @samuelgarcia  on https://github.com/SpikeInterface/spikeinterface/pull/1626 he showed concern that for some neo sorting extractors we were transforming the timestamps to frames and then back to timestamps in some scenarios (the most relevant scenarion being neuroconv). 

I told him that my first intuition was to separate the ` get_unit_spike_train` function so there will be a channel directly from the segment to the option that fetches timestamps instead of frames. @samuelgarcia mentioned that he did not like the idea of patching and that @alejoe91 had exactly the same idea that I have.

This PR is a showcase of this idea. I still don't understand fully @samuelgarcia arguments against it and I think it will be useful to discuss this with a proper diff so we can see what it entails.

This change is not large:
1 ) I implemented a `get_unit_spike_times` method for neo segments.  
2) At the BaseSorting level if there is no `get_unit_spike_times` overiding then ` get_unit_spike_train`  reverts to the old logic.  If there is a `get_unit_spike_times` such as in neo, then it uses that channel to get the timestamps. Everything else is left the same: function signature, spike frames extraction, but now there is a specific way of sending timestamps directly from segments to sorting extractor.
3) This does not change the contract. The classes still need a `get_unit_spiketrain` and that remains the core of spikeinterface sorting extractors. It just adds a way for the segments to send timestamps directly when this is needed.

I think this avoids the problem of back and forth computation that worried Sam and also will make it simpler for us in neuroconv to detect timing errors if they come from neo sorting extractor as there is a specific and independent channel that we can isolate.

What are some downsides of this idea?