### PR TITLE
Fix padded traces testing

### DIFF
--- a/src/spikeinterface/preprocessing/zero_channel_pad.py
+++ b/src/spikeinterface/preprocessing/zero_channel_pad.py
@@ -18,9 +18,11 @@ class TracePaddedRecording(BasePreprocessor):
     parent_recording_segment : BaseRecording
         The parent recording segment from which the traces are to be retrieved.
     padding_start : int
-        The amount of padding to add to the left of the traces. Default is 0. It has to be non-negative
+        The amount of padding to add to the left of the traces. Default is 0. It has to be non-negative.
+        Note that this counts the number of samples, not the number of seconds.
     padding_end : int
         The amount of padding to add to the right of the traces. Default is 0. It has to be non-negative
+        Note that this counts the number of samples, not the number of seconds.
     fill_value: float
         The value to pad with. Default is 0.
     """
@@ -88,20 +90,18 @@ class TracePaddedRecordingSegment(BasePreprocessorSegment):
             raise ValueError(f"Unsupported channel_indices type: {type(channel_indices)} raise an issue on github ")
 
         # This avoids an extra memory allocation if we are within the confines of the old traces
-        if start_frame > self.padding_start and end_frame < self.num_samples_in_original_segment + self.padding_start:
+        end_of_original_traces = self.num_samples_in_original_segment + self.padding_start
+        if start_frame > self.padding_start and end_frame < end_of_original_traces:
             return self.get_original_traces_shifted(start_frame, end_frame, channel_indices)
 
-        # Else, we start with the full padded traces and allocate the original traces in the middle
+        # We start wit the full padded traces and fill in the original traces if necessary
         output_traces = np.full(shape=(trace_size, num_channels), fill_value=self.fill_value, dtype=self.dtype)
 
-        # If start and end frame are outside of the original data region (e.g. for Kilosort), return only paddding
-        if (
-            start_frame > self.num_samples_in_original_segment + self.padding_start
-            and end_frame > self.num_samples_in_original_segment + self.padding_start
-        ):
+        # If start frame is larger than the end of the original traces, we return the padded traces as they are
+        if start_frame >= end_of_original_traces and end_frame > end_of_original_traces:
             return output_traces
 
-        # After the padding, the original traces are placed in the middle until the end of the original traces
+        # We add the original traces if end_frame is larger than the start of the original traces
         if end_frame >= self.padding_start:
             original_traces = self.get_original_traces_shifted(
                 start_frame=start_frame,
@@ -131,7 +131,7 @@ class TracePaddedRecordingSegment(BasePreprocessorSegment):
             start_frame=original_start_frame,
             end_frame=original_end_frame,
             channel_indices=channel_indices,
-        )  # BREAKPOINT HERE!!
+        )
 
         return original_traces
 

--- a/src/spikeinterface/preprocessing/zero_channel_pad.py
+++ b/src/spikeinterface/preprocessing/zero_channel_pad.py
@@ -94,7 +94,7 @@ class TracePaddedRecordingSegment(BasePreprocessorSegment):
         if start_frame > self.padding_start and end_frame < end_of_original_traces:
             return self.get_original_traces_shifted(start_frame, end_frame, channel_indices)
 
-        # We start wit the full padded traces and fill in the original traces if necessary
+        # We start with the full padded traces and fill in the original traces if necessary
         output_traces = np.full(shape=(trace_size, num_channels), fill_value=self.fill_value, dtype=self.dtype)
 
         # If start frame is larger than the end of the original traces, we return the padded traces as they are


### PR DESCRIPTION
This adds some cases that were missing while keeping the preprocessing test that was failing on #1979 with a faster test.

