### PR TITLE
Pass job_kwargs to ZarrRecordingExtractor.write_recording

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -499,7 +499,7 @@ class BaseRecording(BaseRecordingSnippets):
 
             zarr_path = kwargs.pop("zarr_path")
             storage_options = kwargs.pop("storage_options")
-            ZarrRecordingExtractor.write_recording(self, zarr_path, storage_options, **kwargs)
+            ZarrRecordingExtractor.write_recording(self, zarr_path, storage_options, **kwargs, **job_kwargs)
             cached = ZarrRecordingExtractor(zarr_path, storage_options)
 
         elif format == "nwb":


### PR DESCRIPTION
Job kwargs passed through `recording.save_to_zarr` or `recording.save(format="zarr")` are ignored. I think this might be a mistake, since [`add_recording_to_zarr_group` seems to expect job kwargs](https://github.com/SpikeInterface/spikeinterface/blob/2e17f2080896bbfb5d7a751f428e127c2fffddea/src/spikeinterface/core/zarrextractors.py#L362)

Opening this just in case (are there interactions with the zarr storage options to be careful with?)

Best