### PR TITLE
Force original_end_frame >= original_start_frame in tracepad

### DIFF
--- a/src/spikeinterface/preprocessing/zero_channel_pad.py
+++ b/src/spikeinterface/preprocessing/zero_channel_pad.py
@@ -119,6 +119,9 @@ class TracePaddedRecordingSegment(BasePreprocessorSegment):
         """
         original_start_frame = max(start_frame - self.padding_start, 0)
         original_end_frame = min(end_frame - self.padding_start, self.num_samples_in_original_segment)
+        original_end_frame = max(
+            original_end_frame, original_start_frame
+        )  # Avoid negative dimensions errors downstream
         original_traces = self.parent_recording_segment.get_traces(
             start_frame=original_start_frame,
             end_frame=original_end_frame,


### PR DESCRIPTION
Avoids this error in phase_shift (and possibly other places)

```
  File "/home/tbugnon/projects/shared_sortings/spikeinterface/src/spikeinterface/preprocessing/phase_shift.py", line 87, in get_traces
    traces_chunk, left_margin, right_margin = get_chunk_with_margin(
  File "/home/tbugnon/projects/shared_sortings/spikeinterface/src/spikeinterface/core/recording_tools.py", line 280, in get_chunk_with_margin
    traces_chunk2 = np.zeros((full_size, traces_chunk.shape[1]), dtype=dtype)
ValueError: negative dimensions are not allowed
```