### PR TITLE
Fixed bug that prevents dumping AgreementSortingExtractor

### DIFF
--- a/src/spikeinterface/comparison/multicomparisons.py
+++ b/src/spikeinterface/comparison/multicomparisons.py
@@ -228,7 +228,6 @@ class AgreementSortingExtractor(BaseSorting):
         self, sampling_frequency, multisortingcomparison, min_agreement_count=1, min_agreement_count_only=False
     ):
         self._msc = multisortingcomparison
-        self._is_json_serializable = False
 
         if min_agreement_count_only:
             unit_ids = list(
@@ -244,6 +243,8 @@ class AgreementSortingExtractor(BaseSorting):
             )
 
         BaseSorting.__init__(self, sampling_frequency=sampling_frequency, unit_ids=unit_ids)
+
+        self._is_json_serializable = False
 
         if len(unit_ids) > 0:
             for k in ("agreement_number", "avg_agreement", "unit_ids"):


### PR DESCRIPTION
This bug prevents extracting waveforms from an AgreementSortingExtractor as this process requires dumping the AgreementSortingExtractor to disk first.

The issue was that when initialising the AgreementSortingExtractor, BaseSorting.init() is run after self.is_json_serializable = False, which in turn calls BaseExtractor.__init_() which overrides to self._is_json_serializable = True.

The fix is simply to put self.is_json_serializable = False after BaseSorting.init().

Fixes issue #1906