### PR TITLE
Saving the unit_locations as a property of the sorting in generate_ground_truth_recording()

### DIFF
--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -1828,6 +1828,7 @@ def generate_ground_truth_recording(
             dtype=dtype,
             **generate_templates_kwargs,
         )
+        sorting.set_property("unit_locations", unit_locations)
     else:
         assert templates.shape[0] == num_units
 
@@ -1864,6 +1865,6 @@ def generate_ground_truth_recording(
     recording.set_probe(probe, in_place=True)
     recording.set_channel_gains(1.0)
     recording.set_channel_offsets(0.0)
-    sorting.set_property("unit_locations", unit_locations)
+    
 
     return recording, sorting

--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -1865,6 +1865,5 @@ def generate_ground_truth_recording(
     recording.set_probe(probe, in_place=True)
     recording.set_channel_gains(1.0)
     recording.set_channel_offsets(0.0)
-    
 
     return recording, sorting

--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -1864,5 +1864,6 @@ def generate_ground_truth_recording(
     recording.set_probe(probe, in_place=True)
     recording.set_channel_gains(1.0)
     recording.set_channel_offsets(0.0)
+    sorting.set_property('unit_locations', unit_locations)
 
     return recording, sorting

--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -1828,7 +1828,7 @@ def generate_ground_truth_recording(
             dtype=dtype,
             **generate_templates_kwargs,
         )
-        sorting.set_property("unit_locations", unit_locations)
+        sorting.set_property("gt_unit_locations", unit_locations)
     else:
         assert templates.shape[0] == num_units
 

--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -1864,6 +1864,6 @@ def generate_ground_truth_recording(
     recording.set_probe(probe, in_place=True)
     recording.set_channel_gains(1.0)
     recording.set_channel_offsets(0.0)
-    sorting.set_property('unit_locations', unit_locations)
+    sorting.set_property("unit_locations", unit_locations)
 
     return recording, sorting


### PR DESCRIPTION
This is a PR not to forget, as we discussed with Sam, that unit_locations should be saved as a property of the sorting object in order to be easily used later