### PR TITLE
Add note about recommendation not to change batch size in Kilosort1-3

### DIFF
--- a/src/spikeinterface/sorters/external/kilosort.py
+++ b/src/spikeinterface/sorters/external/kilosort.py
@@ -56,7 +56,7 @@ class KilosortSorter(KilosortBase, BaseSorter):
         "freq_max": "Low-pass filter cutoff frequency",
         "ntbuff": "Samples of symmetrical buffer for whitening and spike detection",
         "Nfilt": "Number of clusters to use (if None it is automatically computed)",
-        "NT": "Batch size (if None it is automatically computed)",
+        "NT": "Batch size (if None it is automatically computed--recommended Kilosort behavior if ntbuff also not changed)",
         "wave_length": "size of the waveform extracted around each detected peak, (Default 61, maximum 81)",
         "delete_tmp_files": "Delete temporary files created during sorting (matlab files and the `temp_wh.dat` file that "
         "contains kilosort-preprocessed data). Accepts `False` (deletes no files), `True` (deletes all files) "

--- a/src/spikeinterface/sorters/external/kilosort2.py
+++ b/src/spikeinterface/sorters/external/kilosort2.py
@@ -72,7 +72,7 @@ class Kilosort2Sorter(KilosortBase, BaseSorter):
         "nPCs": "Number of PCA dimensions",
         "ntbuff": "Samples of symmetrical buffer for whitening and spike detection",
         "nfilt_factor": "Max number of clusters per good channel (even temporary ones) 4",
-        "NT": "Batch size (if None it is automatically computed)",
+        "NT": "Batch size (if None it is automatically computed--recommended Kilosort behavior if ntbuff also not changed)",
         "AUCsplit": "Threshold on the area under the curve (AUC) criterion for performing a split in the final step",
         "wave_length": "size of the waveform extracted around each detected peak, (Default 61, maximum 81)",
         "keep_good_only": "If True only 'good' units are returned",

--- a/src/spikeinterface/sorters/external/kilosort3.py
+++ b/src/spikeinterface/sorters/external/kilosort3.py
@@ -77,7 +77,7 @@ class Kilosort3Sorter(KilosortBase, BaseSorter):
         "ntbuff": "Samples of symmetrical buffer for whitening and spike detection",
         "nfilt_factor": "Max number of clusters per good channel (even temporary ones) 4",
         "do_correction": "If True drift registration is applied",
-        "NT": "Batch size (if None it is automatically computed)",
+        "NT": "Batch size (if None it is automatically computed--recommended Kilosort behavior if ntbuff also not changed)",
         "AUCsplit": "Threshold on the area under the curve (AUC) criterion for performing a split in the final step",
         "wave_length": "size of the waveform extracted around each detected peak, (Default 61, maximum 81)",
         "keep_good_only": "If True only 'good' units are returned",


### PR DESCRIPTION
Based on the KS readme [here](https://github.com/MouseLand/Kilosort/tree/main). It is not advised for users to change the batch size `NT`. This just adds a note saying that the SpikeInterface default is the KS recommended value as long as the user doesn't change the ntbuff either. Related to #2562.