### PR TITLE
Treat pyproject-toml changed as core change

### DIFF
--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -66,6 +66,10 @@ jobs:
         id: modules-changed
         run: |
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            if [[ $file == *"pyproject.toml" ]]; then
+              echo "pyproject.toml changed"
+              echo "CORE_CHANGED=true" >> $GITHUB_OUTPUT
+            fi
             if [[ $file == *"/core/"* || $file == *"/extractors/neoextractors/neobaseextractor.py" ]]; then
               echo "Core changed"
               echo "CORE_CHANGED=true" >> $GITHUB_OUTPUT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Operating System :: OS Independent"
 ]
 
+
 dependencies = [
     "numpy",
     "neo>=0.12.0",


### PR DESCRIPTION
Related to #1854

@h-mayorquin another (easier) option is to keep the publish to pypi as is and treat a change in `pyproject.toml` as a core change.

The `prepare-release` branch, with the updated version, will therefore trigger full tests before release, so we can correct any errors prior to tagging.

I think this is a better option than #1854 (and @samuelgarcia too). What do you think?
