### PR TITLE
Missing scipy import in remove_artefacts

### DIFF
--- a/src/spikeinterface/preprocessing/remove_artifacts.py
+++ b/src/spikeinterface/preprocessing/remove_artifacts.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy
 
 from spikeinterface.core.core_tools import define_function_from_class
 


### PR DESCRIPTION
A scipy import is missing, leading to errors in remove_artefacts if using linear or cubic mode