### PR TITLE
Add note to explain that Command Prompt is currently the only officially supported shell

### DIFF
--- a/doc/modules/sorters.rst
+++ b/doc/modules/sorters.rst
@@ -36,6 +36,12 @@ For instance, the :code:`Kilosort2_5Sorter` will handle:
 From the user's point of view all of this is in the background and it happens automatically when using the
 :py:func:`~spikeinterface.sorters.run_sorter` function.
 
+.. note::
+  Because SpikeInterface needs to interact with other programs (e.g. Matlab) it uses shell scripts to load the scripts
+  that it generates. This means that the appropriate shell must be used. Although for macOS and Linux most shells work
+  without any issues, currently only the :code:`Command Prompt` shell for Windows works. This means that using the
+  :code:`PowerShell` or :code:`Windows Terminal` as your default shell may lead to errors while running sorters. Please
+  see Windows documentation for changing your default shell.
 
 
 Running different spike sorters


### PR DESCRIPTION
Fixes #2414.

Based on the issue there were some 'utf' coding errors when someone was trying to use Powershell. So this just adds a note to the documentation to say that the shell that the code was written for is the Command Prompt (Windows original shell). 