### PR TITLE
Circus2 independant channels

### DIFF
--- a/src/spikeinterface/sorters/internal/spyking_circus2.py
+++ b/src/spikeinterface/sorters/internal/spyking_circus2.py
@@ -170,7 +170,7 @@ class Spykingcircus2Sorter(ComponentsBasedSorter):
             neighbours_mask = channel_distance <= radius_um
             if np.all(np.sum(neighbours_mask, axis=0) == 1):
                 if verbose:
-                    print('Independant channels detected, switching to legacy mode')
+                    print("Independant channels detected, switching to legacy mode")
                 legacy = True
 
             if legacy:

--- a/src/spikeinterface/sorters/internal/spyking_circus2.py
+++ b/src/spikeinterface/sorters/internal/spyking_circus2.py
@@ -9,6 +9,7 @@ import numpy as np
 from spikeinterface.core import NumpySorting, load_extractor, BaseRecording
 from spikeinterface.core.job_tools import fix_job_kwargs
 from spikeinterface.core.template import Templates
+from spikeinterface.core import get_channel_distances
 from spikeinterface.core.waveform_tools import estimate_templates
 from spikeinterface.preprocessing import common_reference, zscore, whiten, highpass_filter
 from spikeinterface.sortingcomponents.tools import cache_preprocessing
@@ -165,6 +166,14 @@ class Spykingcircus2Sorter(ComponentsBasedSorter):
                 legacy = clustering_params.pop("legacy")
             else:
                 legacy = False
+
+            contact_locations = recording_f.get_channel_locations()
+            channel_distance = get_channel_distances(recording_f)
+            neighbours_mask = channel_distance <= 0
+            if np.all(np.sum(neighbours_mask, axis=0) == 1):
+                if verbose:
+                    print('Independant channels detected, switching to legacy mode')
+                legacy = True
 
             if legacy:
                 if verbose:

--- a/src/spikeinterface/sortingcomponents/clustering/circus.py
+++ b/src/spikeinterface/sortingcomponents/clustering/circus.py
@@ -152,7 +152,10 @@ class CircusClustering:
         nb_clusters = 0
         for c in np.unique(peaks["channel_index"]):
             mask = peaks["channel_index"] == c
-            tsvd = TruncatedSVD(params["n_svd"][1])
+            if all_pc_data.shape[1] > params["n_svd"][1]:
+                tsvd = TruncatedSVD(params["n_svd"][1])
+            else:
+                tsvd = TruncatedSVD(all_pc_data.shape[1])
             sub_data = all_pc_data[mask]
             hdbscan_data = tsvd.fit_transform(sub_data.reshape(len(sub_data), -1))
             try:

--- a/src/spikeinterface/sortingcomponents/clustering/circus.py
+++ b/src/spikeinterface/sortingcomponents/clustering/circus.py
@@ -72,10 +72,7 @@ class CircusClustering:
         job_kwargs = fix_job_kwargs(params["job_kwargs"])
 
         d = params
-        if "verbose" in job_kwargs:
-            verbose = job_kwargs["verbose"]
-        else:
-            verbose = False
+        verbose = job_kwargs.get("verbose", False)
 
         peak_dtype = [("sample_index", "int64"), ("unit_index", "int64"), ("segment_index", "int64")]
 

--- a/src/spikeinterface/sortingcomponents/clustering/random_projections.py
+++ b/src/spikeinterface/sortingcomponents/clustering/random_projections.py
@@ -70,7 +70,7 @@ class RandomProjectionClustering:
 
         d = params
         if "verbose" in job_kwargs:
-            verbose = job_kwargs["verbose"]
+            verbose = job_kwargs.pop("verbose", False)
         else:
             verbose = False
 

--- a/src/spikeinterface/sortingcomponents/clustering/random_projections.py
+++ b/src/spikeinterface/sortingcomponents/clustering/random_projections.py
@@ -69,10 +69,7 @@ class RandomProjectionClustering:
         job_kwargs = fix_job_kwargs(params["job_kwargs"])
 
         d = params
-        if "verbose" in job_kwargs:
-            verbose = job_kwargs.pop("verbose", False)
-        else:
-            verbose = False
+        verbose = job_kwargs.get("verbose", False)
 
         fs = recording.get_sampling_frequency()
         nbefore = int(params["ms_before"] * fs / 1000.0)


### PR DESCRIPTION
With such a PR, circus2 will automatically revert to legacy clustering if independant channels are detected. Indeed, it turns out that if you have independant channels, using the PCs is more robust than just the ptps, that only make sense for high density probes