### PR TITLE
Various stopping criterion for circus matching

### DIFF
--- a/src/spikeinterface/sorters/internal/spyking_circus2.py
+++ b/src/spikeinterface/sorters/internal/spyking_circus2.py
@@ -153,7 +153,7 @@ class Spykingcircus2Sorter(ComponentsBasedSorter):
         for k in ["ms_before", "ms_after"]:
             waveforms_params[k] = params["general"][k]
 
-        if params["shared_memory"] and not params['debug']:
+        if params["shared_memory"] and not params["debug"]:
             mode = "memory"
             waveforms_folder = None
         else:

--- a/src/spikeinterface/sorters/internal/spyking_circus2.py
+++ b/src/spikeinterface/sorters/internal/spyking_circus2.py
@@ -153,7 +153,7 @@ class Spykingcircus2Sorter(ComponentsBasedSorter):
         for k in ["ms_before", "ms_after"]:
             waveforms_params[k] = params["general"][k]
 
-        if params["shared_memory"]:
+        if params["shared_memory"] and not params['debug']:
             mode = "memory"
             waveforms_folder = None
         else:

--- a/src/spikeinterface/sortingcomponents/matching/circus.py
+++ b/src/spikeinterface/sortingcomponents/matching/circus.py
@@ -660,7 +660,6 @@ class CircusOMPSVDPeeler(BaseTemplateMatchingEngine):
         neighbor_window = num_samples - 1
         min_amplitude, max_amplitude = d["amplitudes"]
         ignored_ids = d["ignored_ids"]
-        stop_criteria = d["stop_criteria"]
         vicinity = d["vicinity"]
         rank = d["rank"]
 

--- a/src/spikeinterface/sortingcomponents/matching/circus.py
+++ b/src/spikeinterface/sortingcomponents/matching/circus.py
@@ -821,7 +821,7 @@ class CircusOMPSVDPeeler(BaseTemplateMatchingEngine):
 
             # We stop when updates do not modify the chosen spikes anymore
             if d['stop_criteria'] == 'omp_min_sps':
-                is_valid = scalar_products > stop_criteria
+                is_valid = scalar_products > stop_criteria[:, np.newaxis]
                 do_loop = np.any(is_valid)
             elif d['stop_criteria'] == "max_failures":
                 is_valid = (final_amplitudes > min_amplitude) * (final_amplitudes < max_amplitude)

--- a/src/spikeinterface/sortingcomponents/matching/circus.py
+++ b/src/spikeinterface/sortingcomponents/matching/circus.py
@@ -709,7 +709,7 @@ class CircusOMPSVDPeeler(BaseTemplateMatchingEngine):
         is_in_vicinity = np.zeros(0, dtype=np.int32)
         
         if d['stop_criteria'] == 'omp_min_sps':
-            stop_criteria = d['omp_min_sps'] * np.maximum(d["norms"], np.sqrt(d["noise_levels"].sum() * d["num_samples"]))
+            stop_criteria = d['omp_min_sps'] * np.maximum(d["norms"], np.sqrt(num_channels * num_samples))
         elif d['stop_criteria'] == "max_failures":
             nb_valids = 0
             nb_failures = d['max_failures']

--- a/src/spikeinterface/sortingcomponents/matching/circus.py
+++ b/src/spikeinterface/sortingcomponents/matching/circus.py
@@ -509,10 +509,10 @@ class CircusOMPSVDPeeler(BaseTemplateMatchingEngine):
 
     _default_params = {
         "amplitudes": [0.6, 2],
-        "stop_criteria" : "max_failures",
-        "max_failures" : 20,
-        "omp_min_sps" : 0.1,
-        "relative_error" : 5e-5,
+        "stop_criteria": "max_failures",
+        "max_failures": 20,
+        "omp_min_sps": 0.1,
+        "relative_error": 5e-5,
         "waveform_extractor": None,
         "rank": 5,
         "sparse_kwargs": {"method": "ptp", "threshold": 1},
@@ -525,7 +525,7 @@ class CircusOMPSVDPeeler(BaseTemplateMatchingEngine):
         waveform_extractor = d["waveform_extractor"]
         num_templates = len(d["waveform_extractor"].sorting.unit_ids)
 
-        assert d['stop_criteria'] in ['max_failures', 'omp_min_sps', 'relative_error']
+        assert d["stop_criteria"] in ["max_failures", "omp_min_sps", "relative_error"]
 
         if not waveform_extractor.is_sparse():
             sparsity = compute_sparsity(waveform_extractor, **d["sparse_kwargs"]).mask
@@ -707,13 +707,13 @@ class CircusOMPSVDPeeler(BaseTemplateMatchingEngine):
 
         all_amplitudes = np.zeros(0, dtype=np.float32)
         is_in_vicinity = np.zeros(0, dtype=np.int32)
-        
-        if d['stop_criteria'] == 'omp_min_sps':
-            stop_criteria = d['omp_min_sps'] * np.maximum(d["norms"], np.sqrt(num_channels * num_samples))
-        elif d['stop_criteria'] == "max_failures":
+
+        if d["stop_criteria"] == "omp_min_sps":
+            stop_criteria = d["omp_min_sps"] * np.maximum(d["norms"], np.sqrt(num_channels * num_samples))
+        elif d["stop_criteria"] == "max_failures":
             nb_valids = 0
-            nb_failures = d['max_failures']
-        elif d['stop_criteria'] == 'relative_error':
+            nb_failures = d["max_failures"]
+        elif d["stop_criteria"] == "relative_error":
             if len(ignored_ids) > 0:
                 new_error = np.linalg.norm(scalar_products[not_ignored])
             else:
@@ -820,17 +820,17 @@ class CircusOMPSVDPeeler(BaseTemplateMatchingEngine):
                 scalar_products[overlapping_templates, idx[0] : idx[1]] -= to_add
 
             # We stop when updates do not modify the chosen spikes anymore
-            if d['stop_criteria'] == 'omp_min_sps':
+            if d["stop_criteria"] == "omp_min_sps":
                 is_valid = scalar_products > stop_criteria[:, np.newaxis]
                 do_loop = np.any(is_valid)
-            elif d['stop_criteria'] == "max_failures":
+            elif d["stop_criteria"] == "max_failures":
                 is_valid = (final_amplitudes > min_amplitude) * (final_amplitudes < max_amplitude)
                 new_nb_valids = np.sum(is_valid)
                 if (new_nb_valids - nb_valids) == 0:
                     nb_failures -= 1
                 nb_valids = new_nb_valids
                 do_loop = nb_failures > 0
-            elif d['stop_criteria'] == 'relative_error':
+            elif d["stop_criteria"] == "relative_error":
                 previous_error = new_error
                 if len(ignored_ids) > 0:
                     new_error = np.linalg.norm(scalar_products[not_ignored])


### PR DESCRIPTION
Add the possibility to select the stopping criteria for the circus engine, in order to ease comparison. The default is now a nb_failures mode, that seems to be similar to relative_error, but at least we can explore. This PR depends on PR #2236 that create a debug mode for SC2