### PR TITLE
Change phy exporter to not save `template_ind` in the case of dense waveform_extractor

### DIFF
--- a/src/spikeinterface/exporters/to_phy.py
+++ b/src/spikeinterface/exporters/to_phy.py
@@ -94,13 +94,16 @@ def export_to_phy(
             "argument to enforce sparsity (see compute_sparsity())"
         )
 
+    save_sparse = True
     if waveform_extractor.is_sparse():
         used_sparsity = waveform_extractor.sparsity
-        assert sparsity is None
+        if sparsity is not None:
+            warnings.warn("If the waveform_extractor is sparse the 'sparsity' argument is ignored")
     elif sparsity is not None:
         used_sparsity = sparsity
     else:
         used_sparsity = ChannelSparsity.create_dense(waveform_extractor)
+        save_sparse = False
     # convenient sparsity dict for the 3 cases to retrieve channl_inds
     sparse_dict = used_sparsity.unit_id_to_channel_indices
 
@@ -200,7 +203,8 @@ def export_to_phy(
         template_similarity = compute_template_similarity(waveform_extractor, method="cosine_similarity")
 
     np.save(str(output_folder / "templates.npy"), templates)
-    np.save(str(output_folder / "template_ind.npy"), templates_ind)
+    if save_sparse:
+        np.save(str(output_folder / "template_ind.npy"), templates_ind)
     np.save(str(output_folder / "similar_templates.npy"), template_similarity)
 
     channel_maps = np.arange(num_chans, dtype="int32")


### PR DESCRIPTION
Fixes #2023. Just trying to do a cleanup of the issue tracker for 0.99.0. Definitely could go later though.

2 things in this PR
1) As discussed in #2023, there is no point in saving the `template_ind.npy` if the data is dense since it is suppose to be the sparsity for phy. So I just set a boolean to not save `template_ind.npy` if the waveform extractor is dense. Phy will use the lack of `template_ind.npy` to treat it as a dense dataset so Phy's behavior isn't affected (might even be improved since it will treat the data as dense from the get go).

2) with the new default of sparse=True (for `extract_waveforms()`), I'm a little worried that users might not realize their input waveform_extractor is automatically sparse and they might try to layer a sparsity on top. In this case rather than stop the program with an assert I changed it to a warning, so that people know the waveform_extractor is already sparse. But if you want the assert instead that can be reverted.