### PR TITLE
Improvement to `get_empty_units()`

### DIFF
--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -366,7 +366,7 @@ class BaseSorting(BaseExtractor):
     def get_non_empty_unit_ids(self):
         num_spikes_per_unit = self.count_num_spikes_per_unit()
 
-        return np.array([unit_id for unit_id in self.unit_ids if num_spikes_per_unit[unit_id] == 0])
+        return np.array([unit_id for unit_id in self.unit_ids if num_spikes_per_unit[unit_id] != 0])
 
     def get_empty_unit_ids(self):
         unit_ids = self.unit_ids

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -353,7 +353,8 @@ class BaseSorting(BaseExtractor):
 
     def remove_empty_units(self):
         """
-        Removes units with empty spike trains
+        Removes units with empty spike trains.
+        For multi-segments, a unit is considered empty if it contains no spikes in all segments.
 
         Returns
         -------

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -364,16 +364,12 @@ class BaseSorting(BaseExtractor):
         return self.select_units(non_empty_units)
 
     def get_non_empty_unit_ids(self):
-        non_empty_units = []
-        for segment_index in range(self.get_num_segments()):
-            for unit in self.get_unit_ids():
-                if len(self.get_unit_spike_train(unit, segment_index=segment_index)) > 0:
-                    non_empty_units.append(unit)
-        non_empty_units = np.unique(non_empty_units)
-        return non_empty_units
+        num_spikes_per_unit = self.count_num_spikes_per_unit()
+
+        return np.array([unit_id for unit_id in self.unit_ids if num_spikes_per_unit[unit_id] == 0])
 
     def get_empty_unit_ids(self):
-        unit_ids = self.get_unit_ids()
+        unit_ids = self.unit_ids
         empty_units = unit_ids[~np.isin(unit_ids, self.get_non_empty_unit_ids())]
         return empty_units
 


### PR DESCRIPTION
`sorting.remove_empty_units()` can be very slow when the spike trains aren't cached

I propose to call `count_num_spikes_per_unit()` which is already optimized.
The downside is that it will not remove a unit that is empty in one segment but not empty in another. Is this a problem?