### PR TITLE
Add DecimateRecording

### DIFF
--- a/src/spikeinterface/preprocessing/decimate.py
+++ b/src/spikeinterface/preprocessing/decimate.py
@@ -121,6 +121,8 @@ class DecimateRecordingSegment(BaseRecordingSegment):
             start_frame = 0
         if end_frame is None:
             end_frame = self.get_num_samples()
+        end_frame = min(end_frame, self.get_num_samples())
+        start_frame = min(start_frame, self.get_num_samples())
 
         # Account for offset and end when querying parent traces
         parent_start_frame = self._decimation_offset + start_frame * self._decimation_factor

--- a/src/spikeinterface/preprocessing/decimate.py
+++ b/src/spikeinterface/preprocessing/decimate.py
@@ -112,7 +112,9 @@ class DecimateRecordingSegment(BaseRecordingSegment):
         self._dtype = dtype
 
     def get_num_samples(self):
-        return len(range(self._decimation_offset, self._parent_segment.get_num_samples(), self._decimation_factor))
+        parent_n_samp = self._parent_segment.get_num_samples()
+        assert self._decimation_offset < parent_n_samp  # Sanity check (already enforced). Formula changes otherwise
+        return np.ceil((parent_n_samp - self._decimation_offset) / self._decimation_factor)
 
     def get_traces(self, start_frame, end_frame, channel_indices):
         if start_frame is None:

--- a/src/spikeinterface/preprocessing/decimate.py
+++ b/src/spikeinterface/preprocessing/decimate.py
@@ -19,9 +19,11 @@ class DecimateRecording(BasePreprocessor):
     Parameters
     ----------
     recording : Recording
-        The recording extractor to be re-referenced
+        The recording extractor to be decimated.
     decimation_frame_step : int
-    decimation_frame_start : int, default 0
+        Step between successive frames sampled from the parent recording.
+    decimation_frame_start : int, default: 0
+        Index of first frame sampled from the parent recording.
 
     Returns
     -------

--- a/src/spikeinterface/preprocessing/decimate.py
+++ b/src/spikeinterface/preprocessing/decimate.py
@@ -114,7 +114,7 @@ class DecimateRecordingSegment(BaseRecordingSegment):
     def get_num_samples(self):
         parent_n_samp = self._parent_segment.get_num_samples()
         assert self._decimation_offset < parent_n_samp  # Sanity check (already enforced). Formula changes otherwise
-        return np.ceil((parent_n_samp - self._decimation_offset) / self._decimation_factor)
+        return int(np.ceil((parent_n_samp - self._decimation_offset) / self._decimation_factor))
 
     def get_traces(self, start_frame, end_frame, channel_indices):
         if start_frame is None:

--- a/src/spikeinterface/preprocessing/decimate.py
+++ b/src/spikeinterface/preprocessing/decimate.py
@@ -24,6 +24,9 @@ class DecimateRecording(BasePreprocessor):
         Step between successive frames sampled from the parent recording.
     decimation_offset : int, default: 0
         Index of first frame sampled from the parent recording.
+        Expecting `decimation_offset` < `decimation_factor`, and `decimation_offset` < parent_recording.get_num_samples()
+        to ensure that the decimated recording has at least one frame. Consider combining DecimateRecording
+        with FrameSliceRecording for fine control on the recording start and end frames.
 
     Returns
     -------
@@ -44,11 +47,17 @@ class DecimateRecording(BasePreprocessor):
     ):
         # Original sampling frequency
         self._orig_samp_freq = recording.get_sampling_frequency()
+        parent_nsamp = recording.get_num_samples()
         if not isinstance(decimation_factor, int) or decimation_factor <= 0:
             raise ValueError(f"Expecting strictly positive integer for `decimation_factor` arg")
         self._decimation_factor = decimation_factor
         if not isinstance(decimation_offset, int) or decimation_factor < 0:
             raise ValueError(f"Expecting positive integer for `decimation_factor` arg")
+        if decimation_offset >= decimation_factor or decimation_offset >= parent_nsamp:
+            raise ValueError(
+                f"Expecting `decimation_offset` < `decimation_factor` and `decimation_offset` < recording.get_num_samples(). "
+                f"Consider combining DecimateRecording with FrameSliceRecording for fine control on the recording start/end frames."
+            )
         self._decimation_offset = decimation_offset
         resample_rate = self._orig_samp_freq / self._decimation_factor
 

--- a/src/spikeinterface/preprocessing/decimate.py
+++ b/src/spikeinterface/preprocessing/decimate.py
@@ -87,7 +87,11 @@ class DecimateRecordingSegment(BaseRecordingSegment):
         decimation_frame_start,
         dtype,
     ):
-        new_t_start = parent_recording_segment + decimation_frame_start / parent_rate
+        if parent_recording_segment.t_start is None:
+            new_t_start = None
+        else:
+            new_t_start = parent_recording_segment.t_start + decimation_frame_start / parent_rate
+
         # Do not use BasePreprocessorSegment bcause we have to reset the sampling rate!
         BaseRecordingSegment.__init__(
             self,

--- a/src/spikeinterface/preprocessing/decimate.py
+++ b/src/spikeinterface/preprocessing/decimate.py
@@ -1,0 +1,124 @@
+import numpy as np
+from spikeinterface.core.core_tools import (
+    define_function_from_class,
+)
+
+from .basepreprocessor import BasePreprocessor
+from .filter import fix_dtype
+from ..core import BaseRecordingSegment
+
+
+class DecimateRecording(BasePreprocessor):
+    """
+    Decimate the recording extractor traces using array slicing
+
+    Important: This uses simple array slicing for decimation rather than eg scipy.decimate.
+    This might introduce aliasing, or skip across signal of interest.
+    Consider  spikeinterface.preprocessing.ResampleRecording for safe resampling.
+
+    Parameters
+    ----------
+    recording : Recording
+        The recording extractor to be re-referenced
+    decimation_frame_step : int
+    decimation_frame_start : int, default 0
+
+    Returns
+    -------
+    decimate_recording: DecimateRecording
+        The decimated recording extractor object. The full traces of the child recording correspond
+        to the parent traces as follows:
+            ```<decimated_traces> = <parent_traces>[<decimation_frame_start>::<decimation_frame_step>]```
+
+    """
+
+    name = "decimate"
+
+    def __init__(
+        self,
+        recording,
+        decimation_frame_step,
+        decimation_frame_start=0,
+    ):
+        # Original sampling frequency
+        self._orig_samp_freq = recording.get_sampling_frequency()
+        if not isinstance(decimation_frame_step, int) or decimation_frame_step <= 0:
+            raise ValueError(f"Expecting strictly positive integer for `decimation_frame_step` arg")
+        self._decimation_frame_step = decimation_frame_step
+        if not isinstance(decimation_frame_start, int) or decimation_frame_step < 0:
+            raise ValueError(f"Expecting positive integer for `decimation_frame_step` arg")
+        self._decimation_frame_start = decimation_frame_start
+        resample_rate = self._orig_samp_freq / self._decimation_frame_step
+        self._sampling_frequency = resample_rate
+        # fix_dtype not always returns the str, make sure it does
+        dtype = fix_dtype(recording, None).str
+
+        BasePreprocessor.__init__(self, recording, sampling_frequency=resample_rate, dtype=dtype)
+
+        # in case there was a time_vector, it will be dropped for sanity.
+        # This is not necessary but consistent with ResampleRecording
+        for parent_segment in recording._recording_segments:
+            parent_segment.time_vector = None
+            self.add_recording_segment(
+                DecimateRecordingSegment(
+                    parent_segment,
+                    resample_rate,
+                    decimation_frame_step,
+                    decimation_frame_start,
+                    dtype,
+                )
+            )
+
+        self._kwargs = dict(
+            recording=recording,
+            decimation_frame_step=decimation_frame_step,
+            decimation_frame_start=decimation_frame_start,
+        )
+
+
+class DecimateRecordingSegment(BaseRecordingSegment):
+    def __init__(
+        self,
+        parent_recording_segment,
+        resample_rate,
+        decimation_frame_step,
+        decimation_frame_start,
+        dtype,
+    ):
+        # Do not use BasePreprocessorSegment bcause we have to reset the sampling rate!
+        BaseRecordingSegment.__init__(
+            self,
+            sampling_frequency=resample_rate,
+            t_start=parent_recording_segment.t_start,
+        )
+        self._parent_segment = parent_recording_segment
+        self._decimation_frame_step = decimation_frame_step
+        self._decimation_frame_start = decimation_frame_start
+        self._dtype = dtype
+
+    def get_num_samples(self):
+        return len(
+            range(self._decimation_frame_start, self._parent_segment.get_num_samples(), self._decimation_frame_step)
+        )
+
+    def get_traces(self, start_frame, end_frame, channel_indices):
+        if start_frame is None:
+            start_frame = 0
+        if end_frame is None:
+            end_frame = self.get_num_samples()
+
+        # Account for offset and end when querying parent traces
+        parent_start_frame = self._decimation_frame_start + start_frame * self._decimation_frame_step
+        parent_end_frame = parent_start_frame + (end_frame - start_frame) * self._decimation_frame_step
+
+        # And now we can decimate without offsetting
+        return self._parent_segment.get_traces(
+            parent_start_frame,
+            parent_end_frame,
+            channel_indices,
+        )[
+            :: self._decimation_frame_step
+        ].astype(self._dtype)
+
+
+decimate = define_function_from_class(source_class=DecimateRecording, name="decimate")

--- a/src/spikeinterface/preprocessing/decimate.py
+++ b/src/spikeinterface/preprocessing/decimate.py
@@ -63,6 +63,7 @@ class DecimateRecording(BasePreprocessor):
                 DecimateRecordingSegment(
                     parent_segment,
                     resample_rate,
+                    self._orig_samp_freq,
                     decimation_frame_step,
                     decimation_frame_start,
                     dtype,
@@ -81,15 +82,17 @@ class DecimateRecordingSegment(BaseRecordingSegment):
         self,
         parent_recording_segment,
         resample_rate,
+        parent_rate,
         decimation_frame_step,
         decimation_frame_start,
         dtype,
     ):
+        new_t_start = parent_recording_segment + decimation_frame_start / parent_rate
         # Do not use BasePreprocessorSegment bcause we have to reset the sampling rate!
         BaseRecordingSegment.__init__(
             self,
             sampling_frequency=resample_rate,
-            t_start=parent_recording_segment.t_start,
+            t_start=new_t_start,
         )
         self._parent_segment = parent_recording_segment
         self._decimation_frame_step = decimation_frame_step

--- a/src/spikeinterface/preprocessing/decimate.py
+++ b/src/spikeinterface/preprocessing/decimate.py
@@ -51,11 +51,8 @@ class DecimateRecording(BasePreprocessor):
             raise ValueError(f"Expecting positive integer for `decimation_frame_step` arg")
         self._decimation_frame_start = decimation_frame_start
         resample_rate = self._orig_samp_freq / self._decimation_frame_step
-        self._sampling_frequency = resample_rate
-        # fix_dtype not always returns the str, make sure it does
-        dtype = fix_dtype(recording, None).str
 
-        BasePreprocessor.__init__(self, recording, sampling_frequency=resample_rate, dtype=dtype)
+        BasePreprocessor.__init__(self, recording, sampling_frequency=resample_rate)
 
         # in case there was a time_vector, it will be dropped for sanity.
         # This is not necessary but consistent with ResampleRecording
@@ -68,7 +65,7 @@ class DecimateRecording(BasePreprocessor):
                     self._orig_samp_freq,
                     decimation_frame_step,
                     decimation_frame_start,
-                    dtype,
+                    self._dtype,
                 )
             )
 

--- a/src/spikeinterface/preprocessing/preprocessinglist.py
+++ b/src/spikeinterface/preprocessing/preprocessinglist.py
@@ -1,5 +1,6 @@
 ### PREPROCESSORS ###
 from .resample import ResampleRecording, resample
+from .decimate import DecimateRecording, decimate
 from .filter import (
     FilterRecording,
     filter,
@@ -65,6 +66,7 @@ preprocessers_full_list = [
     ZeroChannelPaddedRecording,
     DeepInterpolatedRecording,
     ResampleRecording,
+    DecimateRecording,
     HighpassSpatialFilterRecording,
     InterpolateBadChannelsRecording,
     DepthOrderRecording,

--- a/src/spikeinterface/preprocessing/tests/test_decimate.py
+++ b/src/spikeinterface/preprocessing/tests/test_decimate.py
@@ -11,7 +11,7 @@ import numpy as np
 @pytest.mark.parametrize("decimation_offset", [0, 1, 9, 10, 11, 100, 101])
 @pytest.mark.parametrize("decimation_factor", [1, 9, 10, 11, 100, 101])
 @pytest.mark.parametrize("start_frame", [0, 1, 5, None, 1000])
-@pytest.mark.parametrize("end_frame", [None, 1, 5, 20])
+@pytest.mark.parametrize("end_frame", [0, 1, 5, None, 1000])
 def test_decimate(decimation_offset, decimation_factor, start_frame, end_frame):
     rec = generate_recording()
 
@@ -29,6 +29,8 @@ def test_decimate(decimation_offset, decimation_factor, start_frame, end_frame):
 
     if start_frame is None:
         start_frame = decimated_rec.get_num_samples()
+    if end_frame is None:
+        end_frame = decimated_rec.get_num_samples()
 
     assert np.all(decimated_rec.get_traces(0, start_frame, end_frame) == decimated_parent_traces[start_frame:end_frame])
 

--- a/src/spikeinterface/preprocessing/tests/test_decimate.py
+++ b/src/spikeinterface/preprocessing/tests/test_decimate.py
@@ -8,28 +8,26 @@ from spikeinterface.preprocessing.decimate import DecimateRecording
 import numpy as np
 
 
-def test_decimate():
+@pytest.mark.parametrize("decimation_frame_start", [0, 1, 9, 10, 11, 200])
+@pytest.mark.parametrize("decimation_frame_step", [1, 9, 10, 11, 200])
+@pytest.mark.parametrize("start_frame", [0, 1, 5, 20])
+@pytest.mark.parametrize("end_frame", [None, 1, 5, 20])
+def test_decimate(decimation_frame_start, decimation_frame_step, start_frame, end_frame):
     rec = generate_recording()
 
     N = 101
     rec = NumpyRecording([np.arange(N).reshape(N,1)], 1)
     parent_traces = rec.get_traces()
 
-    for decimation_frame_start, decimation_frame_step in itertools.product(
-        [0, 1, 9, 10, 11, 200],
-        [1, 9, 10, 11, 200]
-    ):
+    decimated_rec = DecimateRecording(rec, decimation_frame_step, decimation_frame_start=decimation_frame_start)
+    decimated_parent_traces = parent_traces[decimation_frame_start::decimation_frame_step]
 
-        decimated_rec = DecimateRecording(rec, decimation_frame_step, decimation_frame_start=decimation_frame_start)
-        decimated_parent_traces = parent_traces[decimation_frame_start::decimation_frame_step]
+    if start_frame is None:
+        start_frame = len(decimated_parent_traces)
 
-        for start_frame, end_frame in itertools.product(
-            [0, 1, 5, 20],
-            [len(decimated_parent_traces), 1, 5, 20],
-        ):
-            assert np.all(
-                decimated_rec.get_traces(0, start_frame, end_frame) == decimated_parent_traces[start_frame:end_frame]
-            )
+    assert np.all(
+        decimated_rec.get_traces(0, start_frame, end_frame) == decimated_parent_traces[start_frame:end_frame]
+    )
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/preprocessing/tests/test_decimate.py
+++ b/src/spikeinterface/preprocessing/tests/test_decimate.py
@@ -8,19 +8,19 @@ from spikeinterface.preprocessing.decimate import DecimateRecording
 import numpy as np
 
 
-@pytest.mark.parametrize("decimation_frame_start", [0, 1, 9, 10, 11, 200])
-@pytest.mark.parametrize("decimation_frame_step", [1, 9, 10, 11, 200])
+@pytest.mark.parametrize("decimation_offset", [0, 1, 9, 10, 11, 200])
+@pytest.mark.parametrize("decimation_factor", [1, 9, 10, 11, 200])
 @pytest.mark.parametrize("start_frame", [0, 1, 5, 20])
 @pytest.mark.parametrize("end_frame", [None, 1, 5, 20])
-def test_decimate(decimation_frame_start, decimation_frame_step, start_frame, end_frame):
+def test_decimate(decimation_offset, decimation_factor, start_frame, end_frame):
     rec = generate_recording()
 
     N = 101
     rec = NumpyRecording([np.arange(N).reshape(N, 1)], 1)
     parent_traces = rec.get_traces()
 
-    decimated_rec = DecimateRecording(rec, decimation_frame_step, decimation_frame_start=decimation_frame_start)
-    decimated_parent_traces = parent_traces[decimation_frame_start::decimation_frame_step]
+    decimated_rec = DecimateRecording(rec, decimation_factor, decimation_offset=decimation_offset)
+    decimated_parent_traces = parent_traces[decimation_offset::decimation_factor]
 
     if start_frame is None:
         start_frame = len(decimated_parent_traces)

--- a/src/spikeinterface/preprocessing/tests/test_decimate.py
+++ b/src/spikeinterface/preprocessing/tests/test_decimate.py
@@ -1,0 +1,36 @@
+import pytest
+from pathlib import Path
+
+import itertools
+from spikeinterface import NumpyRecording
+from spikeinterface.core import generate_recording
+from spikeinterface.preprocessing.decimate import DecimateRecording
+import numpy as np
+
+
+def test_decimate():
+    rec = generate_recording()
+
+    N = 101
+    rec = NumpyRecording([np.arange(N).reshape(N,1)], 1)
+    parent_traces = rec.get_traces()
+
+    for decimation_frame_start, decimation_frame_step in itertools.product(
+        [0, 1, 9, 10, 11, 200],
+        [1, 9, 10, 11, 200]
+    ):
+
+        decimated_rec = DecimateRecording(rec, decimation_frame_step, decimation_frame_start=decimation_frame_start)
+        decimated_parent_traces = parent_traces[decimation_frame_start::decimation_frame_step]
+
+        for start_frame, end_frame in itertools.product(
+            [0, 1, 5, 20],
+            [len(decimated_parent_traces), 1, 5, 20],
+        ):
+            assert np.all(
+                decimated_rec.get_traces(0, start_frame, end_frame) == decimated_parent_traces[start_frame:end_frame]
+            )
+
+
+if __name__ == "__main__":
+    test_decimate()

--- a/src/spikeinterface/preprocessing/tests/test_decimate.py
+++ b/src/spikeinterface/preprocessing/tests/test_decimate.py
@@ -8,32 +8,38 @@ from spikeinterface.preprocessing.decimate import DecimateRecording
 import numpy as np
 
 
+@pytest.mark.parametrize("N_segments", [1, 2])
 @pytest.mark.parametrize("decimation_offset", [0, 1, 9, 10, 11, 100, 101])
 @pytest.mark.parametrize("decimation_factor", [1, 9, 10, 11, 100, 101])
 @pytest.mark.parametrize("start_frame", [0, 1, 5, None, 1000])
 @pytest.mark.parametrize("end_frame", [0, 1, 5, None, 1000])
-def test_decimate(decimation_offset, decimation_factor, start_frame, end_frame):
+def test_decimate(N_segments, decimation_offset, decimation_factor, start_frame, end_frame):
     rec = generate_recording()
 
-    N = 101
-    rec = NumpyRecording([np.arange(2 * N).reshape(N, 2)], 1)
-    parent_traces = rec.get_traces()
+    segment_num_samps = [101 + i for i in range(N_segments)]
 
-    if decimation_offset >= N or decimation_offset >= decimation_factor:
+    rec = NumpyRecording([np.arange(2 * N).reshape(N, 2) for N in segment_num_samps], 1)
+
+    parent_traces = [rec.get_traces(i) for i in range(N_segments)]
+
+    if decimation_offset >= min(segment_num_samps) or decimation_offset >= decimation_factor:
         with pytest.raises(ValueError):
             decimated_rec = DecimateRecording(rec, decimation_factor, decimation_offset=decimation_offset)
         return
 
     decimated_rec = DecimateRecording(rec, decimation_factor, decimation_offset=decimation_offset)
-    decimated_parent_traces = parent_traces[decimation_offset::decimation_factor]
+    decimated_parent_traces = [parent_traces[i][decimation_offset::decimation_factor] for i in range(N_segments)]
 
     if start_frame is None:
-        start_frame = decimated_rec.get_num_samples()
+        start_frame = max(decimated_rec.get_num_samples(i) for i in range(N_segments))
     if end_frame is None:
-        end_frame = decimated_rec.get_num_samples()
+        end_frame = max(decimated_rec.get_num_samples(i) for i in range(N_segments))
 
-    assert decimated_rec.get_num_samples() == decimated_parent_traces.shape[0]
-    assert np.all(decimated_rec.get_traces(0, start_frame, end_frame) == decimated_parent_traces[start_frame:end_frame])
+    for i in range(N_segments):
+        assert decimated_rec.get_num_samples(i) == decimated_parent_traces[i].shape[0]
+        assert np.all(
+            decimated_rec.get_traces(i, start_frame, end_frame) == decimated_parent_traces[i][start_frame:end_frame]
+        )
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/preprocessing/tests/test_decimate.py
+++ b/src/spikeinterface/preprocessing/tests/test_decimate.py
@@ -16,7 +16,7 @@ def test_decimate(decimation_frame_start, decimation_frame_step, start_frame, en
     rec = generate_recording()
 
     N = 101
-    rec = NumpyRecording([np.arange(N).reshape(N,1)], 1)
+    rec = NumpyRecording([np.arange(N).reshape(N, 1)], 1)
     parent_traces = rec.get_traces()
 
     decimated_rec = DecimateRecording(rec, decimation_frame_step, decimation_frame_start=decimation_frame_start)
@@ -25,9 +25,7 @@ def test_decimate(decimation_frame_start, decimation_frame_step, start_frame, en
     if start_frame is None:
         start_frame = len(decimated_parent_traces)
 
-    assert np.all(
-        decimated_rec.get_traces(0, start_frame, end_frame) == decimated_parent_traces[start_frame:end_frame]
-    )
+    assert np.all(decimated_rec.get_traces(0, start_frame, end_frame) == decimated_parent_traces[start_frame:end_frame])
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/preprocessing/tests/test_decimate.py
+++ b/src/spikeinterface/preprocessing/tests/test_decimate.py
@@ -10,7 +10,7 @@ import numpy as np
 
 @pytest.mark.parametrize("decimation_offset", [0, 1, 9, 10, 11, 100, 101])
 @pytest.mark.parametrize("decimation_factor", [1, 9, 10, 11, 100, 101])
-@pytest.mark.parametrize("start_frame", [0, 1, 5, 20])
+@pytest.mark.parametrize("start_frame", [0, 1, 5, None, 1000])
 @pytest.mark.parametrize("end_frame", [None, 1, 5, 20])
 def test_decimate(decimation_offset, decimation_factor, start_frame, end_frame):
     rec = generate_recording()
@@ -28,7 +28,7 @@ def test_decimate(decimation_offset, decimation_factor, start_frame, end_frame):
     decimated_parent_traces = parent_traces[decimation_offset::decimation_factor]
 
     if start_frame is None:
-        start_frame = len(decimated_parent_traces)
+        start_frame = decimated_rec.get_num_samples()
 
     assert np.all(decimated_rec.get_traces(0, start_frame, end_frame) == decimated_parent_traces[start_frame:end_frame])
 

--- a/src/spikeinterface/preprocessing/tests/test_decimate.py
+++ b/src/spikeinterface/preprocessing/tests/test_decimate.py
@@ -16,7 +16,7 @@ def test_decimate(decimation_offset, decimation_factor, start_frame, end_frame):
     rec = generate_recording()
 
     N = 101
-    rec = NumpyRecording([np.arange(N).reshape(N, 1)], 1)
+    rec = NumpyRecording([np.arange(2 * N).reshape(N, 2)], 1)
     parent_traces = rec.get_traces()
 
     if decimation_offset >= N or decimation_offset >= decimation_factor:

--- a/src/spikeinterface/preprocessing/tests/test_decimate.py
+++ b/src/spikeinterface/preprocessing/tests/test_decimate.py
@@ -32,6 +32,7 @@ def test_decimate(decimation_offset, decimation_factor, start_frame, end_frame):
     if end_frame is None:
         end_frame = decimated_rec.get_num_samples()
 
+    assert decimated_rec.get_num_samples() == decimated_parent_traces.shape[0]
     assert np.all(decimated_rec.get_traces(0, start_frame, end_frame) == decimated_parent_traces[start_frame:end_frame])
 
 

--- a/src/spikeinterface/preprocessing/tests/test_decimate.py
+++ b/src/spikeinterface/preprocessing/tests/test_decimate.py
@@ -8,8 +8,8 @@ from spikeinterface.preprocessing.decimate import DecimateRecording
 import numpy as np
 
 
-@pytest.mark.parametrize("decimation_offset", [0, 1, 9, 10, 11, 200])
-@pytest.mark.parametrize("decimation_factor", [1, 9, 10, 11, 200])
+@pytest.mark.parametrize("decimation_offset", [0, 1, 9, 10, 11, 100, 101])
+@pytest.mark.parametrize("decimation_factor", [1, 9, 10, 11, 100, 101])
 @pytest.mark.parametrize("start_frame", [0, 1, 5, 20])
 @pytest.mark.parametrize("end_frame", [None, 1, 5, 20])
 def test_decimate(decimation_offset, decimation_factor, start_frame, end_frame):
@@ -18,6 +18,11 @@ def test_decimate(decimation_offset, decimation_factor, start_frame, end_frame):
     N = 101
     rec = NumpyRecording([np.arange(N).reshape(N, 1)], 1)
     parent_traces = rec.get_traces()
+
+    if decimation_offset >= N or decimation_offset >= decimation_factor:
+        with pytest.raises(ValueError):
+            decimated_rec = DecimateRecording(rec, decimation_factor, decimation_offset=decimation_offset)
+        return
 
     decimated_rec = DecimateRecording(rec, decimation_factor, decimation_offset=decimation_offset)
     decimated_parent_traces = parent_traces[decimation_offset::decimation_factor]


### PR DESCRIPTION
Hi,

I needed this because I want to downsample while keeping track of the actual underlying frame ids. In my case I don't care about aliasing etc because I will apply it on a smoothed signal, but it might be a good idea to add some safeguards... Maybe changing the name to avoid confusion with the scipy.decimate function?

Best
Tom