### PR TITLE
Fix add_shift_shuffle section in synthesize_random_firings

### DIFF
--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -359,8 +359,9 @@ def synthesize_random_firings(
             a = refractory_sample
             b = refractory_sample * 20
             shift = a + (b - a) * x**2
+            shift = shift.astype("int64")
             spike_times[some] += shift
-            times0 = times0[(0 <= times0) & (times0 < segment_size)]
+            spike_times = spike_times[(0 <= spike_times) & (spike_times < segment_size)]
 
         (violations,) = np.nonzero(np.diff(spike_times) < refractory_sample)
         spike_times = np.delete(spike_times, violations)


### PR DESCRIPTION
## This PR

Just as a MRE

```python
times, labels = synthesize_random_firings(add_shift_shuffle=True, seed=0)
```

There was a bad variable inside the `add_shift_shuffle` if statement that would break the jitter. In addition the spike_times are in samples so the `shift` needs to be dtype `int64`.

Currently `add_shift_shuffle` is not accessed by the main classes at all (it is not exposed at the high level), so there are no tests for this portion of the function. Do we want a test for this? 


## Side note:
Also while working on this PR I was playing around with the `toy_example` and if you put in a sample_frequency of <=15000 it breaks because the default_params for smooth_ms is (0.03, 0.07) and this breaks the smoothing kernel:

Is this worth a separate issue? Or are we just assuming no one will ever want to make low sampling rate datasets? I thought about adding something to this PR for that, but then I thought maybe we shouldn't even worry about it.

```python
Traceback (most recent call last):

  Cell In[17], line 1
    wf = generate_single_fake_waveform(sampling_frequency=10000, smooth_ms=0.04)

  File ~\Documents\GitHub\spikeinterface\src\spikeinterface\core\generate.py:835 in generate_single_fake_waveform
    wf = np.convolve(wf, smooth_kernel, mode="same")

  File <__array_function__ internals>:200 in convolve

  File ~\anaconda3\envs\spykes\Lib\site-packages\numpy\core\numeric.py:850 in convolve
    raise ValueError('v cannot be empty')

ValueError: v cannot be empty
```