### PR TITLE
Add methods to sparsify and densify waveforms to `ChannelSparsity`

### DIFF
--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -149,7 +149,7 @@ class ChannelSparsity:
 
         assert_msg = (
             "Waveforms must be dense to sparsify them. "
-            f"Their last dimension {waveforms.shape[-1]} must be equal to the number of channels {self.num_chanenls}"
+            f"Their last dimension {waveforms.shape[-1]} must be equal to the number of channels {self.num_channels}"
         )
         assert self.are_waveforms_dense(waveforms=waveforms), assert_msg
 

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -156,9 +156,6 @@ class ChannelSparsity:
         assert self.are_waveforms_dense(waveforms=waveforms), assert_msg
 
         non_zero_indices = self.unit_id_to_channel_indices[unit_id]
-        num_active_channels = len(non_zero_indices)
-        sparsified_shape = waveforms.shape[:-1] + (num_active_channels,)
-        sparsified_waveforms = np.zeros(sparsified_shape, dtype=waveforms.dtype)
         sparsified_waveforms = waveforms[..., non_zero_indices]
 
         return sparsified_waveforms
@@ -194,7 +191,7 @@ class ChannelSparsity:
 
         densified_shape = waveforms.shape[:-1] + (self.num_channels,)
         densified_waveforms = np.zeros(densified_shape, dtype=waveforms.dtype)
-        densified_waveforms[..., non_zero_indices] = waveforms[...]
+        densified_waveforms[..., non_zero_indices] = waveforms
 
         return densified_waveforms
 

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -136,17 +136,16 @@ class ChannelSparsity:
         Parameters
         ----------
         waveforms : np.array
-            Dense waveforms with shape (num_units, num_samples, num_channels).
+            Dense waveforms with shape (num_waveforms, num_samples, num_channels) or a
+            single dense waveform (template) with shape (num_samples, num_channels).
         unit_id : str
             The unit_id for which to sparsify the waveform.
 
         Returns
         -------
         sparsified_waveforms : np.array
-            Sparse waveforms with shape (num_units, num_samples, num_active_channels).
-
-        Where num_active_channels is the number of channels that are active for this unit and should be
-        equal to the number of non-zero elements in the mask for this unit.
+            Sparse waveforms with shape (num_waveforms, num_samples, num_active_channels)
+            or a single sparsified waveform (template) with shape (num_samples, num_active_channels).
         """
 
         assert_msg = (
@@ -170,14 +169,16 @@ class ChannelSparsity:
         Parameters
         ----------
         waveforms : np.array
-            The sparsified waveforms array of shape (num_units, num_samples, num_active_channels).
+            The sparsified waveforms array of shape (num_waveforms, num_samples, num_active_channels) or a single
+            sparse waveform (template) with shape (num_samples, num_active_channels).
         unit_id : str
             The unit_id that was used to sparsify the waveform.
 
         Returns
         -------
         densified_waveforms : np.array
-            The densified waveforms array of shape (num_units, num_samples, num_channels).
+            The densified waveforms array of shape (num_waveforms, num_samples, num_channels) or a single dense
+            waveform (template) with shape (num_samples, num_channels).
 
         """
 

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -100,7 +100,7 @@ class ChannelSparsity:
 
         self.num_channels = self.channel_ids.size
         self.num_units = self.unit_ids.size
-        self.max_active_channels = self.mask.sum(axis=1).max()
+        self.max_num_active_channels = self.mask.sum(axis=1).max()
 
     def __repr__(self):
         density = np.mean(self.mask)

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -34,7 +34,8 @@ _sparsity_doc = """
 class ChannelSparsity:
     """
     Handle channel sparsity for a set of units. That is, for every unit,
-    it indicates which channels are used to represent or active the waveform.
+    it indicates which channels are used to represent the waveform and the rest
+    of the non-represented channels are assumed to be zero.
 
     Internally, sparsity is stored as a boolean mask.
 

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -147,7 +147,12 @@ class ChannelSparsity:
             Sparse waveforms with shape (num_units, num_samples, num_active_channels).
         """
 
-        assert self.are_waveforms_dense(waveforms=waveforms), "Waveforms must be dense to sparsify them."
+        assert_msg = (
+            "Waveforms must be dense to sparsify them. "
+            f"Their last dimension {waveforms.shape[-1]} must be equal to the number of channels {self.num_chanenls}"
+        )
+        assert self.are_waveforms_dense(waveforms=waveforms), assert_msg
+
         unit_id = self.unit_ids[unit_index]
         non_zero_indices = self.unit_id_to_channel_indices[unit_id]
         num_sparse_channels = len(non_zero_indices)

--- a/src/spikeinterface/core/tests/test_sparsity.py
+++ b/src/spikeinterface/core/tests/test_sparsity.py
@@ -75,12 +75,15 @@ def test_sparsify_waveforms():
     for unit_index in range(num_units):
         waveforms_dense = rng.random(size=(num_units, num_samples, num_channels))
 
+        # Test are_waveforms_dense
+        assert sparsity.are_waveforms_dense(waveforms_dense)
+
         # Test sparsify
         waveforms_sparse = sparsity.sparsify_waveforms(waveforms_dense, unit_index=unit_index)
         num_sparse_channels = sparsity.mask[unit_index, :].sum()
         assert waveforms_sparse.shape == (num_units, num_samples, num_sparse_channels)
 
-        # Test round-trip (note this is loosy)
+        # Test round-trip (note that this is loosy)
         unit_id = unit_ids[unit_index]
         non_zero_indices = sparsity.unit_id_to_channel_indices[unit_id]
         waveforms_dense2 = sparsity.densify_waveforms(waveforms_sparse, unit_index=unit_index)
@@ -118,6 +121,9 @@ def test_densify_waveforms():
         non_zero_indices = sparsity.unit_id_to_channel_indices[unit_id]
         num_sparse_channels = len(non_zero_indices)
         waveforms_sparse = rng.random(size=(num_units, num_samples, num_sparse_channels))
+
+        # Test are waveforms sparse
+        assert sparsity.are_waveforms_sparse(waveforms_sparse, unit_index=unit_index)
 
         # Test densify
         waveforms_dense = sparsity.densify_waveforms(waveforms_sparse, unit_index=unit_index)


### PR DESCRIPTION
I have been wanting to add something like this for a while and it will be useful in the context of https://github.com/SpikeInterface/spikeinterface/pull/1982.

The idea is that if we have channel sparsity, it should be possible to use the class to compute a sparse or dense representation of a waveform or a template. Now the `ChannelSparsity` object is part of WaveformExtractor but it does not have a way of changing the representation at a waveform at will in the spot. 

Instead, we do sparsifying operations all over the place directly with the mask:

https://github.com/h-mayorquin/spikeinterface/blob/aa5248454462084dcd7a05296ef82c0bb717a285/src/spikeinterface/core/waveform_extractor.py#L946-L950

https://github.com/h-mayorquin/spikeinterface/blob/aa5248454462084dcd7a05296ef82c0bb717a285/src/spikeinterface/core/waveform_extractor.py#L893-L909

I think it is better to centralize this operation where it semantically make sense (a sparsity class should sparsify!) and test it appropriately.

 