### PR TITLE
Change the signature on kilosort's delete intermediate files parameters.

### DIFF
--- a/src/spikeinterface/sorters/external/kilosort.py
+++ b/src/spikeinterface/sorters/external/kilosort.py
@@ -56,7 +56,7 @@ class KilosortSorter(KilosortBase, BaseSorter):
         "NT": "Batch size (if None it is automatically computed)",
         "wave_length": "size of the waveform extracted around each detected peak, (Default 61, maximum 81)",
         "delete_intermediate_files": "Delete intermediate files created during sorting. Tuple indicating the "
-                                     "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')"
+        "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')",
     }
 
     sorter_description = """Kilosort is a GPU-accelerated and efficient template-matching spike sorter.

--- a/src/spikeinterface/sorters/external/kilosort.py
+++ b/src/spikeinterface/sorters/external/kilosort.py
@@ -42,7 +42,8 @@ class KilosortSorter(KilosortBase, BaseSorter):
         "Nfilt": None,
         "NT": None,
         "wave_length": 61,
-        "delete_intermediate_files": ("matlab_files",),
+        "delete_tmp_files": ("matlab_files",),
+        "delete_recording_dat": False,
     }
 
     _params_description = {
@@ -55,8 +56,10 @@ class KilosortSorter(KilosortBase, BaseSorter):
         "Nfilt": "Number of clusters to use (if None it is automatically computed)",
         "NT": "Batch size (if None it is automatically computed)",
         "wave_length": "size of the waveform extracted around each detected peak, (Default 61, maximum 81)",
-        "delete_intermediate_files": "Delete intermediate files created during sorting. Tuple indicating the "
-        "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')",
+        "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that"
+        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files)"
+        "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
+        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a " "successful run",
     }
 
     sorter_description = """Kilosort is a GPU-accelerated and efficient template-matching spike sorter.

--- a/src/spikeinterface/sorters/external/kilosort.py
+++ b/src/spikeinterface/sorters/external/kilosort.py
@@ -56,8 +56,8 @@ class KilosortSorter(KilosortBase, BaseSorter):
         "Nfilt": "Number of clusters to use (if None it is automatically computed)",
         "NT": "Batch size (if None it is automatically computed)",
         "wave_length": "size of the waveform extracted around each detected peak, (Default 61, maximum 81)",
-        "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that"
-        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files)"
+        "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that "
+        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files) "
         "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
         "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
     }

--- a/src/spikeinterface/sorters/external/kilosort.py
+++ b/src/spikeinterface/sorters/external/kilosort.py
@@ -42,8 +42,7 @@ class KilosortSorter(KilosortBase, BaseSorter):
         "Nfilt": None,
         "NT": None,
         "wave_length": 61,
-        "delete_tmp_files": True,
-        "delete_recording_dat": False,
+        "delete_intermediate_files": ("matlab_files",),
     }
 
     _params_description = {
@@ -56,8 +55,8 @@ class KilosortSorter(KilosortBase, BaseSorter):
         "Nfilt": "Number of clusters to use (if None it is automatically computed)",
         "NT": "Batch size (if None it is automatically computed)",
         "wave_length": "size of the waveform extracted around each detected peak, (Default 61, maximum 81)",
-        "delete_tmp_files": "Whether to delete all temporary files after a successful run",
-        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
+        "delete_intermediate_files": "Delete intermediate files created during sorting. Tuple indicating the "
+                                     "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')"
     }
 
     sorter_description = """Kilosort is a GPU-accelerated and efficient template-matching spike sorter.

--- a/src/spikeinterface/sorters/external/kilosort.py
+++ b/src/spikeinterface/sorters/external/kilosort.py
@@ -57,7 +57,7 @@ class KilosortSorter(KilosortBase, BaseSorter):
         "NT": "Batch size (if None it is automatically computed)",
         "wave_length": "size of the waveform extracted around each detected peak, (Default 61, maximum 81)",
         "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that "
-        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files) "
+        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deletes all files) "
         "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
         "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
     }

--- a/src/spikeinterface/sorters/external/kilosort.py
+++ b/src/spikeinterface/sorters/external/kilosort.py
@@ -59,7 +59,7 @@ class KilosortSorter(KilosortBase, BaseSorter):
         "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that"
         "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files)"
         "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
-        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a " "successful run",
+        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
     }
 
     sorter_description = """Kilosort is a GPU-accelerated and efficient template-matching spike sorter.

--- a/src/spikeinterface/sorters/external/kilosort2.py
+++ b/src/spikeinterface/sorters/external/kilosort2.py
@@ -50,7 +50,8 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": False,
         "scaleproc": None,
         "save_rez_to_mat": False,
-        "delete_intermediate_files": ("matlab_files",),
+        "delete_tmp_files": ("matlab_files",),
+        "delete_recording_dat": False,
     }
 
     _params_description = {
@@ -72,8 +73,10 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": "Can optionaly skip the internal kilosort preprocessing",
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
-        "delete_intermediate_files": "Delete intermediate files created during sorting. Tuple indicating the "
-        "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')",
+        "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that"
+        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files)"
+        "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
+        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a " "successful run",
     }
 
     sorter_description = """Kilosort2 is a GPU-accelerated and efficient template-matching spike sorter. On top of its

--- a/src/spikeinterface/sorters/external/kilosort2.py
+++ b/src/spikeinterface/sorters/external/kilosort2.py
@@ -73,7 +73,7 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
         "delete_intermediate_files": "Delete intermediate files created during sorting. Tuple indicating the "
-                                     "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')"
+        "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')",
     }
 
     sorter_description = """Kilosort2 is a GPU-accelerated and efficient template-matching spike sorter. On top of its

--- a/src/spikeinterface/sorters/external/kilosort2.py
+++ b/src/spikeinterface/sorters/external/kilosort2.py
@@ -50,8 +50,7 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": False,
         "scaleproc": None,
         "save_rez_to_mat": False,
-        "delete_tmp_files": True,
-        "delete_recording_dat": False,
+        "delete_intermediate_files": ("matlab_files",),
     }
 
     _params_description = {
@@ -73,8 +72,8 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": "Can optionaly skip the internal kilosort preprocessing",
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
-        "delete_tmp_files": "Whether to delete all temporary files after a successful run",
-        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
+        "delete_intermediate_files": "Delete intermediate files created during sorting. Tuple indicating the "
+                                     "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')"
     }
 
     sorter_description = """Kilosort2 is a GPU-accelerated and efficient template-matching spike sorter. On top of its

--- a/src/spikeinterface/sorters/external/kilosort2.py
+++ b/src/spikeinterface/sorters/external/kilosort2.py
@@ -74,7 +74,7 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
         "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that "
-        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files) "
+        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deletes all files) "
         "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
         "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
     }

--- a/src/spikeinterface/sorters/external/kilosort2.py
+++ b/src/spikeinterface/sorters/external/kilosort2.py
@@ -76,7 +76,7 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that"
         "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files)"
         "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
-        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a " "successful run",
+        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
     }
 
     sorter_description = """Kilosort2 is a GPU-accelerated and efficient template-matching spike sorter. On top of its

--- a/src/spikeinterface/sorters/external/kilosort2.py
+++ b/src/spikeinterface/sorters/external/kilosort2.py
@@ -73,8 +73,8 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": "Can optionaly skip the internal kilosort preprocessing",
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
-        "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that"
-        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files)"
+        "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that "
+        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files) "
         "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
         "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
     }

--- a/src/spikeinterface/sorters/external/kilosort2_5.py
+++ b/src/spikeinterface/sorters/external/kilosort2_5.py
@@ -86,7 +86,7 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that"
         "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files)"
         "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
-        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a " "successful run",
+        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
     }
 
     sorter_description = """Kilosort2_5 is a GPU-accelerated and efficient template-matching spike sorter. On top of its

--- a/src/spikeinterface/sorters/external/kilosort2_5.py
+++ b/src/spikeinterface/sorters/external/kilosort2_5.py
@@ -83,9 +83,9 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": "Can optionaly skip the internal kilosort preprocessing",
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
-        "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that"
-        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files)"
-        "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
+        "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that "
+        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files) "
+        "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files') ",
         "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
     }
 

--- a/src/spikeinterface/sorters/external/kilosort2_5.py
+++ b/src/spikeinterface/sorters/external/kilosort2_5.py
@@ -84,7 +84,7 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
         "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that "
-        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files) "
+        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deletes all files) "
         "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files') ",
         "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
     }

--- a/src/spikeinterface/sorters/external/kilosort2_5.py
+++ b/src/spikeinterface/sorters/external/kilosort2_5.py
@@ -83,7 +83,7 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
         "delete_intermediate_files": "Delete intermediate files created during sorting. Tuple indicating the "
-                                     "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')"
+        "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')",
     }
 
     sorter_description = """Kilosort2_5 is a GPU-accelerated and efficient template-matching spike sorter. On top of its

--- a/src/spikeinterface/sorters/external/kilosort2_5.py
+++ b/src/spikeinterface/sorters/external/kilosort2_5.py
@@ -57,8 +57,7 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": False,
         "scaleproc": None,
         "save_rez_to_mat": False,
-        "delete_tmp_files": True,
-        "delete_recording_dat": False,
+        "delete_intermediate_files": ("matlab_files",),
     }
 
     _params_description = {
@@ -83,8 +82,8 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": "Can optionaly skip the internal kilosort preprocessing",
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
-        "delete_tmp_files": "Whether to delete all temporary files after a successful run",
-        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
+        "delete_intermediate_files": "Delete intermediate files created during sorting. Tuple indicating the "
+                                     "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')"
     }
 
     sorter_description = """Kilosort2_5 is a GPU-accelerated and efficient template-matching spike sorter. On top of its

--- a/src/spikeinterface/sorters/external/kilosort2_5.py
+++ b/src/spikeinterface/sorters/external/kilosort2_5.py
@@ -57,7 +57,8 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": False,
         "scaleproc": None,
         "save_rez_to_mat": False,
-        "delete_intermediate_files": ("matlab_files",),
+        "delete_tmp_files": ("matlab_files",),
+        "delete_recording_dat": False,
     }
 
     _params_description = {
@@ -82,8 +83,10 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": "Can optionaly skip the internal kilosort preprocessing",
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
-        "delete_intermediate_files": "Delete intermediate files created during sorting. Tuple indicating the "
-        "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')",
+        "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that"
+        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files)"
+        "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
+        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a " "successful run",
     }
 
     sorter_description = """Kilosort2_5 is a GPU-accelerated and efficient template-matching spike sorter. On top of its

--- a/src/spikeinterface/sorters/external/kilosort3.py
+++ b/src/spikeinterface/sorters/external/kilosort3.py
@@ -81,7 +81,7 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
         "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that "
-        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files) "
+        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deletes all files) "
         "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
         "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
     }

--- a/src/spikeinterface/sorters/external/kilosort3.py
+++ b/src/spikeinterface/sorters/external/kilosort3.py
@@ -54,8 +54,7 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": False,
         "scaleproc": None,
         "save_rez_to_mat": False,
-        "delete_tmp_files": True,
-        "delete_recording_dat": False,
+        "delete_intermediate_files": ("matlab_files",),
     }
 
     _params_description = {
@@ -80,8 +79,8 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": "Can optionaly skip the internal kilosort preprocessing",
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
-        "delete_tmp_files": "Whether to delete all temporary files after a successful run",
-        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
+        "delete_intermediate_files": "Delete intermediate files created during sorting. Tuple indicating the "
+                                     "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')"
     }
 
     sorter_description = """Kilosort3 is a GPU-accelerated and efficient template-matching spike sorter. On top of its

--- a/src/spikeinterface/sorters/external/kilosort3.py
+++ b/src/spikeinterface/sorters/external/kilosort3.py
@@ -54,7 +54,8 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": False,
         "scaleproc": None,
         "save_rez_to_mat": False,
-        "delete_intermediate_files": ("matlab_files",),
+        "delete_tmp_files": ("matlab_files",),
+        "delete_recording_dat": False,
     }
 
     _params_description = {
@@ -79,8 +80,10 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": "Can optionaly skip the internal kilosort preprocessing",
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
-        "delete_intermediate_files": "Delete intermediate files created during sorting. Tuple indicating the "
-        "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')",
+        "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that"
+        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files)"
+        "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
+        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a " "successful run",
     }
 
     sorter_description = """Kilosort3 is a GPU-accelerated and efficient template-matching spike sorter. On top of its

--- a/src/spikeinterface/sorters/external/kilosort3.py
+++ b/src/spikeinterface/sorters/external/kilosort3.py
@@ -83,7 +83,7 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
         "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that"
         "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files)"
         "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
-        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a " "successful run",
+        "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
     }
 
     sorter_description = """Kilosort3 is a GPU-accelerated and efficient template-matching spike sorter. On top of its

--- a/src/spikeinterface/sorters/external/kilosort3.py
+++ b/src/spikeinterface/sorters/external/kilosort3.py
@@ -80,7 +80,7 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
         "delete_intermediate_files": "Delete intermediate files created during sorting. Tuple indicating the "
-                                     "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')"
+        "files to delete. Options are: ('recording.dat', 'temp_wh.dat', 'matlab_files')",
     }
 
     sorter_description = """Kilosort3 is a GPU-accelerated and efficient template-matching spike sorter. On top of its

--- a/src/spikeinterface/sorters/external/kilosort3.py
+++ b/src/spikeinterface/sorters/external/kilosort3.py
@@ -80,8 +80,8 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
         "skip_kilosort_preprocessing": "Can optionaly skip the internal kilosort preprocessing",
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "save_rez_to_mat": "Save the full rez internal struc to mat file",
-        "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that"
-        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files)"
+        "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that "
+        "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deltes all files) "
         "or a Tuple containing the files to delete. Options are: ('temp_wh.dat', 'matlab_files')",
         "delete_recording_dat": "Whether to delete the 'recording.dat' file after a successful run",
     }

--- a/src/spikeinterface/sorters/external/kilosortbase.py
+++ b/src/spikeinterface/sorters/external/kilosortbase.py
@@ -215,20 +215,22 @@ class KilosortBase:
             raise Exception(f"{cls.sorter_name} returned a non-zero exit code")
 
         # Clean-up temporary files
-        print(f"Cleaning up temporary files created during sorting: " f"{params['delete_intermediate_files']}")
+        if params["delete_recording_dat"] and (recording_file := sorter_output_folder / "recording.dat").exists():
+            recording_file.unlink()
 
-        if "recording.dat" in params["delete_intermediate_files"]:
-            if (recording_file := sorter_output_folder / "recording.dat").exists():
-                recording_file.unlink()
+        if params["delete_tmp_files"]:
+            tmp_to_remove = (
+                ("matlab_files", "temp_wh.dat") if params["delete_tmp_files"] is True else params["delete_tmp_files"]
+            )
 
-        if "temp_wh.dat" in params["delete_intermediate_files"]:
-            if (temp_wh_file := sorter_output_folder / "temp_wh.dat").exists():
-                temp_wh_file.unlink()
+            if "temp_wh.dat" in tmp_to_remove:
+                if (temp_wh_file := sorter_output_folder / "temp_wh.dat").exists():
+                    temp_wh_file.unlink()
 
-        if "matlab_files" in params["delete_intermediate_files"]:
-            for ext in ["*.m", "*.mat"]:
-                for temp_file in sorter_output_folder.glob(ext):
-                    temp_file.unlink()
+            if "matlab_files" in tmp_to_remove:
+                for ext in ["*.m", "*.mat"]:
+                    for temp_file in sorter_output_folder.glob(ext):
+                        temp_file.unlink()
 
     @classmethod
     def _get_result_from_folder(cls, sorter_output_folder):

--- a/src/spikeinterface/sorters/external/kilosortbase.py
+++ b/src/spikeinterface/sorters/external/kilosortbase.py
@@ -215,15 +215,21 @@ class KilosortBase:
             raise Exception(f"{cls.sorter_name} returned a non-zero exit code")
 
         # Clean-up temporary files
-        if params["delete_tmp_files"]:
-            for temp_file in sorter_output_folder.glob("*.m"):
-                temp_file.unlink()
-            for temp_file in sorter_output_folder.glob("*.mat"):
-                temp_file.unlink()
-            if (sorter_output_folder / "temp_wh.dat").exists():
-                (sorter_output_folder / "temp_wh.dat").unlink()
-        if params["delete_recording_dat"] and (recording_file := sorter_output_folder / "recording.dat").exists():
-            recording_file.unlink()
+        print(f"Cleaning up temporary files created during sorting: "
+              f"{params['delete_intermediate_files']}")
+
+        if "recording.dat" in params["delete_intermediate_files"]:
+            if (recording_file := sorter_output_folder / "recording.dat").exists():
+                recording_file.unlink()
+
+        if "temp_wh.dat" in params["delete_intermediate_files"]:
+            if (temp_wh_file := sorter_output_folder / "temp_wh.dat").exists():
+                temp_wh_file.unlink()
+
+        if "matlab_files" in params["delete_intermediate_files"]:
+            for ext in ["*.m", "*.mat"]:
+                for temp_file in sorter_output_folder.glob(ext):
+                    temp_file.unlink()
 
     @classmethod
     def _get_result_from_folder(cls, sorter_output_folder):

--- a/src/spikeinterface/sorters/external/kilosortbase.py
+++ b/src/spikeinterface/sorters/external/kilosortbase.py
@@ -215,8 +215,7 @@ class KilosortBase:
             raise Exception(f"{cls.sorter_name} returned a non-zero exit code")
 
         # Clean-up temporary files
-        print(f"Cleaning up temporary files created during sorting: "
-              f"{params['delete_intermediate_files']}")
+        print(f"Cleaning up temporary files created during sorting: " f"{params['delete_intermediate_files']}")
 
         if "recording.dat" in params["delete_intermediate_files"]:
             if (recording_file := sorter_output_folder / "recording.dat").exists():

--- a/src/spikeinterface/sorters/external/kilosortbase.py
+++ b/src/spikeinterface/sorters/external/kilosortbase.py
@@ -218,7 +218,15 @@ class KilosortBase:
         if params["delete_recording_dat"] and (recording_file := sorter_output_folder / "recording.dat").exists():
             recording_file.unlink()
 
-        if params["delete_tmp_files"]:
+        if isinstance(params["delete_tmp_files"], bool):
+            if params["delete_tmp_files"]:
+                tmp_to_remove = ("matlab_files", "temp_wh.dat")
+            else:
+                tmp_to_remove = ()
+        else:
+            assert isinstance(params["delete_tmp_files"], (tuple, list)), "..."
+       
+       if "temp_wh.dat" in tmp_to_remove: ... 
             tmp_to_remove = (
                 ("matlab_files", "temp_wh.dat") if params["delete_tmp_files"] is True else params["delete_tmp_files"]
             )

--- a/src/spikeinterface/sorters/external/kilosortbase.py
+++ b/src/spikeinterface/sorters/external/kilosortbase.py
@@ -220,25 +220,23 @@ class KilosortBase:
 
         if isinstance(params["delete_tmp_files"], bool):
             if params["delete_tmp_files"]:
-                tmp_to_remove = ("matlab_files", "temp_wh.dat")
+                tmp_files_to_remove = ("matlab_files", "temp_wh.dat")
             else:
-                tmp_to_remove = ()
+                tmp_files_to_remove = ()
         else:
-            assert isinstance(params["delete_tmp_files"], (tuple, list)), "..."
-       
-       if "temp_wh.dat" in tmp_to_remove: ... 
-            tmp_to_remove = (
-                ("matlab_files", "temp_wh.dat") if params["delete_tmp_files"] is True else params["delete_tmp_files"]
-            )
+            assert isinstance(
+                params["delete_tmp_files"], (tuple, list)
+            ), "`delete_tmp_files` must be a `Bool`, `Tuple` or `List`."
+            tmp_files_to_remove = params["delete_tmp_files"]
 
-            if "temp_wh.dat" in tmp_to_remove:
-                if (temp_wh_file := sorter_output_folder / "temp_wh.dat").exists():
-                    temp_wh_file.unlink()
+        if "temp_wh.dat" in tmp_files_to_remove:
+            if (temp_wh_file := sorter_output_folder / "temp_wh.dat").exists():
+                temp_wh_file.unlink()
 
-            if "matlab_files" in tmp_to_remove:
-                for ext in ["*.m", "*.mat"]:
-                    for temp_file in sorter_output_folder.glob(ext):
-                        temp_file.unlink()
+        if "matlab_files" in tmp_files_to_remove:
+            for ext in ["*.m", "*.mat"]:
+                for temp_file in sorter_output_folder.glob(ext):
+                    temp_file.unlink()
 
     @classmethod
     def _get_result_from_folder(cls, sorter_output_folder):

--- a/src/spikeinterface/sorters/external/kilosortbase.py
+++ b/src/spikeinterface/sorters/external/kilosortbase.py
@@ -218,15 +218,21 @@ class KilosortBase:
         if params["delete_recording_dat"] and (recording_file := sorter_output_folder / "recording.dat").exists():
             recording_file.unlink()
 
+        all_temp_files = ("matlab_files", "temp_wh.dat")
+
         if isinstance(params["delete_tmp_files"], bool):
             if params["delete_tmp_files"]:
-                tmp_files_to_remove = ("matlab_files", "temp_wh.dat")
+                tmp_files_to_remove = all_tmp_files
             else:
                 tmp_files_to_remove = ()
         else:
             assert isinstance(
                 params["delete_tmp_files"], (tuple, list)
             ), "`delete_tmp_files` must be a `Bool`, `Tuple` or `List`."
+
+            for name in params["delete_tmp_files"]:
+                assert name in all_tmp_files, f"{name} is not a valid option, must be one of: {all_tmp_files}"
+
             tmp_files_to_remove = params["delete_tmp_files"]
 
         if "temp_wh.dat" in tmp_files_to_remove:


### PR DESCRIPTION
This PR extends cleanup after kilosort sorting, closes #1896.

The signature for deleting intermediate files is changed slightly and is now a `Tuple` with optional entries, `recording.dat`, `temp_wh.dat` and `matlab_files`. The reason for this extension is to give a little more granularity over the selection of what to delete, and to not delete `temp_wh.dat` by default as it is used for Phy.

For now, have default to delete only `matlab_files` because my understanding is that `recording.dat` is not deleted for other sorters and so this might be confusing if the behaviour is different across sorters. 

Do you think it is worth pushing up this functionality to the `run_sorter` level, so that for any sorter `recording.dat` can be deleted (in the cases it is created). The issue with that approach would be that some intermerdiate files are sorter-specific. Alternatively, each sorter has it's own `delete_intermediate_files` parameter that takes keywords specific to it's output, and these can be accessed with `run_sorter`'s kwargs? (in which case, happy to extend this functionality to other sorters, I am just not very familiar with the intermediate files they all create).