### PR TITLE
Fixed parent spike_vector bug

### DIFF
--- a/src/spikeinterface/core/tests/test_unitsselectionsorting.py
+++ b/src/spikeinterface/core/tests/test_unitsselectionsorting.py
@@ -41,12 +41,11 @@ def test_failure_with_non_unique_unit_ids():
 def test_custom_cache_spike_vector():
     sorting = generate_sorting(num_units=3, durations=[0.100, 0.100], sampling_frequency=30000.0)
 
-    sub_sorting = UnitsSelectionSorting(sorting, unit_ids=[0, 2], renamed_unit_ids=["b", "a"])
-    spike_vector = sub_sorting.to_spike_vector(use_cache=False)
+    sub_sorting = UnitsSelectionSorting(sorting, unit_ids=[2, 0], renamed_unit_ids=["b", "a"])
+    cached_spike_vector = sorting.to_spike_vector(use_cache=True)
+    computed_spike_vector = sub_sorting.to_spike_vector(use_cache=False)
 
-    sorting.to_spike_vector(use_cache=True)
-    sub_sorting._custom_cache_spike_vector()
-    assert np.all(spike_vector == sub_sorting._cached_spike_vector)
+    assert np.all(cached_spike_vector == computed_spike_vector)
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/core/tests/test_unitsselectionsorting.py
+++ b/src/spikeinterface/core/tests/test_unitsselectionsorting.py
@@ -42,9 +42,8 @@ def test_custom_cache_spike_vector():
     sorting = generate_sorting(num_units=3, durations=[0.100, 0.100], sampling_frequency=30000.0)
 
     sub_sorting = UnitsSelectionSorting(sorting, unit_ids=[2, 0], renamed_unit_ids=["b", "a"])
-    cached_spike_vector = sorting.to_spike_vector(use_cache=True)
+    cached_spike_vector = sub_sorting.to_spike_vector(use_cache=True)
     computed_spike_vector = sub_sorting.to_spike_vector(use_cache=False)
-
     assert np.all(cached_spike_vector == computed_spike_vector)
 
 

--- a/src/spikeinterface/core/unitsselectionsorting.py
+++ b/src/spikeinterface/core/unitsselectionsorting.py
@@ -55,13 +55,15 @@ class UnitsSelectionSorting(BaseSorting):
 
         parent_spike_vector = self._parent_sorting._cached_spike_vector
         parent_unit_indices = self._parent_sorting.ids_to_indices(self._unit_ids)
+        sort_indices = np.argsort(parent_unit_indices)
         mask = np.isin(parent_spike_vector["unit_index"], parent_unit_indices)
         spike_vector = np.array(
             parent_spike_vector[mask]
         )  # np.array() necessary to fix 'read-only' crash with memmaps.
-        spike_vector["unit_index"] = np.searchsorted(
-            parent_unit_indices, spike_vector["unit_index"]
+        indices = np.searchsorted(
+            parent_unit_indices, spike_vector["unit_index"], sorter=sort_indices
         )  # Trick to make sure that the new indices are correct.
+        spike_vector["unit_index"] = np.arange(len(parent_unit_indices))[sort_indices][indices]
 
         self._cached_spike_vector = spike_vector
 

--- a/src/spikeinterface/curation/remove_excess_spikes.py
+++ b/src/spikeinterface/curation/remove_excess_spikes.py
@@ -53,12 +53,13 @@ class RemoveExcessSpikesSorting(BaseSorting):
                 return
 
         parent_spike_vector = self._parent_sorting._cached_spike_vector
+        num_segments = self._parent_sorting.get_num_segments()
 
         list_spike_vectors = []
         segments_bounds = np.searchsorted(
-            parent_spike_vector["segment_index"], np.arange(2 + parent_spike_vector["segment_index"][-1])
+            parent_spike_vector["segment_index"], np.arange(1 + num_segments)
         )
-        for segment_index in range(1 + parent_spike_vector["segment_index"][-1]):
+        for segment_index in range(num_segments):
             spike_vector = parent_spike_vector[segments_bounds[segment_index] : segments_bounds[segment_index + 1]]
             end = np.searchsorted(spike_vector["sample_index"], self._num_samples[segment_index])
             list_spike_vectors.append(spike_vector[:end])

--- a/src/spikeinterface/curation/remove_excess_spikes.py
+++ b/src/spikeinterface/curation/remove_excess_spikes.py
@@ -56,9 +56,9 @@ class RemoveExcessSpikesSorting(BaseSorting):
 
         list_spike_vectors = []
         segments_bounds = np.searchsorted(
-            parent_spike_vector["segment_index"], np.arange(1 + parent_spike_vector["segment_index"][-1])
+            parent_spike_vector["segment_index"], np.arange(2 + parent_spike_vector["segment_index"][-1])
         )
-        for segment_index in range(parent_spike_vector["segment_index"][-1]):
+        for segment_index in range(1 + parent_spike_vector["segment_index"][-1]):
             spike_vector = parent_spike_vector[segments_bounds[segment_index] : segments_bounds[segment_index + 1]]
             end = np.searchsorted(spike_vector["sample_index"], self._num_samples[segment_index])
             list_spike_vectors.append(spike_vector[:end])

--- a/src/spikeinterface/curation/remove_excess_spikes.py
+++ b/src/spikeinterface/curation/remove_excess_spikes.py
@@ -56,9 +56,7 @@ class RemoveExcessSpikesSorting(BaseSorting):
         num_segments = self._parent_sorting.get_num_segments()
 
         list_spike_vectors = []
-        segments_bounds = np.searchsorted(
-            parent_spike_vector["segment_index"], np.arange(1 + num_segments)
-        )
+        segments_bounds = np.searchsorted(parent_spike_vector["segment_index"], np.arange(1 + num_segments))
         for segment_index in range(num_segments):
             spike_vector = parent_spike_vector[segments_bounds[segment_index] : segments_bounds[segment_index + 1]]
             end = np.searchsorted(spike_vector["sample_index"], self._num_samples[segment_index])


### PR DESCRIPTION
Fixed a bug introduced in #2353 where the spike vector would be wrong if the given unit_ids were non ordered.