### PR TITLE
Save/load comparison objects with pickle

### DIFF
--- a/src/spikeinterface/comparison/multicomparisons.py
+++ b/src/spikeinterface/comparison/multicomparisons.py
@@ -182,7 +182,9 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
 
     def save_to_folder(self, save_folder):
         warnings.warn(
-            "save_to_folder() is deprecated. You should save and load the multi sorting comparison object using pickle.\n>>> pickle.dump(mcmp, open('mcmp.pkl', 'wb')))))\n>>> mcmp_loaded = pickle.load(open('mcmp.pkl', 'rb'))",
+            "save_to_folder() is deprecated. "
+            "You should save and load the multi sorting comparison object using pickle."
+            "\n>>> pickle.dump(mcmp, open('mcmp.pkl', 'wb')))))\n>>> mcmp_loaded = pickle.load(open('mcmp.pkl', 'rb'))",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -212,7 +214,9 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
     @staticmethod
     def load_from_folder(folder_path):
         warnings.warn(
-            "load_from_folder() is deprecated. You should save and load the multi sorting comparison object using pickle.\n>>> pickle.dump(mcmp, open('mcmp.pkl', 'wb')))))\n>>> mcmp_loaded = pickle.load(open('mcmp.pkl', 'rb'))",
+            "load_from_folder() is deprecated. "
+            "You should save and load the multi sorting comparison object using pickle."
+            "\n>>> pickle.dump(mcmp, open('mcmp.pkl', 'wb')))))\n>>> mcmp_loaded = pickle.load(open('mcmp.pkl', 'rb'))",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/spikeinterface/comparison/multicomparisons.py
+++ b/src/spikeinterface/comparison/multicomparisons.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import json
 import pickle
+import warnings
 
 import numpy as np
 
@@ -180,6 +181,11 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
         return sorting
 
     def save_to_folder(self, save_folder):
+        warnings.warn(
+            "save_to_folder() is deprecated. You should save and load the multi sorting comparison object using pickle.\n>>> pickle.dump(mcmp, open('mcmp.pkl', 'wb')))))\n>>> mcmp_loaded = pickle.load(open('mcmp.pkl', 'rb'))",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         for sorting in self.object_list:
             assert (
                 sorting.check_if_json_serializable()
@@ -205,6 +211,11 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
 
     @staticmethod
     def load_from_folder(folder_path):
+        warnings.warn(
+            "load_from_folder() is deprecated. You should save and load the multi sorting comparison object using pickle.\n>>> pickle.dump(mcmp, open('mcmp.pkl', 'wb')))))\n>>> mcmp_loaded = pickle.load(open('mcmp.pkl', 'rb'))",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         folder_path = Path(folder_path)
         with (folder_path / "kwargs.json").open() as f:
             kwargs = json.load(f)


### PR DESCRIPTION
Closes #2012 

Turns out that all comparison objects (since all sorting objects are now pickleable), are also directly pickleable. This PR only deprecates the `save_to_folder`/`load_from_folder` functions of the `MultiSortingComparison`.

```
# generate
sorting = si.generate_sorting()
sorting_mono = si.generate_sorting(durations=[10])
rec, sort = si.generate_ground_truth_recording()
we = si.extract_waveforms(rec, sort, mode="memory", progress_bar=False, return_scaled=False)

# two sorters
cmp = si.compare_two_sorters(sorting, sorting)
cmp_l = pickle.loads(pickle.dumps(cmp))

cmp_gt = si.compare_sorter_to_ground_truth(sorting, sorting)
cmp_gt_l = pickle.loads(pickle.dumps(cmp_gt))

# multiple sorters
mcmp = si.compare_multiple_sorters([sorting, sorting, sorting])
mcmp_l = pickle.loads(pickle.dumps(mcmp))

# collision and correlograms
cmp_coll = si.CollisionGTComparison(sorting_mono, sorting_mono)
cmp_coll_l = pickle.loads(pickle.dumps(cmp_coll))

cmp_corr = si.CorrelogramGTComparison(sorting_mono, sorting_mono)
cmp_corr_l = pickle.loads(pickle.dumps(cmp_corr))

# templates
cmp_t = si.compare_templates(we, we)
cmp_t_l = pickle.loads(pickle.dumps(cmp_t))

mcmp_t = si.compare_multiple_templates([we, we, we])
mcmp_t_l = pickle.loads(pickle.dumps(mcmp_t))
```