### PR TITLE
Speed up searchsorted calls

### DIFF
--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -473,8 +473,7 @@ class BaseSorting(BaseExtractor):
             if not concatenated:
                 spikes_ = []
                 for segment_index in range(self.get_num_segments()):
-                    s0 = np.searchsorted(spikes["segment_index"], segment_index, side="left")
-                    s1 = np.searchsorted(spikes["segment_index"], segment_index + 1, side="left")
+                    s0, s1 = np.searchsorted(spikes["segment_index"], [segment_index, segment_index + 1], side="left")
                     spikes_.append(spikes[s0:s1])
                 spikes = spikes_
 

--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -1109,8 +1109,7 @@ class InjectTemplatesRecording(BaseRecording):
             num_samples = [num_samples]
 
         for segment_index in range(sorting.get_num_segments()):
-            start = np.searchsorted(self.spike_vector["segment_index"], segment_index, side="left")
-            end = np.searchsorted(self.spike_vector["segment_index"], segment_index, side="right")
+            start, end = np.searchsorted(self.spike_vector["segment_index"], [segment_index, segment_index+1], side="left")
             spikes = self.spike_vector[start:end]
             amplitude_vec = amplitude_vector[start:end] if amplitude_vector is not None else None
             upsample_vec = upsample_vector[start:end] if upsample_vector is not None else None
@@ -1208,8 +1207,8 @@ class InjectTemplatesRecordingSegment(BaseRecordingSegment):
         else:
             traces = np.zeros([end_frame - start_frame, n_channels], dtype=self.dtype)
 
-        start = np.searchsorted(self.spike_vector["sample_index"], start_frame - self.templates.shape[1], side="left")
-        end = np.searchsorted(self.spike_vector["sample_index"], end_frame + self.templates.shape[1], side="right")
+        start, end = np.searchsorted(self.spike_vector["sample_index"], [start_frame - self.templates.shape[1], 
+                                                                    end_frame + self.templates.shape[1] + 1], side="left")
 
         for i in range(start, end):
             spike = self.spike_vector[i]

--- a/src/spikeinterface/core/node_pipeline.py
+++ b/src/spikeinterface/core/node_pipeline.py
@@ -111,8 +111,7 @@ class PeakRetriever(PeakSource):
         # precompute segment slice
         self.segment_slices = []
         for segment_index in range(recording.get_num_segments()):
-            i0 = np.searchsorted(peaks["segment_index"], segment_index)
-            i1 = np.searchsorted(peaks["segment_index"], segment_index + 1)
+            i0, i1 = np.searchsorted(peaks["segment_index"], [segment_index, segment_index + 1])
             self.segment_slices.append(slice(i0, i1))
 
     def get_trace_margin(self):
@@ -125,8 +124,7 @@ class PeakRetriever(PeakSource):
         # get local peaks
         sl = self.segment_slices[segment_index]
         peaks_in_segment = self.peaks[sl]
-        i0 = np.searchsorted(peaks_in_segment["sample_index"], start_frame)
-        i1 = np.searchsorted(peaks_in_segment["sample_index"], end_frame)
+        i0, i1 = np.searchsorted(peaks_in_segment["segment_index"], [start_frame, end_frame])
         local_peaks = peaks_in_segment[i0:i1]
 
         # make sample index local to traces
@@ -183,8 +181,7 @@ class SpikeRetriever(PeakSource):
         # precompute segment slice
         self.segment_slices = []
         for segment_index in range(recording.get_num_segments()):
-            i0 = np.searchsorted(self.peaks["segment_index"], segment_index)
-            i1 = np.searchsorted(self.peaks["segment_index"], segment_index + 1)
+            i0, i1 = np.searchsorted(self.peaks["segment_index"], [segment_index, segment_index + 1])
             self.segment_slices.append(slice(i0, i1))
 
     def get_trace_margin(self):
@@ -197,8 +194,7 @@ class SpikeRetriever(PeakSource):
         # get local peaks
         sl = self.segment_slices[segment_index]
         peaks_in_segment = self.peaks[sl]
-        i0 = np.searchsorted(peaks_in_segment["sample_index"], start_frame)
-        i1 = np.searchsorted(peaks_in_segment["sample_index"], end_frame)
+        i0, i1 = np.searchsorted(peaks_in_segment["segment_index"], [start_frame, end_frame])
         local_peaks = peaks_in_segment[i0:i1]
 
         # make sample index local to traces

--- a/src/spikeinterface/core/numpyextractors.py
+++ b/src/spikeinterface/core/numpyextractors.py
@@ -338,8 +338,7 @@ class NumpySortingSegment(BaseSortingSegment):
         if self.spikes_in_seg is None:
             # the slicing of segment is done only once the first time
             # this fasten the constructor a lot
-            s0 = np.searchsorted(self.spikes["segment_index"], self.segment_index, side="left")
-            s1 = np.searchsorted(self.spikes["segment_index"], self.segment_index + 1, side="left")
+            s0, s1 = np.searchsorted(self.spikes["segment_index"], [self.segment_index, self.segment_index + 1])
             self.spikes_in_seg = self.spikes[s0:s1]
 
         unit_index = self.unit_ids.index(unit_id)

--- a/src/spikeinterface/core/segmentutils.py
+++ b/src/spikeinterface/core/segmentutils.py
@@ -174,8 +174,7 @@ class ProxyConcatenateRecordingSegment(BaseRecordingSegment):
             # Return (0 * num_channels) array of correct dtype
             return self.parent_segments[0].get_traces(0, 0, channel_indices)
 
-        i0 = np.searchsorted(self.cumsum_length, start_frame, side="right") - 1
-        i1 = np.searchsorted(self.cumsum_length, end_frame, side="right") - 1
+        i0, i1 = np.searchsorted(self.cumsum_length, [start_frame, end_frame], side="right") - 1
 
         # several case:
         #  * come from one segment (i0 == i1)
@@ -469,8 +468,7 @@ class ProxyConcatenateSortingSegment(BaseSortingSegment):
         if end_frame is None:
             end_frame = self.get_num_samples()
 
-        i0 = np.searchsorted(self.cumsum_length, start_frame, side="right") - 1
-        i1 = np.searchsorted(self.cumsum_length, end_frame, side="right") - 1
+        i0, i1 = np.searchsorted(self.cumsum_length, [start_frame, end_frame], side="right") - 1
 
         # several case:
         #  * come from one segment (i0 == i1)

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -344,15 +344,13 @@ def _worker_distribute_buffers(segment_index, start_frame, end_frame, worker_ctx
 
     # take only spikes with the correct segment_index
     # this is a slice so no copy!!
-    s0 = np.searchsorted(spikes["segment_index"], segment_index)
-    s1 = np.searchsorted(spikes["segment_index"], segment_index + 1)
+    s0, s1 = np.searchsorted(spikes["segment_index"], [segment_index, segment_index + 1])
     in_seg_spikes = spikes[s0:s1]
 
     # take only spikes in range [start_frame, end_frame]
     # this is a slice so no copy!!
     # the border of segment are protected by nbefore on left an nafter on the right
-    i0 = np.searchsorted(in_seg_spikes["sample_index"], max(start_frame, nbefore))
-    i1 = np.searchsorted(in_seg_spikes["sample_index"], min(end_frame, seg_size - nafter))
+    i0, i1 = np.searchsorted(in_seg_spikes["sample_index"], [max(start_frame, nbefore), min(end_frame, seg_size - nafter)])
 
     # slice in absolut in spikes vector
     l0 = i0 + s0
@@ -562,8 +560,7 @@ def _init_worker_distribute_single_buffer(
     # prepare segment slices
     segment_slices = []
     for segment_index in range(recording.get_num_segments()):
-        s0 = np.searchsorted(spikes["segment_index"], segment_index)
-        s1 = np.searchsorted(spikes["segment_index"], segment_index + 1)
+        s0, s1 = np.searchsorted(spikes["segment_index"], [segment_index, segment_index + 1])
         segment_slices.append((s0, s1))
     worker_ctx["segment_slices"] = segment_slices
 
@@ -590,8 +587,7 @@ def _worker_distribute_single_buffer(segment_index, start_frame, end_frame, work
     # take only spikes in range [start_frame, end_frame]
     # this is a slice so no copy!!
     # the border of segment are protected by nbefore on left an nafter on the right
-    i0 = np.searchsorted(in_seg_spikes["sample_index"], max(start_frame, nbefore))
-    i1 = np.searchsorted(in_seg_spikes["sample_index"], min(end_frame, seg_size - nafter))
+    i0, i1 = np.searchsorted(in_seg_spikes["sample_index"], [max(start_frame, nbefore), min(end_frame, seg_size - nafter)])
 
     # slice in absolut in spikes vector
     l0 = i0 + s0
@@ -685,8 +681,7 @@ def has_exceeding_spikes(recording, sorting):
     """
     spike_vector = sorting.to_spike_vector()
     for segment_index in range(recording.get_num_segments()):
-        start_seg_ind = np.searchsorted(spike_vector["segment_index"], segment_index)
-        end_seg_ind = np.searchsorted(spike_vector["segment_index"], segment_index + 1)
+        start_seg_ind, end_seg_ind = np.searchsorted(spike_vector["segment_index"], [segment_index, segment_index + 1])
         spike_vector_seg = spike_vector[start_seg_ind:end_seg_ind]
         if len(spike_vector_seg) > 0:
             if spike_vector_seg["sample_index"][-1] > recording.get_num_samples(segment_index=segment_index) - 1:

--- a/src/spikeinterface/curation/remove_duplicated_spikes.py
+++ b/src/spikeinterface/curation/remove_duplicated_spikes.py
@@ -82,8 +82,7 @@ class RemoveDuplicatedSpikesSortingSegment(BaseSortingSegment):
         if end_frame == None:
             end_frame = spike_train[-1] if len(spike_train) > 0 else 0
 
-        start = np.searchsorted(spike_train, start_frame, side="left")
-        end = np.searchsorted(spike_train, end_frame, side="right")
+        start, end = np.searchsorted(spike_train, [start_frame, end + 1], side="left")
 
         return spike_train[start:end]
 

--- a/src/spikeinterface/postprocessing/amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/amplitude_scalings.py
@@ -99,8 +99,7 @@ class AmplitudeScalingsCalculator(BaseWaveformExtractorExtension):
         # precompute segment slice
         segment_slices = []
         for segment_index in range(we.get_num_segments()):
-            i0 = np.searchsorted(self.spikes["segment_index"], segment_index)
-            i1 = np.searchsorted(self.spikes["segment_index"], segment_index + 1)
+            i0, i1 = np.searchsorted(self.spikes["segment_index"], [segment_index, segment_index + 1])
             segment_slices.append(slice(i0, i1))
 
         # and run

--- a/src/spikeinterface/postprocessing/principal_component.py
+++ b/src/spikeinterface/postprocessing/principal_component.py
@@ -600,8 +600,7 @@ def _all_pc_extractor_chunk(segment_index, start_frame, end_frame, worker_ctx):
 
     seg_size = recording.get_num_samples(segment_index=segment_index)
 
-    i0 = np.searchsorted(spike_times, start_frame)
-    i1 = np.searchsorted(spike_times, end_frame)
+    i0, i1 = np.searchsorted(spike_times, [start_frame, end_frame])
 
     if i0 != i1:
         # protect from spikes on border :  spike_time<0 or spike_time>seg_size

--- a/src/spikeinterface/postprocessing/spike_amplitudes.py
+++ b/src/spikeinterface/postprocessing/spike_amplitudes.py
@@ -218,9 +218,7 @@ def _spike_amplitudes_chunk(segment_index, start_frame, end_frame, worker_ctx):
     d = np.diff(spike_times)
     assert np.all(d >= 0)
 
-    i0 = np.searchsorted(spike_times, start_frame)
-    i1 = np.searchsorted(spike_times, end_frame)
-
+    i0, i1 = np.searchsorted(spike_times, [start_frame, end_frame])
     n_spikes = i1 - i0
     amplitudes = np.zeros(n_spikes, dtype=recording.get_dtype())
 

--- a/src/spikeinterface/postprocessing/spike_locations.py
+++ b/src/spikeinterface/postprocessing/spike_locations.py
@@ -77,8 +77,7 @@ class SpikeLocationsCalculator(BaseWaveformExtractorExtension):
         elif outputs == "by_unit":
             locations_by_unit = []
             for segment_index in range(self.waveform_extractor.get_num_segments()):
-                i0 = np.searchsorted(self.spikes["segment_index"], segment_index, side="left")
-                i1 = np.searchsorted(self.spikes["segment_index"], segment_index, side="right")
+                i0, i1 = np.searchsorted(self.spikes["segment_index"], [segment_index, segment_index + 1], side="left")
                 spikes = self.spikes[i0:i1]
                 locations = self._extension_data["spike_locations"][i0:i1]
 

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -848,16 +848,14 @@ def compute_drift_metrics(
         spike_vector = sorting.to_spike_vector()
 
         # retrieve spikes in segment
-        i0 = np.searchsorted(spike_vector["segment_index"], segment_index)
-        i1 = np.searchsorted(spike_vector["segment_index"], segment_index + 1)
+        i0, i1 = np.searchsorted(spike_vector["segment_index"], [segment_index, segment_index + 1])
         spikes_in_segment = spike_vector[i0:i1]
         spike_locations_in_segment = spike_locations[i0:i1]
 
         # compute median positions (if less than min_spikes_per_interval, median position is 0)
         median_positions = np.nan * np.zeros((len(unit_ids), num_bin_edges - 1))
         for bin_index, (start_frame, end_frame) in enumerate(zip(bins[:-1], bins[1:])):
-            i0 = np.searchsorted(spikes_in_segment["sample_index"], start_frame)
-            i1 = np.searchsorted(spikes_in_segment["sample_index"], end_frame)
+            i0, i1 = np.searchsorted(spikes_in_segment["sample_index"], [start_frame, end_frame])
             spikes_in_bin = spikes_in_segment[i0:i1]
             spike_locations_in_bin = spike_locations_in_segment[i0:i1][direction]
 

--- a/src/spikeinterface/sortingcomponents/motion_interpolation.py
+++ b/src/spikeinterface/sortingcomponents/motion_interpolation.py
@@ -155,8 +155,7 @@ def interpolate_motion_on_traces(
             **spatial_interpolation_kwargs,
         )
 
-        i0 = np.searchsorted(bin_inds, bin_ind, side="left")
-        i1 = np.searchsorted(bin_inds, bin_ind, side="right")
+        i0, i1 = np.searchsorted(bin_inds, [bin_ind, bin_ind + 1] side="left")
 
         # here we use a simple np.matmul even if dirft_kernel can be super sparse.
         # because the speed for a sparse matmul is not so good when we disable multi threaad (due multi processing


### PR DESCRIPTION
Quite a lot everywhere in spikeinterface, searchsorted is called twice and thus a speedup can be gained by making a single call