### PR TITLE
Use memory efficient numpy for `ScaleRecordingSegment`

### DIFF
--- a/src/spikeinterface/preprocessing/normalize_scale.py
+++ b/src/spikeinterface/preprocessing/normalize_scale.py
@@ -17,14 +17,15 @@ class ScaleRecordingSegment(BasePreprocessorSegment):
         self.offset = offset
         self._dtype = dtype
 
-    def get_traces(self, start_frame, end_frame, channel_indices):
+    def get_traces(self, start_frame, end_frame, channel_indices) -> np.ndarray:
         traces = self.parent_recording_segment.get_traces(start_frame, end_frame, channel_indices)
-        scaled_traces = traces * self.gain[:, channel_indices] + self.offset[:, channel_indices]
+        traces = np.multiply(traces, self.gain[:, channel_indices], out=traces)
+        traces = np.add(traces, self.offset[:, channel_indices], out=traces)
 
         if np.issubdtype(self._dtype, np.integer):
-            scaled_traces = scaled_traces.round()
+            traces = np.round(traces, out=traces)
 
-        return scaled_traces.astype(self._dtype)
+        return traces.astype(self._dtype, copy=False)
 
 
 class NormalizeByQuantileRecording(BasePreprocessor):

--- a/src/spikeinterface/preprocessing/normalize_scale.py
+++ b/src/spikeinterface/preprocessing/normalize_scale.py
@@ -18,7 +18,9 @@ class ScaleRecordingSegment(BasePreprocessorSegment):
         self._dtype = dtype
 
     def get_traces(self, start_frame, end_frame, channel_indices) -> np.ndarray:
-        traces = self.parent_recording_segment.get_traces(start_frame, end_frame, channel_indices)
+        # TODO when we are sure that BaseExtractors get_traces allocate their own buffer instead of just passing
+        # It along we should remove copies in preprocessors including the one in the next line
+        traces = self.parent_recording_segment.get_traces(start_frame, end_frame, channel_indices).copy()
         traces = np.multiply(traces, self.gain[:, channel_indices], out=traces, casting="unsafe")
         traces = np.add(traces, self.offset[:, channel_indices], out=traces, casting="unsafe")
 

--- a/src/spikeinterface/preprocessing/normalize_scale.py
+++ b/src/spikeinterface/preprocessing/normalize_scale.py
@@ -19,8 +19,8 @@ class ScaleRecordingSegment(BasePreprocessorSegment):
 
     def get_traces(self, start_frame, end_frame, channel_indices) -> np.ndarray:
         traces = self.parent_recording_segment.get_traces(start_frame, end_frame, channel_indices)
-        traces = np.multiply(traces, self.gain[:, channel_indices], out=traces)
-        traces = np.add(traces, self.offset[:, channel_indices], out=traces)
+        traces = np.multiply(traces, self.gain[:, channel_indices], out=traces, casting="unsafe")
+        traces = np.add(traces, self.offset[:, channel_indices], out=traces, casting="unsafe")
 
         if np.issubdtype(self._dtype, np.integer):
             traces = np.round(traces, out=traces)

--- a/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
+++ b/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
@@ -82,8 +82,11 @@ def test_zscore():
 def test_zscore_int():
     "I think this is a bad test https://github.com/SpikeInterface/spikeinterface/issues/1972"
     seed = 1
+    from spikeinterface.preprocessing import astype
+
     rec = generate_recording(seed=seed)
-    rec_int = scale(rec, dtype="int16", gain=100)
+    rec_with_sign = astype(rec, dtype="int16")
+    rec_int = scale(rec_with_sign, gain=100)
     with pytest.raises(AssertionError):
         zscore(rec_int, dtype=None)
 

--- a/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
+++ b/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
@@ -82,11 +82,8 @@ def test_zscore():
 def test_zscore_int():
     "I think this is a bad test https://github.com/SpikeInterface/spikeinterface/issues/1972"
     seed = 1
-    from spikeinterface.preprocessing import astype
-
     rec = generate_recording(seed=seed)
-    rec_with_sign = astype(rec, dtype="int16")
-    rec_int = scale(rec_with_sign, gain=100)
+    rec_int = scale(rec, dtype="int16", gain=100)
     with pytest.raises(AssertionError):
         zscore(rec_int, dtype=None)
 


### PR DESCRIPTION
I am taking a look at https://github.com/SpikeInterface/spikeinterface/issues/2312 and I realized the scale function is really memory hungry. This should make it better.

5 times reduction in memory usage reduction for the following script:

```python
import spikeinterface.preprocessing as spre
from spikeinterface.core.generate import generate_recording, generate_recording_by_size

recording = generate_recording_by_size(full_traces_size_GiB=1.0)
recording = spre.scale(recording, gain=100, offset=70)  
recording.get_traces()
```

In main:

```
Total number of allocations: 46166
Total number of frames seen: 2741
Peak memory usage: 5.1 GiB
```

This branch:

```
Total number of allocations: 45810
Total number of frames seen: 2732
Peak memory usage: 1.1 GiB
```

Note that the trace should be 1.0 GiB by design.