### PR TITLE
Expose `lam` and `momentum` in the appropriate kilosorts

### DIFF
--- a/src/spikeinterface/sorters/external/kilosort2.py
+++ b/src/spikeinterface/sorters/external/kilosort2.py
@@ -41,7 +41,7 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         "minfr_goodchannels": 0.1,
         "freq_min": 150,
         "sigmaMask": 30,
-        "lam": 10,
+        "lam": 10.0,
         "nPCs": 3,
         "ntbuff": 64,
         "nfilt_factor": 4,

--- a/src/spikeinterface/sorters/external/kilosort2.py
+++ b/src/spikeinterface/sorters/external/kilosort2.py
@@ -35,11 +35,13 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         "detect_threshold": 6,
         "projection_threshold": [10, 4],
         "preclust_threshold": 8,
+        "momentum": [20.0, 400.0],
         "car": True,
         "minFR": 0.1,
         "minfr_goodchannels": 0.1,
         "freq_min": 150,
         "sigmaMask": 30,
+        "lam": 10,
         "nPCs": 3,
         "ntbuff": 64,
         "nfilt_factor": 4,
@@ -58,11 +60,13 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         "detect_threshold": "Threshold for spike detection",
         "projection_threshold": "Threshold on projections",
         "preclust_threshold": "Threshold crossings for pre-clustering (in PCA projection space)",
+        "momentum": "Number of samples to average over (annealed from first to second value)",
         "car": "Enable or disable common reference",
         "minFR": "Minimum spike rate (Hz), if a cluster falls below this for too long it gets removed",
         "minfr_goodchannels": "Minimum firing rate on a 'good' channel",
         "freq_min": "High-pass filter cutoff frequency",
         "sigmaMask": "Spatial constant in um for computing residual variance of spike",
+        "lam": "The importance of the amplitude penalty (like in Kilosort1: 0 means not used, 10 is average, 50 is a lot)",
         "nPCs": "Number of PCA dimensions",
         "ntbuff": "Samples of symmetrical buffer for whitening and spike detection",
         "nfilt_factor": "Max number of clusters per good channel (even temporary ones) 4",
@@ -130,7 +134,7 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         if p["wave_length"] % 2 != 1:
             p["wave_length"] = p["wave_length"] + 1  # The wave_length must be odd
         if p["wave_length"] > 81:
-            p["wave_length"] = 81  # The wave_length must be less than 81.
+            p["wave_length"] = 81  # The wave_length must be <=81
         return p
 
     @classmethod
@@ -162,7 +166,7 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         ops["Th"] = projection_threshold
 
         # how important is the amplitude penalty (like in Kilosort1, 0 means not used, 10 is average, 50 is a lot)
-        ops["lam"] = 10.0
+        ops["lam"] = params["lam"]
 
         # splitting a cluster at the end requires at least this much isolation for each sub-cluster (max = 1)
         ops["AUCsplit"] = params["AUCsplit"]
@@ -170,8 +174,9 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         # minimum spike rate (Hz), if a cluster falls below this for too long it gets removed
         ops["minFR"] = params["minFR"]
 
+        momentum = [float(mom) for mom in params["momentum"]]
         # number of samples to average over (annealed from first to second value)
-        ops["momentum"] = [20.0, 400.0]
+        ops["momentum"] = momentum
 
         # spatial constant in um for computing residual variance of spike
         ops["sigmaMask"] = params["sigmaMask"]

--- a/src/spikeinterface/sorters/external/kilosort2_5.py
+++ b/src/spikeinterface/sorters/external/kilosort2_5.py
@@ -39,6 +39,7 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         "detect_threshold": 6,
         "projection_threshold": [10, 4],
         "preclust_threshold": 8,
+        "momentum": [20.0, 400.0],
         "car": True,
         "minFR": 0.1,
         "minfr_goodchannels": 0.1,
@@ -46,6 +47,7 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         "sig": 20,
         "freq_min": 150,
         "sigmaMask": 30,
+        "lam": 10,
         "nPCs": 3,
         "ntbuff": 64,
         "nfilt_factor": 4,
@@ -65,6 +67,7 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         "detect_threshold": "Threshold for spike detection",
         "projection_threshold": "Threshold on projections",
         "preclust_threshold": "Threshold crossings for pre-clustering (in PCA projection space)",
+        "momentum": "Number of samples to average over (annealed from first to second value)",
         "car": "Enable or disable common reference",
         "minFR": "Minimum spike rate (Hz), if a cluster falls below this for too long it gets removed",
         "minfr_goodchannels": "Minimum firing rate on a 'good' channel",
@@ -72,6 +75,7 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         "sig": "spatial smoothness constant for registration",
         "freq_min": "High-pass filter cutoff frequency",
         "sigmaMask": "Spatial constant in um for computing residual variance of spike",
+        "lam": "The importance of the amplitude penalty (like in Kilosort1: 0 means not used, 10 is average, 50 is a lot)",
         "nPCs": "Number of PCA dimensions",
         "ntbuff": "Samples of symmetrical buffer for whitening and spike detection",
         "nfilt_factor": "Max number of clusters per good channel (even temporary ones) 4",
@@ -146,7 +150,7 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         if p["wave_length"] % 2 != 1:
             p["wave_length"] = p["wave_length"] + 1  # The wave_length must be odd
         if p["wave_length"] > 81:
-            p["wave_length"] = 81  # The wave_length must be less than 81.
+            p["wave_length"] = 81  # The wave_length must be <=81
         return p
 
     @classmethod
@@ -183,7 +187,7 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         ops["Th"] = projection_threshold
 
         # how important is the amplitude penalty (like in Kilosort1, 0 means not used, 10 is average, 50 is a lot)
-        ops["lam"] = 10.0
+        ops["lam"] = params["lam"]
 
         # splitting a cluster at the end requires at least this much isolation for each sub-cluster (max = 1)
         ops["AUCsplit"] = params["AUCsplit"]
@@ -191,8 +195,9 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         # minimum spike rate (Hz), if a cluster falls below this for too long it gets removed
         ops["minFR"] = params["minFR"]
 
+        momentum = [float(mom) for mom in params["momentum"]]
         # number of samples to average over (annealed from first to second value)
-        ops["momentum"] = [20.0, 400.0]
+        ops["momentum"] = momentum
 
         # spatial constant in um for computing residual variance of spike
         ops["sigmaMask"] = params["sigmaMask"]

--- a/src/spikeinterface/sorters/external/kilosort2_5.py
+++ b/src/spikeinterface/sorters/external/kilosort2_5.py
@@ -47,7 +47,7 @@ class Kilosort2_5Sorter(KilosortBase, BaseSorter):
         "sig": 20,
         "freq_min": 150,
         "sigmaMask": 30,
-        "lam": 10,
+        "lam": 10.0,
         "nPCs": 3,
         "ntbuff": 64,
         "nfilt_factor": 4,

--- a/src/spikeinterface/sorters/external/kilosort3.py
+++ b/src/spikeinterface/sorters/external/kilosort3.py
@@ -43,6 +43,7 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
         "sig": 20,
         "freq_min": 300,
         "sigmaMask": 30,
+        "lam": 20.0,
         "nPCs": 3,
         "ntbuff": 64,
         "nfilt_factor": 4,
@@ -69,6 +70,7 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
         "sig": "spatial smoothness constant for registration",
         "freq_min": "High-pass filter cutoff frequency",
         "sigmaMask": "Spatial constant in um for computing residual variance of spike",
+        "lam": "The importance of the amplitude penalty (like in Kilosort1: 0 means not used, 10 is average, 50 is a lot)",
         "nPCs": "Number of PCA dimensions",
         "ntbuff": "Samples of symmetrical buffer for whitening and spike detection",
         "nfilt_factor": "Max number of clusters per good channel (even temporary ones) 4",
@@ -143,7 +145,7 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
         if p["wave_length"] % 2 != 1:
             p["wave_length"] = p["wave_length"] + 1  # The wave_length must be odd
         if p["wave_length"] > 81:
-            p["wave_length"] = 81  # The wave_length must be less than 81.
+            p["wave_length"] = 81  # The wave_length must be <= 81
 
         return p
 
@@ -172,7 +174,7 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
         ops["Th"] = projection_threshold
 
         # how important is the amplitude penalty (like in Kilosort1, 0 means not used, 10 is average, 50 is a lot)
-        ops["lam"] = 20.0
+        ops["lam"] = params["lam"]
 
         # splitting a cluster at the end requires at least this much isolation for each sub-cluster (max = 1)
         ops["AUCsplit"] = params["AUCsplit"]


### PR DESCRIPTION
Fixes #2352 

Changes:

1) lam and momentum in 2 & 2.5
2) lam in 3

I didn't touch kilosort1 because the lam and momentum are given slightly differently and they are hardcoded with defaults that are different from the kilosort1 defaults. Is there a reason for this? Should I expose those or just wait for a request? 