### PR TITLE
WIP: Switching Docs to `SortingAnalyzer`

### DIFF
--- a/doc/modules/postprocessing.rst
+++ b/doc/modules/postprocessing.rst
@@ -86,7 +86,7 @@ For dense waveforms, sparsity can also be passed as an argument.
 
 .. code-block:: python
 
-    sorting_analyzer.compute(input="principal_components",
+    pc = sorting_analyzer.compute(input="principal_components",
                              n_components=3,
                              mode="by_channel_local")
 
@@ -103,7 +103,7 @@ and is not well suited for high-density probes.
 
 .. code-block:: python
 
-    sorting_analyzer.compute(input="template_similarity", method='cosine_similarity')
+    similarity = sorting_analyzer.compute(input="template_similarity", method='cosine_similarity')
 
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_template_similarity`
@@ -121,7 +121,7 @@ each spike.
 
 .. code-block:: python
 
-    sorting_analyzer.compute(input="spike_amplitudes",
+    amplitudes = sorting_analyzer.compute(input="spike_amplitudes",
                              peak_sign="neg",
                              outputs="concatenated")
 
@@ -141,7 +141,7 @@ with center of mass (:code:`method="center_of_mass"` - fast, but less accurate),
 
 .. code-block:: python
 
-    sorting_analyzer.compute(input="spike_locations",
+    spike_locations = sorting_analyzer.compute(input="spike_locations",
                              ms_before=0.5,
                              ms_after=0.5,
                              spike_retriever_kwargs=dict(
@@ -166,7 +166,7 @@ based on individual waveforms, it calculates at the unit level using templates. 
 
 .. code-block:: python
 
-    sorting_analyzer.compute(input="unit_locations", method="monopolar_triangulation")
+    unit_locations = sorting_analyzer.compute(input="unit_locations", method="monopolar_triangulation")
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_unit_locations`
 
@@ -209,7 +209,7 @@ with shape (num_units, num_units, num_bins) with all correlograms for each pair 
 
 .. code-block:: python
 
-    sorting_analyer.compute(input="correlograms",
+    ccg = sorting_analyzer.compute(input="correlograms",
                             window_ms=50.0,
                             bin_ms=1.0,
                             method="auto")
@@ -226,7 +226,7 @@ This extension computes the histograms of inter-spike-intervals. The computed ou
 
 .. code-block:: python
 
-    sorting_analyer.compute(input="isi_histograms"
+   isi =  sorting_analyer.compute(input="isi_histograms"
                             window_ms=50.0,
                             bin_ms=1.0,
                             method="auto")

--- a/doc/modules/postprocessing.rst
+++ b/doc/modules/postprocessing.rst
@@ -64,10 +64,6 @@ noise_levels
 This extension computes the noise level of each channel using the median absolute deviation.
 As an extension, this expects the :code:`Recording` as input and the computed values are persistent on disk.
 
-The :py:func:`~spikeinterface.core.get_noise_levels(recording)` computes the same values, but starting from a recording
-and without saving the data as an extension.
-
-
 .. code-block:: python
 
     noise = compute_noise_level(recording=recording)
@@ -90,7 +86,7 @@ For dense waveforms, sparsity can also be passed as an argument.
 
 .. code-block:: python
 
-    sorting_analyzer.compute(input="principal_compoents",
+    sorting_analyzer.compute(input="principal_components",
                              n_components=3,
                              mode="by_channel_local")
 
@@ -230,10 +226,10 @@ This extension computes the histograms of inter-spike-intervals. The computed ou
 
 .. code-block:: python
 
-    sorting_analyer.compute_isi_histograms(input="isi_histograms"
-                                            window_ms=50.0,
-                                            bin_ms=1.0,
-                                            method="auto")
+    sorting_analyer.compute(input="isi_histograms"
+                            window_ms=50.0,
+                            bin_ms=1.0,
+                            method="auto")
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_isi_histograms`
 

--- a/doc/modules/postprocessing.rst
+++ b/doc/modules/postprocessing.rst
@@ -5,30 +5,30 @@ Postprocessing module
 
 After spike sorting, we can use the :py:mod:`~spikeinterface.postprocessing` module to further post-process
 the spike sorting output. Most of the post-processing functions require a
-:py:class:`~spikeinterface.core.WaveformExtractor` as input.
+:py:class:`~spikeinterface.core.SortingAnalyzer` as input.
 
 .. _waveform_extensions:
 
-WaveformExtractor extensions
+ResultExtensions
 ----------------------------
 
 There are several postprocessing tools available, and all
-of them are implemented as a :py:class:`~spikeinterface.core.BaseWaveformExtractorExtension`. All computations on top
-of a :code:`WaveformExtractor` will be saved along side the :code:`WaveformExtractor` itself (sub folder, zarr path or sub dict).
+of them are implemented as a :py:class:`~spikeinterface.core.ResultExtension`. All computations on top
+of a :code:`SortingAnalyzer` will be saved along side the :code:`SortingAnalyzer` itself (sub folder, zarr path or sub dict).
 This workflow is convenient for retrieval of time-consuming computations (such as pca or spike amplitudes) when reloading a
-:code:`WaveformExtractor`.
+:code:`SortingAnalyzer`.
 
-:py:class:`~spikeinterface.core.BaseWaveformExtractorExtension` objects are tightly connected to the
-parent :code:`WaveformExtractor` object, so that operations done on the :code:`WaveformExtractor`, such as saving,
+:py:class:`~spikeinterface.core.ResultExtension` objects are tightly connected to the
+parent :code:`SortingAnalyzer` object, so that operations done on the :code:`SortingAnalyzer`, such as saving,
 loading, or selecting units, will be automatically applied to all extensions.
 
-To check what extensions are available for a :code:`WaveformExtractor` named :code:`we`, you can use:
+To check what extensions are available for a :code:`SortingAnalyzer` named :code:`sorting_analyzer`, you can use:
 
 .. code-block:: python
 
     import spikeinterface as si
 
-    available_extension_names = we.get_available_extension_names()
+    available_extension_names = sorting_analyzer.get_load_extension_names()
     print(available_extension_names)
 
 .. code-block:: bash
@@ -40,7 +40,7 @@ To load the extension object you can run:
 
 .. code-block:: python
 
-    ext = we.load_extension("spike_amplitudes")
+    ext = sorting_analyzer.get_extension("spike_amplitudes")
     ext_data = ext.get_data()
 
 Here :code:`ext` is the extension object (in this case the :code:`SpikeAmplitudeCalculator`), and :code:`ext_data` will
@@ -52,12 +52,8 @@ We can also delete an extension:
 
 .. code-block:: python
 
-    we.delete_extension("spike_amplitudes")
+    sorting_analyzer.delete_extension("spike_amplitudes")
 
-
-
-Finally, the waveform extensions can be loaded rather than recalculated by using the :code:`load_if_exists` argument in
-any post-processing function.
 
 Available postprocessing extensions
 -----------------------------------
@@ -66,7 +62,7 @@ noise_levels
 ^^^^^^^^^^^^
 
 This extension computes the noise level of each channel using the median absolute deviation.
-As an extension, this expects the :code:`WaveformExtractor` as input and the computed values are persistent on disk.
+As an extension, this expects the :code:`Recording` as input and the computed values are persistent on disk.
 
 The :py:func:`~spikeinterface.core.get_noise_levels(recording)` computes the same values, but starting from a recording
 and without saving the data as an extension.
@@ -74,10 +70,9 @@ and without saving the data as an extension.
 
 .. code-block:: python
 
-    noise = compute_noise_level(waveform_extractor=we)
+    noise = compute_noise_level(recording=recording)
 
 
-For more information, see :py:func:`~spikeinterface.postprocessing.compute_noise_levels`
 
 
 
@@ -95,9 +90,9 @@ For dense waveforms, sparsity can also be passed as an argument.
 
 .. code-block:: python
 
-    pc = compute_principal_components(waveform_extractor=we,
-                                      n_components=3,
-                                      mode="by_channel_local")
+    sorting_analyzer.compute(input="principal_compoents",
+                             n_components=3,
+                             mode="by_channel_local")
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_principal_components`
 
@@ -112,7 +107,7 @@ and is not well suited for high-density probes.
 
 .. code-block:: python
 
-    similarity = compute_template_similarity(waveform_extractor=we, method='cosine_similarity')
+    sorting_analyzer.compute(input="template_similarity", method='cosine_similarity')
 
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_template_similarity`
@@ -130,9 +125,9 @@ each spike.
 
 .. code-block:: python
 
-    amplitudes = computer_spike_amplitudes(waveform_extractor=we,
-                                           peak_sign="neg",
-                                           outputs="concatenated")
+    sorting_analyzer.compute(input="spike_amplitudes",
+                             peak_sign="neg",
+                             outputs="concatenated")
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_spike_amplitudes`
 
@@ -150,15 +145,15 @@ with center of mass (:code:`method="center_of_mass"` - fast, but less accurate),
 
 .. code-block:: python
 
-    spike_locations = compute_spike_locations(waveform_extractor=we,
-                                              ms_before=0.5,
-                                              ms_after=0.5,
-                                              spike_retriever_kwargs=dict(
-                                                  channel_from_template=True,
-                                                  radius_um=50,
-                                                  peak_sign="neg"
+    sorting_analyzer.compute(input="spike_locations",
+                             ms_before=0.5,
+                             ms_after=0.5,
+                             spike_retriever_kwargs=dict(
+                                channel_from_template=True,
+                                radius_um=50,
+                                peak_sign="neg"
                                               ),
-                                              method="center_of_mass")
+                             method="center_of_mass")
 
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_spike_locations`
@@ -175,8 +170,7 @@ based on individual waveforms, it calculates at the unit level using templates. 
 
 .. code-block:: python
 
-    unit_locations = compute_unit_locations(waveform_extractor=we,
-                                            method="monopolar_triangulation")
+    sorting_analyzer.compute(input="unit_locations", method="monopolar_triangulation")
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_unit_locations`
 
@@ -219,10 +213,10 @@ with shape (num_units, num_units, num_bins) with all correlograms for each pair 
 
 .. code-block:: python
 
-    ccgs, bins = compute_correlograms(waveform_or_sorting_extractor=we,
-                                      window_ms=50.0,
-                                      bin_ms=1.0,
-                                      method="auto")
+    sorting_analyer.compute(input="correlograms",
+                            window_ms=50.0,
+                            bin_ms=1.0,
+                            method="auto")
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_correlograms`
 
@@ -236,10 +230,10 @@ This extension computes the histograms of inter-spike-intervals. The computed ou
 
 .. code-block:: python
 
-    isi_histogram, bins =  compute_isi_histograms(waveform_or_sorting_extractor=we,
-                                                  window_ms=50.0,
-                                                  bin_ms=1.0,
-                                                  method="auto")
+    sorting_analyer.compute_isi_histograms(input="isi_histograms"
+                                            window_ms=50.0,
+                                            bin_ms=1.0,
+                                            method="auto")
 
 For more information, see :py:func:`~spikeinterface.postprocessing.compute_isi_histograms`
 

--- a/doc/modules/qualitymetrics.rst
+++ b/doc/modules/qualitymetrics.rst
@@ -62,7 +62,7 @@ This code snippet shows how to compute quality metrics (with or without principa
      metrics = qm_ext.get_data()
      assert 'isolation_distance' in metrics.columns
 
- 
+
 
 For more information about quality metrics, check out this excellent
 `documentation <https://allensdk.readthedocs.io/en/latest/_static/examples/nb/ecephys_quality_metrics.html>`_

--- a/doc/modules/qualitymetrics.rst
+++ b/doc/modules/qualitymetrics.rst
@@ -51,16 +51,18 @@ This code snippet shows how to compute quality metrics (with or without principa
     sorting_analyzer = si.load_sorting_analyzer(folder='waveforms') # start from a sorting_analyzer
 
     # without PC (depends on "waveforms", "templates", and "noise_levels")
-    sorting_analyzer.compute(input="quality_metrics", metric_names=['snr'], skip_pc_metrics=False)
-    metrics = sorting_analyzer.get_extension(extension_name="quality_metrics")
+    qm_ext = sorting_analyzer.compute(input="quality_metrics", metric_names=['snr'], skip_pc_metrics=True)
+    metrics = qm_ext.get_data()
     assert 'snr' in metrics.columns
 
     # with PCs (depends on "pca" in addition to the above metrics)
 
-    sorting_analyzer.compute(input={"pca": dict(n_components=5, mode="by_channel_local"),
+    qm_ext = sorting_analyzer.compute(input={"pca": dict(n_components=5, mode="by_channel_local"),
                                     "quality_metrics": dict(skip_pc_metrics=False)})
+     metrics = qm_ext.get_data()
+     assert 'isolation_distance' in metrics.columns
 
-
+ 
 
 For more information about quality metrics, check out this excellent
 `documentation <https://allensdk.readthedocs.io/en/latest/_static/examples/nb/ecephys_quality_metrics.html>`_

--- a/doc/modules/qualitymetrics.rst
+++ b/doc/modules/qualitymetrics.rst
@@ -48,17 +48,19 @@ This code snippet shows how to compute quality metrics (with or without principa
 
 .. code-block:: python
 
-    we = si.load_waveforms(folder='waveforms') # start from a waveform extractor
+    sorting_analyzer = si.load_sorting_analyzer(folder='waveforms') # start from a sorting_analyzer
 
-    # without PC
-    metrics = compute_quality_metrics(waveform_extractor=we, metric_names=['snr'])
+    # without PC (depends on "waveforms", "templates", and "noise_levels")
+    sorting_analyzer.compute(input="quality_metrics", metric_names=['snr'], skip_pc_metrics=False)
+    metrics = sorting_analyzer.get_extension(extension_name="quality_metrics")
     assert 'snr' in metrics.columns
 
-    # with PCs
-    from spikeinterface.postprocessing import compute_principal_components
-    pca = compute_principal_components(waveform_extractor=we, n_components=5, mode='by_channel_local')
-    metrics = compute_quality_metrics(waveform_extractor=we)
-    assert 'isolation_distance' in metrics.columns
+    # with PCs (depends on "pca" in addition to the above metrics)
+
+    sorting_analyzer.compute(input={"pca": dict(n_components=5, mode="by_channel_local"),
+                                    "quality_metrics": dict(skip_pc_metrics=False)})
+
+
 
 For more information about quality metrics, check out this excellent
 `documentation <https://allensdk.readthedocs.io/en/latest/_static/examples/nb/ecephys_quality_metrics.html>`_

--- a/doc/modules/qualitymetrics/amplitude_cutoff.rst
+++ b/doc/modules/qualitymetrics/amplitude_cutoff.rst
@@ -23,9 +23,10 @@ Example code
 
 	import spikeinterface.qualitymetrics as sqm
 
-	# It is also recommended to run `compute_spike_amplitudes(wvf_extractor)`
+	# Combine sorting and recording into a sorting_analyzer
+	# It is also recommended to run sorting_analyzer.compute(input="spike_amplitudes")
 	# in order to use amplitudes from all spikes
-	fraction_missing = sqm.compute_amplitude_cutoffs(wvf_extractor, peak_sign="neg")
+	fraction_missing = sqm.compute_amplitude_cutoffs(sorting_analyzer=sorting_analyzer, peak_sign="neg")
 	# fraction_missing is a dict containing the unit IDs as keys,
 	# and their estimated fraction of missing spikes as values.
 

--- a/doc/modules/qualitymetrics/amplitude_cv.rst
+++ b/doc/modules/qualitymetrics/amplitude_cv.rst
@@ -34,10 +34,10 @@ Example code
 
     import spikeinterface.qualitymetrics as sqm
 
-    # Make recording, sorting and wvf_extractor object for your data.
-	# It is required to run `compute_spike_amplitudes(wvf_extractor)` or
-	# `compute_amplitude_scalings(wvf_extractor)` (if missing, values will be NaN)
-    amplitude_cv_median, amplitude_cv_range = sqm.compute_amplitude_cv_metrics(waveform_extractor=wvf_extractor)
+    # Combine a sorting and recording into a sorting_analyzer
+	# It is required to run sorting_analyzer.compute(input="spike_amplitudes") or
+	# sorting_analyzer.compute(input="amplitude_scalings") (if missing, values will be NaN)
+    amplitude_cv_median, amplitude_cv_range = sqm.compute_amplitude_cv_metrics(sorting_analyzer=sorting_analyzer)
     # amplitude_cv_median and  amplitude_cv_range are dicts containing the unit ids as keys,
     # and their amplitude_cv metrics as values.
 

--- a/doc/modules/qualitymetrics/amplitude_median.rst
+++ b/doc/modules/qualitymetrics/amplitude_median.rst
@@ -22,9 +22,9 @@ Example code
 
 	import spikeinterface.qualitymetrics as sqm
 
-	# It is also recommended to run `compute_spike_amplitudes(wvf_extractor)`
+	# It is also recommended to run sorting_analyzer.compute(input="spike_amplitudes")
 	# in order to use amplitude values from all spikes.
-	amplitude_medians = sqm.compute_amplitude_medians(waveform_extractor=wvf_extractor)
+	amplitude_medians = sqm.compute_amplitude_medians(sorting_analyzer)
 	# amplitude_medians is a dict containing the unit IDs as keys,
 	# and their estimated amplitude medians as values.
 

--- a/doc/modules/qualitymetrics/drift.rst
+++ b/doc/modules/qualitymetrics/drift.rst
@@ -42,10 +42,10 @@ Example code
 
 	import spikeinterface.qualitymetrics as sqm
 
-	# Make recording, sorting and wvf_extractor object for your data.
-	# It is required to run `compute_spike_locations(wvf_extractor) first`
+	# Combine sorting and recording into sorting_analyzer
+	# It is required to run sorting_analyzer.compute(input="spike_locations") first
 	# (if missing, values will be NaN)
-	drift_ptps, drift_stds, drift_mads = sqm.compute_drift_metrics(waveform_extractor=wvf_extractor, peak_sign="neg")
+	drift_ptps, drift_stds, drift_mads = sqm.compute_drift_metrics(sorting_analyzer=sorting_analyzer peak_sign="neg")
 	# drift_ptps, drift_stds, and drift_mads are each a dict containing the unit IDs as keys,
 	# and their metrics as values.
 

--- a/doc/modules/qualitymetrics/firing_range.rst
+++ b/doc/modules/qualitymetrics/firing_range.rst
@@ -23,8 +23,8 @@ Example code
 
     import spikeinterface.qualitymetrics as sqm
 
-    # Make recording, sorting and wvf_extractor object for your data.
-    firing_range = sqm.compute_firing_ranges(waveform_extractor=wvf_extractor)
+    # Combine a sorting and recording into a sorting_analyzer
+    firing_range = sqm.compute_firing_ranges(sorting_analyzer=sorting_analyzer)
     # firing_range is a dict containing the unit IDs as keys,
     # and their firing firing_range as values (in Hz).
 

--- a/doc/modules/qualitymetrics/firing_rate.rst
+++ b/doc/modules/qualitymetrics/firing_rate.rst
@@ -39,8 +39,8 @@ With SpikeInterface:
 
     import spikeinterface.qualitymetrics as sqm
 
-    # Make recording, sorting and wvf_extractor object for your data.
-    firing_rate = sqm.compute_firing_rates(waveform_extractor=wvf_extractor)
+    # Combine a sorting and recording into a sorting_analyzer
+    firing_rate = sqm.compute_firing_rates(sorting_analyzer)
     # firing_rate is a dict containing the unit IDs as keys,
     # and their firing rates across segments as values (in Hz).
 

--- a/doc/modules/qualitymetrics/isi_violations.rst
+++ b/doc/modules/qualitymetrics/isi_violations.rst
@@ -79,9 +79,9 @@ With SpikeInterface:
 
     import spikeinterface.qualitymetrics as sqm
 
-    # Make recording, sorting and wvf_extractor object for your data.
+    # Combine sorting and recording into sorting_analyzer
 
-    isi_violations_ratio, isi_violations_count = sqm.compute_isi_violations(wvf_extractor, isi_threshold_ms=1.0)
+    isi_violations_ratio, isi_violations_count = sqm.compute_isi_violations(sorting_analyzer=sorting_analyzer, isi_threshold_ms=1.0)
 
 References
 ----------

--- a/doc/modules/qualitymetrics/presence_ratio.rst
+++ b/doc/modules/qualitymetrics/presence_ratio.rst
@@ -25,9 +25,9 @@ Example code
 
     import spikeinterface.qualitymetrics as sqm
 
-    # Make recording, sorting and wvf_extractor object for your data.
+    # Combine sorting and recording into a sorting_analyzer
 
-    presence_ratio = sqm.compute_presence_ratios(waveform_extractor=wvf_extractor)
+    presence_ratio = sqm.compute_presence_ratios(sorting_analyzer=sorting_analyzer)
     # presence_ratio is a dict containing the unit IDs as keys
     # and their presence ratio (between 0 and 1) as values.
 

--- a/doc/modules/qualitymetrics/sd_ratio.rst
+++ b/doc/modules/qualitymetrics/sd_ratio.rst
@@ -28,7 +28,8 @@ Example code
 
 	import spikeinterface.qualitymetrics as sqm
 
-	sd_ratio = sqm.compute_sd_ratio(wvf_extractor, censored_period_ms=4.0)
+	# In this case we need to combine our sorting and recording into a sorting_analyzer
+	sd_ratio = sqm.compute_sd_ratio(sorting_analyzer=sorting_analyzer censored_period_ms=4.0)
 
 
 References

--- a/doc/modules/qualitymetrics/sliding_rp_violations.rst
+++ b/doc/modules/qualitymetrics/sliding_rp_violations.rst
@@ -29,9 +29,9 @@ With SpikeInterface:
 
     import spikeinterface.qualitymetrics as sqm
 
-    # Make recording, sorting and wvf_extractor object for your data.
+    # Combine sorting and recording into a sorting_analyzer
 
-    contamination = sqm.compute_sliding_rp_violations(waveform_extractor=wvf_extractor, bin_size_ms=0.25)
+    contamination = sqm.compute_sliding_rp_violations(sorting_analyzer=sorting_analyzer, bin_size_ms=0.25)
 
 References
 ----------

--- a/doc/modules/qualitymetrics/snr.rst
+++ b/doc/modules/qualitymetrics/snr.rst
@@ -43,8 +43,8 @@ With SpikeInterface:
 
     import spikeinterface.qualitymetrics as sqm
 
-    # Make recording, sorting and wvf_extractor object for your data.
-    SNRs = sqm.compute_snrs(waveform_extractor=wvf_extractor)
+    # Combining sorting and recording into a sorting_analzyer
+    SNRs = sqm.compute_snrs(sorting_analzyer=sorting_analzyer)
     # SNRs is a dict containing the unit IDs as keys and their SNRs as values.
 
 Links to original implementations

--- a/doc/modules/qualitymetrics/synchrony.rst
+++ b/doc/modules/qualitymetrics/synchrony.rst
@@ -28,8 +28,8 @@ Example code
 .. code-block:: python
 
     import spikeinterface.qualitymetrics as sqm
-    # Make recording, sorting and wvf_extractor object for your data.
-    synchrony = sqm.compute_synchrony_metrics(waveform_extractor=wvf_extractor, synchrony_sizes=(2, 4, 8))
+    # Combine a sorting and recording into a sorting_analyzer
+    synchrony = sqm.compute_synchrony_metrics(sorting_analyzer=sorting_analyzer synchrony_sizes=(2, 4, 8))
     # synchrony is a tuple of dicts with the synchrony metrics for each unit
 
 

--- a/src/spikeinterface/postprocessing/isi.py
+++ b/src/spikeinterface/postprocessing/isi.py
@@ -103,7 +103,7 @@ def compute_isi_histograms_numpy(sorting, window_ms: float = 50.0, bin_ms: float
     window_size = int(round(fs * window_ms * 1e-3))
     bin_size = int(round(fs * bin_ms * 1e-3))
     window_size -= window_size % bin_size
-    bins = np.arange(0, window_size + bin_size, bin_size)# * 1e3 / fs
+    bins = np.arange(0, window_size + bin_size, bin_size)  # * 1e3 / fs
     ISIs = np.zeros((num_units, len(bins) - 1), dtype=np.int64)
 
     # TODO: There might be a better way than a double for loop?
@@ -137,7 +137,7 @@ def compute_isi_histograms_numba(sorting, window_ms: float = 50.0, bin_ms: float
     bin_size = int(round(fs * bin_ms * 1e-3))
     window_size -= window_size % bin_size
 
-    bins = np.arange(0, window_size + bin_size, bin_size)# * 1e3 / fs
+    bins = np.arange(0, window_size + bin_size, bin_size)  # * 1e3 / fs
     spikes = sorting.to_spike_vector(concatenated=False)
 
     ISIs = np.zeros((num_units, len(bins) - 1), dtype=np.int64)
@@ -159,7 +159,7 @@ def compute_isi_histograms_numba(sorting, window_ms: float = 50.0, bin_ms: float
 if HAVE_NUMBA:
 
     @numba.jit(
-        (numba.int64[:, ::1], numba.int64[::1], numba.int32[::1], numba.int64[::1]),            
+        (numba.int64[:, ::1], numba.int64[::1], numba.int32[::1], numba.int64[::1]),
         nopython=True,
         nogil=True,
         cache=True,


### PR DESCRIPTION
I switched postprocessing over to sorting_analyzer.compute notation.

I moved the WaveformExtractor down to a bottom legacy section and opened a blank `SortingAnalyzer` section to be filled in. 

I changed the high level quality metric over to the sorting_analyzer.

The low-level qc stuff should basically be the same right? I would just change that to a sorting_analyzer instead of the waveform_extractor, no? 