### PR TITLE
Fix typo in class attribute for `NeuralynxSortingExtractor`

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/neuralynx.py
+++ b/src/spikeinterface/extractors/neoextractors/neuralynx.py
@@ -61,7 +61,7 @@ class NeuralynxSortingExtractor(NeoBaseSortingExtractor):
 
     mode = "folder"
     NeoRawIOClass = "NeuralynxRawIO"
-    neo_returns_timestamps = False
+    neo_returns_frames = True
     need_t_start_from_signal_stream = True
     name = "neuralynx"
 


### PR DESCRIPTION
As in the title. This is a mistake that was made in:

https://github.com/SpikeInterface/spikeinterface/pull/1626

It is not a bug as the default behavior is still correct but then the attribute was not working as documentation the way we intended it.