### PR TITLE
Fix bug in `GaussianFilter`

### DIFF
--- a/src/spikeinterface/preprocessing/filter_gaussian.py
+++ b/src/spikeinterface/preprocessing/filter_gaussian.py
@@ -102,7 +102,7 @@ class GaussianFilterRecordingSegment(BasePreprocessorSegment):
         else:
             neg_factor = np.zeros((traces.shape[0],))
 
-        filtered_fft = traces_fft * (pos_factor * (1-neg_factor))[:, None]
+        filtered_fft = traces_fft * (pos_factor * (1 - neg_factor))[:, None]
         filtered_traces = np.real(np.fft.ifft(filtered_fft, axis=0))
 
         if np.issubdtype(dtype, np.integer):

--- a/src/spikeinterface/preprocessing/filter_gaussian.py
+++ b/src/spikeinterface/preprocessing/filter_gaussian.py
@@ -102,7 +102,7 @@ class GaussianFilterRecordingSegment(BasePreprocessorSegment):
         else:
             neg_factor = np.zeros((traces.shape[0],))
 
-        filtered_fft = traces_fft * (pos_factor - neg_factor)[:, None]
+        filtered_fft = traces_fft * (pos_factor * (1-neg_factor))[:, None]
         filtered_traces = np.real(np.fft.ifft(filtered_fft, axis=0))
 
         if np.issubdtype(dtype, np.integer):


### PR DESCRIPTION
Following up on the discussion we had in #2397 

Indeed there is a bug in the Gaussian filter implementation, which matters if `freq_min` and `freq_max` are close to one another, or even if the min is above the max

Here is a quick code to check for the bug:

```python
import numpy as np
import plotly.graph_objects as go
import spikeinterface.core as si
import spikeinterface.preprocessing as spre


sf = 30_000.0


# An impulse contains all frequencies equally.
trace = np.zeros([int(sf), 1], dtype=np.float64)
trace[15000] = 1.0

recording = si.NumpyRecording(trace, sf)
recording_f = spre.gaussian_filter(recording, freq_min=600, freq_max=300)

trace_f = recording_f.get_traces()


fig = go.Figure()

fig.add_trace(go.Scatter(
	x=1e3 * np.arange(sf) / sf,
	y=trace[:, 0],
	mode="lines",
	name="Original trace"
))
fig.add_trace(go.Scatter(
	x=1e3 * np.arange(sf) / sf,
	y=trace_f[:, 0],
	mode="lines",
	name="Filtered trace"
))

fig.update_xaxes(title_text="Time (ms)")

fig.show()
```

Here is what the plot looks like before the patch:
![bug_gaussian_before](https://github.com/SpikeInterface/spikeinterface/assets/3465310/421fcf3b-93b2-4ce9-b849-a60868e2c17b)

And what is looks like after this patch:
![bug_gaussian_after](https://github.com/SpikeInterface/spikeinterface/assets/3465310/3411c296-29ae-46a5-b55d-f198baf5de65)

We can see the impulse is no longer going in the other direction, and there is less signal overall (which is expected)
Thanks @TomBugnon for pointing out the issue!
