### PR TITLE
Adjust eps for whitening in case of very small magnitude data

### DIFF
--- a/src/spikeinterface/preprocessing/tests/test_whiten.py
+++ b/src/spikeinterface/preprocessing/tests/test_whiten.py
@@ -20,13 +20,13 @@ def test_whiten():
 
     print(rec.get_channel_locations())
     random_chunk_kwargs = {}
-    W, M = compute_whitening_matrix(rec, "global", random_chunk_kwargs, apply_mean=False, radius_um=None, eps=1e-8)
+    W, M = compute_whitening_matrix(rec, "global", random_chunk_kwargs, apply_mean=False, radius_um=None)
     print(W)
     print(M)
 
     with pytest.raises(AssertionError):
-        W, M = compute_whitening_matrix(rec, "local", random_chunk_kwargs, apply_mean=False, radius_um=None, eps=1e-8)
-    W, M = compute_whitening_matrix(rec, "local", random_chunk_kwargs, apply_mean=False, radius_um=25, eps=1e-8)
+        W, M = compute_whitening_matrix(rec, "local", random_chunk_kwargs, apply_mean=False, radius_um=None)
+    W, M = compute_whitening_matrix(rec, "local", random_chunk_kwargs, apply_mean=False, radius_um=25)
     # W must be sparse
     np.sum(W == 0) == 6
 

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -171,11 +171,11 @@ def compute_whitening_matrix(recording, mode, random_chunk_kwargs, apply_mean, r
     # Typically we can assume that data is in units of
     # microvolts, but this is not always the case. When data
     # is float type and scaled down to very small values, then the
-    # default eps=1e-6 can be too large, resulting in incorrect
+    # default eps=1e-8 can be too large, resulting in incorrect
     # whitening. We therefore check to see if the data is float
     # type and we estimate a more reasonable eps in the case
     # where the data is on a scale less than 1.
-    eps = 1e-6 # the default
+    eps = 1e-8 # the default
     if data.dtype.kind == "f":
         median_data_sqr = np.median(data ** 2) # use the square because cov (and hence S) scales as the square
         if median_data_sqr < 1 and median_data_sqr > 0:

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -167,7 +167,7 @@ def compute_whitening_matrix(recording, mode, random_chunk_kwargs, apply_mean, r
 
     # Here we determine eps used below to avoid division by zero.
     # Typically we can assume that data is in units of
-    # microvolts, but this is not always the case. When data
+    # mV, but this is not always the case. When data
     # is float type and scaled down to very small values, then the
     # default eps=1e-8 can be too large, resulting in incorrect
     # whitening. We therefore check to see if the data is float

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -173,7 +173,7 @@ def compute_whitening_matrix(recording, mode, random_chunk_kwargs, apply_mean, r
     # whitening. We therefore check to see if the data is float
     # type and we estimate a more reasonable eps in the case
     # where the data is on a scale less than 1.
-    eps = 1e-8 # the default
+    eps = 1e-8  # the default
     if data.dtype.kind == "f":
         median_data_sqr = np.median(data**2)  # use the square because cov (and hence S) scales as the square
         if median_data_sqr < 1 and median_data_sqr > 0:

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -15,27 +15,27 @@ class WhitenRecording(BasePreprocessor):
     ----------
     recording: RecordingExtractor
         The recording extractor to be whitened.
-    dtype: None or dtype
+    dtype: None or dtype, default: None
         If None the the parent dtype is kept.
         For integer dtype a int_scale must be also given.
-    mode: 'global' / 'local'
+    mode: 'global' / 'local', default: 'global'
         'global' use the entire covariance matrix to compute the W matrix
         'local' use local covariance (by radius) to compute the W matrix
-    radius_um: None or float
+    radius_um: None or float, default: None
         Used for mode = 'local' to get the neighborhood
-    apply_mean: bool
+    apply_mean: bool, default: False
         Substract or not the mean matrix M before the dot product with W.
-    int_scale : None or float
+    int_scale : None or float, default: None
         Apply a scaling factor to fit the integer range.
         This is used when the dtype is an integer, so that the output is scaled.
         For example, a value of `int_scale=200` will scale the traces value to a standard deviation of 200.
-    eps : float, default 1e-8
+    eps : float or None, default: None
         Small epsilon to regularize SVD.
-        If None, eps is estimated from the data. If the data is float type and scaled down to very small values,
-        then the eps is automatically set to a small fraction of the median of the squared data.
-    W : 2d np.array
-        Pre-computed whitening matrix, by default None
-    M : 1d np.array or None
+        If None, eps is default to 1e-8. If the data is float type and scaled down to very small values,
+        then the eps is automatically set to a small fraction (1e-3) of the median of the squared data.
+    W : 2d np.array, default: None
+        Pre-computed whitening matrix
+    M : 1d np.array or None, default: None
         Pre-computed means.
         M can be None when previously computed with apply_mean=False
     **random_chunk_kwargs : Keyword arguments for `spikeinterface.core.get_random_data_chunk()` function
@@ -56,7 +56,7 @@ class WhitenRecording(BasePreprocessor):
         mode="global",
         radius_um=100.0,
         int_scale=None,
-        eps=1e-8,
+        eps=None,
         W=None,
         M=None,
         **random_chunk_kwargs,
@@ -127,7 +127,7 @@ class WhitenRecordingSegment(BasePreprocessorSegment):
 whiten = define_function_from_class(source_class=WhitenRecording, name="whiten")
 
 
-def compute_whitening_matrix(recording, mode, random_chunk_kwargs, apply_mean, radius_um=None, eps=1e-8):
+def compute_whitening_matrix(recording, mode, random_chunk_kwargs, apply_mean, radius_um=None, eps=None):
     """
     Compute whitening matrix
 
@@ -145,10 +145,11 @@ def compute_whitening_matrix(recording, mode, random_chunk_kwargs, apply_mean, r
         Keyword arguments for  get_random_data_chunks()
     apply_mean : bool
         If True, the mean is removed prior to computing the covariance
-    radius_um : float, optional
-        Used for mode = 'local' to get the neighborhood, by default None
-    eps : float, optional
-        Small epsilon to regularize SVD, by default 1e-8
+    radius_um : float, default: None
+        Used for mode = 'local' to get the neighborhood
+    eps : float, default: None
+        Small epsilon to regularize SVD. If None, the default is set to 1e-8, but if the data is float type and scaled
+        down to very small values, eps is automatically set to a small fraction (1e-3) of the median of the squared data.
 
     Returns
     -------
@@ -180,7 +181,9 @@ def compute_whitening_matrix(recording, mode, random_chunk_kwargs, apply_mean, r
     # whitening. We therefore check to see if the data is float
     # type and we estimate a more reasonable eps in the case
     # where the data is on a scale less than 1.
-    if data.dtype.kind == "f" or eps is None:
+    if eps is None:
+        eps = 1e-8
+    if data.dtype.kind == "f":
         median_data_sqr = np.median(data**2)  # use the square because cov (and hence S) scales as the square
         if median_data_sqr < 1 and median_data_sqr > 0:
             eps = max(1e-16, median_data_sqr * 1e-3)  # use a small fraction of the median of the squared data

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -166,8 +166,8 @@ def compute_whitening_matrix(recording, mode, random_chunk_kwargs, apply_mean, r
     cov = cov / data.shape[0]
 
     # Here we determine eps used below to avoid division by zero.
-    # Typically we can assume that data is in units of
-    # mV, but this is not always the case. When data
+    # Typically we can assume that data is either unscaled integers or in units of
+    # uV, but this is not always the case. When data
     # is float type and scaled down to very small values, then the
     # default eps=1e-8 can be too large, resulting in incorrect
     # whitening. We therefore check to see if the data is float

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -31,7 +31,7 @@ class WhitenRecording(BasePreprocessor):
         For example, a value of `int_scale=200` will scale the traces value to a standard deviation of 200.
     eps : float or None, default: None
         Small epsilon to regularize SVD.
-        If None, eps is default to 1e-8. If the data is float type and scaled down to very small values,
+        If None, eps is defaulted to 1e-8. If the data is float type and scaled down to very small values,
         then the eps is automatically set to a small fraction (1e-3) of the median of the squared data.
     W : 2d np.array, default: None
         Pre-computed whitening matrix


### PR DESCRIPTION
Resolves #2064 

I explain what is happening in the comments



I ran the following test:

```python
import numpy as np
import spikeinterface.extractors as se
import spikeinterface.preprocessing as spre

# toy example
recording, sorting = se.toy_example(num_channels=4, duration=10, seed=0)
recording_whitened = spre.whiten(recording)
traces = recording_whitened.get_traces(segment_index=0)
print(np.var(traces, axis=0))

recording2 = spre.scale(recording, gain=1e-8)
recording2_whitened = spre.whiten(recording2)
traces2 = recording2_whitened.get_traces(segment_index=0)
print(np.var(traces2, axis=0))
```

And got the expected variances close to 1
```bash
[1.0054402  1.0075228  0.9955653  0.96718967]
[0.99692386 0.99832404 0.98711884 0.9610572 ]
```

And without the adjustment the second array is very wrong
```bash
[1.0054402  1.0075228  0.9955653  0.96718967]
[1.1976793e-08 1.1291137e-08 1.2642105e-08 1.6557108e-08]
```

