### PR TITLE
Fix Mearec handling of new arguments before neo release 0.13

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/mearec.py
+++ b/src/spikeinterface/extractors/neoextractors/mearec.py
@@ -8,7 +8,7 @@ import probeinterface as pi
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
 
 
-def drop_neo_arguments_before_version_0_13_0(neo_kwargs):
+def drop_invalid_neo_arguments_before_version_0_13_0(neo_kwargs):
     # Temporary function until neo version 0.13.0 is released
     from packaging.version import parse as parse_version
     from importlib.metadata import version
@@ -68,8 +68,7 @@ class MEArecRecordingExtractor(NeoBaseRecordingExtractor):
             "load_spiketrains": False,
             "load_analogsignal": True,
         }
-        # The possibility of loading only spike_trains or only analog_signals will be added in neo version 0.12.0
-        neo_kwargs = drop_neo_arguments_before_version_0_13_0(neo_kwargs=neo_kwargs)
+        neo_kwargs = drop_invalid_neo_arguments_before_version_0_13_0(neo_kwargs=neo_kwargs)
         return neo_kwargs
 
 
@@ -94,8 +93,7 @@ class MEArecSortingExtractor(NeoBaseSortingExtractor):
             "load_spiketrains": True,
             "load_analogsignal": False,
         }
-        # The possibility of loading only spike_trains or only analog_signals will be added in neo version 0.12.0
-        neo_kwargs = drop_neo_arguments_before_version_0_13_0(neo_kwargs=neo_kwargs)
+        neo_kwargs = drop_invalid_neo_arguments_before_version_0_13_0(neo_kwargs=neo_kwargs)
 
         return neo_kwargs
 

--- a/src/spikeinterface/extractors/neoextractors/mearec.py
+++ b/src/spikeinterface/extractors/neoextractors/mearec.py
@@ -8,8 +8,8 @@ import probeinterface as pi
 from .neobaseextractor import NeoBaseRecordingExtractor, NeoBaseSortingExtractor
 
 
-def drop_neo_arguments_in_version_0_11_0(neo_kwargs):
-    # Temporary function until neo version 0.12.0 is released
+def drop_neo_arguments_before_version_0_13_0(neo_kwargs):
+    # Temporary function until neo version 0.13.0 is released
     from packaging.version import parse as parse_version
     from importlib.metadata import version
 
@@ -17,7 +17,7 @@ def drop_neo_arguments_in_version_0_11_0(neo_kwargs):
     minor_version = parse_version(neo_version).minor
 
     # The possibility of loading only spike_trains or only analog_signals is not present in neo <= 0.11.0
-    if minor_version < 12:
+    if minor_version < 13:
         neo_kwargs.pop("load_spiketrains")
         neo_kwargs.pop("load_analogsignal")
 
@@ -69,7 +69,7 @@ class MEArecRecordingExtractor(NeoBaseRecordingExtractor):
             "load_analogsignal": True,
         }
         # The possibility of loading only spike_trains or only analog_signals will be added in neo version 0.12.0
-        neo_kwargs = drop_neo_arguments_in_version_0_11_0(neo_kwargs=neo_kwargs)
+        neo_kwargs = drop_neo_arguments_before_version_0_13_0(neo_kwargs=neo_kwargs)
         return neo_kwargs
 
 
@@ -95,7 +95,7 @@ class MEArecSortingExtractor(NeoBaseSortingExtractor):
             "load_analogsignal": False,
         }
         # The possibility of loading only spike_trains or only analog_signals will be added in neo version 0.12.0
-        neo_kwargs = drop_neo_arguments_in_version_0_11_0(neo_kwargs=neo_kwargs)
+        neo_kwargs = drop_neo_arguments_before_version_0_13_0(neo_kwargs=neo_kwargs)
 
         return neo_kwargs
 


### PR DESCRIPTION
This is a mistake that I made out of ignorance.

I did this PR here:
https://github.com/SpikeInterface/spikeinterface/pull/1835

Which assumes that the changes here would be available in neo version 0.12. At time I did not know that neo version 0.12 was already out as I did not see the tags in github (it is only in pipy). 

But the changes here are not in neo version 0.12 but will come online in the yet to be 0.13:
https://github.com/NeuralEnsemble/python-neo/pull/1258

This PR fixes this here in dev but **I am afraid that the current release mearec is broken.**  The current release is fixed to neo >= 0.12:

https://github.com/SpikeInterface/spikeinterface/commit/c43295d6d6e8a63d124dbfafb17b1937ce4a168e

But this means that lines that I am modifying here will fail (it will assume that a keyword argument that exists does not).

I am wondering why this did not break the release tests. Maybe there is something wrong with them?