### PR TITLE
Add posion statistics to generate_sorting

### DIFF
--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -263,7 +263,7 @@ class BaseSorting(BaseExtractor):
 
     def get_total_num_spikes(self):
         warnings.warn(
-            "Sorting.get_total_num_spikes() is deprecated, se sorting.count_num_spikes_per_unit()",
+            "Sorting.get_total_num_spikes() is deprecated and will be removed in spikeinterface 0.102, se sorting.count_num_spikes_per_unit()",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -168,7 +168,7 @@ def generate_sorting(
     spikes = []
     for segment_index in range(num_segments):
         num_samples = int(sampling_frequency * durations[segment_index])
-        times, labels = synthesize_random_firings(
+        times, labels = synthesize_random_firings_poisson(
             num_units=num_units,
             sampling_frequency=sampling_frequency,
             duration=durations[segment_index],

--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -386,23 +386,21 @@ def synthesize_random_firings_poisson(
     spike_frames = np.cumsum(inter_spike_frames, axis=1, out=inter_spike_frames)
     spike_frames = spike_frames.ravel()
 
-    # We map units to corresponding spike times and flatten the array
-    unit_indices = np.repeat(np.arange(num_units, dtype="uint16"), num_spikes_max).ravel()
+    # We map un its to corresponding spike times and flatten the array
+    unit_indices = np.repeat(np.arange(num_units, dtype="uint16"), num_spikes_max)
 
     # Eliminate spikes that are beyond the duration
     mask = spike_frames <= max_frames
     num_correct_frames = np.sum(mask)
-    spike_frames[:num_correct_frames] = spike_frames[mask]
-    unit_indices[:num_correct_frames] = unit_indices[mask]
+    spike_frames[:num_correct_frames] = spike_frames[mask]  # Avoids a malloc
+    unit_indices = unit_indices[mask]
 
-    # All of this to avoid a malloc
     spike_frames = spike_frames[:num_correct_frames]
-    unit_indices = unit_indices[:num_correct_frames]
-
     # This should use tim or radix sort which is good for integers and presorted data. I profiled. re-profile in doubt.
     sort_indices = np.argsort(spike_frames, kind="stable")
-    spike_frames = spike_frames[sort_indices]  # This is still generating a malloc, probably the ravel
+
     unit_indices = unit_indices[sort_indices]
+    spike_frames = spike_frames[sort_indices]
 
     return spike_frames, unit_indices
 

--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -396,7 +396,7 @@ def synthesize_random_firings_poisson(
     unit_indices = unit_indices[mask]
 
     spike_frames = spike_frames[:num_correct_frames]
-    # This should use tim or radix sort which is good for integers and presorted data. I profiled. re-profile in doubt.
+    # Stable should use tim or radix sort which is good for integers and presorted data. I profiled. re-profile in doubt.
     sort_indices = np.argsort(spike_frames, kind="stable")
 
     unit_indices = unit_indices[sort_indices]

--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -169,7 +169,7 @@ def generate_sorting(
     spikes = []
     for segment_index in range(num_segments):
         num_samples = int(sampling_frequency * durations[segment_index])
-        samples, labels = synthesize_random_firings_poisson(
+        samples, labels = synthesize_poisson_spike_vector(
             num_units=num_units,
             sampling_frequency=sampling_frequency,
             duration=durations[segment_index],
@@ -318,7 +318,7 @@ def generate_snippets(
 
 
 ## spiketrain zone ##
-def synthesize_random_firings_poisson(
+def synthesize_poisson_spike_vector(
     num_units=20,
     sampling_frequency=30000.0,
     duration=60,

--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -358,11 +358,7 @@ def synthesize_random_firings_poisson(
     Notes
     -----
     - The function uses a geometric distribution to simulate the discrete inter-spike intervals,
-    based that would be an exponential process.
-    - To ensure all spikes within the duration are captured, it initially generates more spikes
-    than expected and then filters out the excess.
-    - Refractory periods are enforced by adding a fixed number of frames to subsequent spikes.
-    - The output is sorted based on spike timings for easier analysis.
+    based that would be an exponential process for continuous time.
     """
 
     rng = np.random.default_rng(seed=seed)
@@ -403,7 +399,7 @@ def synthesize_random_firings_poisson(
     spike_frames = spike_frames[:num_correct_frames]
     unit_indices = unit_indices[:num_correct_frames]
 
-    # This should use tim or radix sort which is good for integers and presorted data. I profiled, re-profile in doubt.
+    # This should use tim or radix sort which is good for integers and presorted data. I profiled. re-profile in doubt.
     sort_indices = np.argsort(spike_frames, kind="stable")
     spike_frames = spike_frames[sort_indices]  # This is still generating a malloc, probably the ravel
     unit_indices = unit_indices[sort_indices]


### PR DESCRIPTION
I added a function that generates spikes as if they are a poisson process which, in my understanding, is the most common statistics of firing rate.

This is is also 3 times faster. Generates a ten hour sorting with 1000 units in 7 seconds instead of 20 as the current one. A ~ 3 speedup.

```
--------------------------------------------------
`synthesize_poisson_spike_vector`
Mean time over 3 iterations: 6.94 seconds
Std over 3 iterations: 0.01 seconds
times=['6.92', '6.96', '6.95']
--------------------------------------------------
`synthesize_random_firings`
Mean time over 3 iterations: 21.12 seconds
Std over 3 iterations: 0.09 seconds
times=['21.05', '21.05', '21.25']

Speedup: 3.04
```

Plus, it is more memory efficient as it has around 70 % memory requirements of the current function (I did try to make it less memory hungry but it is  HARD). It also seems that the current implementation has some kind of leak, see the temporal profile of memory utilizaiton in the profile above.

![image](https://github.com/SpikeInterface/spikeinterface/assets/6429509/2f9309db-7cc5-43b5-bbf9-df83b9314fee)

The first three are the PR implementation, the last three is the current implementation.
