### PR TITLE
Eliminate restore keys in CI and simplify installation of dev version dependencies

### DIFF
--- a/.github/actions/build-test-environment/action.yml
+++ b/.github/actions/build-test-environment/action.yml
@@ -24,18 +24,14 @@ runs:
         pip install -e .[test,extractors,full]
       shell: bash
     - name: Force installation of latest dev from key-packages when running dev (not release)
-      id: version
       run: |
-        source ${{ github.workspace }}/test_env/bin/activate
-        if python ./.github/is_spikeinterface_dev.py; then
+        spikeinterface_is_dev_version=$(python -c "import importlib.metadata; package_name = 'spikeinterface'; version = importlib.metadata.version(package_name); print(version.endswith('dev0'))")
+        if [ $spikeinterface_is_dev_version = "True" ]; then
           echo "Running spikeinterface dev version"
-          pip uninstall -y neo
-          pip uninstall -y probeinterface
-          pip install git+https://github.com/NeuralEnsemble/python-neo
-          pip install git+https://github.com/SpikeInterface/probeinterface
-        else
-          echo "Running tests for release"
+          pip install --no-cache-dir git+https://github.com/NeuralEnsemble/python-neo
+          pip install --no-cache-dir git+https://github.com/SpikeInterface/probeinterface
         fi
+          echo "Running tests for release, using pyproject.toml versions of neo and probeinterface"
       shell: bash
     - name: git-annex install
       run: |

--- a/.github/actions/build-test-environment/action.yml
+++ b/.github/actions/build-test-environment/action.yml
@@ -25,7 +25,8 @@ runs:
       shell: bash
     - name: Force installation of latest dev from key-packages when running dev (not release)
       run: |
-        spikeinterface_is_dev_version=$(python -c "import importlib.metadata; package_name = 'spikeinterface'; version = importlib.metadata.version(package_name); print(version.endswith('dev0'))")
+        source ${{ github.workspace }}/test_env/bin/activate
+        spikeinterface_is_dev_version=$(python -c "import importlib.metadata; version = importlib.metadata.version('spikeinterface'); print(version.endswith('dev0'))")
         if [ $spikeinterface_is_dev_version = "True" ]; then
           echo "Running spikeinterface dev version"
           pip install --no-cache-dir git+https://github.com/NeuralEnsemble/python-neo

--- a/.github/is_spikeinterface_dev.py
+++ b/.github/is_spikeinterface_dev.py
@@ -1,6 +1,0 @@
-import importlib.metadata
-
-package_name = "spikeinterface"
-version = importlib.metadata.version(package_name)
-if version.endswith("dev0"):
-    print(True)

--- a/.github/workflows/full-test-with-codecov.yml
+++ b/.github/workflows/full-test-with-codecov.yml
@@ -32,8 +32,6 @@ jobs:
         with:
           path: ${{ github.workspace }}/test_env
           key: ${{ runner.os }}-venv-${{ hashFiles('**/pyproject.toml') }}-${{ steps.date.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-venv-
       - name: Get ephy_testing_data current head hash
         # the key depends on the last comit repo https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git
         id: vars
@@ -48,8 +46,6 @@ jobs:
         with:
           path: ~/spikeinterface_datasets
           key: ${{ runner.os }}-datasets-${{ steps.vars.outputs.HASH_EPHY_DATASET }}
-          restore-keys: |
-            ${{ runner.os }}-datasets
       - name: Install packages
         uses: ./.github/actions/build-test-environment
       - name: Shows installed packages by pip, git-annex and cached testing files

--- a/.github/workflows/full-test-with-codecov.yml
+++ b/.github/workflows/full-test-with-codecov.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           path: ~/spikeinterface_datasets
           key: ${{ runner.os }}-datasets-${{ steps.vars.outputs.HASH_EPHY_DATASET }}
+          restore-keys: ${{ runner.os }}-datasets
       - name: Install packages
         uses: ./.github/actions/build-test-environment
       - name: Shows installed packages by pip, git-annex and cached testing files

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           path: ~/spikeinterface_datasets
           key: ${{ runner.os }}-datasets-${{ steps.vars.outputs.HASH_EPHY_DATASET }}
+          restore-keys: ${{ runner.os }}-datasets
       - name: Install packages
         uses: ./.github/actions/build-test-environment
       - name: Shows installed packages by pip, git-annex and cached testing files

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -37,8 +37,6 @@ jobs:
         with:
           path: ${{ github.workspace }}/test_env
           key: ${{ runner.os }}-venv-${{ hashFiles('**/pyproject.toml') }}-${{ steps.date.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-venv-
       - name: Get ephy_testing_data current head hash
         # the key depends on the last comit repo https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git
         id: vars
@@ -53,8 +51,6 @@ jobs:
         with:
           path: ~/spikeinterface_datasets
           key: ${{ runner.os }}-datasets-${{ steps.vars.outputs.HASH_EPHY_DATASET }}
-          restore-keys: |
-            ${{ runner.os }}-datasets
       - name: Install packages
         uses: ./.github/actions/build-test-environment
       - name: Shows installed packages by pip, git-annex and cached testing files


### PR DESCRIPTION
Two things:
1) As discussed, the cache mechanism of restoring the close keys will get in the way to run the correct dependencies during release.
2) I simplified a bit the installation of dev version dependencies when testing dev versions.