### PR TITLE
Introduce extractor for Kilosort's `temp_wh.dat`

### DIFF
--- a/src/spikeinterface/extractors/KilosortTempWhExtractor.py
+++ b/src/spikeinterface/extractors/KilosortTempWhExtractor.py
@@ -9,22 +9,49 @@ import runpy
 import numpy as np
 from spikeinterface import WaveformExtractor, extract_waveforms
 from spikeinterface.preprocessing import whiten
+import probeinterface
+
+# from spikeinterface.core import channel_slice
+
+# Short-term workoarund so setting the probe does not error
+__version__ = "0.0.0"
+# Inheriting BinaryRecordingExtractor does not work due to
+# _kwargs need to be `output_path` for self.clone() but
+# must be the Binary kwargs for internal use. But, now,
+# there are other issues because everything has to be set to the
+# BinaryRecordingExtractor which is confusing.
+# Okay this really doesn't work as we need to set the probe
+# in the init but setting the probe re-initialises the
+# entire recording so the probe cannot be
+# set in the init of the recording itself.
+
+# This is super-hacky. We need to re-overwrite any properties that
+# are binary-specific and initialised on the init because to_dict() will
+# use them when cloning. Maybe this scheme is not a good one (nesting Extractors).
+# The alternative is to hold the BinaryRecordingExtractor as an attribute,
+# but this is confusing because then it doesn't behave like a recording object,
+# unless all fields are overridden
+# also, avoids this:
+
+# but, there is a problem here in that we will have to impeement every
+# function and feed it back down to BinaryRecording. and maybe we don't need to set probe.
 
 
 class KilosortTempWhExtractor(BinaryRecordingExtractor):
-    def __init__(self, output_path: Path) -> None:
-        # TODO: store opts e.g. ntb, Nbatch etc here.
-
+    def __init__(self, output_path: Path, **kwargs) -> None:
         if self.has_spikeinterface(output_path):
             self.sorter_output_path = output_path / "sorter_output"
 
+            # TODO: tidy this up and remove redundancy.
             channel_indices = self.get_channel_indices()
 
+            breakpoint()
+            # TODO: exactly what data is this loading? recording.dat or orig data?
+            # it cannot be orig because it has been pp...
             original_recording = load_extractor(output_path / "spikeinterface_recording.json", base_folder=output_path)
+
             channel_ids = original_recording.get_channel_ids()
 
-            # TODO: check this assumption - does KS change the scale / offset? can check
-            #  by performing no processing...
             if original_recording.has_scaled():
                 gain_to_uV = original_recording.get_property("gain_to_uV")[channel_indices]
                 offset_to_uV = original_recording.get_property("offset_to_uV")[channel_indices]
@@ -34,11 +61,12 @@ class KilosortTempWhExtractor(BinaryRecordingExtractor):
 
             channel_locations = original_recording.get_channel_locations()
 
-            # TODO: I think this is safe to assume as if the recording was
-            # sorted then it must have a probe attached.
             probe = original_recording.get_probe()
+            assert isinstance(
+                probe, probeinterface.probe.Probe
+            ), "No probe found on the recording although it was used for sorting."
 
-        elif self.has_valid_sorter_output(output_path):
+        elif self.has_valid_sorter_output(output_path):  # TODO: rename, this is confusing.
             self.sorter_output_path = output_path
 
             channel_indices = self.get_channel_indices()
@@ -52,6 +80,8 @@ class KilosortTempWhExtractor(BinaryRecordingExtractor):
 
         else:
             raise ValueError("")
+
+        self.ks_version = self.get_ks_version()
 
         params = self.load_and_check_kilosort_params_file()
         temp_wh_path = Path(self.sorter_output_path) / "temp_wh.dat"
@@ -73,10 +103,36 @@ class KilosortTempWhExtractor(BinaryRecordingExtractor):
             is_filtered=None,
             num_chan=None,
         )
+        self._kwargs = {
+            "output_path": output_path,
+            "file_paths": [temp_wh_path],
+            "sampling_frequency": params["sample_rate"],
+            "t_starts": None,
+            "num_channels": channel_indices.size,
+            "dtype": params["dtype"],
+            "channel_ids": new_channel_ids,
+            "time_axis": 0,
+            "file_offset": 0,
+            "gain_to_uV": gain_to_uV,
+            "offset_to_uV": offset_to_uV,
+            "is_filtered": None,
+        }
         self.set_channel_locations(new_channel_locations)
 
-    #   if probe:
-    #      self.set_probe(probe)
+    def get_ks_version(self):
+        kilosort_versions = ["kilosort.log", "kilosort2.log", "kilosort2_5.log", "kilosort3.log", "kilosort4.log"]
+        possible_logs = []
+
+        for logfile in kilosort_versions:
+            possible_logs += list(self.sorter_output_path.glob(logfile))
+
+        assert len(possible_logs) == 1, "There should be one log file in the KS output."
+        version = possible_logs[0].stem
+
+        if version in ["kilosort", "kilosort4"]:
+            raise ValueError("Only Kilosort2, Kilosort2.5 or Kilosort3 after supported.")
+
+        return version
 
     def get_channel_indices(self):
         """"""
@@ -121,10 +177,14 @@ class KilosortTempWhExtractor(BinaryRecordingExtractor):
 
 """
 TODO
-- understand the scaling. This is influenced by some scale factors, whiten and this mysterios 20 scale factor (see Phy issues).
+- understand the scaling. This is influenced by some scale factors, whiten and this mysterious 20 scale factor (see Phy issues).
 - implement the get_traces() function. This will do the scaling.
 - understand from Zacks comments the question: (does kilosort > 2 store shanks differently? if channel_map.ndim == 2:  # kilosort > 2)
-
+- Consider how to handle the scale and offset - KS will completely change these I think, so the SI values will be incorrect.
+- store opts e.g. ntb, Nbatch etc here.
+- One idea to checks scaling is to set the same int value in KilosortTempWhExtractor as in the SI recording then
+  these should match exactly if scaled correctly... (I think).
+- Do a check that we are not in KS1 or KS4 - KS1 will not be supported, is not currently.
 TO CHECK
 - check all metadata required for WaveformExtractor is on the probe. This is easiest
   checked in the test environment (non saved vs. saved)
@@ -132,25 +192,30 @@ TO CHECK
 - How this performs in the context of multiple shanks.
 - write a set for channel locations vs. removing channels with `slice_channels`.
 - kilosort outputs channel_map with some channels removed. Ensure this indexing maps 100% to SI indexing.
+
 TO ASK
-- Here we set the probe onto the new recording, with channels removed. Does the probe
-  need to be adjusted? based on `channel_slide` I guess not.
+- Is it okay not to set the probe? It is not possible here.
 - How do we want to handle `get_num_samples` in the context of zero-padding?
 - should is_filtered be `True` if run through KS preprocessing? How would we know?
 - In general, do we store the full channel map in channel contacts or do we
   only save the new subset? My guess is subset for contact_positions, but full probe
   for probe. Check against slice_channels.
+- If Si exists, then probe will exist as not possible to sort without a probe?
+
+TO LIST
+- all the differences between kilosort2 and kilosort2.5 and kilosort3
+    - the ndim of the channel_map.py
+    - the whitening and inverse whitening matrix (this is just scaling in >KS2).
 """
 
 from spikeinterface import extractors
 from spikeinterface import postprocessing
 
-path_ = Path(r"X:\neuroinformatics\scratch\jziminski\ephys\code\sorter_output")  # sorter_output
-recording = KilosortTempWhExtractor(path_ / "sorter_output")  # TODO: without this extra is failing
+path_ = Path(r"X:\neuroinformatics\scratch\jziminski\ephys\code\sorter_output")
+recording = KilosortTempWhExtractor(path_)  # TODO: without this extra is failing
 
+# if False:
 original_recording = load_extractor(path_ / "spikeinterface_recording.json", base_folder=path_)
-
-original_recording = whiten(original_recording, dtype=np.int16, mode="local", int_scale=200)
 
 # Okay this works as a test. Steps are to:
 # 1) run sorting (script below)
@@ -162,8 +227,24 @@ original_recording = whiten(original_recording, dtype=np.int16, mode="local", in
 # Currently the issues discussed in #1908 are a blocker. Once a decision on this is made
 # this PR can be continued with.
 
-x = recording.get_traces(start_frame=0, end_frame=10000, return_scaled=False)  # TODO: figure scaling
-y = original_recording.get_traces(start_frame=0, end_frame=10000, return_scaled=False)
+# Let's just check the KS output channel make makes sense in original space
+
+channel_map = np.load(recording.sorter_output_path / "channel_map.npy").ravel()
+assert np.array_equal(recording.get_channel_ids(), original_recording.get_channel_ids()[channel_map])
+
+
+if recording.ks_version == "kilosort2":
+    original_recording = channel_slice(original_recording, recording.get_channel_ids())
+
+original_recording = whiten(original_recording, dtype=np.int16, mode="local", int_scale=200)
+
+breakpoint()
+x = recording.get_traces(start_frame=0, end_frame=1000, return_scaled=False)
+y = original_recording.get_traces(start_frame=0, end_frame=1000, return_scaled=False)
+
+print(np.corrcoef(x[100:, :].ravel(), y[100:, :].ravel()))
+
+# TODO next, test the waveforms don't change much.
 
 """
 Generate Test Data

--- a/src/spikeinterface/extractors/KilosortTempWhExtractor.py
+++ b/src/spikeinterface/extractors/KilosortTempWhExtractor.py
@@ -1,0 +1,95 @@
+import spikeinterface as si
+from pathlib import Path
+from spikeinterface import BinaryRecordingExtractor
+from spikeinterface import load_extractor
+import sys
+import importlib.util
+import runpy
+import numpy as np
+
+
+class KilosortTempWhExtractor(BinaryRecordingExtractor):
+    def __init__(self, output_path: Path) -> None:
+        self.sorter_output_path = output_path / "sorter_output"
+        # TODO: store opts e.g. ntb, Nbatch etc here.
+
+        params = runpy.run_path(self.sorter_output_path / "params.py")
+
+        file_paths = Path(self.sorter_output_path) / "temp_wh.dat"  # some assert
+        sampling_frequency = params["sample_rate"]
+        dtype = params["dtype"]
+        assert dtype == "int16"
+
+        channel_map = np.load(self.sorter_output_path / "channel_map.npy")
+        if channel_map.ndim == 2:  # kilosort > 2
+            channel_indices = channel_map.ravel()  # TODO: check multiple shanks
+        else:
+            assert channel_map.ndim == 1
+            channel_indices = channel_map
+
+        num_channels = channel_indices.size
+
+        original_recording = load_extractor(output_path / "spikeinterface_recording.json", base_folder=output_path)
+        original_channel_ids = original_recording.get_channel_ids()
+
+        if original_recording.has_scaled():
+            gain_to_uV = original_recording.get_property("gain_to_uV")[
+                channel_indices
+            ]  # TODO: check this assumption - does KS change the scale / offset? can check by performing no processing...
+            offset_to_uV = original_recording.get_property("offset_to_uV")[channel_indices]
+        else:
+            gain_to_uV = None
+            offset_to_uV = None
+
+        self.original_recording_num_samples = original_recording.get_num_samples()
+        new_channel_ids = original_channel_ids[channel_indices]  # TODO: check whether this will erroneously re-order
+        # is_filtered = original_recording.is_filtered or ## params was filtering run
+
+        super(KilosortTempWhExtractor, self).__init__(
+            file_paths,
+            sampling_frequency,
+            dtype,
+            num_channels=num_channels,
+            t_starts=None,
+            channel_ids=new_channel_ids,
+            time_axis=0,
+            file_offset=0,
+            gain_to_uV=gain_to_uV,
+            offset_to_uV=offset_to_uV,
+            is_filtered=None,
+            num_chan=None,
+        )
+
+        # TODO: check, there must be a probe if sorting was run?
+        # change the wiring of the probe
+        # TODO: check this carefully, might be completely wrong
+
+        contact_vector = original_recording.get_property("contact_vector")
+        contact_vector = contact_vector[channel_indices]
+        #      if contact_vector is not None:
+        contact_vector["device_channel_indices"] = np.arange(len(new_channel_ids), dtype="int64")
+        self.set_property("contact_vector", contact_vector)
+
+        data2 = original_recording.get_traces(start_frame=0, end_frame=75000)
+        breakpoint()
+
+
+#        original_probe = original_recording.get_probe()
+# self.set_probe(original_probe)
+
+# 1) figure out metadata and casting for WaveForm Extractor
+# 2) check lazyness etc.
+
+# zero padding can just be kept. Check it plays nice with WaveformExtractor...
+
+# TODO: add provenance
+
+
+#    def get_num_samples(self):
+#       """ ignore Kilosort's zero-padding """
+#      return self.original_recording.get_num_samples()
+
+path_ = Path(r"X:\neuroinformatics\scratch\jziminski\ephys\code\sorter_output")
+data = KilosortTempWhExtractor(path_)
+
+breakpoint()

--- a/src/spikeinterface/extractors/KilosortTempWhExtractor.py
+++ b/src/spikeinterface/extractors/KilosortTempWhExtractor.py
@@ -59,9 +59,6 @@ class KilosortTempWhExtractor(BinaryRecordingExtractor):
         new_channel_ids = channel_ids[channel_indices]
         new_channel_locations = channel_locations[channel_indices]
 
-        # TODO: need to adjust probe?
-        # TODO: check whether this will erroneously re-order
-        # is_filtered = original_recording.is_filtered or ## params was filtering run
         super(KilosortTempWhExtractor, self).__init__(
             temp_wh_path,
             params["sample_rate"],
@@ -122,40 +119,29 @@ class KilosortTempWhExtractor(BinaryRecordingExtractor):
         return params
 
 
-#        original_probe = original_recording.get_probe()
-# self.set_probe(original_probe) TODO: do we need to adjust the probe? what about contact positions?
+"""
+TODO
+- understand the scaling. This is influenced by some scale factors, whiten and this mysterios 20 scale factor (see Phy issues).
+- implement the get_traces() function. This will do the scaling.
+- understand from Zacks comments the question: (does kilosort > 2 store shanks differently? if channel_map.ndim == 2:  # kilosort > 2)
 
-# 1) figure out metadata and casting for WaveForm Extractor
-# 2) check lazyness etc.
+TO CHECK
+- check all metadata required for WaveformExtractor is on the probe. This is easiest
+  checked in the test environment (non saved vs. saved)
+- that the new zero padding places nicely with the WaveformExtractor
+- How this performs in the context of multiple shanks.
+- write a set for channel locations vs. removing channels with `slice_channels`.
+- kilosort outputs channel_map with some channels removed. Ensure this indexing maps 100% to SI indexing.
+TO ASK
+- Here we set the probe onto the new recording, with channels removed. Does the probe
+  need to be adjusted? based on `channel_slide` I guess not.
+- How do we want to handle `get_num_samples` in the context of zero-padding?
+- should is_filtered be `True` if run through KS preprocessing? How would we know?
+- In general, do we store the full channel map in channel contacts or do we
+  only save the new subset? My guess is subset for contact_positions, but full probe
+  for probe. Check against slice_channels.
+"""
 
-# zero padding can just be kept. Check it plays nice with WaveformExtractor...
-
-# TODO: add provenance
-# TODO: what to do about all those zeros?
-
-#    def get_num_samples(self):
-#       """ ignore Kilosort's zero-padding """
-#      return self.original_recording.get_num_samples()
-
-# TODO: check, there must be a probe if sorting was run?
-# change the wiring of the probe
-# TODO: check this carefully, might be completely wrong
-#      if contact_vector is not None:
-
-# if channel_map.ndim == 2:  # kilosort > 2
-#    channel_indices = channel_map.ravel()  # TODO: check multiple shanks
-
-# self.set_channel_locations(new_channel_locations)  # TOOD: check against slice_channels
-
-#             is_filtered=None,  # TODO: need to get from KS provenence?
-
-# In general, do we store the full channel map in channel contacts or do we
-# only save the new subset? My guess is subset for contact_positions, but full probe
-# for probe. Check against slice_channels.
-#             self.set_probe(probe)  # TODO: what does this mean for missing channels?
-
-#         if channel_map.ndim == 2:  # kilosort > 2
-# does kilosort > 2 store shanks differently?             channel_indices = channel_map.ravel()
 from spikeinterface import extractors
 from spikeinterface import postprocessing
 

--- a/src/spikeinterface/extractors/KilosortTempWhExtractor.py
+++ b/src/spikeinterface/extractors/KilosortTempWhExtractor.py
@@ -1,3 +1,4 @@
+from typing import Dict
 import spikeinterface as si
 from pathlib import Path
 from spikeinterface import BinaryRecordingExtractor
@@ -6,50 +7,65 @@ import sys
 import importlib.util
 import runpy
 import numpy as np
+from spikeinterface import WaveformExtractor, extract_waveforms
 
 
 class KilosortTempWhExtractor(BinaryRecordingExtractor):
     def __init__(self, output_path: Path) -> None:
-        self.sorter_output_path = output_path / "sorter_output"
         # TODO: store opts e.g. ntb, Nbatch etc here.
 
-        params = runpy.run_path(self.sorter_output_path / "params.py")
+        if self.has_spikeinterface(output_path):
+            self.sorter_output_path = output_path / "sorter_output"
 
-        file_paths = Path(self.sorter_output_path) / "temp_wh.dat"  # some assert
-        sampling_frequency = params["sample_rate"]
-        dtype = params["dtype"]
-        assert dtype == "int16"
+            channel_indices = self.get_channel_indices()
 
-        channel_map = np.load(self.sorter_output_path / "channel_map.npy")
-        if channel_map.ndim == 2:  # kilosort > 2
-            channel_indices = channel_map.ravel()  # TODO: check multiple shanks
-        else:
-            assert channel_map.ndim == 1
-            channel_indices = channel_map
+            original_recording = load_extractor(output_path / "spikeinterface_recording.json", base_folder=output_path)
+            channel_ids = original_recording.get_channel_ids()
 
-        num_channels = channel_indices.size
+            # TODO: check this assumption - does KS change the scale / offset? can check
+            #  by performing no processing...
+            if original_recording.has_scaled():
+                gain_to_uV = original_recording.get_property("gain_to_uV")[channel_indices]
+                offset_to_uV = original_recording.get_property("offset_to_uV")[channel_indices]
+            else:
+                gain_to_uV = None
+                offset_to_uV = None
 
-        original_recording = load_extractor(output_path / "spikeinterface_recording.json", base_folder=output_path)
-        original_channel_ids = original_recording.get_channel_ids()
+            channel_locations = original_recording.get_channel_locations()
 
-        if original_recording.has_scaled():
-            gain_to_uV = original_recording.get_property("gain_to_uV")[
-                channel_indices
-            ]  # TODO: check this assumption - does KS change the scale / offset? can check by performing no processing...
-            offset_to_uV = original_recording.get_property("offset_to_uV")[channel_indices]
-        else:
+            # TODO: I think this is safe to assume as if the recording was
+            # sorted then it must have a probe attached.
+            probe = original_recording.get_probe()
+
+        elif self.has_valid_sorter_output(output_path):
+            self.sorter_output_path = output_path
+
+            channel_indices = self.get_channel_indices()
+            channel_ids = np.array(channel_indices, dtype=str)
+
             gain_to_uV = None
             offset_to_uV = None
 
-        self.original_recording_num_samples = original_recording.get_num_samples()
-        new_channel_ids = original_channel_ids[channel_indices]  # TODO: check whether this will erroneously re-order
-        # is_filtered = original_recording.is_filtered or ## params was filtering run
+            channel_locations = np.load(self.sorter_output_path / "channel_positions.npy")
+            probe = None
 
+        else:
+            raise ValueError("")
+
+        params = self.load_and_check_kilosort_params_file()
+        temp_wh_path = Path(self.sorter_output_path) / "temp_wh.dat"
+
+        new_channel_ids = channel_ids[channel_indices]
+        new_channel_locations = channel_locations[channel_indices]
+
+        # TODO: need to adjust probe?
+        # TODO: check whether this will erroneously re-order
+        # is_filtered = original_recording.is_filtered or ## params was filtering run
         super(KilosortTempWhExtractor, self).__init__(
-            file_paths,
-            sampling_frequency,
-            dtype,
-            num_channels=num_channels,
+            temp_wh_path,
+            params["sample_rate"],
+            params["dtype"],
+            num_channels=channel_indices.size,
             t_starts=None,
             channel_ids=new_channel_ids,
             time_axis=0,
@@ -59,23 +75,54 @@ class KilosortTempWhExtractor(BinaryRecordingExtractor):
             is_filtered=None,
             num_chan=None,
         )
+        self.set_channel_locations(new_channel_locations)
 
-        # TODO: check, there must be a probe if sorting was run?
-        # change the wiring of the probe
-        # TODO: check this carefully, might be completely wrong
+    #   if probe:
+    #      self.set_probe(probe)
 
-        contact_vector = original_recording.get_property("contact_vector")
-        contact_vector = contact_vector[channel_indices]
-        #      if contact_vector is not None:
-        contact_vector["device_channel_indices"] = np.arange(len(new_channel_ids), dtype="int64")
-        self.set_property("contact_vector", contact_vector)
+    def get_channel_indices(self):
+        """"""
+        channel_map = np.load(self.sorter_output_path / "channel_map.npy")
 
-        data2 = original_recording.get_traces(start_frame=0, end_frame=75000)
-        breakpoint()
+        if channel_map.ndim == 2:
+            channel_indices = channel_map.ravel()
+        else:
+            assert channel_map.ndim == 1
+            channel_indices = channel_map
+
+        return channel_indices
+
+    def has_spikeinterface(self, path_: Path) -> bool:
+        """ """
+        sorter_output = path_ / "sorter_output"
+
+        if not (path_ / "spikeinterface_recording.json").is_file() or not sorter_output.is_dir():
+            return False
+
+        return self.has_valid_sorter_output(sorter_output)
+
+    def has_valid_sorter_output(self, path_: Path) -> bool:
+        """ """
+        required_files = ["temp_wh.dat", "channel_map.npy", "channel_positions.npy"]
+
+        for filename in required_files:
+            if not (path_ / filename).is_file():
+                print(f"The file {filename} cannot be out in {path_}")
+                return False
+        return True
+
+    def load_and_check_kilosort_params_file(self) -> Dict:
+        """ """
+        params = runpy.run_path(self.sorter_output_path / "params.py")
+
+        if params["dtype"] != "int16":
+            raise ValueError("The dtype in kilosort's params.py is expected" "to be `int16`.")
+
+        return params
 
 
 #        original_probe = original_recording.get_probe()
-# self.set_probe(original_probe)
+# self.set_probe(original_probe) TODO: do we need to adjust the probe? what about contact positions?
 
 # 1) figure out metadata and casting for WaveForm Extractor
 # 2) check lazyness etc.
@@ -83,13 +130,113 @@ class KilosortTempWhExtractor(BinaryRecordingExtractor):
 # zero padding can just be kept. Check it plays nice with WaveformExtractor...
 
 # TODO: add provenance
-
+# TODO: what to do about all those zeros?
 
 #    def get_num_samples(self):
 #       """ ignore Kilosort's zero-padding """
 #      return self.original_recording.get_num_samples()
 
-path_ = Path(r"X:\neuroinformatics\scratch\jziminski\ephys\code\sorter_output")
-data = KilosortTempWhExtractor(path_)
+# TODO: check, there must be a probe if sorting was run?
+# change the wiring of the probe
+# TODO: check this carefully, might be completely wrong
+#      if contact_vector is not None:
+
+# if channel_map.ndim == 2:  # kilosort > 2
+#    channel_indices = channel_map.ravel()  # TODO: check multiple shanks
+
+# self.set_channel_locations(new_channel_locations)  # TOOD: check against slice_channels
+
+#             is_filtered=None,  # TODO: need to get from KS provenence?
+
+# In general, do we store the full channel map in channel contacts or do we
+# only save the new subset? My guess is subset for contact_positions, but full probe
+# for probe. Check against slice_channels.
+#             self.set_probe(probe)  # TODO: what does this mean for missing channels?
+
+#         if channel_map.ndim == 2:  # kilosort > 2
+# does kilosort > 2 store shanks differently?             channel_indices = channel_map.ravel()
+
+path_ = Path(r"X:\neuroinformatics\scratch\jziminski\ephys\code\sorter_output")  # sorter_output
+recording_new = KilosortTempWhExtractor(path_)
+
+from spikeinterface import extractors
+from spikeinterface import postprocessing
+
+sorting = extractors.read_kilosort(
+    folder_path=(path_ / "sorter_output").as_posix(),
+    keep_good_only=False,
+)
+
+recording_old = load_extractor(path_ / "spikeinterface_recording.json", base_folder=path_)
+folder_old = Path(r"X:\neuroinformatics\scratch\jziminski\ephys\code\waveform_folder_old")
+waveforms_old = extract_waveforms(
+    recording_old,
+    sorting,
+    folder_old,
+    ms_before=1.5,
+    ms_after=2,
+    max_spikes_per_unit=500,
+    allow_unfiltered=True,
+    load_if_exists=True,
+)  # match kilosort
+
+folder_new = Path(r"X:\neuroinformatics\scratch\jziminski\ephys\code\waveform_folder_new")
+waveforms_new = extract_waveforms(
+    recording_new,
+    sorting,
+    folder_new,
+    ms_before=1.5,
+    ms_after=2,
+    max_spikes_per_unit=500,
+    allow_unfiltered=True,
+    load_if_exists=True,
+)  # match kilosort
 
 breakpoint()
+
+if False:
+    import matplotlib.pyplot as plt
+
+    plt.plot(kilosort_waveform)
+    plt.show()
+
+    plt.plot(test_waveform)
+    plt.show()
+
+
+# if folder.is_dir():
+#   import shutil
+#   shutil.rmtree(folder)
+
+# run sorting without kilosort preprocessing
+# then, the `temp_wh.dat` should match exactly the original file!
+# I think this is a solid way to test. It is not possible to test against
+#
+
+
+if False:
+    original_recording = load_extractor(path_ / "spikeinterface_recording.json", base_folder=path_)
+    waveforms_old = extract_waveforms(
+        original_recording,
+        sorting,
+        folder,
+        ms_before=1.5,
+        ms_after=2.0,
+        max_spikes_per_unit=500,
+        allow_unfiltered=True,
+        load_if_exists=True,
+    )
+
+    original_recording = load_extractor(path_ / "spikeinterface_recording.json", base_folder=path_)
+
+    # TODO: unit locations don't match kilosort very well, at least in the 1-spike case.
+    # But, this could be due to windowing and should average out over many spikes
+    breakpoint()
+
+    unit_locations_old = postprocessing.compute_unit_locations(waveforms, method="center_of_mass", outputs="by_unit")
+    unit_locations_pandas = pd.DataFrame.from_dict(unit_locations, orient="index", columns=["x", "y"])
+    unit_locations_pandas.to_csv(unit_locations_path)
+
+    utils.message_user(f"Unit locations saved to {unit_locations_path}")
+
+    print(we)

--- a/src/spikeinterface/extractors/extractorlist.py
+++ b/src/spikeinterface/extractors/extractorlist.py
@@ -71,7 +71,6 @@ recording_extractor_full_list = [
     CompressedBinaryIblExtractor,
     IblStreamingRecordingExtractor,
     MCSH5RecordingExtractor,
-    KilosortTempWhExtractor,
 ]
 recording_extractor_full_list += neo_recording_extractors_list
 

--- a/src/spikeinterface/extractors/extractorlist.py
+++ b/src/spikeinterface/extractors/extractorlist.py
@@ -71,6 +71,7 @@ recording_extractor_full_list = [
     CompressedBinaryIblExtractor,
     IblStreamingRecordingExtractor,
     MCSH5RecordingExtractor,
+    KilosortTempWhExtractor,
 ]
 recording_extractor_full_list += neo_recording_extractors_list
 


### PR DESCRIPTION
This PR is currently in-progress. The main is to load Kilosort's `temp_wh.dat` file for Kilosort 1-3. 

For kilosort 2.5 and 3, Phy uses the `temp_wh.dat` file, which (as far as I can tell) always contains all available channels.

For kilosort 1 and 2, the `temp_wh.dat` file is not used for Phy (although waveforms, etc. have previoulsy been calculated from it prior to saving in `.npy` files as it is the kilosort-preprocessed data). Kilosort 1 and 2 will remove channels for inactivity prior to sorting, and saves the used channels in `channel_map.npy`.

The `temp_wh.dat` is zero-padded at the end to match size of N * NT. The attached powerpoint indicates the method kilosort 2.5 and 3 uses for batching during preprocessing. The method is slightly different for 1, 2 but as far as I can tell results in the same output.

The main thing the extractor needs to do is handle the missing channels. The recording also contains zero-padding, but I'm hoping these can just be left there and will not effect waveforms as all spiketimes should be outside of the zero-padded region.

[kilosort_preprocessing_batching.pptx](https://github.com/SpikeInterface/spikeinterface/files/12501589/kilosort_preprocessing_batching.pptx)





