### PR TITLE
`get_num_frames` to return a python int 

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -152,7 +152,7 @@ class BaseRecording(BaseRecordingSnippets):
             The number of samples
         """
         segment_index = self._check_segment_index(segment_index)
-        return self._recording_segments[segment_index].get_num_samples()
+        return int(self._recording_segments[segment_index].get_num_samples())
 
     get_num_frames = get_num_samples
 


### PR DESCRIPTION
This will avoid errors like:
https://github.com/SpikeInterface/spikeinterface/pull/2325
And
https://github.com/SpikeInterface/spikeinterface/pull/2223

The problem is that some formats might return a numpy scalar which casts other python ints to numpy scalars and then overflow in large multiplications. 

Given that num_channels is a python int:

https://github.com/h-mayorquin/spikeinterface/blob/8eb51ed6a5a777ec9328143c355512eacbaf334a/src/spikeinterface/core/baserecordingsnippets.py#L45-L46

The errors have to come from here. 