### PR TITLE
Use run_sorter function in test_containers_singularity_gpu

### DIFF
--- a/.github/workflows/test_containers_singularity_gpu.yml
+++ b/.github/workflows/test_containers_singularity_gpu.yml
@@ -1,4 +1,4 @@
-name: CI-Test in AWS for GPU
+name: Test GPU sorter images in singularity on AWS
 
 on:
   workflow_dispatch:

--- a/src/spikeinterface/sorters/external/tests/test_singularity_containers_gpu.py
+++ b/src/spikeinterface/sorters/external/tests/test_singularity_containers_gpu.py
@@ -41,31 +41,32 @@ def run_kwargs():
 
 def test_kilosort2(run_kwargs):
     clean_singularity_cache()
-    sorting = ss.run_kilosort2(output_folder="kilosort2", **run_kwargs)
+    sorting = ss.run_sorter(sorter_name="kilosort2", output_folder="kilosort2", **run_kwargs)
     print(sorting)
 
 
 def test_kilosort2_5(run_kwargs):
     clean_singularity_cache()
-    sorting = ss.run_kilosort2_5(output_folder="kilosort2_5", **run_kwargs)
+    sorting = ss.run_sorter(sorter_name="kilosort2_5", output_folder="kilosort2_5", **run_kwargs)
     print(sorting)
 
 
 def test_kilosort3(run_kwargs):
     clean_singularity_cache()
-    sorting = ss.run_kilosort3(output_folder="kilosort3", **run_kwargs)
-    print(sorting)
-
-
-def test_yass(run_kwargs):
-    clean_singularity_cache()
-    sorting = ss.run_yass(output_folder="yass", **run_kwargs)
+    sorting = ss.run_sorter(sorter_name="kilosort3", output_folder="kilosort3", **run_kwargs)
     print(sorting)
 
 
 def test_pykilosort(run_kwargs):
     clean_singularity_cache()
-    sorting = ss.run_pykilosort(output_folder="pykilosort", **run_kwargs)
+    sorting = ss.run_sorter(sorter_name="pykilosort", output_folder="pykilosort", **run_kwargs)
+    print(sorting)
+
+
+@pytest.mark.skip("YASS is not supported anymore for Python>=3.8")
+def test_yass(run_kwargs):
+    clean_singularity_cache()
+    sorting = ss.run_sorter(sorter_name="yass", output_folder="yass", **run_kwargs)
     print(sorting)
 
 


### PR DESCRIPTION
Tests are failing because the test functions still used the deprecated `run_{sorter_name}` functions