### PR TITLE
Improve Documentation VIII

### DIFF
--- a/doc/development/development.rst
+++ b/doc/development/development.rst
@@ -359,19 +359,10 @@ Now you can start filling out the required methods:
         return sorting
 
 When your spike sorter class is implemented, you have to add it to the list of available spike sorters in the
-`sorterlist.py`
-Moreover, you have to add a launcher function like `run_XXXX()`.
-
-.. code-block:: python
-
-    def run_myspikesorter(*args, **kwargs):
-        return run_sorter('myspikesorter', *args, **kwargs)
-
-
-When you are done you need to write a test in **tests/test_myspikesorter.py**. In order to be tested, you can
+`sorterlist.py`. Then you need to write a test in **tests/test_myspikesorter.py**. In order to be tested, you can
 install the required packages by changing the **pyproject.toml**. Note that MATLAB based tests cannot be run at the moment,
 but we recommend testing the implementation locally.
 
-After this you need to add a block in **doc/sorters_info.rst**
+After this you need to add a block in **doc/sorters_info.rst** to describe your sorter.
 
-Finally, make a pull request to the spikesorters repo, so we can review the code and merge it to the spikesorters!
+Finally, make a pull request so we can review the code and incorporate into the sorters module of SpikeInterface!

--- a/doc/modules/comparison.rst
+++ b/doc/modules/comparison.rst
@@ -197,7 +197,7 @@ Tested units are classified depending on their performance. We identify three di
   * **over-merged** units
 
 A **well-detected** unit is a unit whose performance is good. By default, a good performance is measured by an accuracy
-greater than 0.8-
+greater than 0.8.
 
 A **false positive** unit has low agreement scores for all GT units and is not matched.
 
@@ -216,11 +216,11 @@ An **over-merged** unit has a relatively high agreement (>= 0.2 by default) for 
 
 
     # run a sorter and compare to ground truth
-    sorting_HS = run_sorter('herdingspike', recording)
+    sorting_HS = run_sorter(sorter_name='herdingspike', recording=recording)
     cmp_gt_HS = sc.compare_sorter_to_ground_truth(sorting_true, sorting_HS, exhaustive_gt=True)
 
 
-    # To have an overview of the match we can use the ordered agreement matrix
+    # To have an overview of the match we can use the ordered agreement matrix
     plot_agreement_matrix(cmp_gt_HS, ordered=True)
 
     # This function first matches the ground-truth and spike sorted units, and
@@ -229,13 +229,13 @@ An **over-merged** unit has a relatively high agreement (>= 0.2 by default) for 
     perf = cmp_gt_HS.get_performance()
 
 
-    # The confusion matrix is also a good summary of the score as it has
-    # the same shape as an agreement matrix, but it contains an extra column for FN
+    # The confusion matrix is also a good summary of the score as it has
+    # the same shape as an agreement matrix, but it contains an extra column for FN
     # and an extra row for FP
     plot_confusion_matrix(cmp_gt_HS)
 
     # We can query the well and poorly detected units. By default, the threshold
-    # on accuracy is 0.95.
+    # for accuracy is 0.95.
     cmp_gt_HS.get_well_detected_units(well_detected_score=0.95)
 
     cmp_gt_HS.get_false_positive_units(redundant_score=0.2)
@@ -246,7 +246,7 @@ An **over-merged** unit has a relatively high agreement (>= 0.2 by default) for 
 **Example: compare many sorters with a Ground Truth Study**
 
 We also have a high level class to compare many sorters against ground truth:
-:py:func:`~spiekinterface.comparison.GroundTruthStudy()`
+:py:func:`~spikeinterface.comparison.GroundTruthStudy()`
 
 A study is a systematic performance comparison of several ground truth recordings with several sorters or several cases
 like the different parameter sets.
@@ -254,7 +254,7 @@ like the different parameter sets.
 The study class proposes high-level tool functions to run many ground truth comparisons with many "cases"
 on many recordings and then collect and aggregate results in an easy way.
 
-The all mechanism is based on an intrinsic organization into a "study_folder" with several subfolder:
+The all mechanism is based on an intrinsic organization into a "study_folder" with several subfolders:
 
   * datasets: contains ground truth datasets
   * sorters : contains outputs of sorters
@@ -282,7 +282,7 @@ The all mechanism is based on an intrinsic organization into a "study_folder" wi
         "toy1": (rec1, gt_sorting1),
     }
 
-    # define some "cases" here we want to tests tridesclous2 on 2 datasets and spykingcircus on one dataset
+    # define some "cases" here we want to test tridesclous2 on 2 datasets and spykingcircus2 on one dataset
     # so it is a two level study (sorter_name, dataset)
     # this could be more complicated like (sorter_name, dataset, params)
     cases = {
@@ -310,8 +310,8 @@ The all mechanism is based on an intrinsic organization into a "study_folder" wi
             },
         },
     }
-    # this initilize a folder
-    study = GroundTruthStudy.create(study_folder, datasets=datasets, cases=cases,
+    # this initilizes a folder
+    study = GroundTruthStudy.create(study_folder=study_folder, datasets=datasets, cases=cases,
                                     levels=["sorter_name", "dataset"])
 
 
@@ -319,13 +319,13 @@ The all mechanism is based on an intrinsic organization into a "study_folder" wi
     study.run_sorters()
 
     # Collect comparisons
-    #  
+    #
     # You can collect in one shot all results and run the
     # GroundTruthComparison on it.
     # So you can have fine access to all individual results.
-    #  
+    #
     # Note: use exhaustive_gt=True when you know exactly how many
-    # units in ground truth (for synthetic datasets)
+    # units in the ground truth (for synthetic datasets)
 
     # run all comparisons and loop over the results
     study.run_comparisons(exhaustive_gt=True)
@@ -340,13 +340,13 @@ The all mechanism is based on an intrinsic organization into a "study_folder" wi
         perf_avg = comp.get_performance(method='pooled_with_average')
         # some plots
         m = comp.get_confusion_matrix()
-        w_comp = sw.plot_agreement_matrix(comp)
+        w_comp = sw.plot_agreement_matrix(sorting_comparison=comp)
 
     # Collect synthetic dataframes and display
     # As shown previously, the performance is returned as a pandas dataframe.
-    # The :py:func:`~spikeinterface.comparison.get_performance_by_unit()` function,
-    # gathers all the outputs in the study folder and merges them in a single dataframe.
-    # Same idea for :py:func:`~spikeinterface.comparison.get_count_units()`
+    # The spikeinterface.comparison.get_performance_by_unit() function,
+    # gathers all the outputs in the study folder and merges them into a single dataframe.
+    # Same idea for spikeinterface.comparison.get_count_units()
 
     # this is a dataframe
     perfs = study.get_performance_by_unit()
@@ -358,7 +358,7 @@ The all mechanism is based on an intrinsic organization into a "study_folder" wi
     run_times = study.get_run_times()
     print(run_times)
 
-    # Easy plot with seaborn
+    # Easy plotting with seaborn
     fig1, ax1 = plt.subplots()
     sns.barplot(data=run_times, x='rec_name', y='run_time', hue='sorter_name', ax=ax1)
     ax1.set_title('Run times')
@@ -395,17 +395,22 @@ The :py:func:`~spikeinterface.comparison.compare_two_sorters()` returns the comp
 
 .. code-block:: python
 
+    import spikeinterface as si
+    import spikeinterface.extractors as se
+    import spikeinterface.sorters as ss
+    import spikeinterface.comparisons as sc
+    import spikinterface.widgets as sw
 
     # First, let's download a simulated dataset
     local_path = si.download_dataset(remote_path='mearec/mearec_test_10s.h5')
     recording, sorting = se.read_mearec(local_path)
 
     # Then run two spike sorters and compare their outputs.
-    sorting_HS = ss.run_sorter('herdingspikes', recording)
-    sorting_TDC = ss.run_sorter('tridesclous', recording)
+    sorting_HS = ss.run_sorter(sorter_name='herdingspikes', recording=recording)
+    sorting_TDC = ss.run_sorter(sorter_name='tridesclous', recording=recording)
 
     # Run the comparison
-    # Let’s see how to inspect and access this matching.
+    # Let's see how to inspect and access this matching.
     cmp_HS_TDC = sc.compare_two_sorters(
         sorting1=sorting_HS,
         sorting2=sorting_TDC,
@@ -413,16 +418,16 @@ The :py:func:`~spikeinterface.comparison.compare_two_sorters()` returns the comp
         sorting2_name='TDC',
     )
 
-    # We can check the agreement matrix to inspect the matching.
-    plot_agreement_matrix(cmp_HS_TDC)
+    # We can check the agreement matrix to inspect the matching.
+    sw.plot_agreement_matrix(sorting_comparison=cmp_HS_TDC)
 
-    # Some useful internal dataframes help to check the match and count
-    #  like **match_event_count** or **agreement_scores**
+    # Some useful internal dataframes help to check the match and count
+    # like **match_event_count** or **agreement_scores**
     print(cmp_HS_TDC.match_event_count)
     print(cmp_HS_TDC.agreement_scores)
 
-    # In order to check which units were matched, the :code:`get_matching`
-    # method can be used. If units are not matched they are listed as -1.
+    # In order to check which units were matched, the `comparison.get_matching()`
+    # method can be used. If units are not matched they are listed as -1.
     sc_to_tdc, tdc_to_sc = cmp_HS_TDC.get_matching()
     print('matching HS to TDC')
     print(sc_to_tdc)
@@ -457,9 +462,9 @@ Comparison of multiple sorters uses the following procedure:
     recording, sorting = se.read_mearec(local_path)
 
     # Then run 3 spike sorters and compare their outputs.
-    sorting_MS4 = ss.run_sorter('mountainsort4', recording)
-    sorting_HS = ss.run_sorter('herdingspikes', recording)
-    sorting_TDC = ss.run_sorter('tridesclous', recording)
+    sorting_MS4 = ss.run_sorter(sorter_name='mountainsort4', recording=recording)
+    sorting_HS = ss.run_sorter(sorter_name='herdingspikes', recording=recording)
+    sorting_TDC = ss.run_sorter(sorter_name='tridesclous', recording=recording)
 
     # Compare multiple spike sorter outputs
     mcmp = sc.compare_multiple_sorters(
@@ -477,12 +482,12 @@ Comparison of multiple sorters uses the following procedure:
     print(mcmp.comparisons[('MS4', 'TDC')].get_matching())
 
     # The global multi comparison can be visualized with this graph
-    sw.plot_multicomp_graph(mcmp)
+    sw.plot_multicomp_graph(multi_comparison=mcmp)
 
     # Consensus-based method
-    #  
+    #
     # We can pull the units in agreement with different sorters using the
-    # :py:func:`~spikeinterface.comparison.MultiSortingComparison.get_agreement_sorting` method.
+    # spikeinterface.comparison.MultiSortingComparison.get_agreement_sorting method.
     # This allows us to make spike sorting more robust by integrating the outputs of several algorithms.
     # On the other hand, it might suffer from weak performances of single algorithms.
     # When extracting the units in agreement, the spike trains are modified so
@@ -498,7 +503,7 @@ Comparison of multiple sorters uses the following procedure:
     agr_all = mcmp.get_agreement_sorting()
 
     # The unit index of the different sorters can also be retrieved from the
-    # agreement sorting object (:code:`agr_3`) property :code:`sorter_unit_ids`.
+    # agreement sorting object (`agr_3`) property `sorter_unit_ids`.
 
     print(agr_3.get_property('unit_ids'))
 
@@ -515,7 +520,7 @@ Template comparison
 For template comparisons, the underlying ideas are very similar to :ref:`symmetric` and :ref:`multiple`, for
 pairwise and multiple comparisons, respectively. In contrast to spike train comparisons, agreement is assessed
 in the similarity of templates rather than spiking events.
-This enables us to use exatly the same tools for both types of comparisons, just by changing the way that agreement
+This enables us to use exactly the same tools for both types of comparisons, just by changing the way that agreement
 scores are computed.
 
 The functions to compare templates take a list of :py:class:`~spikeinterface.core.WaveformExtractor` objects as input,
@@ -527,10 +532,10 @@ waveform extractors from day 1 (:code:`we_day1`) to day 5 (:code:`we_day5`):
     we_list = [we_day1, we_day2, we_day3, we_day4, we_day5]
 
     # match only day 1 and 2
-    p_tcmp = sc.compare_templates(we_day1, we_day2, we1_name="Day1", we2_name="Day2")
+    p_tcmp = sc.compare_templates(we1=we_day1, we2=we_day2, we1_name="Day1", we2_name="Day2")
 
     # match all
-    m_tcmp = sc.compare_multiple_templates(we_list,
+    m_tcmp = sc.compare_multiple_templates(waveform_list=we_list,
                                            name_list=["D1", "D2", "D3", "D4", "D5"])
 
 
@@ -538,7 +543,7 @@ waveform extractors from day 1 (:code:`we_day1`) to day 5 (:code:`we_day5`):
 Benchmark spike collisions
 --------------------------
 
-SpikeInterface also has a specific toolset to benchmark how good sorters are at recovering spikes in "collision".
+SpikeInterface also has a specific toolset to benchmark how well sorters are at recovering spikes in "collision".
 
 We have three classes to handle collision-specific comparisons, and also to quantify the effects on correlogram
 estimation:

--- a/doc/modules/core.rst
+++ b/doc/modules/core.rst
@@ -9,7 +9,7 @@ The :py:mod:`spikeinterface.core` module provides the basic classes and tools of
 Several Base classes are implemented here and inherited throughout the SI code-base.
 The core classes are: :py:class:`~spikeinterface.core.BaseRecording` (for raw data),
 :py:class:`~spikeinterface.core.BaseSorting` (for spike-sorted data), and
-:py:class:`~spikeinterface.core.WaveformExtarctor` (for waveform extraction and postprocessing).
+:py:class:`~spikeinterface.core.WaveformExtractor` (for waveform extraction and postprocessing).
 
 There are additional classes to allow to retrieve events (:py:class:`~spikeinterface.core.BaseEvent`) and to
 handle unsorted waveform cutouts, or *snippets*, which are recorded by some acquisition systems
@@ -25,7 +25,7 @@ All classes support:
 Recording
 ---------
 
-The :py:class:`~spikeinterface.core.BaseRecording` class serves as the basis for all
+The :py:class:`~spikeinterface.core.BaseRecording` class serves as the basis of all
 :code:`Recording` classes.
 It interfaces with the raw traces and has the following features:
 
@@ -90,7 +90,7 @@ with 16 channels:
 
     # set times (for synchronization) - assume our times start at 300 seconds
     timestamps = np.arange(num_samples) / sampling_frequency + 300
-    recording.set_times(timestamps, segment_index=0)
+    recording.set_times(times=timestamps, segment_index=0)
 
 **Note**:
 Raw data formats often store data as integer values for memory efficiency. To give these integers meaningful physical units (uV), you can apply a gain and an offset.
@@ -148,7 +148,7 @@ with 10 units:
     sorting_select_units = sorting.select_units(unit_ids=unit_ids[:4])
 
     # register 'recording' from the previous example and get the spike trains in seconds
-    sorting.register_recording(recording)
+    sorting.register_recording(recording=recording)
     spike_train_s = sorting.get_unit_spike_train(unit_id=unit0, segment_index=0,
                                                  return_times=True)
     ### NOTE ###
@@ -180,7 +180,7 @@ The :py:class:`~spikeinterface.core.WaveformExtractor` allows us to:
 * save sparse waveforms or *sparsify* dense waveforms
 * select units and associated waveforms
 
-The default format (:code:`mode='folder'`) which waveforms are saved to a folder structure with waveforms as
+In the default format (:code:`mode='folder'`) waveforms are saved to a folder structure with waveforms as
 :code:`.npy` files.
 In addition, waveforms can also be extracted in-memory for fast computations (:code:`mode='memory'`).
 Note that this mode can quickly fill up your RAM... Use it wisely!
@@ -217,8 +217,8 @@ Finally, an existing :py:class:`~spikeinterface.core.WaveformExtractor` can be s
     we_loaded = load_waveforms(folder="waveforms")
 
     # retrieve waveforms and templates for a unit
-    waveforms0 = we.get_waveforms(unit0)
-    template0 = we.get_template(unit0)
+    waveforms0 = we.get_waveforms(unit_id=unit0)
+    template0 = we.get_template(unit_id=unit0)
 
     # compute template standard deviations (average is computed by default)
     # (this can also be done within the 'extract_waveforms')
@@ -393,8 +393,8 @@ probes, such as Neuropixels, because the waveforms of a unit will only appear on
 Sparsity is defined as the subset of channels on which waveforms (and related information) are defined. Of course,
 sparsity is not global, but it is unit-specific.
 
-**NOTE** As of version :code:`0.99.0` the default for a :code:`extract_waveforms()` has `sparse=True`, ie every :code:`waveform_extractor`
-will be sparse by default. Thus for users that wish to have dense waveforms they must set `sparse=False`. Keyword arguments
+**NOTE** As of version :code:`0.99.0` the default for a :code:`extract_waveforms()` has :code:`sparse=True`, i.e. every :code:`waveform_extractor`
+will be sparse by default. Thus for users that wish to have dense waveforms they must set :code:`sparse=False`. Keyword arguments
 can still be input into the :code:`extract_wavforms()` to generate the desired sparsity as explained below.
 
 Sparsity can be computed from a :py:class:`~spikeinterface.core.WaveformExtractor` object with the
@@ -429,7 +429,7 @@ The computed sparsity can be used in several postprocessing and visualization fu
 
 .. code-block:: python
 
-    we_sparse = we.save(waveform_extractor=we, sparsity=sparsity, folder="waveforms_sparse")
+    we_sparse = we.save(sparsity=sparsity, folder="waveforms_sparse")
 
 The :code:`we_sparse` object will now have an associated sparsity (:code:`we.sparsity`), which is automatically taken
 into consideration for downstream analysis (with the :py:meth:`~spikeinterface.core.WaveformExtractor.is_sparse`
@@ -549,7 +549,7 @@ In order to do this, one can use the :code:`Numpy*` classes, :py:class:`~spikein
 but they are not bound to a file.
 
 Also note the class :py:class:`~spikeinterface.core.SharedMemorySorting` which is very similar to
-Similar to :py:class:`~spikeinterface.core.NumpySorting` but with an underlying SharedMemory which is useful for
+:py:class:`~spikeinterface.core.NumpySorting` but with an underlying SharedMemory which is useful for
 parallel computing.
 
 In this example, we create a recording and a sorting object from numpy objects:
@@ -603,14 +603,14 @@ Manipulating objects: slicing, aggregating
 :py:class:`~spikeinterface.core.BaseRecording` (and :py:class:`~spikeinterface.core.BaseSnippets`)
 and :py:class:`~spikeinterface.core.BaseSorting` objects can be sliced on the time or channel/unit axis.
 
-This operations are completely lazy, as there is no data duplication. After slicing or aggregating,
-the new objects will be a *view* of the original ones.
+These operations are completely lazy, as there is no data duplication. After slicing or aggregating,
+the new objects will be *views* of the original ones.
 
 .. code-block:: python
 
     # here we load a very long recording and sorting
-    recording = read_spikeglx('np_folder')
-    sorting =read_kilosort('ks_folder')
+    recording = read_spikeglx(folder_path='np_folder')
+    sorting =read_kilosort(folder_path='ks_folder')
 
     # keep one channel of every tenth channel
     keep_ids = recording.channel_ids[::10]

--- a/doc/modules/curation.rst
+++ b/doc/modules/curation.rst
@@ -98,7 +98,7 @@ The manual curation (including merges and labels) can be applied to a SpikeInter
     from spikeinterface.widgets import plot_sorting_summary
 
     # run a sorter and export waveforms
-    sorting = run_sorter(sorter_name'kilosort2', recording=recording)
+    sorting = run_sorter(sorter_name='kilosort2', recording=recording)
     we = extract_waveforms(recording=recording, sorting=sorting, folder='wf_folder')
 
     # some postprocessing is required

--- a/doc/modules/motion_correction.rst
+++ b/doc/modules/motion_correction.rst
@@ -8,8 +8,8 @@ Overview
 --------
 
 Mechanical drift, often observed in recordings, is currently a major issue for spike sorting. This is especially striking
-with the new generation of high-density devices used for in-vivo electrophyisology such as the neuropixel electrodes.
-The first sorter that has introduced motion/drift correction as a prepossessing step was Kilosort2.5 (see [Steinmetz2021]_ [SteinmetzDataset]_)
+with the new generation of high-density devices used for in-vivo electrophysiology such as the neuropixel electrodes.
+The first sorter that introduced motion/drift correction as a prepossessing step was Kilosort2.5 (see [Steinmetz2021]_ [SteinmetzDataset]_)
 
 Long story short, the main idea is the same as the one used for non-rigid image registration, for example with calcium
 imaging. However, because with extracellular recording we do not have a proper image to use as a reference, the main idea
@@ -18,7 +18,7 @@ activity profile should be kept constant over time, the motion can be estimated,
 (i.e. depth) so that we can interpolate the traces to compensate for this estimated motion.
 Users with a need to handle drift were currently forced to stick to the use of Kilosort2.5 or pyKilosort (see [Pachitariu2023]_). Recently, the Paninski
 group from Columbia University introduced a possibly more accurate method to estimate the drift (see [Varol2021]_
-and [Windolf2023]_), but this new method was not properly integrated into any sorter.
+and [Windolf2023]_), but this new method has not yet been integrated into any sorter.
 
 Because motion registration is a hard topic, with numerous hypotheses and/or implementations details that might have a large
 impact on the spike sorting performances (see [Garcia2023]_), in SpikeInterface, we developed a full motion estimation
@@ -28,7 +28,7 @@ then used for any sorter!** In short, the motion correction is decoupled from th
 
 This gives the user an incredible flexibility to check/test and correct the drift before the sorting process.
 
-Here is an overview of the motion correction as a preprocessing:
+Here is an overview of motion correction as part of preprocessing a recording:
 
 .. image:: ../images/motion_correction_overview.png
   :align: center
@@ -39,7 +39,7 @@ The motion correction process can be split into 3 steps:
   2. **motion inference**: estimate the drift motion (by spatial blocks for non-rigid motion)
   3. **motion interpolation**: interpolate traces using the estimated motion
 
-For every steps, we implemented several methods. The combination of the yellow boxes should give more or less what
+For each step, we have implemented several methods. The combination of the yellow boxes should give more or less what
 Kilosort2.5/3 is doing. Similarly, the combination of the green boxes gives the method developed by the Paninski group.
 Of course the end user can combine any of these methods to get the best motion correction possible.
 This also makes an incredible framework for testing new ideas.
@@ -70,7 +70,7 @@ We currently have 3 presets:
                       Note that, in this case the drift is considered as "rigid" over the electrode.
   * **"kilosort_like"**: It consists of *grid convolution + iterative_template + kriging*, to mimic what is done in Kilosort (see [Pachitariu2023]_).
                          Note that this is not exactly 100% what Kilosort is doing, because the peak detection is done with a template matching
-                         in Kilosort, while in SpikeInterface we used a threshold-based method. However, this "preset" gives similar
+                         in Kilosort, while in SpikeInterface we use a threshold-based method. However, this "preset" gives similar
                          results to Kilosort2.5.
 
 
@@ -117,7 +117,7 @@ Optionally any parameter from the preset can be overwritten:
                                    )
 
 Importantly, all the result and intermediate computations can be saved into a folder for further loading
-and checking. The folder will contain the motion vector itself of course but also detected peaks, peak location, and more.
+and verification. The folder will contain the motion vector itself of course but also detected peaks, peak location, and more.
 
 
 .. code-block:: python

--- a/doc/modules/postprocessing.rst
+++ b/doc/modules/postprocessing.rst
@@ -56,6 +56,9 @@ We can also delete an extension:
 
 
 
+Finally, the waveform extensions can be loaded rather than recalculated by using the :code:`load_if_exists` argument in
+any post-processing function.
+
 Available postprocessing extensions
 -----------------------------------
 
@@ -67,6 +70,11 @@ As an extension, this expects the :code:`WaveformExtractor` as input and the com
 
 The :py:func:`~spikeinterface.core.get_noise_levels(recording)` computes the same values, but starting from a recording
 and without saving the data as an extension.
+
+
+.. code-block:: python
+
+    noise = compute_noise_level(waveform_extractor=we)
 
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_noise_levels`
@@ -85,6 +93,12 @@ This extension computes the principal components of the waveforms. There are sev
 If the input :code:`WaveformExtractor` is sparse, the sparsity is used when computing the PCA.
 For dense waveforms, sparsity can also be passed as an argument.
 
+.. code-block:: python
+
+    pc = compute_principal_components(waveform_extractor=we,
+                                 n_components=3,
+                                 mode="by_channel_local")
+
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_principal_components`
 
 template_similarity
@@ -95,6 +109,10 @@ This extension computes the similarity of the templates to each other. This info
 merging. Currently, the only available similarity method is the cosine similarity, which is the angle between the
 high-dimensional flattened template arrays. Note that cosine similarity does not take into account amplitude differences
 and is not well suited for high-density probes.
+
+.. code-block:: python
+
+    similarity = compute_template_similarity(waveform_extractor=we, method='cosine_similarity')
 
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_template_similarity`
@@ -110,6 +128,12 @@ each spike.
 **NOTE:** computing spike amplitudes is highly recommended before calculating amplitude-based quality metrics, such as
 :ref:`amp_cutoff` and :ref:`amp_median`.
 
+.. code-block:: python
+
+    amplitudes = computer_spike_amplitudes(waveform_extractor=we,
+                                           peak_sign="neg",
+                                           outputs="concatenated")
+
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_spike_amplitudes`
 
 
@@ -117,11 +141,24 @@ spike_locations
 ^^^^^^^^^^^^^^^
 
 
-This extension estimates the location of each spike in the sorting output. Spike location estimates can be done either
-with center of mass (:code:`method="center_of_mass"` - fast, but less accurate), or using a monopolar triangulation
-(:code:`method="monopolar_triangulation"` - slow, but more accurate).
+This extension estimates the location of each spike in the sorting output. Spike location estimates can be done
+with center of mass (:code:`method="center_of_mass"` - fast, but less accurate), a monopolar triangulation
+(:code:`method="monopolar_triangulation"` - slow, but more accurate), or with the method of grid convolution
+(:code:`method="grid_convolution"`)
 
 **NOTE:** computing spike locations is required to compute :ref:`drift_metrics`.
+
+.. code-block:: python
+
+    spike_locations = compute_spike_locations(waveform_extractor=we,
+                                              ms_before=0.5,
+                                              ms_after=0.5,
+                                              spike_retriever_kwargs=dict(
+                                                  channel_from_template=True,
+                                                  radius_um=50,
+                                                  peak_sign="neg"
+                                              ),
+                                              method="center_of_mass")
 
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_spike_locations`
@@ -133,7 +170,13 @@ unit_locations
 
 This extension is similar to the :code:`spike_locations`, but instead of estimating a location for each spike
 based on individual waveforms, it calculates at the unit level using templates. The same localization methods
-(:code:`method="center_of_mass" | "monopolar_triangulation"`) are available.
+(:code:`method="center_of_mass" | "monopolar_triangulation" | "grid_convolution"`) are available.
+
+
+.. code-block:: python
+
+    unit_locations = compute_unit_locations(waveform_extractor=we,
+                                            method="monopolar_triangulation")
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_unit_locations`
 
@@ -149,6 +192,16 @@ By default, the following metrics are computed:
 * "peak_to_trough_ratio": ratio between negative and positive peaks
 * "recovery_slope": speed in V/s to recover from the negative peak to 0
 * "repolarization_slope": speed in V/s to repolarize from the positive peak to 0
+* "num_positive_peaks": the number of positive peaks
+* "num_negative_peaks": the number of negative peaks
+
+Optionally, the following multi-channel metrics can be computed by setting:
+:code:`include_multi_channel_metrics=True`
+
+* "velocity_above": the velocity above the max channel of the template
+* "velocity_below": the velocity below the max channel of the template
+* "exp_decay": the exponential decay of the template amplitude over distance
+* "spread": the spread of the template amplitude over distance
 
 .. figure:: ../images/1d_waveform_features.png
 
@@ -164,6 +217,13 @@ correlograms
 This extension computes correlograms (both auto- and cross-) for spike trains. The computed output is a 3d array
 with shape (num_units, num_units, num_bins) with all correlograms for each pair of units (diagonals are auto-correlograms).
 
+.. code-block:: python
+
+    ccgs, bins = compute_correlograms(waveform_or_sorting_extractor=we,
+                                      window_ms=50.0,
+                                      bin_ms=1.0,
+                                      method="auto")
+
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_correlograms`
 
 
@@ -172,6 +232,14 @@ isi_histograms
 
 This extension computes the histograms of inter-spike-intervals. The computed output is a 2d array with shape
 (num_units, num_bins), with the isi histogram of each unit.
+
+
+.. code-block:: python
+
+    isi_histogram, bins =  compute_isi_histograms(waveform_or_sorting_extractor=we,
+                                                  window_ms=50.0,
+                                                  bin_ms=1.0,
+                                                  method="auto")
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_isi_histograms`
 

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -38,7 +38,7 @@ save the object:
 .. code-block:: python
 
     # here the spykingcircus2 sorter engine directly uses the lazy "recording_cmr" object
-    sorting = run_sorter(recording=recording_cmr, sorter_name='spykingcircus2')
+    sorting = run_sorter(sorter='spykingcircus2', recording=recording_cmr, sorter_name='spykingcircus2')
 
 Most of the external sorters, however, will need a binary file as input, so we can optionally save the processed
 recording with the efficient SpikeInterface :code:`save()` function:
@@ -315,7 +315,6 @@ Motion/drift correction
 
 Motion/drift correction is one of the most sophisticated preprocessing. See the :ref:`motion_correction` page for a full
 explanation.
-
 
 
 

--- a/doc/modules/qualitymetrics/sd_ratio.rst
+++ b/doc/modules/qualitymetrics/sd_ratio.rst
@@ -31,6 +31,11 @@ Example code
 	sd_ratio = sqm.compute_sd_ratio(wvf_extractor, censored_period_ms=4.0)
 
 
+References
+----------
+
+.. autofunction:: spikeinterface.qualitymetrics.misc_metrics.compute_sd_ratio
+
 Literature
 ----------
 

--- a/doc/modules/sorters.rst
+++ b/doc/modules/sorters.rst
@@ -51,7 +51,7 @@ to easily run spike sorters:
     # run Tridesclous
     sorting_TDC = run_sorter(sorter_name="tridesclous", recording=recording, output_folder="/folder_TDC")
     # run Kilosort2.5
-    sorting_KS2_5 = run_sorter(sorter_name="kilosort2_5", recording=recording, output_folder="/folder_KS2.5")
+    sorting_KS2_5 = run_sorter(sorter_name="kilosort2_5", recording=recording, output_folder="/folder_KS2_5")
     # run IronClust
     sorting_IC = run_sorter(sorter_name="ironclust", recording=recording, output_folder="/folder_IC")
     # run pyKilosort
@@ -84,7 +84,7 @@ Spike-sorter-specific parameters can be controlled directly from the
     sorting_TDC = run_sorter(sorter_name='tridesclous', recording=recording, output_folder="/folder_TDC",
                              detect_threshold=8.)
 
-    sorting_KS2_5 = run_sorter(sorter_name="kilosort2_5", recording=recording, output_folder="/folder_KS2.5"
+    sorting_KS2_5 = run_sorter(sorter_name="kilosort2_5", recording=recording, output_folder="/folder_KS2_5"
                                do_correction=False, preclust_threshold=6, freq_min=200.)
 
 
@@ -92,10 +92,10 @@ Parameters from all sorters can be retrieved with these functions:
 
 .. code-block:: python
 
-    params = get_default_sorter_params('spykingcircus')
+    params = get_default_sorter_params(sorter_name_or_class='spykingcircus')
     print("Parameters:\n", params)
 
-    desc = get_sorter_params_description('spykingcircus')
+    desc = get_sorter_params_description(sorter_name_or_class='spykingcircus')
     print("Descriptions:\n", desc)
 
 .. parsed-literal::
@@ -163,7 +163,7 @@ need to be installed. Only NVIDIA GPUs are supported for now.
 
 
 For Docker users, you can either install `Docker Desktop <https://www.docker.com/products/docker-desktop/>`_
-(recommended for Windows and MacOS) or the `Docker Engine  <https://docs.docker.com/engine/install/ubuntu/>`_
+(recommended for Windows and MacOS) or `Docker Engine  <https://docs.docker.com/engine/install/ubuntu/>`_
 (recommended for Linux).
 To enable :code:`Docker Desktop` to download the containers, you need to create an account on
 `DockerHub <https://hub.docker.com/>`_ (free) and perform the login in :code:`Docker Desktop`.
@@ -246,7 +246,7 @@ There are three options:
 3. **local copy**: if you installed :code:`spikeinterface` from source and you have some changes in your branch or fork
    that are not in the :code:`main` branch, you can install a copy of your :code:`spikeinterface` package in the container.
    To do so, you need to set en environment variable :code:`SPIKEINTERFACE_DEV_PATH` to the location where you cloned the
-   :code:`spikeinterface` repo (e.g. on Linux: :code:`export SPIKEINTERFACE_DEV_PATH="path-to-spikeinterface-clone"`.
+   :code:`spikeinterface` repo (e.g. on Linux: :code:`export SPIKEINTERFACE_DEV_PATH="path-to-spikeinterface-clone"`).
 
 In all cases, the :code:`[full]` extra is installed, which includes all optional dependencies.
 
@@ -450,31 +450,31 @@ versions.
 
 Here is the list of external sorters accessible using the run_sorter wrapper:
 
-* **HerdingSpikes2** :code:`run_sorter('herdingspikes')`
-* **IronClust** :code:`run_sorter('ironclust')`
-* **Kilosort**  :code:`run_sorter('kilosort')`
-* **Kilosort2** :code:`run_sorter('kilosort2')`
-* **Kilosort2.5** :code:`run_sorter('kilosort2_5')`
-* **Kilosort3** :code:`run_sorter('kilosort3')`
-* **PyKilosort** :code:`run_sorter('pykilosort')`
-* **Klusta** :code:`run_sorter('klusta')`
-* **Mountainsort4** :code:`run_sorter('mountainsort4')`
-* **Mountainsort5** :code:`run_sorter('mountainsort5')`
-* **SpyKING Circus** :code:`run_sorter('spykingcircus')`
-* **Tridesclous** :code:`run_sorter('tridesclous')`
-* **Wave clus** :code:`run_sorter('waveclus')`
-* **Combinato** :code:`run_sorter('combinato')`
-* **HDSort** :code:`run_sorter('hdsort')`
-* **YASS** :code:`run_sorter('yass')`
+* **HerdingSpikes2** :code:`run_sorter(sorter_name='herdingspikes')`
+* **IronClust** :code:`run_sorter(sorter_name='ironclust')`
+* **Kilosort**  :code:`run_sorter(sorter_name='kilosort')`
+* **Kilosort2** :code:`run_sorter(sorter_name='kilosort2')`
+* **Kilosort2.5** :code:`run_sorter(sorter_name='kilosort2_5')`
+* **Kilosort3** :code:`run_sorter(sorter_name='kilosort3')`
+* **PyKilosort** :code:`run_sorter(sorter_name='pykilosort')`
+* **Klusta** :code:`run_sorter(sorter_name='klusta')`
+* **Mountainsort4** :code:`run_sorter(sorter_name='mountainsort4')`
+* **Mountainsort5** :code:`run_sorter(sorter_name='mountainsort5')`
+* **SpyKING Circus** :code:`run_sorter(sorter_name='spykingcircus')`
+* **Tridesclous** :code:`run_sorter(sorter_name='tridesclous')`
+* **Wave clus** :code:`run_sorter(sorter_name='waveclus')`
+* **Combinato** :code:`run_sorter(sorter_name='combinato')`
+* **HDSort** :code:`run_sorter(sorter_name='hdsort')`
+* **YASS** :code:`run_sorter(sorter_name='yass')`
 
 
 Here a list of internal sorter based on `spikeinterface.sortingcomponents`; they are totally
 experimental for now:
 
-* **Spyking Circus2** :code:`run_sorter('spykingcircus2')`
-* **Tridesclous2** :code:`run_sorter('tridesclous2')`
+* **Spyking Circus2** :code:`run_sorter(sorter_name='spykingcircus2')`
+* **Tridesclous2** :code:`run_sorter(sorter_name='tridesclous2')`
 
-In 2023, we expect to add many more sorters to this list.
+In 2024, we expect to add many more sorters to this list.
 
 
 Installed Sorters

--- a/src/spikeinterface/postprocessing/correlograms.py
+++ b/src/spikeinterface/postprocessing/correlograms.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import math
 import warnings
 import numpy as np
@@ -139,7 +140,7 @@ def compute_correlograms(
     load_if_exists=False,
     window_ms: float = 50.0,
     bin_ms: float = 1.0,
-    method: str = "auto",
+    method: "auto" | "numpy" | "numba" = "auto",
 ):
     """Compute auto and cross correlograms.
 
@@ -161,7 +162,7 @@ def compute_correlograms(
     ccgs : np.array
         Correlograms with shape (num_units, num_units, num_bins)
         The diagonal of ccgs is the auto correlogram.
-        ccgs[A, B, :] is the symetrie of ccgs[B, A, :]
+        ccgs[A, B, :] is the symmetry of ccgs[B, A, :]
         ccgs[A, B, :] have to be read as the histogram of spiketimesA - spiketimesB
     bins :  np.array
         The bin edges in ms
@@ -302,7 +303,7 @@ def compute_correlograms_numba(sorting, window_size, bin_size):
     Implementation: Aurélien Wyngaard
     """
 
-    assert HAVE_NUMBA
+    assert HAVE_NUMBA, "numba version of this function requires installation of numba"
 
     num_bins = 2 * int(window_size / bin_size)
     num_units = len(sorting.unit_ids)

--- a/src/spikeinterface/postprocessing/principal_component.py
+++ b/src/spikeinterface/postprocessing/principal_component.py
@@ -711,7 +711,7 @@ def compute_principal_components(
     ----------
     waveform_extractor: WaveformExtractor
         The waveform extractor
-    load_if_exists: bool
+    load_if_exists: bool, default: False
         If True and pc scores are already in the waveform extractor folders, pc scores are loaded and not recomputed.
     n_components: int, default: 5
         Number of components fo PCA
@@ -744,7 +744,7 @@ def compute_principal_components(
     Examples
     --------
     >>> we = si.extract_waveforms(recording, sorting, folder='waveforms')
-    >>> pc = st.compute_principal_components(we, n_components=3, mode='by_channel_local')
+    >>> pc = si.compute_principal_components(we, n_components=3, mode='by_channel_local')
     >>> # get pre-computed projections for unit_id=1
     >>> projections = pc.get_projections(unit_id=1)
     >>> # get all pre-computed projections and labels

--- a/src/spikeinterface/postprocessing/spike_amplitudes.py
+++ b/src/spikeinterface/postprocessing/spike_amplitudes.py
@@ -150,7 +150,7 @@ def compute_spike_amplitudes(
         Whether to load precomputed spike amplitudes, if they already exist.
     peak_sign: "neg" | "pos" | "both", default: "neg
         The sign to compute maximum channel
-    return_scaled: bool
+    return_scaled: bool, deafult: True
         If True and recording has gain_to_uV/offset_to_uV properties, amplitudes are converted to uV.
     outputs: "concatenated" | "by_unit", default: "concatenated"
         How the output should be returned

--- a/src/spikeinterface/sortingcomponents/peak_localization.py
+++ b/src/spikeinterface/sortingcomponents/peak_localization.py
@@ -304,7 +304,7 @@ class LocalizeMonopolarTriangulation(PipelineNode):
 
 
 class LocalizeGridConvolution(PipelineNode):
-    """Localize peaks using convlution with a grid of fake templates
+    """Localize peaks using convolution with a grid of fake templates
 
     Notes
     -----
@@ -314,19 +314,19 @@ class LocalizeGridConvolution(PipelineNode):
     need_waveforms = True
     name = "grid_convolution"
     params_doc = """
-    radius_um: float
+    radius_um: float, default: 40.0
         Radius in um for channel sparsity.
-    upsampling_um: float
+    upsampling_um: float, default: 5.0
         Upsampling resolution for the grid of templates
-    sigma_um: np.array
+    sigma_um: np.array, default: np.linspace(5.0, 25.0, 5)
         Spatial decays of the fake templates
-    sigma_ms: float
+    sigma_ms: float, default: 0.25
         The temporal decay of the fake templates
-    margin_um: float
+    margin_um: float, default: 50.0
         The margin for the grid of fake templates
-    prototype: np.array
+    prototype: np.array | None, default: None
         Fake waveforms for the templates. If None, generated as Gaussian
-    percentile: float, default: 5
+    percentile: float, default: 5.0
         The percentage in [0, 100] of the best scalar products kept to
         estimate the position
     sparsity_threshold: float, default: 0.01


### PR DESCRIPTION
Figured I would do another pass before the next release.

In this PR:

1) removed reference to `run_xxxx` in dev docs since that has been removed
2) added short examples in postprocessing since preprocessing already had that format
3) removed some sphinx links inside of code blocks since those cannot be rendered
4) add some more missing kw arguments
5) typos fixes