### PR TITLE
Add `read_npz_sorting` to extractors

### DIFF
--- a/src/spikeinterface/extractors/extractorlist.py
+++ b/src/spikeinterface/extractors/extractorlist.py
@@ -13,6 +13,7 @@ from spikeinterface.core import (
     ZarrRecordingExtractor,
     read_binary,
     read_zarr,
+    read_npz_sorting,
 )
 
 # sorting/recording/event from neo


### PR DESCRIPTION
Right now only the class is accessible in extractors, but shouldn't the function be easy to call from extractors as well? I think it can be confusing to have some readers in core for the same reason you exposed `read_binary` and `read_zarr` in extractors as well as core. 