### PR TITLE
Add stream_folders path to OpenEphysBinaryRecordingExtractor

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/openephys.py
+++ b/src/spikeinterface/extractors/neoextractors/openephys.py
@@ -217,12 +217,14 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
                 self.set_property("inter_sample_shift", sample_shifts)
 
         # load synchronized timestamps and set_times to recording
-        if load_sync_timestamps:
-            recording_folder = Path(folder_path) / record_node
-            for segment_index in range(self.get_num_segments()):
-                stream_folder = (
-                    recording_folder / f"experiment{exp_id}" / f"recording{segment_index+1}" / "continuous" / oe_stream
-                )
+        recording_folder = Path(folder_path) / record_node
+        stream_folders = []
+        for segment_index in range(self.get_num_segments()):
+            stream_folder = (
+                recording_folder / f"experiment{exp_id}" / f"recording{segment_index+1}" / "continuous" / oe_stream
+            )
+            stream_folders.append(stream_folder)
+            if load_sync_timestamps:
                 if (stream_folder / "sample_numbers.npy").is_file():
                     # OE version>=v0.6
                     sync_times = np.load(stream_folder / "timestamps.npy")
@@ -236,7 +238,7 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
                 except AssertionError:
                     warnings.warn(f"Could not load synchronized timestamps for {stream_name}")
 
-        self._stream_folder = stream_folder
+        self._stream_folders = stream_folders
 
         self._kwargs.update(
             dict(

--- a/src/spikeinterface/extractors/neoextractors/openephys.py
+++ b/src/spikeinterface/extractors/neoextractors/openephys.py
@@ -236,6 +236,8 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
                 except AssertionError:
                     warnings.warn(f"Could not load synchronized timestamps for {stream_name}")
 
+        self._stream_folder = stream_folder
+
         self._kwargs.update(
             dict(
                 folder_path=str(Path(folder_path).absolute()),
@@ -244,7 +246,6 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
                 experiment_names=experiment_names,
             )
         )
-        self._stream_folder = stream_folder
 
     @classmethod
     def map_to_neo_kwargs(cls, folder_path, load_sync_channel=False, experiment_names=None):

--- a/src/spikeinterface/extractors/neoextractors/openephys.py
+++ b/src/spikeinterface/extractors/neoextractors/openephys.py
@@ -242,6 +242,7 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
                 load_sync_channel=load_sync_channel,
                 load_sync_timestamps=load_sync_timestamps,
                 experiment_names=experiment_names,
+                stream_folder=stream_folder,
             )
         )
 

--- a/src/spikeinterface/extractors/neoextractors/openephys.py
+++ b/src/spikeinterface/extractors/neoextractors/openephys.py
@@ -242,9 +242,9 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
                 load_sync_channel=load_sync_channel,
                 load_sync_timestamps=load_sync_timestamps,
                 experiment_names=experiment_names,
-                stream_folder=stream_folder,
             )
         )
+        self._stream_folder = stream_folder
 
     @classmethod
     def map_to_neo_kwargs(cls, folder_path, load_sync_channel=False, experiment_names=None):


### PR DESCRIPTION
For other analyses I require the direct data path of the raw data of on Binary Open Ephys recording (continuous.dat). 
For easy acces I propose to add it to the _kwargs property of the OpenEphysBinaryRecordingExtractor. 
Thanks! :) 