### PR TITLE
Use `sampling_frequency` instead of `get_sampling_frequency` in `_make_bins`

### DIFF
--- a/src/spikeinterface/postprocessing/correlograms.py
+++ b/src/spikeinterface/postprocessing/correlograms.py
@@ -68,7 +68,7 @@ WaveformExtractor.register_extension(CorrelogramsCalculator)
 
 
 def _make_bins(sorting, window_ms, bin_ms):
-    fs = sorting.get_sampling_frequency()
+    fs = sorting.sampling_frequency
 
     window_size = int(round(fs * window_ms / 2 * 1e-3))
     bin_size = int(round(fs * bin_ms * 1e-3))


### PR DESCRIPTION
The [`_make_bins`](https://github.com/SpikeInterface/spikeinterface/blob/main/src/spikeinterface/postprocessing/correlograms.py#L70) accepts both a sorting and a WaveformExtractor object. However, the `get_sampling_frequency()` is only supported by the sorting. Both objects have the `sampling_frequency` property.