### PR TITLE
Fix improper method call mktemp

### DIFF
--- a/src/spikeinterface/extractors/mdaextractors.py
+++ b/src/spikeinterface/extractors/mdaextractors.py
@@ -449,6 +449,7 @@ def _download_bytes_to_tmpfile(url, start, end):
     headers = {"Range": "bytes={}-{}".format(start, end - 1)}
     r = requests.get(url, headers=headers, stream=True)
     fd, tmp_fname = tempfile.mkstemp()
+    os.close(fd)
     with open(tmp_fname, "wb") as f:
         for chunk in r.iter_content(chunk_size=1024):
             if chunk:

--- a/src/spikeinterface/preprocessing/deepinterpolation/generators.py
+++ b/src/spikeinterface/preprocessing/deepinterpolation/generators.py
@@ -3,6 +3,7 @@ import tempfile
 import json
 from typing import Optional
 import numpy as np
+import os
 
 from ...core import load_extractor, concatenate_recordings, BaseRecording, BaseRecordingSegment
 
@@ -85,7 +86,8 @@ class SpikeInterfaceRecordingGenerator(SequentialGenerator):
         sequential_generator_params["total_samples"] = self.total_samples
         sequential_generator_params["pre_post_omission"] = pre_post_omission
 
-        json_path = tempfile.mktemp(suffix=".json")
+        json_fd, json_path = tempfile.mkstemp(suffix=".json")
+        os.close(json_fd)
         with open(json_path, "w") as f:
             json.dump(sequential_generator_params, f)
         super().__init__(json_path)
@@ -243,7 +245,8 @@ class SpikeInterfaceRecordingSegmentGenerator(SequentialGenerator):
         sequential_generator_params["total_samples"] = self.total_samples
         sequential_generator_params["pre_post_omission"] = pre_post_omission
 
-        json_path = tempfile.mktemp(suffix=".json")
+        json_fd, json_path = tempfile.mkstemp(suffix=".json")
+        os.close(json_fd)
         with open(json_path, "w") as f:
             json.dump(sequential_generator_params, f)
         super().__init__(json_path)


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [generators.py](https://github.com/SpikeInterface/spikeinterface/blob/main/src/spikeinterface/preprocessing/deepinterpolation/generators.py#L88), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using `mkstemp` which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of mktemp with `mkstemp`.


#### Resources Related to `mktemp`
- [POC - Improper Method Call - python - mktemp.mp4](https://drive.google.com/file/d/16YKuKgv7iItWcac2biRyi2Cm8upJ3HP_/view?usp=share_link)
- [MISC - Python - Taking a peek under the tempfile library.mp4](https://drive.google.com/file/d/1ns2_x_ZDvzFwj0eNNxyay-HUMclLasNT/view?usp=share_link)


## Changes
- Replaced `mktemp()` method with `mkstemp()`
- Closed the opened file-descriptor in file `spikeinterface/src/spikeinterface/extractors/mdaextractors.py`


## Previously Found & Fixed
- https://www.github.com/spcl/dace/pull/1428
- https://www.github.com/invesalius/invesalius3/pull/679
- https://www.github.com/Azure/azure-linux-extensions/pull/1816
- https://www.github.com/celery/billiard/pull/394


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
