### PR TITLE
Fix: save a copy of group ids in CommonReferenceRecording

### DIFF
--- a/src/spikeinterface/preprocessing/common_reference.py
+++ b/src/spikeinterface/preprocessing/common_reference.py
@@ -98,7 +98,9 @@ class CommonReferenceRecording(BasePreprocessor):
 
         # tranforms groups (ids) to groups (indices)
         if groups is not None:
-            groups = [self.ids_to_indices(g) for g in groups]
+            groups_inds = [self.ids_to_indices(g) for g in groups]
+        else:
+            groups_inds = None
         if ref_channel_ids is not None:
             ref_channel_inds = self.ids_to_indices(ref_channel_ids)
         else:
@@ -106,7 +108,7 @@ class CommonReferenceRecording(BasePreprocessor):
 
         for parent_segment in recording._recording_segments:
             rec_segment = CommonReferenceRecordingSegment(
-                parent_segment, reference, operator, groups, ref_channel_inds, local_radius, neighbors, dtype_
+                parent_segment, reference, operator, groups_inds, ref_channel_inds, local_radius, neighbors, dtype_
             )
             self.add_recording_segment(rec_segment)
 
@@ -123,13 +125,13 @@ class CommonReferenceRecording(BasePreprocessor):
 
 class CommonReferenceRecordingSegment(BasePreprocessorSegment):
     def __init__(
-        self, parent_recording_segment, reference, operator, groups, ref_channel_inds, local_radius, neighbors, dtype
+        self, parent_recording_segment, reference, operator, groups_inds, ref_channel_inds, local_radius, neighbors, dtype
     ):
         BasePreprocessorSegment.__init__(self, parent_recording_segment)
 
         self.reference = reference
         self.operator = operator
-        self.groups = groups
+        self.groups_inds = groups_inds
         self.ref_channel_inds = ref_channel_inds
         self.local_radius = local_radius
         self.neighbors = neighbors
@@ -175,8 +177,8 @@ class CommonReferenceRecordingSegment(BasePreprocessorSegment):
     def _groups(self, channel_indices):
         selected_groups = []
         selected_channels = []
-        if self.groups:
-            for chan_inds in self.groups:
+        if self.groups_inds:
+            for chan_inds in self.groups_inds:
                 sel_inds = [ind for ind in channel_indices if ind in chan_inds]
                 # if no channels are in a group, do not return the group
                 if len(sel_inds) > 0:

--- a/src/spikeinterface/preprocessing/common_reference.py
+++ b/src/spikeinterface/preprocessing/common_reference.py
@@ -100,7 +100,7 @@ class CommonReferenceRecording(BasePreprocessor):
         if groups is not None:
             group_indices = [self.ids_to_indices(g) for g in groups]
         else:
-            groups_inds = None
+            group_indices = None
         if ref_channel_ids is not None:
             ref_channel_inds = self.ids_to_indices(ref_channel_ids)
         else:
@@ -108,7 +108,7 @@ class CommonReferenceRecording(BasePreprocessor):
 
         for parent_segment in recording._recording_segments:
             rec_segment = CommonReferenceRecordingSegment(
-                parent_segment, reference, operator, groups_inds, ref_channel_inds, local_radius, neighbors, dtype_
+                parent_segment, reference, operator, group_indices, ref_channel_inds, local_radius, neighbors, dtype_
             )
             self.add_recording_segment(rec_segment)
 
@@ -129,7 +129,7 @@ class CommonReferenceRecordingSegment(BasePreprocessorSegment):
         parent_recording_segment,
         reference,
         operator,
-        groups_inds,
+        group_indices,
         ref_channel_inds,
         local_radius,
         neighbors,
@@ -139,7 +139,7 @@ class CommonReferenceRecordingSegment(BasePreprocessorSegment):
 
         self.reference = reference
         self.operator = operator
-        self.groups_inds = groups_inds
+        self.group_indices = group_indices
         self.ref_channel_inds = ref_channel_inds
         self.local_radius = local_radius
         self.neighbors = neighbors
@@ -185,8 +185,8 @@ class CommonReferenceRecordingSegment(BasePreprocessorSegment):
     def _groups(self, channel_indices):
         selected_groups = []
         selected_channels = []
-        if self.groups_inds:
-            for chan_inds in self.groups_inds:
+        if self.group_indices:
+            for chan_inds in self.group_indices:
                 sel_inds = [ind for ind in channel_indices if ind in chan_inds]
                 # if no channels are in a group, do not return the group
                 if len(sel_inds) > 0:

--- a/src/spikeinterface/preprocessing/common_reference.py
+++ b/src/spikeinterface/preprocessing/common_reference.py
@@ -125,7 +125,15 @@ class CommonReferenceRecording(BasePreprocessor):
 
 class CommonReferenceRecordingSegment(BasePreprocessorSegment):
     def __init__(
-        self, parent_recording_segment, reference, operator, groups_inds, ref_channel_inds, local_radius, neighbors, dtype
+        self,
+        parent_recording_segment,
+        reference,
+        operator,
+        groups_inds,
+        ref_channel_inds,
+        local_radius,
+        neighbors,
+        dtype,
     ):
         BasePreprocessorSegment.__init__(self, parent_recording_segment)
 

--- a/src/spikeinterface/preprocessing/common_reference.py
+++ b/src/spikeinterface/preprocessing/common_reference.py
@@ -98,7 +98,7 @@ class CommonReferenceRecording(BasePreprocessor):
 
         # tranforms groups (ids) to groups (indices)
         if groups is not None:
-            groups_inds = [self.ids_to_indices(g) for g in groups]
+            group_indices = [self.ids_to_indices(g) for g in groups]
         else:
             groups_inds = None
         if ref_channel_ids is not None:


### PR DESCRIPTION
Hi,

I found a potential bug and fix while using `common_reference`.

**Problem scenario**: In my original recording object, channel IDs are the same as channel indices. I use `common_reference` after a combination of `channel_slice` and `split_by` while keeping the original IDs. Then when re-loading my latest recording object from the JSON file, the `ids_to_indices` function of the `CommonReferenceRecording` object would raise error suggesting the channel ID is not found. 

**My guess for the cause**: After `channel_slice`, the channel IDs and indices are different. When initializing `CommonReferenceRecording`, the `groups` property is directly modified to reflect indices. Then when re-loading from kwargs, it would run the function `ids_to_indices` again, but this time the input property `groups` reflects indices and it should really reflect IDs. This causes error on some occasion (in my case, `split_by` is called after `channel_slice` so that may complicate the IDs of each channel), although most of the usual cases would not elicit the error.

I upload my fix here, treating `groups` property similarly as `ref_channel_ids`. Would you take a look?

Thanks!