### PR TITLE
Update a test expression to remove two logical short circuits

### DIFF
--- a/src/spikeinterface/preprocessing/remove_artifacts.py
+++ b/src/spikeinterface/preprocessing/remove_artifacts.py
@@ -165,7 +165,9 @@ class RemoveArtifactsRecording(BasePreprocessor):
                 for l in np.unique(labels):
                     assert l in artifacts.keys(), f"Artefacts are provided but label {l} has no value!"
             else:
-                assert "ms_before" is not None and "ms_after" is not None, f"ms_before/after should not be None for mode {mode}"
+                assert (
+                    "ms_before" is not None and "ms_after" is not None
+                ), f"ms_before/after should not be None for mode {mode}"
                 sorting = NumpySorting.from_times_labels(list_triggers, list_labels, recording.get_sampling_frequency())
                 sorting = sorting.save()
                 waveforms_kwargs.update({"ms_before": ms_before, "ms_after": ms_after})

--- a/src/spikeinterface/preprocessing/remove_artifacts.py
+++ b/src/spikeinterface/preprocessing/remove_artifacts.py
@@ -165,7 +165,7 @@ class RemoveArtifactsRecording(BasePreprocessor):
                 for l in np.unique(labels):
                     assert l in artifacts.keys(), f"Artefacts are provided but label {l} has no value!"
             else:
-                assert "ms_before" != None and "ms_after" != None, f"ms_before/after should not be None for mode {mode}"
+                assert "ms_before" is not None and "ms_after" is not None, f"ms_before/after should not be None for mode {mode}"
                 sorting = NumpySorting.from_times_labels(list_triggers, list_labels, recording.get_sampling_frequency())
                 sorting = sorting.save()
                 waveforms_kwargs.update({"ms_before": ms_before, "ms_after": ms_after})

--- a/src/spikeinterface/preprocessing/remove_artifacts.py
+++ b/src/spikeinterface/preprocessing/remove_artifacts.py
@@ -166,7 +166,7 @@ class RemoveArtifactsRecording(BasePreprocessor):
                     assert l in artifacts.keys(), f"Artefacts are provided but label {l} has no value!"
             else:
                 assert (
-                    "ms_before" is not None and "ms_after" is not None
+                    ms_before is not None and ms_after is not None
                 ), f"ms_before/after should not be None for mode {mode}"
                 sorting = NumpySorting.from_times_labels(list_triggers, list_labels, recording.get_sampling_frequency())
                 sorting = sorting.save()


### PR DESCRIPTION
In file: remove_artifacts.py, method: `__init__`, a logical equality check operation was performed. The operands are such that the comparison operation always returns either true or false. Such logical short circuits in code lead to unintended behavior. In this case both parts of a test expression were always returning false.

I suggested that the logical operation should be reviewed for correctness. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.