### PR TITLE
Fix sparsity check for old waveform extractor

### DIFF
--- a/examples/modules_gallery/core/plot_4_sorting_analyzer.py
+++ b/examples/modules_gallery/core/plot_4_sorting_analyzer.py
@@ -18,7 +18,7 @@ This :py:class:`~spikeinterface.core.SortingAnalyzer` class:
     * "noise_levels" : compute noise level from traces (usefull to get snr of units)
   * can be in memory or persistent to disk (2 formats binary/npy or zarr)
 
-More extesions are available in `spikeinterface.postprocessing` like "principal_components", "spike_amplitudes", 
+More extesions are available in `spikeinterface.postprocessing` like "principal_components", "spike_amplitudes",
 "unit_lcations", ...
 
 

--- a/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
+++ b/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
@@ -362,7 +362,7 @@ def _read_old_waveforms_extractor_binary(folder):
         params = json.load(f)
 
     sparsity_file = folder / "sparsity.json"
-    if params_file.exists():
+    if sparsity_file.exists():
         with open(sparsity_file, "r") as f:
             sparsity_dict = json.load(f)
             sparsity = ChannelSparsity.from_dict(sparsity_dict)


### PR DESCRIPTION
Fix bug when reading old dense waveforms.

Only sparse waveforms have a `sparsity.json` file so this should be checked to decide sparsity, rather than the parameter file.