### PR TITLE
Addition of a peak centerer to align peaks correctly

### DIFF
--- a/src/spikeinterface/postprocessing/spike_locations.py
+++ b/src/spikeinterface/postprocessing/spike_locations.py
@@ -19,11 +19,11 @@ class SpikeLocationsCalculator(BaseWaveformExtractorExtension):
 
     extension_name = "spike_locations"
 
-    def __init__(self, waveform_extractor, peak_sign='neg'):
+    def __init__(self, waveform_extractor, peak_sign="neg"):
         BaseWaveformExtractorExtension.__init__(self, waveform_extractor)
         extremum_channel_inds = get_template_extremum_channel(self.waveform_extractor, peak_sign, outputs="index")
         self.spikes = self.waveform_extractor.sorting.to_spike_vector(extremum_channel_inds=extremum_channel_inds)
-        
+
     def _set_params(self, ms_before=0.5, ms_after=0.5, method="center_of_mass", method_kwargs={}, radius_um=None):
         params = dict(ms_before=ms_before, ms_after=ms_after, method=method, radius_um=radius_um)
         params.update(**method_kwargs)
@@ -102,7 +102,7 @@ def compute_spike_locations(
     method="center_of_mass",
     method_kwargs={},
     outputs="concatenated",
-    peak_sign='neg',
+    peak_sign="neg",
     radius_um=None,
     **job_kwargs,
 ):
@@ -143,7 +143,9 @@ def compute_spike_locations(
         slc = waveform_extractor.load_extension(SpikeLocationsCalculator.extension_name)
     else:
         slc = SpikeLocationsCalculator(waveform_extractor, peak_sign)
-        slc.set_params(ms_before=ms_before, ms_after=ms_after, method=method, method_kwargs=method_kwargs, radius_um=radius_um)
+        slc.set_params(
+            ms_before=ms_before, ms_after=ms_after, method=method, method_kwargs=method_kwargs, radius_um=radius_um
+        )
         slc.run(**job_kwargs)
 
     locs = slc.get_data(outputs=outputs)

--- a/src/spikeinterface/sortingcomponents/peak_localization.py
+++ b/src/spikeinterface/sortingcomponents/peak_localization.py
@@ -6,6 +6,7 @@ from .peak_pipeline import (
     run_node_pipeline,
     find_parent_of_type,
     PeakRetriever,
+    PeakCenterer,
     PipelineNode,
     WaveformsNode,
     ExtractDenseWaveforms,
@@ -26,7 +27,7 @@ from ..postprocessing.unit_localization import (
 from .tools import get_prototype_spike
 
 
-def localize_peaks(recording, peaks, method="center_of_mass", ms_before=0.5, ms_after=0.5, **kwargs):
+def localize_peaks(recording, peaks, method="center_of_mass", ms_before=0.5, ms_after=0.5, radius_um=None, **kwargs):
     """Localize peak (spike) in 2D or 3D depending the method.
 
     When a probe is 2D then:
@@ -40,6 +41,9 @@ def localize_peaks(recording, peaks, method="center_of_mass", ms_before=0.5, ms_
         The recording extractor object.
     peaks: array
         Peaks array, as returned by detect_peaks() in "compact_numpy" way.
+    radius_um: float (default None)
+        If not None, the radius used to perform peak centering, i.e. find the real channel where
+        the peaks actually occur
 
     {method_doc}
 
@@ -57,7 +61,11 @@ def localize_peaks(recording, peaks, method="center_of_mass", ms_before=0.5, ms_
 
     method_kwargs, job_kwargs = split_job_kwargs(kwargs)
 
-    peak_retriever = PeakRetriever(recording, peaks)
+    if radius_um is not None:
+        peak_retriever = PeakCenterer(recording, peaks, radius_um=radius_um)
+    else:
+        peak_retriever = PeakRetriever(recording, peaks)
+
     if method == "center_of_mass":
         extract_dense_waveforms = ExtractDenseWaveforms(
             recording, parents=[peak_retriever], ms_before=ms_before, ms_after=ms_after, return_output=False

--- a/src/spikeinterface/sortingcomponents/peak_pipeline.py
+++ b/src/spikeinterface/sortingcomponents/peak_pipeline.py
@@ -127,8 +127,7 @@ class PeakRetriever(PipelineNode):
 
 
 class PeakCenterer(PeakRetriever):
-
-    def __init__(self, recording, peaks, radius_um=50, peak_sign='neg'):
+    def __init__(self, recording, peaks, radius_um=50, peak_sign="neg"):
         PeakRetriever.__init__(self, recording, peaks)
         self.radius_um = radius_um
         self.contact_locations = recording.get_channel_locations()
@@ -153,18 +152,19 @@ class PeakCenterer(PeakRetriever):
         # make sample index local to traces
         local_peaks = local_peaks.copy()
         local_peaks["sample_index"] -= start_frame - max_margin
-        
+
         for i, peak in enumerate(local_peaks):
             (chans,) = np.nonzero(self.neighbours_mask[peak["channel_index"]])
             sparse_wfs = traces[peak["sample_index"], chans]
-            if self.peak_sign == 'neg':
-                local_peaks[i]['channel_index'] = chans[np.argmin(sparse_wfs)]
-            elif self.peak_sign == 'pos':
-                local_peaks[i]['channel_index'] = chans[np.argmax(sparse_wfs)]
-            elif self.peak_sign == 'both':
-                local_peaks[i]['channel_index'] = chans[np.argmax(np.abs(sparse_wfs))]
-    
+            if self.peak_sign == "neg":
+                local_peaks[i]["channel_index"] = chans[np.argmin(sparse_wfs)]
+            elif self.peak_sign == "pos":
+                local_peaks[i]["channel_index"] = chans[np.argmax(sparse_wfs)]
+            elif self.peak_sign == "both":
+                local_peaks[i]["channel_index"] = chans[np.argmax(np.abs(sparse_wfs))]
+
         return (local_peaks,)
+
 
 class WaveformsNode(PipelineNode):
     """
@@ -345,7 +345,9 @@ def check_graph(nodes):
 
     node0 = nodes[0]
     if not (isinstance(node0, PeakDetector) or isinstance(node0, PeakRetriever) or isinstance(node0, PeakCenterer)):
-        raise ValueError("Peak pipeline graph must contain PeakDetector or PeakRetriever or PeakCenterer as first element")
+        raise ValueError(
+            "Peak pipeline graph must contain PeakDetector or PeakRetriever or PeakCenterer as first element"
+        )
 
     for i, node in enumerate(nodes):
         assert isinstance(node, PipelineNode), f"Node {node} is not an instance of PipelineNode"


### PR DESCRIPTION
Creation of a PeakCenterer object to be used in localize() and compute_spike_locations(). In fact, after a sorting, using the channel of the extrememum of the template as a reference channel hides the noise due to peak detection, and the fact that peaks might be sometimes off-centered. The PeakCenterer compensates for that. Using a given radius, for each peak, it will look for the channel where the extremum is obtained to accuretly reflect what happened during the peak detection