### PR TITLE
Add from `__future__ import annotations` to core base.

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 import re
 from typing import Any, Iterable, List, Optional, Sequence, Union


### PR DESCRIPTION
#2301 adds improved type hints to `core/base.py` `ids_to_indices()` function. These include the pipe `|` operator as alias for `Union` which requires `from __future__ import annotations` for python < 3.10, which this PR adds.

I have no idea why there is an arrow in the line above :sweat_smile: