### PR TITLE
Add tests for unique names in channel slice and unit selection

### DIFF
--- a/src/spikeinterface/core/tests/test_channelslicerecording.py
+++ b/src/spikeinterface/core/tests/test_channelslicerecording.py
@@ -74,7 +74,7 @@ def test_ChannelSliceRecording():
     assert np.all(traces3[:, 1] == 2)
 
 
-def test_failre_with_non_unique_channel_ids():
+def test_failure_with_non_unique_channel_ids():
     durations = [1.0]
     seed = 10
     rec = generate_recording(num_channels=4, durations=durations, set_probe=False, seed=seed)

--- a/src/spikeinterface/core/tests/test_channelslicerecording.py
+++ b/src/spikeinterface/core/tests/test_channelslicerecording.py
@@ -79,7 +79,7 @@ def test_failure_with_non_unique_channel_ids():
     seed = 10
     rec = generate_recording(num_channels=4, durations=durations, set_probe=False, seed=seed)
     with pytest.raises(AssertionError):
-        rec_sliced = ChannelSliceRecording(rec, channel_ids=[0, 0])
+        rec_sliced = ChannelSliceRecording(rec, channel_ids=[0, 1], renamed_channel_ids=[0, 0])
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/core/tests/test_channelslicerecording.py
+++ b/src/spikeinterface/core/tests/test_channelslicerecording.py
@@ -7,6 +7,7 @@ import numpy as np
 import probeinterface
 
 from spikeinterface.core import ChannelSliceRecording, BinaryRecordingExtractor
+from spikeinterface.core.generate import generate_recording
 
 
 def test_ChannelSliceRecording():
@@ -71,6 +72,12 @@ def test_ChannelSliceRecording():
     traces3 = rec_saved.get_traces(segment_index=0)
     assert np.all(traces3[:, 0] == 0)
     assert np.all(traces3[:, 1] == 2)
+
+
+def test_unique_channel_ids():
+    rec = generate_recording(num_channels=4, num_segments=2)
+    with pytest.raises(AssertionError):
+        rec_sliced = ChannelSliceRecording(rec, channel_ids=[0, 0])
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/core/tests/test_channelslicerecording.py
+++ b/src/spikeinterface/core/tests/test_channelslicerecording.py
@@ -74,7 +74,7 @@ def test_ChannelSliceRecording():
     assert np.all(traces3[:, 1] == 2)
 
 
-def test_unique_channel_ids():
+def test_failre_with_non_unique_channel_ids():
     durations = [1.0]
     seed = 10
     rec = generate_recording(num_channels=4, durations=durations, set_probe=False, seed=seed)

--- a/src/spikeinterface/core/tests/test_channelslicerecording.py
+++ b/src/spikeinterface/core/tests/test_channelslicerecording.py
@@ -75,7 +75,9 @@ def test_ChannelSliceRecording():
 
 
 def test_unique_channel_ids():
-    rec = generate_recording(num_channels=4, num_segments=2)
+    durations = [1.0]
+    seed = 10
+    rec = generate_recording(num_channels=4, durations=durations, set_probe=False, seed=seed)
     with pytest.raises(AssertionError):
         rec_sliced = ChannelSliceRecording(rec, channel_ids=[0, 0])
 

--- a/src/spikeinterface/core/tests/test_unitsselectionsorting.py
+++ b/src/spikeinterface/core/tests/test_unitsselectionsorting.py
@@ -32,7 +32,8 @@ def test_basic_functions():
 
 
 def test_no_repeated_names():
-    sorting = generate_sorting(num_units=3, durations=[0.100, 0.100], sampling_frequency=30000.0)
+    seed = 10
+    sorting = generate_sorting(num_units=3, durations=[0.100], sampling_frequency=30000.0, seed=seed)
     with pytest.raises(AssertionError):
         sorting2 = UnitsSelectionSorting(sorting, unit_ids=[0, 2], renamed_unit_ids=["a", "a"])
 

--- a/src/spikeinterface/core/tests/test_unitsselectionsorting.py
+++ b/src/spikeinterface/core/tests/test_unitsselectionsorting.py
@@ -31,7 +31,7 @@ def test_basic_functions():
     )
 
 
-def test_no_repeated_names():
+def test_failure_with_non_unique_unit_ids():
     seed = 10
     sorting = generate_sorting(num_units=3, durations=[0.100], sampling_frequency=30000.0, seed=seed)
     with pytest.raises(AssertionError):

--- a/src/spikeinterface/core/tests/test_unitsselectionsorting.py
+++ b/src/spikeinterface/core/tests/test_unitsselectionsorting.py
@@ -4,34 +4,16 @@ from pathlib import Path
 
 from spikeinterface.core import UnitsSelectionSorting
 
-from spikeinterface.core import NpzSortingExtractor, load_extractor
-from spikeinterface.core.base import BaseExtractor
-
-from spikeinterface.core import create_sorting_npz
+from spikeinterface.core.generate import generate_sorting
 
 
-if hasattr(pytest, "global_test_folder"):
-    cache_folder = pytest.global_test_folder / "core"
-else:
-    cache_folder = Path("cache_folder") / "core"
-
-
-def test_unitsselectionsorting():
-    num_seg = 2
-    file_path = cache_folder / "test_BaseSorting.npz"
-
-    create_sorting_npz(num_seg, file_path)
-
-    sorting = NpzSortingExtractor(file_path)
-    print(sorting)
-    print(sorting.unit_ids)
+def test_basic_functions():
+    sorting = generate_sorting(num_units=3, durations=[0.100, 0.100], sampling_frequency=30000.0)
 
     sorting2 = UnitsSelectionSorting(sorting, unit_ids=[0, 2])
-    print(sorting2.unit_ids)
     assert np.array_equal(sorting2.unit_ids, [0, 2])
 
     sorting3 = UnitsSelectionSorting(sorting, unit_ids=[0, 2], renamed_unit_ids=["a", "b"])
-    print(sorting3.unit_ids)
     assert np.array_equal(sorting3.unit_ids, ["a", "b"])
 
     assert np.array_equal(
@@ -49,5 +31,11 @@ def test_unitsselectionsorting():
     )
 
 
+def test_no_repeated_names():
+    sorting = generate_sorting(num_units=3, durations=[0.100, 0.100], sampling_frequency=30000.0)
+    with pytest.raises(AssertionError):
+        sorting2 = UnitsSelectionSorting(sorting, unit_ids=[0, 2], renamed_unit_ids=["a", "a"])
+
+
 if __name__ == "__main__":
-    test_unitsselectionsorting()
+    test_basic_functions()


### PR DESCRIPTION
* Adds tests for #2252 and should come after it.
* Uses generate sorgting instead of saving to disk with `NpzSortingExtractor`
* Eliminates some prints.