### PR TITLE
Pin down z-scale normalized to integer (!) failure by separating the tests

### DIFF
--- a/src/spikeinterface/preprocessing/normalize_scale.py
+++ b/src/spikeinterface/preprocessing/normalize_scale.py
@@ -293,7 +293,7 @@ class ZScoreRecording(BasePreprocessor):
             means = means[None, :]
             stds = np.std(random_data, axis=0)
             stds = stds[None, :]
-            gain = 1 / stds
+            gain = 1.0 / stds
             offset = -means / stds
 
         if int_scale is not None:

--- a/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
+++ b/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
@@ -80,8 +80,8 @@ def test_zscore():
 
 
 def test_zscore_int():
-    seed = 0
-    rec = generate_recording(seed=seed, mode="lazy")
+    seed = 1
+    rec = generate_recording(seed=seed, mode="legacy")
     rec_int = scale(rec, dtype="int16", gain=100)
     with pytest.raises(AssertionError):
         zscore(rec_int, dtype=None)

--- a/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
+++ b/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
@@ -78,13 +78,18 @@ def test_zscore():
     assert np.all(np.abs(np.mean(tr, axis=0)) < 0.01)
     assert np.all(np.abs(np.std(tr, axis=0) - 1) < 0.01)
 
+
+def test_zscore_int():
+    seed = 0
+    rec = generate_recording(seed=seed, mode="lazy")
     rec_int = scale(rec, dtype="int16", gain=100)
     with pytest.raises(AssertionError):
-        rec4 = zscore(rec_int, dtype=None)
-    rec4 = zscore(rec_int, dtype="int16", int_scale=256, mode="mean+std", seed=seed)
-    tr = rec4.get_traces(segment_index=0)
-    trace_mean = np.mean(tr, axis=0)
-    trace_std = np.std(tr, axis=0)
+        zscore(rec_int, dtype=None)
+
+    zscore_recording = zscore(rec_int, dtype="int16", int_scale=256, mode="mean+std", seed=seed)
+    traces = zscore_recording.get_traces(segment_index=0)
+    trace_mean = np.mean(traces, axis=0)
+    trace_std = np.std(traces, axis=0)
     assert np.all(np.abs(trace_mean) < 1)
     assert np.all(np.abs(trace_std - 256) < 1)
 


### PR DESCRIPTION
I have this tests failing in #1970 which I have seen failing before. It is not failing in my computer so I want to separate it in its own test to hopefully isolate the failure.