### PR TITLE
Use versioned kilosort options as default in `skip_preprocessed_data`.

### DIFF
--- a/src/spikeinterface/sorters/external/kilosort2_5_master.m
+++ b/src/spikeinterface/sorters/external/kilosort2_5_master.m
@@ -64,7 +64,7 @@ function kilosort2_5_master(fpath, kilosortPath)
             rez.ops.Nbatch = Nbatch;
             rez.ops.NTbuff = NTbuff;
 
-            tic;  % tocs are coming TODO
+            tic;  % tocs are supplied in other parts of KS code
 
         else
             % preprocess data to create temp_wh.dat

--- a/src/spikeinterface/sorters/external/kilosort2_5_master.m
+++ b/src/spikeinterface/sorters/external/kilosort2_5_master.m
@@ -26,7 +26,7 @@ function kilosort2_5_master(fpath, kilosortPath)
         if skip_kilosort_preprocessing
             % hack to skip the internal preprocessing
             % this mimic the preprocessDataSub() function
-            fprintf("SKIP kilosort2.5 preprocessing\n");
+            fprintf("Skipping kilosort2.5 preprocessing\n");
 
             ops.nt0 	  = getOr(ops, {'nt0'}, 61); % number of time samples for the templates (has to be <=81 due to GPU shared memory)
             ops.nt0min  = getOr(ops, 'nt0min', ceil(20 * ops.nt0/61)); % time sample where the negative peak should be aligned
@@ -49,11 +49,13 @@ function kilosort2_5_master(fpath, kilosortPath)
             rez.xcoords = xc;
             rez.ycoords = yc;
             Nbatch      = ceil(ops.sampsToRead / ops.NT); % number of data batches
+            ops.Nbatch = Nbatch;
             NTbuff      = ops.NT + 3*ops.ntbuff; % we need buffers on both sides for filtering
 
             rez.Wrot    = eye(ops.Nchan); % fake whitenning
             rez.temp.Nbatch = Nbatch;
-            % fproc is the same as the binary
+            % fproc (preprocessed output) is the same as the fbinary (unprocessed input)
+            % because we are skipping preprocessing.
             ops.fproc = ops.fbinary;
 
             rez.ops = ops; % memorize ops
@@ -62,7 +64,7 @@ function kilosort2_5_master(fpath, kilosortPath)
             rez.ops.Nbatch = Nbatch;
             rez.ops.NTbuff = NTbuff;
 
-            tic;  % tocs are coming
+            tic;  % tocs are coming TODO
 
         else
             % preprocess data to create temp_wh.dat

--- a/src/spikeinterface/sorters/external/kilosort2_master.m
+++ b/src/spikeinterface/sorters/external/kilosort2_master.m
@@ -64,7 +64,7 @@ function kilosort2_master(fpath, kilosortPath)
             rez.ops.Nbatch = Nbatch;
             rez.ops.NTbuff = NTbuff;
 
-            tic;  % tocs are coming TODO
+            tic;  % tocs are supplied in other parts of KS code
 
         else
             % preprocess data to create temp_wh.dat

--- a/src/spikeinterface/sorters/external/kilosort2_master.m
+++ b/src/spikeinterface/sorters/external/kilosort2_master.m
@@ -26,7 +26,7 @@ function kilosort2_master(fpath, kilosortPath)
         if skip_kilosort_preprocessing
             % hack to skip the internal preprocessing
             % this mimic the preprocessDataSub() function
-            fprintf("SKIP kilosort2.5 preprocessing\n");
+            fprintf("Skipping kilosort2 preprocessing\n");
 
             ops.nt0 	  = getOr(ops, {'nt0'}, 61); % number of time samples for the templates (has to be <=81 due to GPU shared memory)
             ops.nt0min  = getOr(ops, 'nt0min', ceil(20 * ops.nt0/61)); % time sample where the negative peak should be aligned
@@ -48,12 +48,14 @@ function kilosort2_master(fpath, kilosortPath)
             rez.yc = yc;
             rez.xcoords = xc;
             rez.ycoords = yc;
-            Nbatch      = ceil(ops.sampsToRead / ops.NT); % number of data batches
-            NTbuff      = ops.NT + 3*ops.ntbuff; % we need buffers on both sides for filtering
+            Nbatch      = ceil(ops.sampsToRead /(NT-ops.ntbuff)); % number of data batches
+            ops.Nbatch = Nbatch;
+            NTbuff      = NT + 4*ops.ntbuff; % we need buffers on both sides for filtering
 
             rez.Wrot    = eye(ops.Nchan); % fake whitenning
             rez.temp.Nbatch = Nbatch;
-            % fproc is the same as the binary
+            % fproc (preprocessed output) is the same as the fbinary (unprocessed input)
+            % because we are skipping preprocessing.
             ops.fproc = ops.fbinary;
 
             rez.ops = ops; % memorize ops
@@ -62,7 +64,7 @@ function kilosort2_master(fpath, kilosortPath)
             rez.ops.Nbatch = Nbatch;
             rez.ops.NTbuff = NTbuff;
 
-            tic;  % tocs are coming
+            tic;  % tocs are coming TODO
 
         else
             % preprocess data to create temp_wh.dat

--- a/src/spikeinterface/sorters/external/kilosort3_master.m
+++ b/src/spikeinterface/sorters/external/kilosort3_master.m
@@ -26,7 +26,7 @@ function kilosort3_master(fpath, kilosortPath)
         if skip_kilosort_preprocessing
             % hack to skip the internal preprocessing
             % this mimic the preprocessDataSub() function
-            fprintf("SKIP kilosort2.5 preprocessing\n");
+            fprintf("Skipping kilosort3 preprocessing\n");
 
             ops.nt0 	  = getOr(ops, {'nt0'}, 61); % number of time samples for the templates (has to be <=81 due to GPU shared memory)
             ops.nt0min  = getOr(ops, 'nt0min', ceil(20 * ops.nt0/61)); % time sample where the negative peak should be aligned
@@ -49,11 +49,13 @@ function kilosort3_master(fpath, kilosortPath)
             rez.xcoords = xc;
             rez.ycoords = yc;
             Nbatch      = ceil(ops.sampsToRead / ops.NT); % number of data batches
+            ops.Nbatch = Nbatch;
             NTbuff      = ops.NT + 3*ops.ntbuff; % we need buffers on both sides for filtering
 
             rez.Wrot    = eye(ops.Nchan); % fake whitenning
             rez.temp.Nbatch = Nbatch;
-            % fproc is the same as the binary
+            % fproc (preprocessed output) is the same as the fbinary (unprocessed input)
+            % because we are skipping preprocessing.
             ops.fproc = ops.fbinary;
 
             rez.ops = ops; % memorize ops
@@ -62,7 +64,7 @@ function kilosort3_master(fpath, kilosortPath)
             rez.ops.Nbatch = Nbatch;
             rez.ops.NTbuff = NTbuff;
 
-            tic;  % tocs are coming
+            tic;  % tocs are coming TODO
 
         else
             % preprocess data to create temp_wh.dat

--- a/src/spikeinterface/sorters/external/kilosort3_master.m
+++ b/src/spikeinterface/sorters/external/kilosort3_master.m
@@ -64,7 +64,7 @@ function kilosort3_master(fpath, kilosortPath)
             rez.ops.Nbatch = Nbatch;
             rez.ops.NTbuff = NTbuff;
 
-            tic;  % tocs are coming TODO
+            tic;  % tocs are supplied in other parts of KS code
 
         else
             % preprocess data to create temp_wh.dat


### PR DESCRIPTION
closes #1977.

When using `skip_preprocessed_data` option in kilosort, default options are set from Kilosort's `preprocessDataSub.m` file. Kilosort2 is subtly different to Kilosort2.5 and Kilosort3 but the previous default values did not reflect this. This PR updates the default configs to match those found in `preprocessDataSub.m` of kilosort 2, 2.5 and 3 respectively. This did not require much, only slightly changing 2 variables for kilosort2.

I had a couple of questions:

1) 
  I saw this code back
  ```
  ops.NchanTOT = getOr(ops, 'NchanTOT', NchanTOTdefault); % if NchanTOT was left empty, then overwrite with the default
  ```
  in all three KS versions but not in the master matlab files. I guess this is because NchanTOT is expected to always be filled in. But I just wanted to check.

2) maybe now is a good time to also fix the `tic`/`toc` issue?

I'll take another look tomorrow just in case I missed anything!