### PR TITLE
Add `import os` to recording_tools

### DIFF
--- a/src/spikeinterface/core/recording_tools.py
+++ b/src/spikeinterface/core/recording_tools.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from typing import Literal
 import warnings
 from pathlib import Path
+import os
 import gc
 import mmap
 import tqdm


### PR DESCRIPTION
If you look at Line47 `os.fstat` is used, but os is never imported. This function probably needs a test since this import error hasn't shown up before...