### PR TITLE
Fix `zero_channel_pad` case when selected frames are outside of original data region

### DIFF
--- a/src/spikeinterface/preprocessing/tests/test_zero_padding.py
+++ b/src/spikeinterface/preprocessing/tests/test_zero_padding.py
@@ -257,9 +257,9 @@ def test_trace_padded_recording_retrieve_traces_with_partial_padding(recording, 
     expected_zeros = np.zeros((number_of_paded_frames_at_end, num_channels))
     assert np.allclose(padded_traces_end, expected_zeros)
 
+
 @pytest.mark.parametrize("padding_start, padding_end", [(5000, 5000), (5000, 0), (0, 5000)])
 def test_trace_padded_recording_retrieve_full_recording_with_preprocessing(recording, padding_start, padding_end):
-
     num_samples = recording.get_num_samples()
     num_channels = recording.get_num_channels()
 
@@ -281,13 +281,14 @@ def test_trace_padded_recording_retrieve_full_recording_with_preprocessing(recor
     end_frames = start_frames + step
 
     for start_frame, end_frame in zip(start_frames, end_frames):
-
         padded_trace = padded_recording.get_traces(start_frame=start_frame, end_frame=end_frame)
 
         end_padding_region_first_idx = padding_start + num_samples
 
         if padding_start <= start_frame < end_padding_region_first_idx:
-            original_trace = recording.get_traces(start_frame=start_frame - padding_start, end_frame=end_frame - padding_start)
+            original_trace = recording.get_traces(
+                start_frame=start_frame - padding_start, end_frame=end_frame - padding_start
+            )
             assert np.allclose(padded_trace, original_trace, rtol=0, atol=1e-10)
         else:
             assert np.all(padded_trace == padded_recording.fill_value)
@@ -295,7 +296,6 @@ def test_trace_padded_recording_retrieve_full_recording_with_preprocessing(recor
 
 @pytest.mark.parametrize("padding_start, padding_end", [(5000, 5000), (5000, 0), (0, 5000)])
 def test_trace_padded_recording_retrieve_full_recording_with_preprocessing(recording, padding_start, padding_end):
-
     num_samples = recording.get_num_samples()
     num_channels = recording.get_num_channels()
 
@@ -317,13 +317,14 @@ def test_trace_padded_recording_retrieve_full_recording_with_preprocessing(recor
     end_frames = start_frames + step
 
     for start_frame, end_frame in zip(start_frames, end_frames):
-
         padded_trace = padded_recording.get_traces(start_frame=start_frame, end_frame=end_frame)
 
         end_padding_region_first_idx = padding_start + num_samples
 
         if padding_start <= start_frame < end_padding_region_first_idx:
-            original_trace = recording.get_traces(start_frame=start_frame - padding_start, end_frame=end_frame - padding_start)
+            original_trace = recording.get_traces(
+                start_frame=start_frame - padding_start, end_frame=end_frame - padding_start
+            )
             assert np.allclose(padded_trace, original_trace, rtol=0, atol=1e-10)
         else:
             assert np.all(padded_trace == padded_recording.fill_value)

--- a/src/spikeinterface/preprocessing/tests/test_zero_padding.py
+++ b/src/spikeinterface/preprocessing/tests/test_zero_padding.py
@@ -6,7 +6,7 @@ from spikeinterface import set_global_tmp_folder
 from spikeinterface.core import generate_recording
 from spikeinterface.core.numpyextractors import NumpyRecording
 
-from spikeinterface.preprocessing import zero_channel_pad, bandpass_filter, common_reference
+from spikeinterface.preprocessing import zero_channel_pad, bandpass_filter, phase_shift
 from spikeinterface.preprocessing.zero_channel_pad import TracePaddedRecording
 
 if hasattr(pytest, "global_test_folder"):
@@ -258,12 +258,19 @@ def test_trace_padded_recording_retrieve_traces_with_partial_padding(recording, 
     assert np.allclose(padded_traces_end, expected_zeros)
 
 
+@pytest.mark.parametrize("preprocessing", ["bandpass_filter", "phase_shift"])
 @pytest.mark.parametrize("padding_start, padding_end", [(5000, 5000), (5000, 0), (0, 5000)])
-def test_trace_padded_recording_retrieve_full_recording_with_preprocessing(recording, padding_start, padding_end):
+def test_trace_padded_recording_retrieve_full_recording_with_preprocessing(recording, padding_start, padding_end, preprocessing):
     num_samples = recording.get_num_samples()
     num_channels = recording.get_num_channels()
 
-    recording = bandpass_filter(recording, freq_min=300, freq_max=6000)
+    if preprocessing == "bandpass_filter":
+        recording = bandpass_filter(recording, freq_min=300, freq_max=6000)
+    else:
+        sample_shift_size = 0.4
+        inter_sample_shift = np.arange(recording.get_num_channels()) * sample_shift_size
+        recording.set_property("inter_sample_shift", inter_sample_shift)
+        recording = phase_shift(recording)
 
     padded_recording = TracePaddedRecording(
         parent_recording=recording,
@@ -294,40 +301,7 @@ def test_trace_padded_recording_retrieve_full_recording_with_preprocessing(recor
             assert np.all(padded_trace == padded_recording.fill_value)
 
 
-@pytest.mark.parametrize("padding_start, padding_end", [(5000, 5000), (5000, 0), (0, 5000)])
-def test_trace_padded_recording_retrieve_full_recording_with_preprocessing(recording, padding_start, padding_end):
-    num_samples = recording.get_num_samples()
-    num_channels = recording.get_num_channels()
 
-    recording = bandpass_filter(recording, freq_min=300, freq_max=6000)
-
-    padded_recording = TracePaddedRecording(
-        parent_recording=recording,
-        padding_start=padding_start,
-        padding_end=padding_end,
-    )
-
-    # Cycle through the whole recording, using get_traces() to pull chunks of
-    # size `step`. This emulates the processing of writing to a binary file.
-    # Data that lie within the padding region should be fill value only, while
-    # data from original trace should match exactly. Note that the step
-    # size must be chosen to retreieve data that is purely padding or original data
-    step = 1000
-    start_frames = np.arange(padded_recording.get_num_samples(), step=step)
-    end_frames = start_frames + step
-
-    for start_frame, end_frame in zip(start_frames, end_frames):
-        padded_trace = padded_recording.get_traces(start_frame=start_frame, end_frame=end_frame)
-
-        end_padding_region_first_idx = padding_start + num_samples
-
-        if padding_start <= start_frame < end_padding_region_first_idx:
-            original_trace = recording.get_traces(
-                start_frame=start_frame - padding_start, end_frame=end_frame - padding_start
-            )
-            assert np.allclose(padded_trace, original_trace, rtol=0, atol=1e-10)
-        else:
-            assert np.all(padded_trace == padded_recording.fill_value)
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/preprocessing/tests/test_zero_padding.py
+++ b/src/spikeinterface/preprocessing/tests/test_zero_padding.py
@@ -260,7 +260,9 @@ def test_trace_padded_recording_retrieve_traces_with_partial_padding(recording, 
 
 @pytest.mark.parametrize("preprocessing", ["bandpass_filter", "phase_shift"])
 @pytest.mark.parametrize("padding_start, padding_end", [(5000, 5000), (5000, 0), (0, 5000)])
-def test_trace_padded_recording_retrieve_full_recording_with_preprocessing(recording, padding_start, padding_end, preprocessing):
+def test_trace_padded_recording_retrieve_full_recording_with_preprocessing(
+    recording, padding_start, padding_end, preprocessing
+):
     num_samples = recording.get_num_samples()
     num_channels = recording.get_num_channels()
 
@@ -299,9 +301,6 @@ def test_trace_padded_recording_retrieve_full_recording_with_preprocessing(recor
             assert np.allclose(padded_trace, original_trace, rtol=0, atol=1e-10)
         else:
             assert np.all(padded_trace == padded_recording.fill_value)
-
-
-
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/preprocessing/zero_channel_pad.py
+++ b/src/spikeinterface/preprocessing/zero_channel_pad.py
@@ -94,6 +94,10 @@ class TracePaddedRecordingSegment(BasePreprocessorSegment):
         # Else, we start with the full padded traces and allocate the original traces in the middle
         output_traces = np.full(shape=(trace_size, num_channels), fill_value=self.fill_value, dtype=self.dtype)
 
+        # If start and end frame are outside of the original data region (e.g. for Kilosort), return only paddding
+        if start_frame > self.num_samples_in_original_segment and end_frame > self.num_samples_in_original_segment:
+            return output_traces
+
         # After the padding, the original traces are placed in the middle until the end of the original traces
         if end_frame >= self.padding_start:
             original_traces = self.get_original_traces_shifted(

--- a/src/spikeinterface/preprocessing/zero_channel_pad.py
+++ b/src/spikeinterface/preprocessing/zero_channel_pad.py
@@ -95,7 +95,7 @@ class TracePaddedRecordingSegment(BasePreprocessorSegment):
         output_traces = np.full(shape=(trace_size, num_channels), fill_value=self.fill_value, dtype=self.dtype)
 
         # If start and end frame are outside of the original data region (e.g. for Kilosort), return only paddding
-        if start_frame > self.num_samples_in_original_segment and end_frame > self.num_samples_in_original_segment:
+        if start_frame > self.num_samples_in_original_segment + self.padding_start and end_frame > self.num_samples_in_original_segment + self.padding_start:
             return output_traces
 
         # After the padding, the original traces are placed in the middle until the end of the original traces
@@ -123,11 +123,8 @@ class TracePaddedRecordingSegment(BasePreprocessorSegment):
         """
         original_start_frame = max(start_frame - self.padding_start, 0)
         original_end_frame = min(end_frame - self.padding_start, self.num_samples_in_original_segment)
-        original_traces = self.parent_recording_segment.get_traces(
-            start_frame=original_start_frame,
-            end_frame=original_end_frame,
-            channel_indices=channel_indices,
-        )
+
+        original_traces = self.parent_recording_segment.get_traces(start_frame=original_start_frame, end_frame=original_end_frame, channel_indices=channel_indices,)  # BREAKPOINT HERE!!
 
         return original_traces
 

--- a/src/spikeinterface/preprocessing/zero_channel_pad.py
+++ b/src/spikeinterface/preprocessing/zero_channel_pad.py
@@ -95,7 +95,10 @@ class TracePaddedRecordingSegment(BasePreprocessorSegment):
         output_traces = np.full(shape=(trace_size, num_channels), fill_value=self.fill_value, dtype=self.dtype)
 
         # If start and end frame are outside of the original data region (e.g. for Kilosort), return only paddding
-        if start_frame > self.num_samples_in_original_segment + self.padding_start and end_frame > self.num_samples_in_original_segment + self.padding_start:
+        if (
+            start_frame > self.num_samples_in_original_segment + self.padding_start
+            and end_frame > self.num_samples_in_original_segment + self.padding_start
+        ):
             return output_traces
 
         # After the padding, the original traces are placed in the middle until the end of the original traces
@@ -124,7 +127,11 @@ class TracePaddedRecordingSegment(BasePreprocessorSegment):
         original_start_frame = max(start_frame - self.padding_start, 0)
         original_end_frame = min(end_frame - self.padding_start, self.num_samples_in_original_segment)
 
-        original_traces = self.parent_recording_segment.get_traces(start_frame=original_start_frame, end_frame=original_end_frame, channel_indices=channel_indices,)  # BREAKPOINT HERE!!
+        original_traces = self.parent_recording_segment.get_traces(
+            start_frame=original_start_frame,
+            end_frame=original_end_frame,
+            channel_indices=channel_indices,
+        )  # BREAKPOINT HERE!!
 
         return original_traces
 


### PR DESCRIPTION
I was running into an error when using Kilosort's `skip_kilosort_preprocessing`  that would crash when running preprocessing during binary-writing prior to sorting.

The (test) file I was running had a period at the end of the trace which was required to be purely padding (for running in kilosort), and was larger than the chunk size. This meant that calls were made to `zero_channel_pad.get_traces()` which had both a start and end frame larger than the original data size. This led to the below function call:

```
            original_traces = self.get_original_traces_shifted(
                start_frame=start_frame,
                end_frame=end_frame,
                channel_indices=channel_indices,
            )
```

with `start_frame` and `end_frame` that were larger than the original data. 

As a fix, this PR adds another case in which both the `start_frame` and `end_frame` are larger than the data - if this is `True`, then an array that consists of only padding is returned.

I must admit I am not very familiar with the uses of `zero_channel_pad.py` and have not considered deeply the effect of adding this code to other uses of the function beyond fixing the problem I was having. However, I think in the case that:

```
start_frame > self.num_samples_in_original_segment and end_frame > self.num_samples_in_original_segment
```
There is nothing else that you could possibly need to do except return an array full of padding? And this is quite a rare and unique circumstance, so I don't think this conditional will erroneously catch other cases.