### PR TITLE
avoid double parsing in Plexon

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -21,7 +21,9 @@ class _NeoBaseExtractor:
     NeoRawIOClass = None
 
     def __init__(self, block_index, **neo_kwargs):
-        if not hasattr(self, "neo_reader"):  # Avoid double initialization
+
+        # Avoids double initiation of the neo reader if it was already done in the __init__ of the child class
+        if not hasattr(self, "neo_reader"):
             self.neo_reader = self.get_neo_io_reader(self.NeoRawIOClass, **neo_kwargs)
 
         if self.neo_reader.block_count() > 1 and block_index is None:

--- a/src/spikeinterface/extractors/neoextractors/plexon.py
+++ b/src/spikeinterface/extractors/neoextractors/plexon.py
@@ -32,7 +32,7 @@ class PlexonRecordingExtractor(NeoBaseRecordingExtractor):
         NeoBaseRecordingExtractor.__init__(
             self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
         )
-        self._kwargs.update({"file_path": str(Path(file_path).absolute())})
+        self._kwargs.update({"file_path": str(Path(file_path).resolve())})
 
     @classmethod
     def map_to_neo_kwargs(cls, file_path):
@@ -60,10 +60,9 @@ class PlexonSortingExtractor(NeoBaseSortingExtractor):
     def __init__(self, file_path):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
         self.neo_reader = NeoBaseSortingExtractor.get_neo_io_reader(self.NeoRawIOClass, **neo_kwargs)
-        self.neo_reader.parse_header()
         sampling_frequency = self.neo_reader._global_ssampling_rate
         NeoBaseSortingExtractor.__init__(self, sampling_frequency=sampling_frequency, **neo_kwargs)
-        self._kwargs = {"file_path": str(Path(file_path).absolute())}
+        self._kwargs = {"file_path": str(Path(file_path).resolve())}
 
     @classmethod
     def map_to_neo_kwargs(cls, file_path):


### PR DESCRIPTION
A small improvement for Plexon to avoid double parsing. This inefficiency was pointed out by @weiglszonja.

