### PR TITLE
Add quality_metrics specific module requirements to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ widgets = [
     "sortingview>=0.11.15",
 ]
 
-quality_metrics = [
+qualitymetrics = [
     "scikit-learn",
     "scipy",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,13 @@ widgets = [
     "sortingview>=0.11.15",
 ]
 
+quality_metrics = [
+    "scikit-learn",
+    "scipy",
+    "pandas",
+    "numba",
+]
+
 test_core = [
     "pytest",
     "zarr",

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -1,6 +1,5 @@
 """Cluster quality metrics computed from principal components."""
 
-from cmath import nan
 from copy import deepcopy
 
 import numpy as np
@@ -16,7 +15,6 @@ try:
 except:
     pass
 
-import spikeinterface as si
 from ..core import get_random_data_chunks, compute_sparsity, WaveformExtractor
 from ..core.job_tools import tqdm_joblib
 from ..core.template_tools import get_template_extremum_channel

--- a/src/spikeinterface/qualitymetrics/utils.py
+++ b/src/spikeinterface/qualitymetrics/utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.stats import norm, multivariate_normal
+from scipy.stats import multivariate_normal
 
 
 def create_ground_truth_pc_distributions(center_locations, total_points):


### PR DESCRIPTION
Fixes #1223 

There could always be more submodule specific options in the toml, but since qm is a smaller module and since it was requested should be an easy addition.

Also deleted a couple of unused imports.