### PR TITLE
Add version limit to `threadpoolctl`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 dependencies = [
     "numpy",
-    "threadpoolctl",
+    "threadpoolctl>=3.0.0",
     "tqdm",
     "zarr",
     "neo>=0.12.0",


### PR DESCRIPTION
See associated issue #2412, but base Anaconda ships with 2.2.0. 

The short story: < 3 can have some issues that can break parallel processing for users (see https://github.com/SpikeInterface/spikeinterface/issues/2401 and https://github.com/SpikeInterface/spikeinterface/issues/2310).

This PR just sets that limit at 3.0.0.

(Fixes #2412 , Fixes #2401, Fixes #2310)