### PR TITLE
Fix the [full] install for Macs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,9 +151,9 @@ docs = [
     # for notebooks in the gallery
     "MEArec",   # Use as an example
     "datalad==0.16.2",  # Download mearec data, not sure if needed as is installed with conda as well because of git-annex
-    "pandas", # Don't know where this is needed
-    "hdbscan>=0.8.33",   # For sorters, probably spikingcircus
-    "numba", # For sorters, probably spikingcircus
+    "pandas", # in the modules gallery comparison tutorial
+    "hdbscan>=0.8.33",   # For sorters spykingcircus2 + tridesclous
+    "numba", # For many postprocessing functions
     # for release we need pypi, so this needs to be commented
     "probeinterface @ git+https://github.com/SpikeInterface/probeinterface.git",  # We always build from the latest version
     "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",  # We always build from the latest version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ full = [
     "networkx",
     "distinctipy",
     "matplotlib",
-    "cuda-python; sys_platform != 'darwin'",
+    "cuda-python; platform_system != 'Darwin'",
     "numba",
 ]
 


### PR DESCRIPTION
Error with trying to install ".[full]" on a Mac.
```
ERROR: Could not find a version that satisfies the requirement cuda-python; extra == "full" (from spikeinterface[full]) (from versions: none)
ERROR: No matching distribution found for cuda-python; extra == "full"
```

I think they are trying to switch from sys_platform to platform_system in general, but I haven't read too deeply, but based on the fact the old way is error on my M- Mac...

Turns out the boolean can be written as I have (using platform instead of sys). It is discussed here:
https://peps.python.org/pep-0508/#environment-markers

and is now the example given by the 
PyPA for setuptools
https://setuptools.pypa.io/en/latest/userguide/dependency_management.html

(go down about 1/3 the page)