### PR TITLE
Handle case when mp_context is None

### DIFF
--- a/src/spikeinterface/sortingcomponents/clustering/split.py
+++ b/src/spikeinterface/sortingcomponents/clustering/split.py
@@ -59,7 +59,7 @@ def split_clusters(
 
     job_kwargs = fix_job_kwargs(job_kwargs)
     n_jobs = job_kwargs["n_jobs"]
-    mp_context = job_kwargs["mp_context"]
+    mp_context = job_kwargs.get("mp_context", None)
     progress_bar = job_kwargs["progress_bar"]
     max_threads_per_process = job_kwargs["max_threads_per_process"]
 
@@ -72,7 +72,7 @@ def split_clusters(
     with Executor(
         max_workers=n_jobs,
         initializer=split_worker_init,
-        mp_context=get_context(mp_context),
+        mp_context=get_context(method=mp_context),
         initargs=(recording, features_dict_or_folder, original_labels, method, method_kwargs, max_threads_per_process),
     ) as pool:
         labels_set = np.setdiff1d(peak_labels, [-1])


### PR DESCRIPTION
This should fix recent CI errors: https://github.com/SpikeInterface/spikeinterface/actions/runs/6533283388/job/17738163459

The problem is that the `fix_job_kwargs` removes entries if they are `None`:
See https://github.com/SpikeInterface/spikeinterface/blob/main/src/spikeinterface/core/job_tools.py#L61-L66