### PR TITLE
Allow relative_to with recursive=False (in-place on objects)

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -936,8 +936,8 @@ class BaseExtractor:
 
 
 def _make_paths_relative(d, relative, copy=True) -> dict:
-    relative = str(Path(relative).absolute())
-    func = lambda p: os.path.relpath(str(p), start=relative)
+    relative = Path(relative).absolute()
+    func = lambda p: os.path.relpath(p, start=relative)
     return recursive_path_modifier(d, func, target="path", copy=copy)
 
 

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -621,6 +621,8 @@ class BaseExtractor:
             If True, all dicitionaries in the kwargs are expanded with `to_dict` as well, by default False.
         """
         assert self.check_if_dumpable(), "The extractor is not dumpable to pickle"
+        if relative_to:
+            assert recursive, "When relative_to is given, recursive must be True"
         dump_dict = self.to_dict(
             include_annotations=True,
             include_properties=include_properties,
@@ -633,9 +635,7 @@ class BaseExtractor:
 
         file_path.write_bytes(pickle.dumps(dump_dict))
 
-        if relative_to:
-            # Make paths absolute again
-            dump_dict = _make_paths_absolute(dump_dict, relative_to, copy=False, skip_warning=True)
+        # we don't need to make paths absolute, because for pickle this is only available for recursive=True
 
     @staticmethod
     def load(file_path: Union[str, Path], base_folder=None) -> "BaseExtractor":

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -396,8 +396,8 @@ class BaseExtractor:
             relative_to = Path(relative_to).resolve().absolute()
             assert relative_to.is_dir(), "'relative_to' must be an existing directory"
             copy = False if dict_contains_extractors(dump_dict) else True
-            dump_dict["kwargs"] = _make_paths_relative(
-                dump_dict["kwargs"], relative_to, copy=copy, skip_warning=skip_recursive_path_modifier_warning
+            dump_dict = _make_paths_relative(
+                dump_dict, relative_to, copy=copy, skip_warning=skip_recursive_path_modifier_warning
             )
 
         if folder_metadata is not None:

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -573,7 +573,7 @@ class BaseExtractor:
         recursive: bool
             If True, all dicitionaries in the kwargs are expanded with `to_dict` as well, by default False.
         """
-        assert self.check_if_json_serializable()
+        assert self.check_if_json_serializable(), "The extractor is not json serializable"
         dump_dict = self.to_dict(
             include_annotations=True,
             include_properties=False,
@@ -614,7 +614,7 @@ class BaseExtractor:
         recursive: bool
             If True, all dicitionaries in the kwargs are expanded with `to_dict` as well, by default False.
         """
-        assert self.check_if_dumpable()
+        assert self.check_if_dumpable(), "The extractor is not dumpable to pickle"
         dump_dict = self.to_dict(
             include_annotations=True,
             include_properties=include_properties,

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -530,8 +530,8 @@ class BaseRecording(BaseRecordingSnippets):
             cached.set_probegroup(probegroup)
 
         for segment_index, rs in enumerate(self._recording_segments):
-            d = rs.get_times_kwargs()
-            time_vector = d["time_vector"]
+            time_kwargs = rs.get_times_kwargs()
+            time_vector = time_kwargs["time_vector"]
             if time_vector is not None:
                 cached._recording_segments[segment_index].time_vector = time_vector
 
@@ -559,8 +559,8 @@ class BaseRecording(BaseRecordingSnippets):
 
         # save time vector if any
         for segment_index, rs in enumerate(self._recording_segments):
-            d = rs.get_times_kwargs()
-            time_vector = d["time_vector"]
+            time_kwargs = rs.get_times_kwargs()
+            time_vector = time_kwargs["time_vector"]
             if time_vector is not None:
                 np.save(folder / f"times_cached_seg{segment_index}.npy", time_vector)
 

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -385,8 +385,8 @@ class BaseRecording(BaseRecordingSnippets):
         """
         segment_index = self._check_segment_index(segment_index)
         rs = self._recording_segments[segment_index]
-        d = rs.get_times_kwargs()
-        return d["time_vector"] is not None
+        time_kwargs = rs.get_times_kwargs()
+        return time_kwargs["time_vector"] is not None
 
     def set_times(self, times, segment_index=None, with_warning=True):
         """Set times for a recording segment.
@@ -501,8 +501,8 @@ class BaseRecording(BaseRecordingSnippets):
             # save time vector if any
             t_starts = np.zeros(self.get_num_segments(), dtype="float64") * np.nan
             for segment_index, rs in enumerate(self._recording_segments):
-                d = rs.get_times_kwargs()
-                time_vector = d["time_vector"]
+                time_kwargs = rs.get_times_kwargs()
+                time_vector = time_kwargs["time_vector"]
                 if time_vector is not None:
                     _ = zarr_root.create_dataset(
                         name=f"times_seg{segment_index}",
@@ -511,7 +511,7 @@ class BaseRecording(BaseRecordingSnippets):
                         compressor=zarr_kwargs["compressor"],
                     )
                 elif d["t_start"] is not None:
-                    t_starts[segment_index] = d["t_start"]
+                    t_starts[segment_index] = time_kwargs["t_start"]
 
             if np.any(~np.isnan(t_starts)):
                 zarr_root.create_dataset(name="t_starts", data=t_starts, compressor=None)

--- a/src/spikeinterface/core/binaryfolder.py
+++ b/src/spikeinterface/core/binaryfolder.py
@@ -33,22 +33,23 @@ class BinaryFolderRecording(BinaryRecordingExtractor):
         folder_path = Path(folder_path)
 
         with open(folder_path / "binary.json", "r") as f:
-            d = json.load(f)
+            dictionary = json.load(f)
 
-        if not d["class"].endswith(".BinaryRecordingExtractor"):
+        if not dictionary["class"].endswith(".BinaryRecordingExtractor"):
             raise ValueError("This folder is not a binary spikeinterface folder")
 
-        assert d["relative_paths"]
+        assert dictionary["relative_paths"]
 
-        d = _make_paths_absolute(d, folder_path)
+        kwargs = dictionary["kwargs"]
+        kwargs = _make_paths_absolute(kwargs, folder_path)
 
-        BinaryRecordingExtractor.__init__(self, **d["kwargs"])
+        BinaryRecordingExtractor.__init__(self, **kwargs)
 
         folder_metadata = folder_path
         self.load_metadata_from_folder(folder_metadata)
 
         self._kwargs = dict(folder_path=str(folder_path.absolute()))
-        self._bin_kwargs = d["kwargs"]
+        self._bin_kwargs = kwargs
         if "num_channels" not in self._bin_kwargs:
             assert "num_chan" in self._bin_kwargs, "Cannot find num_channels or num_chan in binary.json"
             self._bin_kwargs["num_channels"] = self._bin_kwargs["num_chan"]

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -900,7 +900,6 @@ def recursive_path_modifier(dictionary, func, target="path", copy=True, skip_tar
             else:
                 # relative_paths is protected!
                 if target in name and target not in skip_targets:
-                    print(target, name, value)
                     # paths can be str or list of str or None
                     if value is None:
                         continue

--- a/src/spikeinterface/core/npyfoldersnippets.py
+++ b/src/spikeinterface/core/npyfoldersnippets.py
@@ -34,22 +34,23 @@ class NpyFolderSnippets(NpySnippetsExtractor):
         folder_path = Path(folder_path)
 
         with open(folder_path / "npy.json", "r") as f:
-            d = json.load(f)
+            dictionary = json.load(f)
 
-        if not d["class"].endswith(".NpySnippetsExtractor"):
+        if not dictionary["class"].endswith(".NpySnippetsExtractor"):
             raise ValueError("This folder is not a binary spikeinterface folder")
 
-        assert d["relative_paths"]
+        assert dictionary["relative_paths"]
 
-        d = _make_paths_absolute(d, folder_path)
+        kwargs = dictionary["kwargs"]
+        kwargs = _make_paths_absolute(kwargs, folder_path)
 
-        NpySnippetsExtractor.__init__(self, **d["kwargs"])
+        NpySnippetsExtractor.__init__(self, **kwargs)
 
         folder_metadata = folder_path
         self.load_metadata_from_folder(folder_metadata)
 
         self._kwargs = dict(folder_path=str(folder_path.absolute()))
-        self._bin_kwargs = d["kwargs"]
+        self._bin_kwargs = kwargs
 
 
 read_npy_snippets_folder = define_function_from_class(source_class=NpyFolderSnippets, name="read_npy_snippets_folder")

--- a/src/spikeinterface/core/npzfolder.py
+++ b/src/spikeinterface/core/npzfolder.py
@@ -33,22 +33,23 @@ class NpzFolderSorting(NpzSortingExtractor):
         folder_path = Path(folder_path)
 
         with open(folder_path / "npz.json", "r") as f:
-            d = json.load(f)
+            dictionary = json.load(f)
 
-        if not d["class"].endswith(".NpzSortingExtractor"):
+        if not dictionary["class"].endswith(".NpzSortingExtractor"):
             raise ValueError("This folder is not an npz spikeinterface folder")
 
-        assert d["relative_paths"]
+        assert dictionary["relative_paths"]
 
-        d = _make_paths_absolute(d, folder_path)
+        kwargs = dictionary["kwargs"]
+        kwargs = _make_paths_absolute(kwargs, folder_path)
 
-        NpzSortingExtractor.__init__(self, **d["kwargs"])
+        NpzSortingExtractor.__init__(self, **kwargs)
 
         folder_metadata = folder_path
         self.load_metadata_from_folder(folder_metadata)
 
         self._kwargs = dict(folder_path=str(folder_path.absolute()))
-        self._npz_kwargs = d["kwargs"]
+        self._npz_kwargs = kwargs
 
 
 read_npz_folder = define_function_from_class(source_class=NpzFolderSorting, name="read_npz_folder")

--- a/src/spikeinterface/core/tests/test_base.py
+++ b/src/spikeinterface/core/tests/test_base.py
@@ -120,12 +120,15 @@ def test_relative_to(recording, tmp_path):
     recording_loaded3 = BaseExtractor.from_dict(d4, base_folder=relative_folder)
     check_recordings_equal(recording_nested, recording_loaded3, return_scaled=False)
 
+    # check that dump to json/pickle don't modify paths
+    # full_folder_path = str(recording_saved._kwargs["folder_path"])
+
 
 if __name__ == "__main__":
     recording = generate()
-    # test_check_if_dumpable(recording)
-    # test_check_if_json_serializable(recording)
-    # test_to_dict(recording)
+    test_check_if_dumpable(recording)
+    test_check_if_json_serializable(recording)
+    test_to_dict(recording)
     import tempfile
 
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/src/spikeinterface/core/tests/test_base.py
+++ b/src/spikeinterface/core/tests/test_base.py
@@ -111,6 +111,15 @@ def test_relative_to(recording, tmp_path):
     recording_loaded = BaseExtractor.from_dict(d2, base_folder=relative_folder)
     check_recordings_equal(recording_saved, recording_loaded, return_scaled=False)
 
+    # test double pass in memory
+    recording_nested = recording_saved.channel_slice(recording_saved.channel_ids)
+    d3 = recording_nested.to_dict(relative_to=relative_folder)
+    recording_loaded2 = BaseExtractor.from_dict(d3, base_folder=relative_folder)
+    check_recordings_equal(recording_nested, recording_loaded2, return_scaled=False)
+    d4 = recording_nested.to_dict(relative_to=relative_folder)
+    recording_loaded3 = BaseExtractor.from_dict(d4, base_folder=relative_folder)
+    check_recordings_equal(recording_nested, recording_loaded3, return_scaled=False)
+
 
 if __name__ == "__main__":
     recording = generate()

--- a/src/spikeinterface/core/tests/test_base.py
+++ b/src/spikeinterface/core/tests/test_base.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from spikeinterface.core.base import BaseExtractor
 from spikeinterface.core import generate_recording, concatenate_recordings
 from spikeinterface.core.core_tools import dict_contains_extractors
+from spikeinterface.core.testing import check_recordings_equal
 
 
 class DummyDictExtractor(BaseExtractor):
@@ -106,6 +107,9 @@ def test_relative_to(recording, tmp_path):
     assert (
         str((relative_folder / Path(d2["kwargs"]["folder_path"])).resolve().absolute()) == d1["kwargs"]["folder_path"]
     )
+
+    recording_loaded = BaseExtractor.from_dict(d2, base_folder=relative_folder)
+    check_recordings_equal(recording_saved, recording_loaded, return_scaled=False)
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/core/tests/test_base.py
+++ b/src/spikeinterface/core/tests/test_base.py
@@ -123,9 +123,9 @@ def test_relative_to(recording, tmp_path):
 
 if __name__ == "__main__":
     recording = generate()
-    test_check_if_dumpable(recording)
-    test_check_if_json_serializable(recording)
-    test_to_dict(recording)
+    # test_check_if_dumpable(recording)
+    # test_check_if_json_serializable(recording)
+    # test_to_dict(recording)
     import tempfile
 
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/src/spikeinterface/core/tests/test_basesorting.py
+++ b/src/spikeinterface/core/tests/test_basesorting.py
@@ -134,7 +134,7 @@ def test_npy_sorting():
     seg_nframes = [9, 5]
     rec = NumpyRecording([np.zeros((nframes, 10)) for nframes in seg_nframes], sampling_frequency=sfreq)
     # assert_raises(Exception, sorting.register_recording, rec)
-    with pytest.warns():
+    with pytest.warns(UserWarning):
         sorting.register_recording(rec)
 
     # Registering a rec with too many segments

--- a/src/spikeinterface/core/tests/test_core_tools.py
+++ b/src/spikeinterface/core/tests/test_core_tools.py
@@ -148,7 +148,7 @@ def test_write_memory_recording():
 
 def test_recursive_path_modifier():
     # this test nested depth 2 path modifier
-    d = {
+    d1 = {
         "kwargs": {
             "path": "/yep/path1",
             "recording": {
@@ -161,7 +161,7 @@ def test_recursive_path_modifier():
         }
     }
 
-    d2 = recursive_path_modifier(d, lambda p: p.replace("/yep", "/yop"))
+    d2 = recursive_path_modifier(d1, lambda p: p.replace("/yep", "/yop"))
     assert d2["kwargs"]["path"].startswith("/yop")
     assert d2["kwargs"]["recording"]["kwargs"]["path"].startswith("/yop")
 
@@ -173,5 +173,6 @@ if __name__ == "__main__":
     with tempfile.TemporaryDirectory() as tmpdirname:
         tmp_path = Path(tmpdirname)
         test_write_binary_recording(tmp_path)
-        # test_write_memory_recording()
-        # test_recursive_path_modifier()
+        test_write_memory_recording()
+        test_recursive_path_modifier()
+    test_recursive_path_modifier()

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -921,10 +921,12 @@ class WaveformExtractor:
             zarr_root.attrs["params"] = check_json(self._params)
             if self.has_recording():
                 if self.recording.check_if_json_serializable():
-                    rec_dict = self.recording.to_dict(relative_to=relative_to)
+                    # use recursive True to avoid modifying objects in place
+                    rec_dict = self.recording.to_dict(relative_to=relative_to, recursive=True)
                     zarr_root.attrs["recording"] = check_json(rec_dict)
             if self.sorting.check_if_json_serializable():
-                sort_dict = self.sorting.to_dict(relative_to=relative_to)
+                # use recursive True to avoid modifying objects in place
+                sort_dict = self.sorting.to_dict(relative_to=relative_to, recursive=True)
                 zarr_root.attrs["sorting"] = check_json(sort_dict)
             else:
                 warn(

--- a/src/spikeinterface/preprocessing/motion.py
+++ b/src/spikeinterface/preprocessing/motion.py
@@ -331,7 +331,8 @@ def correct_motion(
         )
         (folder / "parameters.json").write_text(json.dumps(parameters, indent=4, cls=SIJsonEncoder), encoding="utf8")
         (folder / "run_times.json").write_text(json.dumps(run_times, indent=4), encoding="utf8")
-        recording.dump_to_json(folder / "recording.json")
+        if recording.check_if_json_serializable():
+            recording.dump_to_json(folder / "recording.json")
 
         np.save(folder / "peaks.npy", peaks)
         np.save(folder / "peak_locations.npy", peak_locations)

--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -385,8 +385,9 @@ def run_sorter_container(
     parent_folder = output_folder.parent.absolute().resolve()
     parent_folder.mkdir(parents=True, exist_ok=True)
 
-    # find input folder of recording for folder bind
+    # here we need recursive True because we need a copy of the dict to be saved to JSON
     rec_dict = recording.to_dict(recursive=True)
+    # find input folder of recording for folder bind
     recording_input_folders = find_recording_folders(rec_dict)
 
     if platform.system() == "Windows":

--- a/src/spikeinterface/sorters/tests/test_launcher.py
+++ b/src/spikeinterface/sorters/tests/test_launcher.py
@@ -245,9 +245,9 @@ if __name__ == "__main__":
     # pass
     # test_run_sorters_with_list()
 
-    # test_run_sorter_by_property()
+    test_run_sorter_by_property()
 
-    test_run_sorters_with_dict()
+    # test_run_sorters_with_dict()
 
     # test_run_sorters_joblib()
 


### PR DESCRIPTION
Might fix #1819 

For very long chains, dumping with `recursive=True` is a performance killer. However, that was required to make paths relative.
This PRs refactors completely the `recursive_path_finder` function to allow to modify the paths _in place_ on `BaseExtractor` objects. Note that this is only possible if `copy=False` and it raises an exception if `copy=True` 

See: https://github.com/alejoe91/spikeinterface/blob/non-recursive-relative-paths/src/spikeinterface/core/core_tools.py#L825-L896

- Also added a helper function `dict_contains_extractor` to check the "status" of a dictionary.
- Removed a bunch of `d = ` that do not play well with debugger..

@DradeAW can you test this?

