### PR TITLE
Add warning that `fork` for the `mp_context` is not recommended for macOS

### DIFF
--- a/.github/workflows/installation-tips-test.yml
+++ b/.github/workflows/installation-tips-test.yml
@@ -36,4 +36,4 @@ jobs:
       run: python ./installation_tips/check_your_install.py --ci # ci flag turns off gui
     - name: Windows cleanup
       if: ${{ matrix.label == 'windows' }}
-      run: python .installation_tips/cleanup_for_windows.py
+      run: python ./installation_tips/cleanup_for_windows.py

--- a/.github/workflows/installation-tips-test.yml
+++ b/.github/workflows/installation-tips-test.yml
@@ -36,4 +36,4 @@ jobs:
       run: python ./installation_tips/check_your_install.py --ci # ci flag turns off gui
     - name: Windows cleanup
       if: ${{ matrix.label == 'windows' }}
-      run: python ./installation_tips/cleanup_for_windows.py
+      run: python .installation_tips/cleanup_for_windows.py

--- a/doc/modules/core.rst
+++ b/doc/modules/core.rst
@@ -518,9 +518,9 @@ These are a set of keyword arguments which are common to all functions that supp
     A float like 0.5 means half of the availables core.
 * progress_bar: bool
     If True, a progress bar is printed
-* mp_context: str or None
-    Context for multiprocessing. It can be None (default), "fork" or "spawn".
-    Note that "fork" is only available on UNIX systems (not Windows)
+* mp_context: "fork" | "spawn" | None, default: None
+        "fork" or "spawn". If None, the context is taken by the recording.get_preferred_mp_context().
+        "fork" is only safely available on LINUX systems.
 
 The default **job_kwargs** are :code:`n_jobs=1, chunk_duration="1s", progress_bar=True`.
 

--- a/src/spikeinterface/core/job_tools.py
+++ b/src/spikeinterface/core/job_tools.py
@@ -335,8 +335,6 @@ class ChunkRecordingExecutor:
             assert mp_context != "fork", "'fork' mp_context not supported on Windows!"
         elif mp_context == "fork" and platform.system() == "Darwin":
             warnings.warn('As of Python 3.8 "fork" is no longer considered safe on macOS')
-        elif mp_context == "fork":
-            warnings.warn('Use of "fork" will be deprecated in Python. Consider "spawn" in the future')
 
         self.mp_context = mp_context
 

--- a/src/spikeinterface/core/job_tools.py
+++ b/src/spikeinterface/core/job_tools.py
@@ -333,8 +333,10 @@ class ChunkRecordingExecutor:
             mp_context = recording.get_preferred_mp_context()
         if mp_context is not None and platform.system() == "Windows":
             assert mp_context != "fork", "'fork' mp_context not supported on Windows!"
-        elif mp_context is not None and platform.system() == "Darwin":
-            warnings.warn('As of Python 3.8 "fork" is no longer considered safe on MacOS')
+        elif mp_context == "fork" and platform.system() == "Darwin":
+            warnings.warn('As of Python 3.8 "fork" is no longer considered safe on macOS')
+        elif mp_context == "fork":
+            warnings.warn('Use of "fork" will be deprecated in Python. Consider "spawn" in the future')
 
         self.mp_context = mp_context
 


### PR DESCRIPTION
Actually I was reading up on multiprocessing and learned that as of 3.8 `fork` should really be avoided on macOS since the resource manager might spin threads. Docs [here](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods). 

Although fork can be used on macOS it is not guaranteed to work safely ( and now `spawn` is the macOS and Windows default), so I added a warning into the job_tools to warn users that setting to fork on macOS is no longer considered safe.

I could change Linux to "not macOS POSIX-based systems" if you'd like though.

+ I noticed one typo in the workflow I wrote for `check_your_install` so I fixed that.