### PR TITLE
Handle probe when load_sync_channel=True for SpikeGLX and OpenEphys

### DIFF
--- a/src/spikeinterface/core/baserecordingsnippets.py
+++ b/src/spikeinterface/core/baserecordingsnippets.py
@@ -147,7 +147,7 @@ class BaseRecordingSnippets(BaseExtractor):
         if number_of_device_channel_indices >= self.get_num_channels():
             error_msg = (
                 f"The given Probe have 'device_channel_indices' that do not match channel count \n"
-                f"{number_of_device_channel_indices} vs {self.get_num_channels()} \n"
+                f"{number_of_device_channel_indices + 1} vs {self.get_num_channels()} \n"
                 f"device_channel_indices are the following: {device_channel_indices} \n"
                 f"recording channels are the following: {self.get_channel_ids()} \n"
             )


### PR DESCRIPTION
Fixes #1826

Unifies the behavior of `load_sync_channel` between Open Ephys and SpikeGLX:

In case `load_sync_channel=True`, a probe group with an additional dummy 1-channel probe for the sync channel is set. @samuelgarcia note that previously spikeglx was just skipping probe loading.

@neuronzoo could you test this on the Open Ephys dataset? It would also be great if you could record and share with us a very short (<0.5s) dataset with sync channel on so we can use it for testing!