### PR TITLE
Fix peak activity example & bugs in `peak_activity`

### DIFF
--- a/examples/modules_gallery/widgets/plot_4_peaks_gallery.py
+++ b/examples/modules_gallery/widgets/plot_4_peaks_gallery.py
@@ -48,6 +48,8 @@ print(peaks.dtype.fields.keys())
 
 si.plot_peak_activity(recording=rec_filtred, peaks=peaks)
 
+plt.show()
+
 ##############################################################################
 # can be also animated with bin_duration_s=1.
 

--- a/examples/modules_gallery/widgets/plot_4_peaks_gallery.py
+++ b/examples/modules_gallery/widgets/plot_4_peaks_gallery.py
@@ -2,7 +2,7 @@
 Peaks Widgets Gallery
 =====================
 
-Some widgets are useful before sorting and works with "peaks" given by detect_peaks()
+Some widgets are useful before sorting and works with the "peaks" given by the detect_peaks()
 function.
 
 They are useful to check drift before running sorters.
@@ -21,14 +21,14 @@ rec, sorting = si.read_mearec(local_path)
 
 
 ##############################################################################
-# Lets filter and detect peak on it
+# Let's filter and detect peaks on it
 
 from spikeinterface.sortingcomponents.peak_detection import detect_peaks
 
-rec_filtred = si.bandpass_filter(rec, freq_min=300., freq_max=6000., margin_ms=5.0)
+rec_filtred = si.bandpass_filter(recording=rec, freq_min=300., freq_max=6000., margin_ms=5.0)
 print(rec_filtred)
 peaks = detect_peaks(
-        rec_filtred, method='locally_exclusive',
+        recording=rec_filtred, method='locally_exclusive',
         peak_sign='neg', detect_threshold=6, exclude_sweep_ms=0.3,
         radius_um=100,
         noise_levels=None,
@@ -46,12 +46,12 @@ print(peaks.dtype.fields.keys())
 # This "peaks" vector can be used in several widgets, for instance
 # plot_peak_activity()
 
-si.plot_peak_activity(rec_filtred, peaks=peaks)
+si.plot_peak_activity(recording=rec_filtred, peaks=peaks)
 
 ##############################################################################
 # can be also animated with bin_duration_s=1.
 
-si.plot_peak_activity(rec_filtred, bin_duration_s=1.)
+si.plot_peak_activity(recording=rec_filtred, peaks=peaks, bin_duration_s=1.)
 
 
 plt.show()

--- a/src/spikeinterface/widgets/peak_activity.py
+++ b/src/spikeinterface/widgets/peak_activity.py
@@ -120,7 +120,7 @@ class PeakActivityMapWidget(BaseWidget):
         if with_contact_color:
             text_on_contact = None
             if with_channel_ids:
-                text_on_contact = self.recording.channel_ids
+                text_on_contact = rec.channel_ids
 
             from probeinterface.plotting import plot_probe
 

--- a/src/spikeinterface/widgets/peak_activity.py
+++ b/src/spikeinterface/widgets/peak_activity.py
@@ -95,13 +95,13 @@ class PeakActivityMapWidget(BaseWidget):
                 i0, i1 = np.searchsorted(peaks["sample_index"], [bin_size * i, bin_size * (i + 1)])
                 local_peaks = peaks[i0:i1]
                 artists = self._plot_one_bin(
-                    rec,
-                    probe,
-                    local_peaks,
-                    dp.with_channel_ids,
-                    dp.bin_duration_s,
-                    dp.with_contact_color,
-                    dp.with_interpolated_map,
+                    rec=rec,
+                    probe=probe,
+                    peaks=local_peaks,
+                    duration=dp.bin_duration_s,
+                    with_channel_ids=dp.with_channel_ids,
+                    with_contact_color=dp.with_contact_color,
+                    with_interpolated_map=dp.with_interpolated_map,
                 )
                 return artists
 


### PR DESCRIPTION
The final function in the example was missing the `peaks` argument causing it to fail. (See link)

https://spikeinterface.readthedocs.io/en/latest/modules_gallery/widgets/plot_4_peaks_gallery.html#sphx-glr-modules-gallery-widgets-plot-4-peaks-gallery-py

I also added keyword arguments to encourage their use and make clear what arguments are going into the examples.