### PR TITLE
Make `dump_to_pickle` great again!

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -403,7 +403,7 @@ class BaseExtractor:
         if relative_to is not None:
             relative_to = Path(relative_to).resolve().absolute()
             assert relative_to.is_dir(), "'relative_to' must be an existing directory"
-            dump_dict = _make_paths_relative(dump_dict, relative_to, copy=False)
+            dump_dict = _make_paths_relative(dump_dict, relative_to)
 
         if folder_metadata is not None:
             if relative_to is not None:

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -1005,16 +1005,16 @@ class BaseExtractor:
         return cached
 
 
-def _make_paths_relative(d, relative, copy=True) -> dict:
+def _make_paths_relative(d, relative) -> dict:
     relative = str(Path(relative).resolve().absolute())
     func = lambda p: os.path.relpath(str(p), start=relative)
-    return recursive_path_modifier(d, func, target="path", copy=copy)
+    return recursive_path_modifier(d, func, target="path", copy=True)
 
 
-def _make_paths_absolute(d, base, copy=True):
+def _make_paths_absolute(d, base):
     base = Path(base)
     func = lambda p: str((base / p).resolve())
-    return recursive_path_modifier(d, func, target="path", copy=copy)
+    return recursive_path_modifier(d, func, target="path", copy=True)
 
 
 def _load_extractor_from_dict(dic) -> BaseExtractor:

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -815,8 +815,8 @@ class BaseExtractor:
         self.copy_metadata(cached)
         return cached
 
-    # TODO rename to saveto_binary_folder
-    def save_to_folder(self, name=None, overwrite=False, folder=None, verbose=True, **save_kwargs):
+    # TODO rename to save_to_binary_folder
+    def save_to_folder(self, name=None, folder=None, overwrite=False, verbose=True, **save_kwargs):
         """
         Save extractor to folder.
 
@@ -847,6 +847,8 @@ class BaseExtractor:
         folder: None str or Path
             Name of the folder.
             If "folder" is given, "name" must be None.
+        overwrite: bool, default: False
+            If True, the folder is removed if it already exists
 
         Returns
         -------
@@ -867,7 +869,12 @@ class BaseExtractor:
                         print(f"Use cache_folder={folder}")
         else:
             folder = Path(folder)
-        assert not folder.exists(), f"folder {folder} already exists, choose another name"
+        if overwrite and folder.is_dir():
+            import shutil
+
+            shutil.rmtree(folder)
+
+        assert not folder.exists(), f"folder {folder} already exists, choose another name or use overwrite=True"
         folder.mkdir(parents=True, exist_ok=False)
 
         # dump provenance
@@ -889,8 +896,7 @@ class BaseExtractor:
 
         # dump
         # cached.dump(folder / f'cached.json', relative_to=folder, folder_metadata=folder)
-        file_path = folder / f"si_folder.json"
-        cached.dump(file_path=file_path, relative_to=folder)
+        cached.dump(folder / f"si_folder.json", relative_to=folder)
 
         return cached
 

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -706,7 +706,6 @@ class BaseExtractor:
                 # Load the file path with pickle
                 BaseExtractor.base_folder = base_folder
                 d = pickle.load(file_path.open("rb"))
-
                 BaseExtractor.base_folder = None
             else:
                 raise ValueError(f"Impossible to load {file_path}")


### PR DESCRIPTION
I tesed in core, let's hope it does not break anything else
@DradeAW this should allow you to use `relative_to` with pickle in a fast way. Can you test it for your use case and if it fails show me that json work for that case with a small example?

```python
---------------------
results for branch main
---------------------
---------------------
Pickling with dump_to_pickle
Time elapsed for saving: 0.18831443786621094
Time elapsed for loading: 3.6071527004241943
Memory used by loading: 88.28515625 MiB
---------------------
Pickling directly
Time elapsed for saving: 0.00238800048828125
Time elapsed for loading: 0.14467382431030273
Memory used by loading: 0.625 MiB
Peak memory usage: 285.4609375 MiB

---------------------
results for branch pickle_fix
---------------------
---------------------
Pickling with dump_to_pickle
Time elapsed for saving: 0.06076359748840332
Time elapsed for loading: 0.03839468955993652
Memory used by loading: 0.125 MiB
---------------------
Pickling directly
Time elapsed for saving: 0.0024383068084716797
Time elapsed for loading: 0.03805899620056152
Memory used by loading: 1.125 MiB
Peak memory usage: 194.58203125 MiB

```
Check this script:
https://gist.github.com/h-mayorquin/10fa5b0594d5ce71f0ada1bc7f72f0ec

Main drawback:
The implementation relies on a very weak of metaprograming (we could use global variables as well but I like them even less). Maybe there is a better way of doing this but I just wanted to show a proof of concept.

If this works for @DradeAW I will clean this further.
 