### PR TITLE
Add `rename_channels` method to recording extractors

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -548,6 +548,23 @@ class BaseRecording(BaseRecordingSnippets):
             if time_vector is not None:
                 np.save(folder / f"times_cached_seg{segment_index}.npy", time_vector)
 
+    def rename_channels(self, new_channel_ids: list | np.array | tuple):
+        """
+        Returns a new recording object with renamed channel ids.
+
+        Parameters
+        ----------
+        new_channel_ids : list or np.array or tuple
+            The new channel ids. They are mapped possitionally to the old channel ids.
+        """
+        from .channelslice import ChannelSliceRecording
+
+        assert len(new_channel_ids) == self.get_num_channels(), (
+            "new_channel_ids must have the same length as the " "number of channels in the recording"
+        )
+
+        return ChannelSliceRecording(self, renamed_channel_ids=new_channel_ids)
+
     def _channel_slice(self, channel_ids, renamed_channel_ids=None):
         from .channelslice import ChannelSliceRecording
 

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -555,7 +555,7 @@ class BaseRecording(BaseRecordingSnippets):
         Parameters
         ----------
         new_channel_ids : list or np.array or tuple
-            The new channel ids. They are mapped possitionally to the old channel ids.
+            The new channel ids. They are mapped positionally to the old channel ids.
         """
         from .channelslice import ChannelSliceRecording
 

--- a/src/spikeinterface/core/tests/test_baserecording.py
+++ b/src/spikeinterface/core/tests/test_baserecording.py
@@ -345,5 +345,12 @@ def test_BaseRecording():
     assert np.allclose(rec_u.get_traces(cast_unsigned=True), rec_i.get_traces().astype("float"))
 
 
+def test_rename_channels():
+    recording = generate_recording(durations=[1.0], num_channels=3)
+    renamed_recording = recording.rename_channels(new_channel_ids=["a", "b", "c"])
+    renamed_channel_ids = renamed_recording.get_channel_ids()
+    assert np.array_equal(renamed_channel_ids, ["a", "b", "c"])
+
+
 if __name__ == "__main__":
     test_BaseRecording()


### PR DESCRIPTION
Easier for users to discover this method with tab completion instead of having to find out by themselves that they need to use channel slice of which this is a particular case. 

