### PR TITLE
CellExplorer: fix tests and deprecation

### DIFF
--- a/src/spikeinterface/extractors/cellexplorersortingextractor.py
+++ b/src/spikeinterface/extractors/cellexplorersortingextractor.py
@@ -40,7 +40,6 @@ class CellExplorerSortingExtractor(BaseSorting):
         sampling_frequency: float | None = None,
         session_info_file_path: str | Path | None = None,
         spikes_matfile_path: str | Path | None = None,
-        session_info_matfile_path: str | Path | None = None,
     ):
         try:
             from pymatreader import read_mat
@@ -66,11 +65,6 @@ class CellExplorerSortingExtractor(BaseSorting):
                     DeprecationWarning,
                 )
             file_path = spikes_matfile_path if file_path is None else file_path
-
-        if session_info_matfile_path is not None:
-            raise ValueError(
-                "The session_info_matfile_path argument is no longer supported in. Use session_info_file_path instead."
-            )
 
         self.spikes_cellinfo_path = Path(file_path)
         self.session_path = self.spikes_cellinfo_path.parent

--- a/src/spikeinterface/extractors/cellexplorersortingextractor.py
+++ b/src/spikeinterface/extractors/cellexplorersortingextractor.py
@@ -68,23 +68,8 @@ class CellExplorerSortingExtractor(BaseSorting):
             file_path = spikes_matfile_path if file_path is None else file_path
 
         if session_info_matfile_path is not None:
-            # Raise an error if the warning period has expired
-            deprecation_issued = datetime.datetime(2023, 4, 1)
-            deprecation_deadline = deprecation_issued + datetime.timedelta(days=180)
-            if datetime.datetime.now() > deprecation_deadline:
-                raise ValueError(
-                    "The session_info_matfile_path argument is no longer supported in. Use session_info_file_path instead."
-                )
-
-            # Otherwise, issue a DeprecationWarning
-            else:
-                warnings.warn(
-                    "The session_info_matfile_path argument is deprecated and will be removed in six months. "
-                    "Use session_info_file_path instead.",
-                    DeprecationWarning,
-                )
-            session_info_file_path = (
-                session_info_matfile_path if session_info_file_path is None else session_info_file_path
+            raise ValueError(
+                "The session_info_matfile_path argument is no longer supported in. Use session_info_file_path instead."
             )
 
         self.spikes_cellinfo_path = Path(file_path)

--- a/src/spikeinterface/extractors/tests/test_cellexplorerextractor.py
+++ b/src/spikeinterface/extractors/tests/test_cellexplorerextractor.py
@@ -26,7 +26,7 @@ class CellExplorerSortingTest(SortingCommonTestSuite, unittest.TestCase):
         (
             "cellexplorer/dataset_2/20170504_396um_0um_merge.spikes.cellinfo.mat",
             {
-                "session_info_matfile_path": local_folder
+                "session_info_file_path": local_folder
                 / "cellexplorer/dataset_2/20170504_396um_0um_merge.sessionInfo.mat"
             },
         ),


### PR DESCRIPTION
We had a deprecation period in the `CellExplorerSorting` which has expired.

This PR updates the tests and raises an exception ins tead of a warning.