### PR TITLE
Use `Probe` `__eq__` in Template Object `__eq__`

### DIFF
--- a/src/spikeinterface/core/template.py
+++ b/src/spikeinterface/core/template.py
@@ -209,9 +209,7 @@ class Templates:
                     return False
                 if not np.array_equal(s_field.channel_ids, o_field.channel_ids):
                     return False
-            elif isinstance(s_field, Probe):
-                # TODO implement __eq__ in probeinterface...
-                pass
+
             else:
                 if s_field != o_field:
                     return False


### PR DESCRIPTION
Uses the new developed dunder equality method of the `Probe` object:

https://github.com/SpikeInterface/probeinterface/pull/248

Requires:
https://github.com/SpikeInterface/spikeinterface/pull/2458