### PR TITLE
Add missing tic in ks*_master when skipping prepro

### DIFF
--- a/src/spikeinterface/sorters/external/kilosort2_5_master.m
+++ b/src/spikeinterface/sorters/external/kilosort2_5_master.m
@@ -62,6 +62,7 @@ function kilosort2_5_master(fpath, kilosortPath)
             rez.ops.Nbatch = Nbatch;
             rez.ops.NTbuff = NTbuff;
 
+            tic;  % tocs are coming
 
         else
             % preprocess data to create temp_wh.dat

--- a/src/spikeinterface/sorters/external/kilosort2_master.m
+++ b/src/spikeinterface/sorters/external/kilosort2_master.m
@@ -62,6 +62,7 @@ function kilosort2_master(fpath, kilosortPath)
             rez.ops.Nbatch = Nbatch;
             rez.ops.NTbuff = NTbuff;
 
+            tic;  % tocs are coming
 
         else
             % preprocess data to create temp_wh.dat

--- a/src/spikeinterface/sorters/external/kilosort3_master.m
+++ b/src/spikeinterface/sorters/external/kilosort3_master.m
@@ -62,6 +62,7 @@ function kilosort3_master(fpath, kilosortPath)
             rez.ops.Nbatch = Nbatch;
             rez.ops.NTbuff = NTbuff;
 
+            tic;  % tocs are coming
 
         else
             % preprocess data to create temp_wh.dat


### PR DESCRIPTION
Avoids `error using toc` in datashift2 

![image](https://github.com/SpikeInterface/spikeinterface/assets/14128078/7ff80388-13c7-461e-b7b2-6cfd136d3d42)
