### PR TITLE
Avoid loading `channel_name` property in NwbRecording`

### DIFF
--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -376,6 +376,9 @@ class NwbRecordingExtractor(BaseRecording):
             for column in electrodes_table.colnames:
                 if isinstance(electrodes_table[column][electrode_table_index], ElectrodeGroup):
                     continue
+                if column == "channel_name":
+                    # channel_names are already set as channel ids!
+                    continue
                 elif column == "group_name":
                     group = unique_electrode_group_names.index(electrodes_table[column][electrode_table_index])
                     if "group" not in properties:

--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -376,7 +376,7 @@ class NwbRecordingExtractor(BaseRecording):
             for column in electrodes_table.colnames:
                 if isinstance(electrodes_table[column][electrode_table_index], ElectrodeGroup):
                     continue
-                if column == "channel_name":
+                elif column == "channel_name":
                     # channel_names are already set as channel ids!
                     continue
                 elif column == "group_name":


### PR DESCRIPTION
As in title. Note that this could potentially cause troubles when loading an NWB file saved by SpikeInterface and saving/appending using `neuroconv`.