### PR TITLE
Avoid duplicated template and quality metric names

### DIFF
--- a/src/spikeinterface/postprocessing/template_metrics.py
+++ b/src/spikeinterface/postprocessing/template_metrics.py
@@ -60,7 +60,7 @@ class TemplateMetricsCalculator(BaseWaveformExtractorExtension):
             metric_names += get_multi_channel_template_metric_names()
         metrics_kwargs = metrics_kwargs or dict()
         params = dict(
-            metric_names=[str(name) for name in metric_names],
+            metric_names=[str(name) for name in np.unique(metric_names)],
             sparsity=sparsity,
             peak_sign=peak_sign,
             upsampling_factor=int(upsampling_factor),

--- a/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -61,7 +61,7 @@ class QualityMetricCalculator(BaseWaveformExtractorExtension):
                 qm_params_[k]["peak_sign"] = peak_sign
 
         params = dict(
-            metric_names=[str(name) for name in metric_names],
+            metric_names=[str(name) for name in np.unique(metric_names)],
             sparsity=sparsity,
             peak_sign=peak_sign,
             seed=seed,


### PR DESCRIPTION
In principle, the user can set duplicated metrics name. This simple PR makes a unique of the metric names to avoid duplication in the output dataframes