### PR TITLE
Fix #2201

### DIFF
--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -204,43 +204,6 @@ def _init_binary_worker(recording, file_path_dict, dtype, byte_offest, cast_unsi
     return worker_ctx
 
 
-# used by write_binary_recording + ChunkRecordingExecutor
-def _write_binary_chunk(segment_index, start_frame, end_frame, worker_ctx):
-    # recover variables of the worker
-    recording = worker_ctx["recording"]
-    dtype = worker_ctx["dtype"]
-    byte_offset = worker_ctx["byte_offset"]
-    cast_unsigned = worker_ctx["cast_unsigned"]
-    file = worker_ctx["file_dict"][segment_index]
-
-    # Open the memmap
-    # What we need is the file_path
-    num_channels = recording.get_num_channels()
-    num_frames = recording.get_num_frames(segment_index=segment_index)
-    shape = (num_frames, num_channels)
-    dtype_size_bytes = np.dtype(dtype).itemsize
-    data_size_bytes = dtype_size_bytes * num_frames * num_channels
-
-    # Offset (The offset needs to be multiple of the page size)
-    # The mmap offset is associated to be as big as possible but still a multiple of the page size
-    # The array offset takes care of the reminder
-    mmap_offset, array_offset = divmod(byte_offset, mmap.ALLOCATIONGRANULARITY)
-    mmmap_length = data_size_bytes + array_offset
-    memmap_obj = mmap.mmap(file.fileno(), length=mmmap_length, access=mmap.ACCESS_WRITE, offset=mmap_offset)
-
-    array = np.ndarray.__new__(np.ndarray, shape=shape, dtype=dtype, buffer=memmap_obj, order="C", offset=array_offset)
-    # apply function
-    traces = recording.get_traces(
-        start_frame=start_frame, end_frame=end_frame, segment_index=segment_index, cast_unsigned=cast_unsigned
-    )
-    if traces.dtype != dtype:
-        traces = traces.astype(dtype)
-    array[start_frame:end_frame, :] = traces
-
-    # Close the memmap
-    memmap_obj.flush()
-
-
 def write_binary_recording(
     recording,
     file_paths,
@@ -310,6 +273,43 @@ def write_binary_recording(
         recording, func, init_func, init_args, job_name="write_binary_recording", **job_kwargs
     )
     executor.run()
+
+
+# used by write_binary_recording + ChunkRecordingExecutor
+def _write_binary_chunk(segment_index, start_frame, end_frame, worker_ctx):
+    # recover variables of the worker
+    recording = worker_ctx["recording"]
+    dtype = worker_ctx["dtype"]
+    byte_offset = worker_ctx["byte_offset"]
+    cast_unsigned = worker_ctx["cast_unsigned"]
+    file = worker_ctx["file_dict"][segment_index]
+
+    # Open the memmap
+    # What we need is the file_path
+    num_channels = recording.get_num_channels()
+    num_frames = recording.get_num_frames(segment_index=segment_index)
+    shape = (num_frames, num_channels)
+    dtype_size_bytes = np.dtype(dtype).itemsize
+    data_size_bytes = dtype_size_bytes * num_frames * num_channels
+
+    # Offset (The offset needs to be multiple of the page size)
+    # The mmap offset is associated to be as big as possible but still a multiple of the page size
+    # The array offset takes care of the reminder
+    mmap_offset, array_offset = divmod(byte_offset, mmap.ALLOCATIONGRANULARITY)
+    mmmap_length = data_size_bytes + array_offset
+    memmap_obj = mmap.mmap(file.fileno(), length=mmmap_length, access=mmap.ACCESS_WRITE, offset=mmap_offset)
+
+    array = np.ndarray.__new__(np.ndarray, shape=shape, dtype=dtype, buffer=memmap_obj, order="C", offset=array_offset)
+    # apply function
+    traces = recording.get_traces(
+        start_frame=start_frame, end_frame=end_frame, segment_index=segment_index, cast_unsigned=cast_unsigned
+    )
+    if traces.dtype != dtype:
+        traces = traces.astype(dtype)
+    array[start_frame:end_frame, :] = traces
+
+    # Close the memmap
+    memmap_obj.flush()
 
 
 write_binary_recording.__doc__ = write_binary_recording.__doc__.format(_shared_job_kwargs_doc)

--- a/src/spikeinterface/core/segmentutils.py
+++ b/src/spikeinterface/core/segmentutils.py
@@ -122,13 +122,13 @@ class ConcatenateSegmentRecording(BaseRecording):
         parent_segments = []
         for rec in recording_list:
             for parent_segment in rec._recording_segments:
-                d = parent_segment.get_times_kwargs()
+                time_kwargs = parent_segment.get_times_kwargs()
                 if not ignore_times:
-                    assert d["time_vector"] is None, (
+                    assert time_kwargs["time_vector"] is None, (
                         "ConcatenateSegmentRecording does not handle time_vector. "
                         "Use ignore_times=True to ignore time information."
                     )
-                    assert d["t_start"] is None, (
+                    assert time_kwargs["t_start"] is None, (
                         "ConcatenateSegmentRecording does not handle t_start. "
                         "Use ignore_times=True to ignore time information."
                     )
@@ -148,17 +148,17 @@ class ConcatenateSegmentRecording(BaseRecording):
 class ProxyConcatenateRecordingSegment(BaseRecordingSegment):
     def __init__(self, parent_segments, sampling_frequency, ignore_times=True):
         if ignore_times:
-            d = {}
-            d["t_start"] = None
-            d["time_vector"] = None
-            d["sampling_frequency"] = sampling_frequency
+            time_kwargs = {}
+            time_kwargs["t_start"] = None
+            time_kwargs["time_vector"] = None
+            time_kwargs["sampling_frequency"] = sampling_frequency
         else:
-            d = parent_segments[0].get_times_kwargs()
-        BaseRecordingSegment.__init__(self, **d)
+            time_kwargs = parent_segments[0].get_times_kwargs()
+        BaseRecordingSegment.__init__(self, **time_kwargs)
         self.parent_segments = parent_segments
         self.all_length = [rec_seg.get_num_samples() for rec_seg in self.parent_segments]
-        self.cumsum_length = np.cumsum([0] + self.all_length)
-        self.total_length = np.sum(self.all_length)
+        self.cumsum_length = np.cumsum([0] + self.all_length).item()
+        self.total_length = np.sum(self.all_length).item()
 
     def get_num_samples(self):
         return self.total_length

--- a/src/spikeinterface/core/segmentutils.py
+++ b/src/spikeinterface/core/segmentutils.py
@@ -157,8 +157,8 @@ class ProxyConcatenateRecordingSegment(BaseRecordingSegment):
         BaseRecordingSegment.__init__(self, **time_kwargs)
         self.parent_segments = parent_segments
         self.all_length = [rec_seg.get_num_samples() for rec_seg in self.parent_segments]
-        self.cumsum_length = np.cumsum([0] + self.all_length).item()
-        self.total_length = np.sum(self.all_length).item()
+        self.cumsum_length = np.cumsum([0] + self.all_length)
+        self.total_length = int(np.sum(self.all_length))
 
     def get_num_samples(self):
         return self.total_length

--- a/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -313,10 +313,7 @@ class NeoRecordingSegment(BaseRecordingSegment):
             block_index=self.block_index, seg_index=self.segment_index, stream_index=self.stream_index
         )
 
-        # Transform the num_samples to integer if if it is a numpy scalar
-        if isinstance(num_samples, np.generic):
-            num_samples = int(num_samples)
-        return num_samples
+        return int(num_samples)
 
     def get_traces(
         self,

--- a/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -312,6 +312,10 @@ class NeoRecordingSegment(BaseRecordingSegment):
         num_samples = self.neo_reader.get_signal_size(
             block_index=self.block_index, seg_index=self.segment_index, stream_index=self.stream_index
         )
+
+        # Transform the num_samples to integer if if it is a numpy scalar
+        if isinstance(num_samples, np.generic):
+            num_samples = int(num_samples)
         return num_samples
 
     def get_traces(


### PR DESCRIPTION
Annoying bug that happens with concatenation but can happen with any recording that is long enough. Here is the problem. To create the file, the size of the file-to-be is esimated with this line:

https://github.com/h-mayorquin/spikeinterface/blob/65e4c178dc3bd0f826ce2b10fcb31a8e7da4698b/src/spikeinterface/core/core_tools.py#L297

But sometimes the number of frames is a numpy scalar (and not a python integer). Numpy scalars behave like numpy objects and they have an overflow.  That means that the file size ends up being smaller than it should and the writting to the buffer fails.

You can see that there is an overflown ins the screenshot that the user shared with us:

![image](https://github.com/SpikeInterface/spikeinterface/assets/6429509/af65f8c5-6a5e-4501-9c9a-dbd8892f44f6)

Plus, you can see that the concatenated recording is smaller than the pieces. 

So, to solves it, we need to be sure that `get_num_samples()`i is not a numpy scalar but a python scalar (they can be as long as as they need to be). I modified the code to do that.
