### PR TITLE
For the cronjob, avoid re-downloading the cache dataset if present

### DIFF
--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           path: ~/spikeinterface_datasets
           key: ${{ runner.os }}-datasets-${{ steps.repo_hash.outputs.dataset_hash }}
+          lookup-only: 'true'
       - name: Cache found?
         run: echo "Cache-hit == ${{steps.cache-datasets.outputs.cache-hit == 'true'}}"
       - name: Installing datalad and git-annex
@@ -89,7 +90,7 @@ jobs:
         run: |
           cd $HOME
           pwd
-          du -hs spikeinterface_datasets
+          du -hs spikeinterface_datasets  # Should show the size of ephy_testing_data
           cd spikeinterface_datasets
           pwd
           ls -lh  # Should show ephy_testing_data

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/test_env
           key: ${{ runner.os }}-venv-${{ steps.dependencies.outputs.hash }}-${{ steps.date.outputs.date }}
-          lookup-only: 'true'
+          lookup-only: 'true'   # Avoids downloading the data, saving behavior is not affected.
       - name: Cache found?
         run: echo "Cache-hit == ${{steps.cache-venv.outputs.cache-hit == 'true'}}"
       - name: Create the virtual environment to be cached

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           path: ~/spikeinterface_datasets
           key: ${{ runner.os }}-datasets-${{ steps.repo_hash.outputs.dataset_hash }}
-          lookup-only: 'true'
+          lookup-only: 'true'   # Avoids downloading the data, saving behavior is not affected.
       - name: Cache found?
         run: echo "Cache-hit == ${{steps.cache-datasets.outputs.cache-hit == 'true'}}"
       - name: Installing datalad and git-annex

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/test_env
           key: ${{ runner.os }}-venv-${{ steps.dependencies.outputs.hash }}-${{ steps.date.outputs.date }}
+          lookup-only: 'true'
       - name: Cache found?
         run: echo "Cache-hit == ${{steps.cache-venv.outputs.cache-hit == 'true'}}"
       - name: Create the virtual environment to be cached


### PR DESCRIPTION
There is a new option in the cache machinery that allows for only checking if the cache is available and not downloading it:

https://github.com/actions/cache#inputs

This will save some unecessary computation and bandwith use and as an important side effect make @samuelgarcia happier.

This is used in the daily cron job to checks if it is necessary to create new caches for both the gin data and pip dependencies.