### PR TITLE
Add bit depth compensation to unsigned_to_signed

### DIFF
--- a/src/spikeinterface/preprocessing/tests/test_unsigned_to_signed.py
+++ b/src/spikeinterface/preprocessing/tests/test_unsigned_to_signed.py
@@ -16,13 +16,19 @@ def test_unsigned_to_signed():
     traces_uint16 = traces.astype("uint16")
     traces = rng.rand(10000, 4) * 100 + 2**31
     traces_uint32 = traces.astype("uint32")
+    traces = rng.rand(10000, 4) * 100 + 2**11
+    traces_uint16_12bits = traces.astype("uint16")
     rec_uint16 = NumpyRecording(traces_uint16, sampling_frequency=30000)
     rec_uint32 = NumpyRecording(traces_uint32, sampling_frequency=30000)
+    rec_uint16_12bits = NumpyRecording(traces_uint16_12bits, sampling_frequency=30000)
 
     traces_int16 = (traces_uint16.astype("int32") - 2**15).astype("int16")
     np.testing.assert_array_equal(traces_int16, unsigned_to_signed(rec_uint16).get_traces())
     traces_int32 = (traces_uint32.astype("int64") - 2**31).astype("int32")
     np.testing.assert_array_equal(traces_int32, unsigned_to_signed(rec_uint32).get_traces())
+    traces_int16_12bits = (traces_uint16_12bits.astype("int32") - 2**11).astype("int16")
+    np.testing.assert_array_equal(traces_int16_12bits, 
+                                  unsigned_to_signed(rec_uint16_12bits, bit_depth=12).get_traces())
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/preprocessing/tests/test_unsigned_to_signed.py
+++ b/src/spikeinterface/preprocessing/tests/test_unsigned_to_signed.py
@@ -27,8 +27,7 @@ def test_unsigned_to_signed():
     traces_int32 = (traces_uint32.astype("int64") - 2**31).astype("int32")
     np.testing.assert_array_equal(traces_int32, unsigned_to_signed(rec_uint32).get_traces())
     traces_int16_12bits = (traces_uint16_12bits.astype("int32") - 2**11).astype("int16")
-    np.testing.assert_array_equal(traces_int16_12bits, 
-                                  unsigned_to_signed(rec_uint16_12bits, bit_depth=12).get_traces())
+    np.testing.assert_array_equal(traces_int16_12bits, unsigned_to_signed(rec_uint16_12bits, bit_depth=12).get_traces())
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/preprocessing/unsigned_to_signed.py
+++ b/src/spikeinterface/preprocessing/unsigned_to_signed.py
@@ -8,6 +8,7 @@ from .filter import fix_dtype
 class UnsignedToSignedRecording(BasePreprocessor):
     """
     Converts a recording with unsigned traces to a signed one.
+    
     Parameters
     ----------
     recording: Recording

--- a/src/spikeinterface/preprocessing/unsigned_to_signed.py
+++ b/src/spikeinterface/preprocessing/unsigned_to_signed.py
@@ -15,17 +15,18 @@ class UnsignedToSignedRecording(BasePreprocessor):
     def __init__(
         self,
         recording,
+        bit_depth=None,
     ):
         dtype = np.dtype(recording.dtype)
         assert dtype.kind == "u", "Recording is not unsigned!"
         itemsize = dtype.itemsize
         assert itemsize < 8, "Cannot convert uint64 to int64."
-        dtype_signed = dtype.str.replace("uint", "int")
+        dtype_signed = dtype.name.replace("uint", "int")
 
         BasePreprocessor.__init__(self, recording, dtype=dtype_signed)
 
         for parent_segment in recording._recording_segments:
-            rec_segment = UnsignedToSignedRecordingSegment(parent_segment, dtype_signed)
+            rec_segment = UnsignedToSignedRecordingSegment(parent_segment, dtype_signed, bit_depth)
             self.add_recording_segment(rec_segment)
 
         self._kwargs = dict(
@@ -34,9 +35,10 @@ class UnsignedToSignedRecording(BasePreprocessor):
 
 
 class UnsignedToSignedRecordingSegment(BasePreprocessorSegment):
-    def __init__(self, parent_recording_segment, dtype_signed):
+    def __init__(self, parent_recording_segment, dtype_signed, bit_depth):
         BasePreprocessorSegment.__init__(self, parent_recording_segment)
         self.dtype_signed = dtype_signed
+        self.bit_depth = bit_depth
 
     def get_traces(self, start_frame, end_frame, channel_indices):
         if channel_indices is None:
@@ -46,7 +48,11 @@ class UnsignedToSignedRecordingSegment(BasePreprocessorSegment):
         traces_dtype = traces.dtype
         nbits = traces_dtype.itemsize * 8
         signed_dtype = f"int{2 * (traces_dtype.itemsize) * 8}"
-        offset = 2 ** (nbits - 1)
+        if self.bit_depth is not None:
+            offset = 2 ** (self.bit_depth - 1)
+        else:
+            # offset = 2 ** (nbits - 1)
+            offset = 0
         # upcast to int with double itemsize
         traces = traces.astype(signed_dtype, copy=False) - offset
         return traces.astype(self.dtype_signed, copy=False)

--- a/src/spikeinterface/preprocessing/unsigned_to_signed.py
+++ b/src/spikeinterface/preprocessing/unsigned_to_signed.py
@@ -8,6 +8,13 @@ from .filter import fix_dtype
 class UnsignedToSignedRecording(BasePreprocessor):
     """
     Converts a recording with unsigned traces to a signed one.
+    Parameters
+    ----------
+    recording: Recording
+        The recording to be signed.
+    bit_depth: int or None, default: None
+        In case the bit depth of the ADC does not match that of the data type,
+        specifying the bit depth corrects the offset.
     """
 
     name = "unsigned_to_signed"
@@ -46,13 +53,12 @@ class UnsignedToSignedRecordingSegment(BasePreprocessorSegment):
         traces = self.parent_recording_segment.get_traces(start_frame, end_frame, channel_indices)
         # if uint --> take care of offset
         traces_dtype = traces.dtype
-        nbits = traces_dtype.itemsize * 8
-        signed_dtype = f"int{2 * (traces_dtype.itemsize) * 8}"
         if self.bit_depth is not None:
-            offset = 2 ** (self.bit_depth - 1)
+            nbits = self.bit_depth
         else:
-            # offset = 2 ** (nbits - 1)
-            offset = 0
+            nbits = traces_dtype.itemsize * 8
+        signed_dtype = f"int{2 * (traces_dtype.itemsize) * 8}"
+        offset = 2 ** (nbits - 1)
         # upcast to int with double itemsize
         traces = traces.astype(signed_dtype, copy=False) - offset
         return traces.astype(self.dtype_signed, copy=False)

--- a/src/spikeinterface/preprocessing/unsigned_to_signed.py
+++ b/src/spikeinterface/preprocessing/unsigned_to_signed.py
@@ -8,7 +8,7 @@ from .filter import fix_dtype
 class UnsignedToSignedRecording(BasePreprocessor):
     """
     Converts a recording with unsigned traces to a signed one.
-    
+
     Parameters
     ----------
     recording: Recording

--- a/src/spikeinterface/preprocessing/unsigned_to_signed.py
+++ b/src/spikeinterface/preprocessing/unsigned_to_signed.py
@@ -15,7 +15,8 @@ class UnsignedToSignedRecording(BasePreprocessor):
         The recording to be signed.
     bit_depth: int or None, default: None
         In case the bit depth of the ADC does not match that of the data type,
-        specifying the bit depth corrects the offset.
+        it specifies the bit depth of the ADC to estimate the offset.
+        For example, a `bit_depth` of 12 will correct for an offset of `2**11`
     """
 
     name = "unsigned_to_signed"


### PR DESCRIPTION
Circling back to NeuralEnsemble/python-neo#1348 : 

This PR, as is, returns correct traces from BioCAM recordings when processed through 
`signed_rec = spre.unsigned_to_signed(recording,bit_depth=12)`.

Looking at traces with : 
```
traces = recording.get_traces(channel_ids=['35','26','15','23','8'],
                               end_frame=4096) # Picking a few random channels
plt.plot(traces)
```
Raw  : 
![raw](https://github.com/SpikeInterface/spikeinterface/assets/83828302/0b6d177a-c11e-4775-ad3a-c9d4663993d9)

Processed : 
![processed](https://github.com/SpikeInterface/spikeinterface/assets/83828302/78edab6b-8008-48b3-8b85-14e0193a31f6)

A few questions : 

 - I'm not sure which version of numpy was around when this function was written, but on line 23 : 
 https://github.com/SpikeInterface/spikeinterface/blob/c2f18bd536437e9f500a4e24f7a0f3773bd79d3a/src/spikeinterface/preprocessing/unsigned_to_signed.py#L23
`dtype.str` now returns the data type as byte order + kind + item size, which means that `.replace("uint", "int")` does nothing and `dtype_signed` ends up being the same as `dtype`, thus traces get returned with the same data type as the raw recording.
I believe `dtype.name` behaves as expected.

 - Also might be related to numpy version, but `.astype()` does not seem to change the value of an array when doubling bit depth as in here : 
 https://github.com/SpikeInterface/spikeinterface/blob/c2f18bd536437e9f500a4e24f7a0f3773bd79d3a/src/spikeinterface/preprocessing/unsigned_to_signed.py#L47-L51

I'm not sure why substracting an offset is necessary in this situation. In fact, when looking at processed traces with the correct data type but the current offset calculations, the traces look like this : 
![offset](https://github.com/SpikeInterface/spikeinterface/assets/83828302/fd7227c7-0ef5-4c2b-a4d4-d595580165f9)
Which is about the calculated offset minus the 12 bits offset (32768 - 2048 = 30720).

 - Should the 12 bits offset compensation be on by default when open recordings through the BioCAM extractor ? Or at least some kind of warning when opening non-compensated recordings ?

 - I'm not sure in which use case this function is meant to be used, but are there any situations where having a signed data type might cause issues ?