### PR TITLE
Add streaming extractors dependencies to full

### DIFF
--- a/.github/actions/build-test-environment/action.yml
+++ b/.github/actions/build-test-environment/action.yml
@@ -21,7 +21,7 @@ runs:
         python -m pip install -U pip  # Official recommended way
         source ${{ github.workspace }}/test_env/bin/activate
         pip install tabulate  # This produces summaries at the end
-        pip install -e .[test,extractors,full]
+        pip install -e .[test,extractors,streaming_extractors,full]
       shell: bash
     - name: Force installation of latest dev from key-packages when running dev (not release)
       run: |

--- a/src/spikeinterface/extractors/tests/test_nwb_s3_extractor.py
+++ b/src/spikeinterface/extractors/tests/test_nwb_s3_extractor.py
@@ -48,6 +48,7 @@ def test_recording_s3_nwb_ros3(tmp_path):
     check_recordings_equal(rec, reloaded_recording)
 
 
+@pytest.mark.streaming_extractors
 @pytest.mark.parametrize("cache", [True, False])  # Test with and without cache
 def test_recording_s3_nwb_fsspec(tmp_path, cache):
     file_path = (


### PR DESCRIPTION
Full tests are failing as reported by @alejoe91 .

It seemst that before fsspec and some other network dependencies were being installed indrectly when we ran the full tests so things were working OK (probably [these guys here](https://github.com/SpikeInterface/spikeinterface/blob/ef96db00b79f42fc234b8cf80ee29485d5ac8766/pyproject.toml#L66-L68))

This PR just adds the streaming_extractors dependencies (fsspec and remfile mainly) to the environment that is used on the full tests. 

