### PR TITLE
Patch for save_to_memory

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -849,6 +849,8 @@ class BaseExtractor:
 
     def save_to_memory(self, **kwargs) -> "BaseExtractor":
         # used only by recording at the moment
+        if "format" not in kwargs:
+            kwargs["format"] = "memory"
         cached = self._save(**kwargs)
         self.copy_metadata(cached)
         return cached


### PR DESCRIPTION
Currently, the following code is leading to a crash

`a = rec.save(format='memory')
b = rec.save_to_memory()
`
a is working fine, but not b, because of an inconsistencies in the way to use the internal _save() function of base. This patch the problem, and make sure that when calling save_to_memory, if no format is specified, the memory one is added