### PR TITLE
Make `chunksize` in `get_random_data_chunks` throw warning and clip if under limit.

### DIFF
--- a/src/spikeinterface/core/recording_tools.py
+++ b/src/spikeinterface/core/recording_tools.py
@@ -48,13 +48,14 @@ def get_random_data_chunks(
     # check chunk size
     num_segments = recording.get_num_segments()
     for segment_index in range(num_segments):
-        if chunk_size > recording.get_num_frames(segment_index) - 2 * margin_frames:
-            error_message = (
+        chunk_size_limit = recording.get_num_frames(segment_index) - 2 * margin_frames
+        if chunk_size > chunk_size_limit:
+            chunk_size = chunk_size_limit - 1
+            warnings.warn(
                 f"chunk_size is greater than the number "
                 f"of samples for segment index {segment_index}. "
-                f"Use a smaller chunk_size!"
+                f"Using {chunk_size}."
             )
-            raise ValueError(error_message)
 
     rng = np.random.default_rng(seed)
     chunk_list = []


### PR DESCRIPTION
This PR proposes to change how `get_random_data_chunks()` acts if the passed `chunk_size` is too small for the dataset. At present, an error is thrown. However, for me this is causing problems running small datasets for testing, because often this argument is not accessible from surface API (for example, when computing quality metrics).

The proposed solution is to rather than assert if the chunk size is too big, instead clip it and throw a warning. My understanding is this chunk size is pretty much always set internally rather than by the user, so maybe an assert is too strict; the default is somewhat arbitrary anyway, and so can be tailored to the dataset. However, it may cause unintended side-effects, and  an alternative solution would be to ensure the argument is exposed across the high-level API, which I am happy to help implement in this PR. 