### PR TITLE
Fixed `numba.jit` and `binary num_chan` warnings

### DIFF
--- a/src/spikeinterface/comparison/tests/test_groundtruthstudy.py
+++ b/src/spikeinterface/comparison/tests/test_groundtruthstudy.py
@@ -1,3 +1,4 @@
+import importlib
 import shutil
 import pytest
 from pathlib import Path
@@ -33,6 +34,7 @@ def _setup_comparison_study():
     study = GroundTruthStudy.create(study_folder, gt_dict)
 
 
+@pytest.mark.skipif(importlib.util.find_spec("tridesclous") is None, reason="Test requires Python package 'tridesclous'")
 def test_run_study_sorters():
     study = GroundTruthStudy(study_folder)
     sorter_list = [
@@ -45,6 +47,7 @@ def test_run_study_sorters():
     study.run_sorters(sorter_list)
 
 
+@pytest.mark.skipif(importlib.util.find_spec("tridesclous") is None, reason="Test requires Python package 'tridesclous'")
 def test_extract_sortings():
     study = GroundTruthStudy(study_folder)
 

--- a/src/spikeinterface/comparison/tests/test_groundtruthstudy.py
+++ b/src/spikeinterface/comparison/tests/test_groundtruthstudy.py
@@ -7,6 +7,13 @@ from spikeinterface.extractors import toy_example
 from spikeinterface.sorters import installed_sorters
 from spikeinterface.comparison import GroundTruthStudy
 
+try:
+    import tridesclous
+
+    HAVE_TDC = True
+except ImportError:
+    HAVE_TDC = False
+
 
 if hasattr(pytest, "global_test_folder"):
     cache_folder = pytest.global_test_folder / "comparison"
@@ -34,9 +41,7 @@ def _setup_comparison_study():
     study = GroundTruthStudy.create(study_folder, gt_dict)
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("tridesclous") is None, reason="Test requires Python package 'tridesclous'"
-)
+@pytest.mark.skipif(not HAVE_TDC, reason="Test requires Python package 'tridesclous'")
 def test_run_study_sorters():
     study = GroundTruthStudy(study_folder)
     sorter_list = [
@@ -49,9 +54,7 @@ def test_run_study_sorters():
     study.run_sorters(sorter_list)
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("tridesclous") is None, reason="Test requires Python package 'tridesclous'"
-)
+@pytest.mark.skipif(not HAVE_TDC, reason="Test requires Python package 'tridesclous'")
 def test_extract_sortings():
     study = GroundTruthStudy(study_folder)
 

--- a/src/spikeinterface/comparison/tests/test_groundtruthstudy.py
+++ b/src/spikeinterface/comparison/tests/test_groundtruthstudy.py
@@ -34,7 +34,9 @@ def _setup_comparison_study():
     study = GroundTruthStudy.create(study_folder, gt_dict)
 
 
-@pytest.mark.skipif(importlib.util.find_spec("tridesclous") is None, reason="Test requires Python package 'tridesclous'")
+@pytest.mark.skipif(
+    importlib.util.find_spec("tridesclous") is None, reason="Test requires Python package 'tridesclous'"
+)
 def test_run_study_sorters():
     study = GroundTruthStudy(study_folder)
     sorter_list = [
@@ -47,7 +49,9 @@ def test_run_study_sorters():
     study.run_sorters(sorter_list)
 
 
-@pytest.mark.skipif(importlib.util.find_spec("tridesclous") is None, reason="Test requires Python package 'tridesclous'")
+@pytest.mark.skipif(
+    importlib.util.find_spec("tridesclous") is None, reason="Test requires Python package 'tridesclous'"
+)
 def test_extract_sortings():
     study = GroundTruthStudy(study_folder)
 

--- a/src/spikeinterface/core/tests/test_core_tools.py
+++ b/src/spikeinterface/core/tests/test_core_tools.py
@@ -35,7 +35,7 @@ def test_write_binary_recording(tmp_path):
 
     # Check if written data matches original data
     recorder_binary = BinaryRecordingExtractor(
-        file_paths=file_paths, sampling_frequency=sampling_frequency, num_chan=num_channels, dtype=dtype
+        file_paths=file_paths, sampling_frequency=sampling_frequency, num_channels=num_channels, dtype=dtype
     )
     assert np.allclose(recorder_binary.get_traces(), recording.get_traces())
 
@@ -62,7 +62,7 @@ def test_write_binary_recording_offset(tmp_path):
     recorder_binary = BinaryRecordingExtractor(
         file_paths=file_paths,
         sampling_frequency=sampling_frequency,
-        num_chan=num_channels,
+        num_channels=num_channels,
         dtype=dtype,
         file_offset=byte_offset,
     )
@@ -91,7 +91,7 @@ def test_write_binary_recording_parallel(tmp_path):
 
     # Check if written data matches original data
     recorder_binary = BinaryRecordingExtractor(
-        file_paths=file_paths, sampling_frequency=sampling_frequency, num_chan=num_channels, dtype=dtype
+        file_paths=file_paths, sampling_frequency=sampling_frequency, num_channels=num_channels, dtype=dtype
     )
     for segment_index in range(recording.get_num_segments()):
         binary_traces = recorder_binary.get_traces(segment_index=segment_index)
@@ -118,7 +118,7 @@ def test_write_binary_recording_multiple_segment(tmp_path):
 
     # Check if written data matches original data
     recorder_binary = BinaryRecordingExtractor(
-        file_paths=file_paths, sampling_frequency=sampling_frequency, num_chan=num_channels, dtype=dtype
+        file_paths=file_paths, sampling_frequency=sampling_frequency, num_channels=num_channels, dtype=dtype
     )
 
     for segment_index in range(recording.get_num_segments()):

--- a/src/spikeinterface/sortingcomponents/clustering/sliding_nn.py
+++ b/src/spikeinterface/sortingcomponents/clustering/sliding_nn.py
@@ -367,7 +367,7 @@ class SlidingNNClustering:
 
 if HAVE_NUMBA:
 
-    @numba.jit(fastmath=True, cache=True)
+    @numba.jit(nopython=True, fastmath=True, cache=True)
     def sparse_euclidean(x, y, n_samples, n_dense):
         """Euclidean distance metric over sparse vectors, where first n_dense
         elements are indices, and n_samples is the length of the second dimension

--- a/src/spikeinterface/sortingcomponents/peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/peak_detection.py
@@ -640,7 +640,7 @@ class DetectPeakLocallyExclusiveTorch(PeakDetectorWrapper):
 
 if HAVE_NUMBA:
 
-    @numba.jit(parallel=False)
+    @numba.jit(nopython=True, parallel=False)
     def _numba_detect_peak_pos(
         traces, traces_center, peak_mask, exclude_sweep_size, abs_threholds, peak_sign, neighbours_mask
     ):
@@ -665,7 +665,7 @@ if HAVE_NUMBA:
                         break
         return peak_mask
 
-    @numba.jit(parallel=False)
+    @numba.jit(nopython=True, parallel=False)
     def _numba_detect_peak_neg(
         traces, traces_center, peak_mask, exclude_sweep_size, abs_threholds, peak_sign, neighbours_mask
     ):


### PR DESCRIPTION
The `numba` warnings came from the fact that `nopython` default behaviour will change in the future with numba 0.59.
Setting `nopython=True` solves this problem.

Also changed a couple `num_chan` to `num_channels` since this is the new name.