### PR TITLE
WaveformExtractor.select_units also functional if  we.has_recording()=False

### DIFF
--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -1995,7 +1995,6 @@ class BaseWaveformExtractorExtension:
                 elif ext_data_file.suffix == ".pkl":
                     ext_data = pickle.load(ext_data_file.open("rb"))
                 else:
-                    print(f"{ext_data_file.name} not created by spikeinterface, skipping this file")
                     continue
                 self._extension_data[ext_data_name] = ext_data
         elif self.format == "zarr":

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -1994,6 +1994,9 @@ class BaseWaveformExtractorExtension:
                     ext_data = pd.read_csv(ext_data_file, index_col=0)
                 elif ext_data_file.suffix == ".pkl":
                     ext_data = pickle.load(ext_data_file.open("rb"))
+                else:
+                    print({} "not created by spikeinterface, skipping this file".format(ext_data_file.name))
+                    continue
                 self._extension_data[ext_data_name] = ext_data
         elif self.format == "zarr":
             for ext_data_name in self.extension_group.keys():

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -800,8 +800,8 @@ class WaveformExtractor:
 
                 if self.has_recording():
                     self.recording.dump(new_folder / "recording.json", relative_to=relative_to)
-                else:
-                    shutil.copytree(self.folder / "recording_info", new_folder / "recording_info")
+
+                shutil.copytree(self.folder / "recording_info", new_folder / "recording_info")
 
                 sorting.dump(new_folder / "sorting.json", relative_to=relative_to)
 

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -800,6 +800,9 @@ class WaveformExtractor:
 
                 if self.has_recording():
                     self.recording.dump(new_folder / "recording.json", relative_to=relative_to)
+                else:
+                    shutil.copytree(self.folder / "recording_info", new_folder / "recording_info")
+
                 sorting.dump(new_folder / "sorting.json", relative_to=relative_to)
 
                 # create and populate waveforms folder
@@ -824,7 +827,8 @@ class WaveformExtractor:
                     with (new_folder / "sparsity.json").open("w") as f:
                         json.dump(check_json(new_sparsity.to_dict()), f)
 
-                we = WaveformExtractor.load(new_folder)
+                we = WaveformExtractor.load(new_folder, with_recording=self.has_recording())
+
             elif self.format == "zarr":
                 raise NotImplementedError(
                     "For zarr format, `select_units()` to a folder is not supported yet. "

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -1995,7 +1995,7 @@ class BaseWaveformExtractorExtension:
                 elif ext_data_file.suffix == ".pkl":
                     ext_data = pickle.load(ext_data_file.open("rb"))
                 else:
-                    print({} "not created by spikeinterface, skipping this file".format(ext_data_file.name))
+                    print("{} not created by spikeinterface, skipping this file".format(ext_data_file.name))
                     continue
                 self._extension_data[ext_data_name] = ext_data
         elif self.format == "zarr":


### PR DESCRIPTION
 This is a pull request following up on issue #2281.
The proposed changes enable the method WaveformExtractor.select_units to also work if the WaveformExtractor had not recording. 