### PR TITLE
Use core packages on core tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,11 @@ qualitymetrics = [
 test_core = [
     "pytest",
     "psutil",
+
+    # for github test : probeinterface and neo from master
+    # for release we need pypi, so this need to be commented
+    "probeinterface @ git+https://github.com/SpikeInterface/probeinterface.git",
+    "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",
 ]
 
 test = [


### PR DESCRIPTION
After some failing tests I realized that we are not using the latest dev of probeinterface and neo on the core tests. I guess the reason was that neo does not make much sense but probeinterface does as it is tightly integrated to the core.