### PR TITLE
Drop figurl-jupyter dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ widgets = [
     "ipympl",
     "ipywidgets",
     "sortingview>=0.11.15",
-    "figurl-jupyter"
 ]
 
 test_core = [

--- a/src/spikeinterface/widgets/sortingview/base_sortingview.py
+++ b/src/spikeinterface/widgets/sortingview/base_sortingview.py
@@ -43,8 +43,9 @@ class SortingviewPlotter(BackendPlotter):
 
     def handle_display_and_url(self, view, **backend_kwargs):
         self.set_view(view)
-        if self.is_notebook() and backend_kwargs["display"]:
-            display(self.view.jupyter(height=backend_kwargs["height"]))
+        # figurl_jupyter is broken. Comment it out for now.
+        # if self.is_notebook() and backend_kwargs["display"]:
+        #     display(self.view.jupyter(height=backend_kwargs["height"]))
         if backend_kwargs["generate_url"]:
             figlabel = backend_kwargs.get("figlabel")
             if figlabel is None:


### PR DESCRIPTION
The current verison of figurl-jupyter is broken.

Let's remove the functionality for now, since it's unclear if it will be maintained.

See: https://github.com/flatironinstitute/kachery-cloud/issues/22

FYI @samuelgarcia 