### PR TITLE
Fix crash when default start / end frame arguments on `motion interpolation` are used.

### DIFF
--- a/src/spikeinterface/sortingcomponents/motion_interpolation.py
+++ b/src/spikeinterface/sortingcomponents/motion_interpolation.py
@@ -386,18 +386,18 @@ class InterpolateMotionRecordingSegment(BasePreprocessorSegment):
                 "time_vector for InterpolateMotionRecording do not work because temporal_bins start from 0"
             )
             # times = np.asarray(self.time_vector[start_frame:end_frame])
-        else:
-            if start_frame is None:
-                start_frame = 0
-            if end_frame is None:
-                end_frame = self.get_num_samples()
 
-            times = np.arange((end_frame or self.get_num_samples()) - (start_frame or 0), dtype="float64")
-            times /= self.sampling_frequency
-            t0 = start_frame / self.sampling_frequency
-            # if self.t_start is not None:
-            #     t0 = t0 + self.t_start
-            times += t0
+        if start_frame is None:
+            start_frame = 0
+        if end_frame is None:
+            end_frame = self.get_num_samples()
+
+        times = np.arange((end_frame or self.get_num_samples()) - (start_frame or 0), dtype="float64")
+        times /= self.sampling_frequency
+        t0 = start_frame / self.sampling_frequency
+        # if self.t_start is not None:
+        #     t0 = t0 + self.t_start
+        times += t0
 
         traces = self.parent_recording_segment.get_traces(start_frame, end_frame, channel_indices=slice(None))
 

--- a/src/spikeinterface/sortingcomponents/motion_interpolation.py
+++ b/src/spikeinterface/sortingcomponents/motion_interpolation.py
@@ -392,7 +392,7 @@ class InterpolateMotionRecordingSegment(BasePreprocessorSegment):
         if end_frame is None:
             end_frame = self.get_num_samples()
 
-        times = np.arange((end_frame or self.get_num_samples()) - (start_frame or 0), dtype="float64")
+        times = np.arange(end_frame - start_frame, dtype="float64")
         times /= self.sampling_frequency
         t0 = start_frame / self.sampling_frequency
         # if self.t_start is not None:

--- a/src/spikeinterface/sortingcomponents/motion_interpolation.py
+++ b/src/spikeinterface/sortingcomponents/motion_interpolation.py
@@ -387,6 +387,11 @@ class InterpolateMotionRecordingSegment(BasePreprocessorSegment):
             )
             # times = np.asarray(self.time_vector[start_frame:end_frame])
         else:
+            if start_frame is None:
+                start_frame = 0
+            if end_frame is None:
+                end_frame = self.get_num_samples()
+
             times = np.arange((end_frame or self.get_num_samples()) - (start_frame or 0), dtype="float64")
             times /= self.sampling_frequency
             t0 = start_frame / self.sampling_frequency


### PR DESCRIPTION
Currently if motion correction is performed then `get_traces()` is called with default arguments (i.e. `start_frame=None` or `end_frame=None`) then the routine crashes. This form of calling `get_traces()` is used in some sorters.

This fixes by setting `start_frame=0` and `end_frame = self.get_num_samples()` if either of these values are `None`, which I saw was done elsewhere in the codebase. Let me know if any changes are needed!