### PR TITLE
Add SPIKEINTERFACE_DEV_PATH to aws gpu tests

### DIFF
--- a/.github/workflows/test_containers_singularity_gpu.yml
+++ b/.github/workflows/test_containers_singularity_gpu.yml
@@ -46,5 +46,6 @@ jobs:
       - name: Run test singularity containers with GPU
         env:
           REPO_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          SPIKEINTERFACE_DEV_PATH: ${{ github.workspace }}
         run: |
           pytest -vv --capture=tee-sys -rA src/spikeinterface/sorters/external/tests/test_singularity_containers_gpu.py


### PR DESCRIPTION
@samuelgarcia  @h-mayorquin  this should fix the GPU tests on AWS

https://github.com/SpikeInterface/spikeinterface/actions/runs/6457918395