### PR TITLE
Allow to postprocess on read-only waveform folders

### DIFF
--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -1754,7 +1754,7 @@ class BaseWaveformExtractorExtension:
                     if not self.waveform_extractor.is_read_only():
                         self.extension_folder.mkdir()
                     else:
-                        raise Exception(
+                        warn(
                             "WaveformExtractor: cannot save extension in read-only mode. "
                             "Extension will be saved in memory."
                         )
@@ -1770,7 +1770,7 @@ class BaseWaveformExtractorExtension:
                     if not self.waveform_extractor.is_read_only():
                         self.extension_group = zarr_root.create_group(self.extension_name)
                     else:
-                        raise Exception(
+                        warn(
                             "WaveformExtractor: cannot save extension in read-only mode. "
                             "Extension will be saved in memory."
                         )

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -1751,9 +1751,7 @@ class BaseWaveformExtractorExtension:
             if self.format == "binary":
                 self.extension_folder = self.folder / self.extension_name
                 if not self.extension_folder.is_dir():
-                    if not self.waveform_extractor.is_read_only():
-                        self.extension_folder.mkdir()
-                    else:
+                    if self.waveform_extractor.is_read_only():
                         warn(
                             "WaveformExtractor: cannot save extension in read-only mode. "
                             "Extension will be saved in memory."
@@ -1761,15 +1759,16 @@ class BaseWaveformExtractorExtension:
                         self.format = "memory"
                         self.extension_folder = None
                         self.folder = None
+                    else:
+                        self.extension_folder.mkdir()
+
             else:
                 import zarr
 
                 mode = "r+" if not self.waveform_extractor.is_read_only() else "r"
                 zarr_root = zarr.open(self.folder, mode=mode)
                 if self.extension_name not in zarr_root.keys():
-                    if not self.waveform_extractor.is_read_only():
-                        self.extension_group = zarr_root.create_group(self.extension_name)
-                    else:
+                    if self.waveform_extractor.is_read_only():
                         warn(
                             "WaveformExtractor: cannot save extension in read-only mode. "
                             "Extension will be saved in memory."
@@ -1777,6 +1776,8 @@ class BaseWaveformExtractorExtension:
                         self.format = "memory"
                         self.extension_folder = None
                         self.folder = None
+                    else:
+                        self.extension_group = zarr_root.create_group(self.extension_name)
                 else:
                     self.extension_group = zarr_root[self.extension_name]
         else:
@@ -1893,56 +1894,58 @@ class BaseWaveformExtractorExtension:
         self._save(**kwargs)
 
     def _save(self, **kwargs):
-        if not self.waveform_extractor.is_read_only():
-            if self.format == "binary":
-                import pandas as pd
+        # Only save if not read only
+        if self.waveform_extractor.is_read_only():
+            return
+        if self.format == "binary":
+            import pandas as pd
 
-                for ext_data_name, ext_data in self._extension_data.items():
-                    if isinstance(ext_data, dict):
-                        with (self.extension_folder / f"{ext_data_name}.json").open("w") as f:
-                            json.dump(ext_data, f)
-                    elif isinstance(ext_data, np.ndarray):
-                        np.save(self.extension_folder / f"{ext_data_name}.npy", ext_data)
-                    elif isinstance(ext_data, pd.DataFrame):
-                        ext_data.to_csv(self.extension_folder / f"{ext_data_name}.csv", index=True)
-                    else:
-                        try:
-                            with (self.extension_folder / f"{ext_data_name}.pkl").open("wb") as f:
-                                pickle.dump(ext_data, f)
-                        except:
-                            raise Exception(f"Could not save {ext_data_name} as extension data")
-            elif self.format == "zarr":
-                from .zarrrecordingextractor import get_default_zarr_compressor
-                import pandas as pd
-                import numcodecs
+            for ext_data_name, ext_data in self._extension_data.items():
+                if isinstance(ext_data, dict):
+                    with (self.extension_folder / f"{ext_data_name}.json").open("w") as f:
+                        json.dump(ext_data, f)
+                elif isinstance(ext_data, np.ndarray):
+                    np.save(self.extension_folder / f"{ext_data_name}.npy", ext_data)
+                elif isinstance(ext_data, pd.DataFrame):
+                    ext_data.to_csv(self.extension_folder / f"{ext_data_name}.csv", index=True)
+                else:
+                    try:
+                        with (self.extension_folder / f"{ext_data_name}.pkl").open("wb") as f:
+                            pickle.dump(ext_data, f)
+                    except:
+                        raise Exception(f"Could not save {ext_data_name} as extension data")
+        elif self.format == "zarr":
+            from .zarrrecordingextractor import get_default_zarr_compressor
+            import pandas as pd
+            import numcodecs
 
-                compressor = kwargs.get("compressor", None)
-                if compressor is None:
-                    compressor = get_default_zarr_compressor()
-                for ext_data_name, ext_data in self._extension_data.items():
-                    if ext_data_name in self.extension_group:
-                        del self.extension_group[ext_data_name]
-                    if isinstance(ext_data, dict):
+            compressor = kwargs.get("compressor", None)
+            if compressor is None:
+                compressor = get_default_zarr_compressor()
+            for ext_data_name, ext_data in self._extension_data.items():
+                if ext_data_name in self.extension_group:
+                    del self.extension_group[ext_data_name]
+                if isinstance(ext_data, dict):
+                    self.extension_group.create_dataset(
+                        name=ext_data_name, data=[ext_data], object_codec=numcodecs.JSON()
+                    )
+                    self.extension_group[ext_data_name].attrs["dict"] = True
+                elif isinstance(ext_data, np.ndarray):
+                    self.extension_group.create_dataset(name=ext_data_name, data=ext_data, compressor=compressor)
+                elif isinstance(ext_data, pd.DataFrame):
+                    ext_data.to_xarray().to_zarr(
+                        store=self.extension_group.store,
+                        group=f"{self.extension_group.name}/{ext_data_name}",
+                        mode="a",
+                    )
+                    self.extension_group[ext_data_name].attrs["dataframe"] = True
+                else:
+                    try:
                         self.extension_group.create_dataset(
-                            name=ext_data_name, data=[ext_data], object_codec=numcodecs.JSON()
+                            name=ext_data_name, data=ext_data, object_codec=numcodecs.Pickle()
                         )
-                        self.extension_group[ext_data_name].attrs["dict"] = True
-                    elif isinstance(ext_data, np.ndarray):
-                        self.extension_group.create_dataset(name=ext_data_name, data=ext_data, compressor=compressor)
-                    elif isinstance(ext_data, pd.DataFrame):
-                        ext_data.to_xarray().to_zarr(
-                            store=self.extension_group.store,
-                            group=f"{self.extension_group.name}/{ext_data_name}",
-                            mode="a",
-                        )
-                        self.extension_group[ext_data_name].attrs["dataframe"] = True
-                    else:
-                        try:
-                            self.extension_group.create_dataset(
-                                name=ext_data_name, data=ext_data, object_codec=numcodecs.Pickle()
-                            )
-                        except:
-                            raise Exception(f"Could not save {ext_data_name} as extension data")
+                    except:
+                        raise Exception(f"Could not save {ext_data_name} as extension data")
 
     def reset(self):
         """

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -521,8 +521,22 @@ class WaveformExtractor:
         exists: bool
             Whether the extension exists or not
         """
-        # Extensions are always loaded in memory
-        return extension_name in self._loaded_extensions
+        if self.folder is None:
+            return extension_name in self._loaded_extensions
+        else:
+            # Extensions already loaded in memory
+            if extension_name in self._loaded_extensions:
+                return True
+            else:
+                if self.format == "binary":
+                    return (self.folder / extension_name).is_dir() and (
+                        self.folder / extension_name / "params.json"
+                    ).is_file()
+                elif self.format == "zarr":
+                    return (
+                        extension_name in self._waveforms_root.keys()
+                        and "params" in self._waveforms_root[extension_name].attrs.keys()
+                    )
 
     def load_extension(self, extension_name):
         """

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -523,20 +523,20 @@ class WaveformExtractor:
         """
         if self.folder is None:
             return extension_name in self._loaded_extensions
+
+        if extension_name in self._loaded_extensions:
+            # extension already loaded in memory
+            return True
         else:
-            # Extensions already loaded in memory
-            if extension_name in self._loaded_extensions:
-                return True
-            else:
-                if self.format == "binary":
-                    return (self.folder / extension_name).is_dir() and (
-                        self.folder / extension_name / "params.json"
-                    ).is_file()
-                elif self.format == "zarr":
-                    return (
-                        extension_name in self._waveforms_root.keys()
-                        and "params" in self._waveforms_root[extension_name].attrs.keys()
-                    )
+            if self.format == "binary":
+                return (self.folder / extension_name).is_dir() and (
+                    self.folder / extension_name / "params.json"
+                ).is_file()
+            elif self.format == "zarr":
+                return (
+                    extension_name in self._waveforms_root.keys()
+                    and "params" in self._waveforms_root[extension_name].attrs.keys()
+                )
 
     def load_extension(self, extension_name):
         """

--- a/src/spikeinterface/exporters/to_phy.py
+++ b/src/spikeinterface/exporters/to_phy.py
@@ -178,7 +178,11 @@ def export_to_phy(
         templates[unit_ind, :, :][:, : len(chan_inds)] = template
         templates_ind[unit_ind, : len(chan_inds)] = chan_inds
 
-    template_similarity = compute_template_similarity(waveform_extractor, method="cosine_similarity")
+    if waveform_extractor.is_extension("similarity"):
+        tmc = waveform_extractor.load_extension("similarity")
+        template_similarity = tmc.get_data()
+    else:
+        template_similarity = compute_template_similarity(waveform_extractor, method="cosine_similarity")
 
     np.save(str(output_folder / "templates.npy"), templates)
     np.save(str(output_folder / "template_ind.npy"), templates_ind)

--- a/src/spikeinterface/postprocessing/tests/common_extension_tests.py
+++ b/src/spikeinterface/postprocessing/tests/common_extension_tests.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 import pandas as pd
 import shutil
+import platform
 from pathlib import Path
 
 from spikeinterface import extract_waveforms, load_extractor, load_waveforms, compute_sparsity
@@ -78,12 +79,13 @@ class WaveformExtensionCommonTestSuite:
         self.we2 = we2
 
         # make we read-only
-        we_ro_folder = cache_folder / "toy_waveforms_2seg_readonly"
-        if not we_ro_folder.is_dir():
-            shutil.copytree(we2.folder, we_ro_folder)
+        if platform.system() != "Windows":
+            we_ro_folder = cache_folder / "toy_waveforms_2seg_readonly"
+            if not we_ro_folder.is_dir():
+                shutil.copytree(we2.folder, we_ro_folder)
             # change permissions (R+X)
-        we_ro_folder.chmod(0o555)
-        self.we_ro = load_waveforms(we_ro_folder)
+            we_ro_folder.chmod(0o555)
+            self.we_ro = load_waveforms(we_ro_folder)
 
         self.sparsity2 = compute_sparsity(we2, method="radius", radius_um=30)
         we_memory = extract_waveforms(
@@ -108,8 +110,9 @@ class WaveformExtensionCommonTestSuite:
 
     def tearDown(self):
         # allow pytest to delete RO folder
-        we_ro_folder = cache_folder / "toy_waveforms_2seg_readonly"
-        we_ro_folder.chmod(0o777)
+        if platform.system() != "Windows":
+            we_ro_folder = cache_folder / "toy_waveforms_2seg_readonly"
+            we_ro_folder.chmod(0o777)
 
     def _test_extension_folder(self, we, in_memory=False):
         if self.extension_function_kwargs_list is None:
@@ -193,8 +196,9 @@ class WaveformExtensionCommonTestSuite:
                     print(f"{ext_data_name} of type {type(ext_data_mem)} not tested.")
 
         # read-only - Extension is memory only
-        _ = self.extension_class.get_extension_function()(self.we_ro, load_if_exists=False)
-        assert self.extension_class.extension_name in self.we_ro.get_available_extension_names()
-        ext_ro = self.we_ro.load_extension(self.extension_class.extension_name)
-        assert ext_ro.format == "memory"
-        assert ext_ro.extension_folder is None
+        if platform.system() != "Windows":
+            _ = self.extension_class.get_extension_function()(self.we_ro, load_if_exists=False)
+            assert self.extension_class.extension_name in self.we_ro.get_available_extension_names()
+            ext_ro = self.we_ro.load_extension(self.extension_class.extension_name)
+            assert ext_ro.format == "memory"
+            assert ext_ro.extension_folder is None

--- a/src/spikeinterface/postprocessing/tests/common_extension_tests.py
+++ b/src/spikeinterface/postprocessing/tests/common_extension_tests.py
@@ -4,7 +4,7 @@ import pandas as pd
 import shutil
 from pathlib import Path
 
-from spikeinterface import extract_waveforms, load_extractor, compute_sparsity
+from spikeinterface import extract_waveforms, load_extractor, load_waveforms, compute_sparsity
 from spikeinterface.extractors import toy_example
 
 if hasattr(pytest, "global_test_folder"):
@@ -76,6 +76,15 @@ class WaveformExtensionCommonTestSuite:
             overwrite=True,
         )
         self.we2 = we2
+
+        # make we read-only
+        we_ro_folder = cache_folder / "toy_waveforms_2seg_readonly"
+        if not we_ro_folder.is_dir():
+            shutil.copytree(we2.folder, we_ro_folder)
+            # change permissions (R+X)
+        we_ro_folder.chmod(0o555)
+        self.we_ro = load_waveforms(we_ro_folder)
+
         self.sparsity2 = compute_sparsity(we2, method="radius", radius_um=30)
         we_memory = extract_waveforms(
             recording,
@@ -96,6 +105,11 @@ class WaveformExtensionCommonTestSuite:
         self.we_sparse = we_memory.save(
             folder=cache_folder / "toy_sorting_2seg_sparse", format="binary", sparsity=sparsity, overwrite=True
         )
+
+    def tearDown(self):
+        # allow pytest to delete RO folder
+        we_ro_folder = cache_folder / "toy_waveforms_2seg_readonly"
+        we_ro_folder.chmod(0o777)
 
     def _test_extension_folder(self, we, in_memory=False):
         if self.extension_function_kwargs_list is None:
@@ -177,3 +191,10 @@ class WaveformExtensionCommonTestSuite:
                     assert ext_data_mem.equals(ext_data_zarr)
                 else:
                     print(f"{ext_data_name} of type {type(ext_data_mem)} not tested.")
+
+        # read-only - Extension is memory only
+        _ = self.extension_class.get_extension_function()(self.we_ro, load_if_exists=False)
+        assert self.extension_class.extension_name in self.we_ro.get_available_extension_names()
+        ext_ro = self.we_ro.load_extension(self.extension_class.extension_name)
+        assert ext_ro.format == "memory"
+        assert ext_ro.extension_folder is None

--- a/src/spikeinterface/postprocessing/unit_localization.py
+++ b/src/spikeinterface/postprocessing/unit_localization.py
@@ -570,6 +570,8 @@ def enforce_decrease_shells_data(wf_data, maxchan, radial_parents, in_place=Fals
 def get_grid_convolution_templates_and_weights(
     contact_locations, radius_um=50, upsampling_um=5, sigma_um=np.linspace(10, 50.0, 5), margin_um=50
 ):
+    import sklearn.metrics
+
     x_min, x_max = contact_locations[:, 0].min(), contact_locations[:, 0].max()
     y_min, y_max = contact_locations[:, 1].min(), contact_locations[:, 1].max()
 
@@ -592,8 +594,6 @@ def get_grid_convolution_templates_and_weights(
     template_positions = np.zeros((nb_templates, 2))
     template_positions[:, 0] = all_x.flatten()
     template_positions[:, 1] = all_y.flatten()
-
-    import sklearn
 
     # mask to get nearest template given a channel
     dist = sklearn.metrics.pairwise_distances(contact_locations, template_positions)


### PR DESCRIPTION
In some cases a waveform extractor folder can be loaded in read-only mode (e.g., precomputed waverorms on the cloud, attached as data).

The waveform extensions always inherit the `format` from the parent `WaveformExtractor`. However, if the parent is read-only all postprocessing crashes because it tries to add folders to the parent folder.

This PR adds the `is_read_only()` method to the `WaveformExtractor`. In case a waveform extractor is read-only, extensions can be computed, but they will be in memory and not persistent to disk.


EDIT:

Added a small fix to load the `similarity` extension in the `export_to_phy` if that's already available!