### PR TITLE
Add group by preprocessing conveneience function.

### DIFF
--- a/src/spikeinterface/preprocessing/group_by_recording.py
+++ b/src/spikeinterface/preprocessing/group_by_recording.py
@@ -3,39 +3,42 @@ from typing import Dict
 from spikeinterface import load_extractor
 import numpy as np
 
-from spikeinterface.core.core_tools import define_function_from_class
 
-from spikeinterface.preprocessing.basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 from spikeinterface.core.channelsaggregationrecording import ChannelsAggregationRecording, aggregate_channels
+import spikeinterface.preprocessing as spre
 
 
-def group_preprocessing_by_property(recording_):  # TODO: rename
-    """ """
+def group_preprocessing_by_property(recording_):
+    """
+    1) Recursively loop through recording ._kwargs storing applied
+       preprocessing steps and _kwargs until the initial recording is found
+    2) Re-apply all steps back onto the base recording.
+    """
     loop_recording = copy.deepcopy(recording_)
     preprocessing_step_list = []
     preprocessing_kwargs_list = []
     while True:
-        # There is a general problem here in that the __init__ sets everything
-        # up according to the full recording but then we split by channel.
-        # However it is not possible to know what kwargs are user-passed and
-        # what are setup during init.
+        # Recursively loop through recordings on kwargs, storing the preprocessing
+        # steps and the associated kwargs ----------------------------------------------
+
         if isinstance(loop_recording, ChannelsAggregationRecording):
             raise ValueError(
                 "Cannot group by recording a recording that" "has already been aggregated with `aggregate_channels`"
             )
 
-        if (
+        if (  # TODO: Handle ZeroChannelPaddedRecording that saves to 'parent_recording rather than 'recording'
             "recording" not in loop_recording._kwargs and "parent_recording" not in loop_recording._kwargs
-        ):  # ZeroChannelPaddedRecording
+        ):
             raise ValueError(f"The recording {loop_recording.__class__} " f"cannot be run in `group_by_recording`.")
 
-        if "recording" in loop_recording._kwargs:  # ZeroChannelPaddedRecording
+        if "recording" in loop_recording._kwargs:
             assert "parent_recording" not in loop_recording._kwargs
             parent_recording = loop_recording._kwargs.pop("recording")
         else:
             parent_recording = loop_recording._kwargs.pop("parent_recording")
 
-        if loop_recording.__class__ == spre.WhitenRecording:  # Hacky, discusss how to handle
+        # TODO: Hacky workaround to handle WhitenRecording
+        if loop_recording.__class__ == spre.WhitenRecording:
             kwargs = copy.deepcopy(loop_recording._kwargs)
             kwargs["W"] = None
             kwargs["M"] = None
@@ -43,15 +46,18 @@ def group_preprocessing_by_property(recording_):  # TODO: rename
             kwargs = loop_recording._kwargs
 
         preprocessing_step_list.append(loop_recording.__class__)
-        preprocessing_kwargs_list.append(kwargs)  # TODO: messy
+        preprocessing_kwargs_list.append(kwargs)
 
-        if isinstance(parent_recording, Dict):  # TODO: for silence periods, raise an issue.
+        # TODO: ZeroSilencePeriods saves as a dict
+        if isinstance(parent_recording, Dict):
             parent_recording = load_extractor(parent_recording)
 
-        if "recording" not in parent_recording._kwargs:  # ZeroSilencePeriods
+        if "recording" not in parent_recording._kwargs:
             root_recording = parent_recording
             break
         loop_recording = parent_recording
+
+    # Re-apply the preprocessing steps to the base function ----------------------------
 
     split_recording = root_recording.split_by("group")
 
@@ -63,67 +69,3 @@ def group_preprocessing_by_property(recording_):  # TODO: rename
     recombined_recording = aggregate_channels(preprocessed_recordings)
 
     return recombined_recording
-
-
-from spikeinterface.core import generate_recording
-from spikeinterface.preprocessing import common_reference, highpass_spatial_filter
-import spikeinterface.preprocessing as spre
-
-num_channels = 84
-recording = generate_recording(num_channels=num_channels)
-groups = np.repeat([0, 1, 2, 3], num_channels / 4)
-recording.set_property("group", groups)  # TODO: be clearler to copy
-
-pp_recording = spre.whiten(recording)
-pp_recording.get_traces(segment_index=0)
-
-explicitly_per_shank = []
-explicitly_split_recording = recording.split_by("group")
-
-for shank_rec in explicitly_split_recording.values():
-    explicitly_per_shank.append(spre.whiten(shank_rec))
-
-agg_recording = aggregate_channels(explicitly_per_shank)
-agg_recording.get_traces(segment_index=0)
-
-recx = group_preprocessing_by_property(pp_recording)
-recx.get_traces(segment_index=0)
-# split_recording = group_preprocessing_by_property(pp_recording)
-
-if False:
-    from spikeinterface.core import generate_recording
-    from spikeinterface.preprocessing import common_reference, highpass_spatial_filter
-
-    num_channels = 84
-
-    recording = generate_recording(num_channels=num_channels)
-    groups = np.repeat([0, 1, 2, 3], num_channels / 4)
-    recording.set_property("group", groups)  # TODO: be clearler to copy
-
-    referenced_all_shanks = highpass_spatial_filter(recording, n_channel_pad=5)
-    referenced_all_shanks_data = referenced_all_shanks.get_traces(segment_index=0)
-
-    split_recording = group_by_recording(referenced_all_shanks)
-    split_recording_data = split_recording.get_traces(segment_index=0)
-
-    assert not np.array_equal(referenced_all_shanks_data, split_recording_data)
-
-    # so certain 'all_traces' features are applied during
-
-    # another sanity check (own test)
-    explicitly_per_shank = []
-    explicitly_split_recording = recording.split_by("group")
-
-    for shank_rec in explicitly_split_recording.values():
-        explicitly_per_shank.append(highpass_spatial_filter(shank_rec, n_channel_pad=5))
-
-    explicitly_per_shank_rec = aggregate_channels(explicitly_per_shank)
-    explicitly_per_shank_rec_data = explicitly_per_shank_rec.get_traces(segment_index=0)
-
-    assert np.array_equal(split_recording_data, explicitly_per_shank_rec_data)  # TODO: why is this not exact?
-
-    rec = aggregate_channels(explicitly_per_shank_rec)
-    split_recording = group_by_recording(referenced_all_shanks)
-    # check a second preprocessing step is not per-shank
-
-    # also add 2 in a row to check this.

--- a/src/spikeinterface/preprocessing/group_by_recording.py
+++ b/src/spikeinterface/preprocessing/group_by_recording.py
@@ -1,0 +1,129 @@
+import copy
+from typing import Dict
+from spikeinterface import load_extractor
+import numpy as np
+
+from spikeinterface.core.core_tools import define_function_from_class
+
+from spikeinterface.preprocessing.basepreprocessor import BasePreprocessor, BasePreprocessorSegment
+from spikeinterface.core.channelsaggregationrecording import ChannelsAggregationRecording, aggregate_channels
+
+
+def group_preprocessing_by_property(recording_):  # TODO: rename
+    """ """
+    loop_recording = copy.deepcopy(recording_)
+    preprocessing_step_list = []
+    preprocessing_kwargs_list = []
+    while True:
+        # There is a general problem here in that the __init__ sets everything
+        # up according to the full recording but then we split by channel.
+        # However it is not possible to know what kwargs are user-passed and
+        # what are setup during init.
+        if isinstance(loop_recording, ChannelsAggregationRecording):
+            raise ValueError(
+                "Cannot group by recording a recording that" "has already been aggregated with `aggregate_channels`"
+            )
+
+        if (
+            "recording" not in loop_recording._kwargs and "parent_recording" not in loop_recording._kwargs
+        ):  # ZeroChannelPaddedRecording
+            raise ValueError(f"The recording {loop_recording.__class__} " f"cannot be run in `group_by_recording`.")
+
+        if "recording" in loop_recording._kwargs:  # ZeroChannelPaddedRecording
+            assert "parent_recording" not in loop_recording._kwargs
+            parent_recording = loop_recording._kwargs.pop("recording")
+        else:
+            parent_recording = loop_recording._kwargs.pop("parent_recording")
+
+        if loop_recording.__class__ == spre.WhitenRecording:  # Hacky, discusss how to handle
+            kwargs = copy.deepcopy(loop_recording._kwargs)
+            kwargs["W"] = None
+            kwargs["M"] = None
+        else:
+            kwargs = loop_recording._kwargs
+
+        preprocessing_step_list.append(loop_recording.__class__)
+        preprocessing_kwargs_list.append(kwargs)  # TODO: messy
+
+        if isinstance(parent_recording, Dict):  # TODO: for silence periods, raise an issue.
+            parent_recording = load_extractor(parent_recording)
+
+        if "recording" not in parent_recording._kwargs:  # ZeroSilencePeriods
+            root_recording = parent_recording
+            break
+        loop_recording = parent_recording
+
+    split_recording = root_recording.split_by("group")
+
+    preprocessed_recordings = []
+    for shank_rec in split_recording.values():
+        for pp_step, pp_kwargs in zip(preprocessing_step_list, preprocessing_kwargs_list):
+            preprocessed_recordings.append(pp_step(shank_rec, **pp_kwargs))
+
+    recombined_recording = aggregate_channels(preprocessed_recordings)
+
+    return recombined_recording
+
+
+from spikeinterface.core import generate_recording
+from spikeinterface.preprocessing import common_reference, highpass_spatial_filter
+import spikeinterface.preprocessing as spre
+
+num_channels = 84
+recording = generate_recording(num_channels=num_channels)
+groups = np.repeat([0, 1, 2, 3], num_channels / 4)
+recording.set_property("group", groups)  # TODO: be clearler to copy
+
+pp_recording = spre.whiten(recording)
+pp_recording.get_traces(segment_index=0)
+
+explicitly_per_shank = []
+explicitly_split_recording = recording.split_by("group")
+
+for shank_rec in explicitly_split_recording.values():
+    explicitly_per_shank.append(spre.whiten(shank_rec))
+
+agg_recording = aggregate_channels(explicitly_per_shank)
+agg_recording.get_traces(segment_index=0)
+
+recx = group_preprocessing_by_property(pp_recording)
+recx.get_traces(segment_index=0)
+# split_recording = group_preprocessing_by_property(pp_recording)
+
+if False:
+    from spikeinterface.core import generate_recording
+    from spikeinterface.preprocessing import common_reference, highpass_spatial_filter
+
+    num_channels = 84
+
+    recording = generate_recording(num_channels=num_channels)
+    groups = np.repeat([0, 1, 2, 3], num_channels / 4)
+    recording.set_property("group", groups)  # TODO: be clearler to copy
+
+    referenced_all_shanks = highpass_spatial_filter(recording, n_channel_pad=5)
+    referenced_all_shanks_data = referenced_all_shanks.get_traces(segment_index=0)
+
+    split_recording = group_by_recording(referenced_all_shanks)
+    split_recording_data = split_recording.get_traces(segment_index=0)
+
+    assert not np.array_equal(referenced_all_shanks_data, split_recording_data)
+
+    # so certain 'all_traces' features are applied during
+
+    # another sanity check (own test)
+    explicitly_per_shank = []
+    explicitly_split_recording = recording.split_by("group")
+
+    for shank_rec in explicitly_split_recording.values():
+        explicitly_per_shank.append(highpass_spatial_filter(shank_rec, n_channel_pad=5))
+
+    explicitly_per_shank_rec = aggregate_channels(explicitly_per_shank)
+    explicitly_per_shank_rec_data = explicitly_per_shank_rec.get_traces(segment_index=0)
+
+    assert np.array_equal(split_recording_data, explicitly_per_shank_rec_data)  # TODO: why is this not exact?
+
+    rec = aggregate_channels(explicitly_per_shank_rec)
+    split_recording = group_by_recording(referenced_all_shanks)
+    # check a second preprocessing step is not per-shank
+
+    # also add 2 in a row to check this.

--- a/src/spikeinterface/preprocessing/highpass_spatial_filter.py
+++ b/src/spikeinterface/preprocessing/highpass_spatial_filter.py
@@ -78,11 +78,14 @@ class HighpassSpatialFilterRecording(BasePreprocessor):
 
         # Check single group
         channel_groups = recording.get_channel_groups()
-        assert len(np.unique(channel_groups)) == 1, (
-            "The recording contains multiple groups! It is recommended to apply spatial filtering "
-            "separately for each group. You can split by group with: "
-            ">>> recording_split = recording.split_by(property='group')"
-        )
+        # TODO: decide where to put this. Either
+        # 1) only throw a warning here
+        # 2) set a switch if recording is split, and assert if not set during `get_traces()`
+        #        assert len(np.unique(channel_groups)) == 1, (
+        #            "The recording contains multiple groups! It is recommended to apply spatial filtering "
+        #            "separately for each group. You can split by group with: "
+        #            ">>> recording_split = recording.split_by(property='group')"
+        #        )
         # If location are not sorted, estimate forward and reverse sorting
         channel_locations = recording.get_channel_locations()
         dim = ["x", "y", "z"].index(direction)

--- a/src/spikeinterface/preprocessing/tests/test_filter.py
+++ b/src/spikeinterface/preprocessing/tests/test_filter.py
@@ -19,7 +19,7 @@ set_global_tmp_folder(cache_folder)
 
 
 def test_filter():
-    rec = generate_recording()
+    rec = generate_recording(num_channels=84)
     rec = rec.save()
 
     rec2 = bandpass_filter(rec, freq_min=300.0, freq_max=6000.0)

--- a/src/spikeinterface/preprocessing/tests/test_group_by_recording.py
+++ b/src/spikeinterface/preprocessing/tests/test_group_by_recording.py
@@ -1,0 +1,105 @@
+import numpy as np
+import pytest
+from pathlib import Path
+from spikeinterface.core import load_extractor, set_global_tmp_folder
+from spikeinterface.core.testing import check_recordings_equal
+from spikeinterface.core.generate import generate_recording
+from spikeinterface.preprocessing import gaussian_bandpass_filter
+from spikeinterface.preprocessing.preprocessinglist import installed_preprocessers_list as pp_list
+from spikeinterface.preprocessing.group_by_recording import group_preprocessing_by_property
+from spikeinterface import aggregate_channels
+
+import spikeinterface.preprocessing as spre
+
+CANNOT_TEST = [
+    spre.DeepInterpolatedRecording,
+    spre.UnsignedToSignedRecording,  # TODO: have a function that manipulates depending on test.
+    spre.PhaseShiftRecording,
+    # spre.ScaleRecording,
+    spre.ZScoreRecording,
+    spre.BlankSaturationRecording,
+    spre.InterpolateBadChannelsRecording,  # recording.get_property("contact_vector") is None:
+]
+
+# TODO: check WhitenRecording and HighpassSpatialFilterRecording play nice with splitting... something weird there
+# We might need to rearrange this error, either warn only or throw an error on get_traces?
+
+# TODO: check all passed kwargs to preprocessing are stored unchanged in kwargs.
+
+
+# WhitenRecording
+# HighpassSpatialFilterRecording
+class TestGroupByRecording:
+    def set_properties_on_recording_for_preprocessor(self, recording, preprocessor):
+        if preprocessor == spre.ScaleRecording:
+            breakpoint()
+            recording.set_property("gain", np.ones(recording.get_num_channels()) * 2)  # [np.newaxis, :]
+            recording.set_property("offset", np.ones(recording.get_num_channels()) * 2)
+            # recording.set_property("offset", 2)
+
+        return recording
+
+    @pytest.mark.parametrize("preprocessor", [spre.ScaleRecording])  # [pp for pp in pp_list if pp not in CANNOT_TEST])
+    def test_all_preprocessors(self, preprocessor):
+        """
+        Perform a smoke test over all preprocessors to check
+        no preprocessors just crash with this function.
+        """
+        num_channels = 84
+        recording = generate_recording(num_channels=num_channels, set_probe=True)
+        groups = np.repeat([0, 1, 2, 3], num_channels / 4)
+
+        recording.set_property("group", groups)
+
+        recording = self.set_properties_on_recording_for_preprocessor(recording, preprocessor)
+
+        preprocessed_recording = preprocessor(recording, **self.get_preprocessing_kwargs(preprocessor))
+
+        split_recording = group_preprocessing_by_property(preprocessed_recording)
+
+        test_split_recording = self.manually_split_preprocess_aggregate(recording, preprocessor)
+
+        for segment_index in range(recording.get_num_segments()):
+            split_recording_data = split_recording.get_traces(segment_index=segment_index)
+
+            explicitly_per_shank_rec_data = test_split_recording.get_traces(segment_index=segment_index)
+
+            assert np.array_equal(split_recording_data, explicitly_per_shank_rec_data)
+
+    # check once it is indeed changed.
+
+    def manually_split_preprocess_aggregate(self, recording, preprocessor):
+        """"""
+        explicitly_per_shank = []
+        explicitly_split_recording = recording.split_by("group")
+
+        for shank_rec in explicitly_split_recording.values():
+            explicitly_per_shank.append(preprocessor(shank_rec, **self.get_preprocessing_kwargs(preprocessor)))
+        manually_split_rec = aggregate_channels(explicitly_per_shank)  # TODO: rename
+
+        return manually_split_rec
+
+    # Check errorsgg
+    def get_preprocessing_kwargs(self, preprocessor):
+        """"""
+        kwarg_dict = {
+            spre.SilencedPeriodsRecording: {"list_periods": [[(0, 0.5), (0.6, 0.8)], [(0, 0.2)]]},
+            spre.RemoveArtifactsRecording: {"list_triggers": [[0, 0.5], [0, 0.2]]},
+            spre.ZeroChannelPaddedRecording: {"num_channels": 50},
+            spre.DeepInterpolatedRecording: {"model_path": Path("cache_folder") / "deepinterpolation"},
+            spre.InterpolateBadChannelsRecording: {"bad_channel_ids": np.array([0, 20, 25, 55, 64, 83])},
+            spre.ResampleRecording: {"resample_rate": 60000},
+            spre.HighpassSpatialFilterRecording: {"n_channel_pad": 5},
+        }
+        if preprocessor in kwarg_dict:
+            kwargs = kwarg_dict[preprocessor]
+        else:
+            kwargs = {}
+
+        return kwargs
+
+    # [PhaseShiftRecording] - AssertionError: 'inter_sample_shift' is not a property!
+    #
+    # Check more complex
+    # check preprocessing, split, then more preprocessing
+    # Check multiple complex chains of preprocessing

--- a/src/spikeinterface/preprocessing/zero_channel_pad.py
+++ b/src/spikeinterface/preprocessing/zero_channel_pad.py
@@ -211,9 +211,12 @@ class ZeroChannelPaddedRecordingSegment(BasePreprocessorSegment):
         if end_frame is None:
             end_frame = self.get_num_samples()
         traces = np.zeros((end_frame - start_frame, self.num_channels))
-        traces[:, self.channel_mapping] = self.parent_recording_segment.get_traces(
-            start_frame=start_frame, end_frame=end_frame, channel_indices=self.channel_mapping
-        )
+        try:
+            traces[:, self.channel_mapping] = self.parent_recording_segment.get_traces(
+                start_frame=start_frame, end_frame=end_frame, channel_indices=self.channel_mapping
+            )
+        except:
+            breakpoint()
         return traces[:, channel_indices]
 
 


### PR DESCRIPTION
This PR creates a convenience function to run all preprocessing by a property (currently just "group") as discussed in #2033. @alejoe91 @h-mayorquin 

In this draft implementation, first all preprocesing steps and associated kwargs are iteratively discovered from the recordings `_kwargs` property. Then these are re-applied to the base recording.

However, testing shows this approach is brittle because often,  the `_kwargs` parameters do not contain only the user-passed kwargs but additional logic based on the recording. For example, in `whiten` the whitening matrix is computed based on the passed `recording` and stored in `kwargs` `W` parameter. Then, trying to apply this to smaller subsets of recordings fails. This kind of pattern occurs a number of times across preprocessors.

A possible solutions to the current implementation is to somehow ensure all preprocessors only store user-passed `kwargs` in their `_kwargs` option, but this seems like a bad idea. Maybe there is another way to get these user-passed kwargs.

Alternatively, the preprocessing steps and associated kwargs could be explicitly passed to the function as suggested in #2033. In this case though if I have understood correctly the user would have to reformat all inputs like:

```
group_by_preprocessing(recording, [PreprocessingClass1, PreprocessingClass2, ...], [preprocessing_kwargs_1, preprocessing_kwargs_2])
```
But personally if this is correct it feels easier to use the existing method of wrap standard preprocessing API in the split for-loop then aggregate rather than having to reformat the pipeline.

To summarise my thoughts on possible approaches for this convenience function / class are:

1) It is difficult to have this as a class / function applied at the end of preprocessing chain due to the issue mentioned above.
2) It does not seem possible to insert this at the start of the preproecssing chain, such that all following preprocessing steps are split. The `get_traces()` of the first-applied class should output as a single array not multiple arrays (i.e. it cannot somehow return 1 array per shank for later preprocessing). My understanding is a class that holds a split version of the recording and applies all subsequent preprocessing steps to each would still need to be handled at the level of each individual preprocessing class.
3) It would be possible to apply a user-defined list of preprocessing steps and parameters, but I'm not sure if it's use is much easier than the existing API.

Now I wonder if adding a bit more documentation to the existing API (e.g. a short tutorial 'preprocessing by shank') would be a better approach (happy to do this).


### An aside

During testing I found two cases where the API of some preprocessors does not match what seems to be standard.
- `ZeroChannelPaddedRecording` saves it's parent recording to a `parent_recording` kwarg not a `recording` kwarg that seems to be used elsewhere.
- `ZeroSilencePeriods` stores the parent recording as a dict not a recording.
Is it worth standardising these? Maybe there are some practicalities to consider that make this not possible.