### PR TITLE
get_chunk_with_margin handling return_scaled

### DIFF
--- a/src/spikeinterface/core/recording_tools.py
+++ b/src/spikeinterface/core/recording_tools.py
@@ -186,15 +186,17 @@ def get_noise_levels(
 
 
 def get_chunk_with_margin(
-    rec_segment,
+    recording,
+    segment_index,
     start_frame,
     end_frame,
-    channel_indices,
+    channel_inds,
     margin,
     add_zeros=False,
     add_reflect_padding=False,
     window_on_margin=False,
     dtype=None,
+    return_scaled=False
 ):
     """
     Helper to get chunk with margin
@@ -205,10 +207,11 @@ def get_chunk_with_margin(
     case zero padding is used, in the second case np.pad is called
     with mod="reflect".
     """
+    rec_segment = recording._recording_segments[segment_index]
     length = rec_segment.get_num_samples()
 
-    if channel_indices is None:
-        channel_indices = slice(None)
+    if channel_inds is None:
+        channel_inds = recording.channel_ids
 
     if not (add_zeros or add_reflect_padding):
         if window_on_margin and not add_zeros:
@@ -230,10 +233,12 @@ def get_chunk_with_margin(
         else:
             right_margin = margin
 
-        traces_chunk = rec_segment.get_traces(
+        traces_chunk = recording.get_traces(
+            segment_index,
             start_frame - left_margin,
             end_frame + right_margin,
-            channel_indices,
+            channel_inds,
+            return_scaled=return_scaled
         )
 
     else:
@@ -260,7 +265,7 @@ def get_chunk_with_margin(
             end_frame2 = end_frame + margin
             right_pad = 0
 
-        traces_chunk = rec_segment.get_traces(start_frame2, end_frame2, channel_indices)
+        traces_chunk = recording.get_traces(segment_index, start_frame2, end_frame2, channel_inds, return_scaled=return_scaled)
 
         if dtype is not None or window_on_margin or left_pad > 0 or right_pad > 0:
             need_copy = True

--- a/src/spikeinterface/core/tests/test_recording_tools.py
+++ b/src/spikeinterface/core/tests/test_recording_tools.py
@@ -73,50 +73,50 @@ def test_get_chunk_with_margin():
     rec_seg = rec._recording_segments[0]
     length = rec_seg.get_num_samples()
 
-    #  rec_segment, start_frame, end_frame, channel_indices, sample_margin
+    # rec_segment, start_frame, end_frame, channel_indices, sample_margin
 
-    traces, l, r = get_chunk_with_margin(rec_seg, None, None, None, 10)
+    traces, l, r = get_chunk_with_margin(rec, 0, None, None, None, 10)
     assert l == 0 and r == 0
 
-    traces, l, r = get_chunk_with_margin(rec_seg, 5, None, None, 10)
+    traces, l, r = get_chunk_with_margin(rec, 0, 5, None, None, 10)
     assert l == 5 and r == 0
 
-    traces, l, r = get_chunk_with_margin(rec_seg, length - 1000, length - 5, None, 10)
+    traces, l, r = get_chunk_with_margin(rec, 0, length - 1000, length - 5, None, 10)
     assert l == 10 and r == 5
     assert traces.shape[0] == 1010
 
-    traces, l, r = get_chunk_with_margin(rec_seg, 2000, 3000, None, 10)
+    traces, l, r = get_chunk_with_margin(rec, 0, 2000, 3000, None, 10)
     assert l == 10 and r == 10
     assert traces.shape[0] == 1020
 
     # add zeros
-    traces, l, r = get_chunk_with_margin(rec_seg, 5, 1005, None, 10, add_zeros=True)
+    traces, l, r = get_chunk_with_margin(rec, 0, 5, 1005, None, 10, add_zeros=True)
     assert traces.shape[0] == 1020
     assert l == 10
     assert r == 10
     assert np.all(traces[:5] == 0)
 
-    traces, l, r = get_chunk_with_margin(rec_seg, length - 1005, length - 5, None, 10, add_zeros=True)
+    traces, l, r = get_chunk_with_margin(rec, 0, length - 1005, length - 5, None, 10, add_zeros=True)
     assert traces.shape[0] == 1020
     assert np.all(traces[-5:] == 0)
     assert l == 10
     assert r == 10
 
-    traces, l, r = get_chunk_with_margin(rec_seg, length - 500, length + 500, None, 10, add_zeros=True)
+    traces, l, r = get_chunk_with_margin(rec, 0, length - 500, length + 500, None, 10, add_zeros=True)
     assert traces.shape[0] == 1020
     assert np.all(traces[-510:] == 0)
     assert l == 10
     assert r == 510
 
     # add zeros + window and/or dtype
-    traces_windowed, l, r = get_chunk_with_margin(rec_seg, 5, 1005, None, 20, add_zeros=True, window_on_margin=True)
+    traces_windowed, l, r = get_chunk_with_margin(rec, 0, 5, 1005, None, 20, add_zeros=True, window_on_margin=True)
     traces_windowed, l, r = get_chunk_with_margin(
-        rec_seg, length - 1005, length - 5, None, 20, add_zeros=True, window_on_margin=True
+        rec, 0, length - 1005, length - 5, None, 20, add_zeros=True, window_on_margin=True
     )
     traces_windowed, l, r = get_chunk_with_margin(
-        rec_seg, length - 500, length + 500, None, 10, add_zeros=True, window_on_margin=True
+        rec, 0, length - 500, length + 500, None, 10, add_zeros=True, window_on_margin=True
     )
-    traces, l, r = get_chunk_with_margin(rec_seg, length - 1005, length - 5, None, 20, add_zeros=True, dtype="float64")
+    traces, l, r = get_chunk_with_margin(rec, 0, length - 1005, length - 5, None, 20, add_zeros=True, dtype="float64")
     assert traces.dtype == "float64"
 
     # import matplotlib.pyplot as plt


### PR DESCRIPTION
As mentionned in #2387 this PR fixes the problem of return_scaled within the node pipeline. Now, everything will be handled with the scaling, and while it might be slightly slower (marginally), it will avoid issues as observed in #2346 . Plus, all the templates obtained via internal spike sorting pipelines will be in appropriate units