### PR TITLE
Convert from samples<->times directly on BaseRecordings

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -1,18 +1,18 @@
-from typing import Iterable, List, Union
-from pathlib import Path
 import warnings
+from pathlib import Path
+from typing import Iterable, List, Union
+from warnings import warn
 
 import numpy as np
-
-from probeinterface import Probe, ProbeGroup, write_probeinterface, read_probeinterface, select_axes
+from probeinterface import (Probe, ProbeGroup, read_probeinterface,
+                            select_axes, write_probeinterface)
 
 from .base import BaseSegment
 from .baserecordingsnippets import BaseRecordingSnippets
-from .core_tools import write_binary_recording, write_memory_recording, write_traces_to_zarr, check_json
+from .core_tools import (check_json, convert_bytes_to_str,
+                         convert_seconds_to_str, write_binary_recording,
+                         write_memory_recording, write_traces_to_zarr)
 from .job_tools import split_job_kwargs
-from .core_tools import convert_bytes_to_str, convert_seconds_to_str
-
-from warnings import warn
 
 
 class BaseRecording(BaseRecordingSnippets):
@@ -415,6 +415,19 @@ class BaseRecording(BaseRecordingSnippets):
                 "times are not always propagated to across preprocessing"
                 "Use use this carefully!"
             )
+
+    def sample_index_to_time(self, sample_ind, segment_index=None):
+        """
+        Transform sample index into time in seconds
+        """
+        segment_index = self._check_segment_index(segment_index)
+        rs = self._recording_segments[segment_index]
+        return rs.sample_index_to_time(sample_ind)
+
+    def time_to_sample_index(self, time_s, segment_index=None):
+        segment_index = self._check_segment_index(segment_index)
+        rs = self._recording_segments[segment_index]
+        return rs.time_to_sample_index(time_s)
 
     def _save(self, format="binary", **save_kwargs):
         """

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -4,14 +4,18 @@ from typing import Iterable, List, Union
 from warnings import warn
 
 import numpy as np
-from probeinterface import (Probe, ProbeGroup, read_probeinterface,
-                            select_axes, write_probeinterface)
+from probeinterface import Probe, ProbeGroup, read_probeinterface, select_axes, write_probeinterface
 
 from .base import BaseSegment
 from .baserecordingsnippets import BaseRecordingSnippets
-from .core_tools import (check_json, convert_bytes_to_str,
-                         convert_seconds_to_str, write_binary_recording,
-                         write_memory_recording, write_traces_to_zarr)
+from .core_tools import (
+    check_json,
+    convert_bytes_to_str,
+    convert_seconds_to_str,
+    write_binary_recording,
+    write_memory_recording,
+    write_traces_to_zarr,
+)
 from .job_tools import split_job_kwargs
 
 


### PR DESCRIPTION
This implements `sample_index_to_time` and reverse on `BaseRecording`, which is something I noticed I wanted the other day. Are you guys open to this change? If so, I can add a test -- `BaseRecordingSegment.sample_index_to_time` didn't have tests anywhere so wasn't sure where to put it, maybe in `test_time_handling.py`?