### PR TITLE
Zarr backcompatibility: map root_path to folder_path

### DIFF
--- a/src/spikeinterface/core/zarrrecordingextractor.py
+++ b/src/spikeinterface/core/zarrrecordingextractor.py
@@ -2,4 +2,12 @@
 This file is for backwards compatibility with the old zarr extractor file structure.
 """
 
-from .zarrextractors import ZarrRecordingExtractor
+from __future__ import annotations
+
+from pathlib import Path
+from .zarrextractors import ZarrRecordingExtractor as ZarrRecordingExtractorNew
+
+
+class ZarrRecordingExtractor(ZarrRecordingExtractorNew):
+    def __init__(self, root_path: Path | str, storage_options: dict | None = None):
+        super().__init__(folder_path=root_path, storage_options=storage_options)


### PR DESCRIPTION
This PR fixes a back-compatibility issue with the Zarr extractor, since we renamed `root_path` to `folder_path`