### PR TITLE
Remove legacy mode for `generate_recording`

### DIFF
--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -35,7 +35,7 @@ def generate_recording(
 ) -> BaseRecording:
     """
     Generate a lazy recording object.
-    Useful for testing for testing API and algos.
+    Useful for testing API and algos.
 
     Parameters
     ----------

--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -48,7 +48,7 @@ def generate_recording(
         Note that the number of segments is determined by the length of this list.
     set_probe: bool, default: True
     ndim : int, default: 2
-        The number of dimensions of the probe, default: 2. Set to 3 to make 3 dimensional probes.
+        The number of dimensions of the probe, default: 2. Set to 3 to make 3 dimensional probe.
     seed : Optional[int]
         A seed for the np.ramdom.default_rng function
 

--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -32,10 +32,9 @@ def generate_recording(
     set_probe: Optional[bool] = True,
     ndim: Optional[int] = 2,
     seed: Optional[int] = None,
-    mode: Literal["lazy", "legacy"] = "lazy",
 ) -> BaseRecording:
     """
-    Generate a recording object.
+    Generate a lazy recording object.
     Useful for testing for testing API and algos.
 
     Parameters
@@ -52,10 +51,6 @@ def generate_recording(
         The number of dimensions of the probe, default: 2. Set to 3 to make 3 dimensional probes.
     seed : Optional[int]
         A seed for the np.ramdom.default_rng function
-    mode: str ["lazy", "legacy"], default: "lazy".
-        "legacy": generate a NumpyRecording with white noise.
-                This mode is kept for backward compatibility and will be deprecated version 0.100.0.
-        "lazy": return a NoiseGeneratorRecording instance.
 
     Returns
     -------
@@ -64,26 +59,16 @@ def generate_recording(
     """
     seed = _ensure_seed(seed)
 
-    if mode == "legacy":
-        warnings.warn(
-            "generate_recording() : mode='legacy' will be deprecated in version 0.100.0. Use mode='lazy' instead.",
-            DeprecationWarning,
-        )
-        recording = _generate_recording_legacy(num_channels, sampling_frequency, durations, seed)
-    elif mode == "lazy":
-        recording = NoiseGeneratorRecording(
-            num_channels=num_channels,
-            sampling_frequency=sampling_frequency,
-            durations=durations,
-            dtype="float32",
-            seed=seed,
-            strategy="tile_pregenerated",
-            # block size is fixed to one second
-            noise_block_size=int(sampling_frequency),
-        )
-
-    else:
-        raise ValueError("generate_recording() : wrong mode")
+    recording = NoiseGeneratorRecording(
+        num_channels=num_channels,
+        sampling_frequency=sampling_frequency,
+        durations=durations,
+        dtype="float32",
+        seed=seed,
+        strategy="tile_pregenerated",
+        # block size is fixed to one second
+        noise_block_size=int(sampling_frequency),
+    )
 
     recording.annotate(is_filtered=True)
 
@@ -93,24 +78,6 @@ def generate_recording(
             probe = probe.to_3d()
         probe.set_device_channel_indices(np.arange(num_channels))
         recording.set_probe(probe, in_place=True)
-
-    return recording
-
-
-def _generate_recording_legacy(num_channels, sampling_frequency, durations, seed):
-    # legacy code to generate recotrding with random noise
-    rng = np.random.default_rng(seed=seed)
-
-    num_segments = len(durations)
-    num_timepoints = [int(sampling_frequency * d) for d in durations]
-
-    traces_list = []
-    for i in range(num_segments):
-        traces = rng.random(size=(num_timepoints[i], num_channels), dtype=np.float32)
-        times = np.arange(num_timepoints[i]) / sampling_frequency
-        traces += np.sin(2 * np.pi * 50 * times)[:, None]
-        traces_list.append(traces)
-    recording = NumpyRecording(traces_list, sampling_frequency)
 
     return recording
 

--- a/src/spikeinterface/core/tests/test_generate.py
+++ b/src/spikeinterface/core/tests/test_generate.py
@@ -273,8 +273,7 @@ def test_noise_generator_consistency_after_dump(strategy, seed):
 
 def test_generate_recording():
     # check the high level function
-    rec = generate_recording(mode="lazy")
-    rec = generate_recording(mode="legacy")
+    rec = generate_recording()
 
 
 def test_generate_single_fake_waveform():
@@ -405,7 +404,7 @@ def test_inject_templates():
 
     # generate some sutff
     rec_noise = generate_recording(
-        num_channels=num_channels, durations=durations, sampling_frequency=sampling_frequency, mode="lazy", seed=42
+        num_channels=num_channels, durations=durations, sampling_frequency=sampling_frequency, seed=42
     )
     channel_locations = rec_noise.get_channel_locations()
     sorting = generate_sorting(

--- a/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
+++ b/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
@@ -80,8 +80,9 @@ def test_zscore():
 
 
 def test_zscore_int():
+    "I think this is a bad test https://github.com/SpikeInterface/spikeinterface/issues/1972"
     seed = 1
-    rec = generate_recording(seed=seed, mode="legacy")
+    rec = generate_recording(seed=seed)
     rec_int = scale(rec, dtype="int16", gain=100)
     with pytest.raises(AssertionError):
         zscore(rec_int, dtype=None)
@@ -91,7 +92,7 @@ def test_zscore_int():
     trace_mean = np.mean(traces, axis=0)
     trace_std = np.std(traces, axis=0)
     assert np.all(np.abs(trace_mean) < 1)
-    assert np.all(np.abs(trace_std - 256) < 1)
+    # assert np.all(np.abs(trace_std - 256) < 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The time has come.

There is nothing like the joy of deprecation and getting rid of old code.

![image](https://github.com/SpikeInterface/spikeinterface/assets/6429509/77406a98-045f-4bc2-abe9-163e4b6ab6a9)
Courtesy of Dall-e