### PR TITLE
Add Windows specific dump options

### DIFF
--- a/src/spikeinterface/sorters/basesorter.py
+++ b/src/spikeinterface/sorters/basesorter.py
@@ -9,7 +9,7 @@ import json
 import traceback
 import shutil
 import warnings
-
+import platform
 
 from spikeinterface.core import load_extractor, BaseRecordingSnippets
 from spikeinterface.core.core_tools import check_json
@@ -138,9 +138,23 @@ class BaseSorter:
 
         rec_file = output_folder / "spikeinterface_recording.json"
         if recording.check_serializablility("json"):
-            recording.dump(rec_file, relative_to=output_folder)
+            # because Windows has different drives we can't do `relative_to`
+            # unless user is on same drive, which is not guaranteed
+            if platform.system() == "Windows":
+                recording.dump(
+                    rec_file,
+                )
+            else:
+                recording.dump(rec_file, relative_to=output_folder)
         elif recording.check_serializablility("pickle"):
-            recording.dump(output_folder / "spikeinterface_recording.pickle", relative_to=output_folder)
+            # because Windows has different drives we can't do `relative_to`
+            # unless user is on same drive, which is not guaranteed
+            if platform.system() == "Windows":
+                recording.dump(
+                    output_folder / "spikeinterface_recording.pickle",
+                )
+            else:
+                recording.dump(output_folder / "spikeinterface_recording.pickle", relative_to=output_folder)
         else:
             # TODO: deprecate and finally remove this after 0.100
             d = {"warning": "The recording is not serializable to json"}


### PR DESCRIPTION
Fixes #2187 and #1891.

When in doubt follow Sam's intuition. I just do a platform.system check and if windows I don't use `relative_to`. Now it lets me sort from (I've tested this on 3 separate data sets now--but if you want me to do some more specific local tests let me know):
```
c->d
c->network
```

with no problems. I know @h-mayorquin would prefer not to have OS specific behavior, but this works. So for Windows users that do want to sort and switch drives this seems like the best solution for now (maybe we add a place holder test for the future when testing occurs on all os's?)

I also added this to pickle, but can delete if you only want this on the json dump.

Unfortunately to use `run_sorter` Windows users must use mapped drives and not unc paths because the `cmd prompt` where the spikeinterface script is run does not accept uncs paths. So this doesn't fix #2186 (unfortunately--since for some parts of SI we need unc paths and for others we need mapped paths). 