### PR TITLE
Use GPU in `Kilosort4Sorter`

### DIFF
--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -15,6 +15,7 @@ class Kilosort4Sorter(BaseSorter):
 
     sorter_name: str = "kilosort4"
     requires_locations = True
+    gpu_compatibility = "nvidia-required"
 
     _default_params = {
         "nblocks": 1,

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -15,7 +15,7 @@ class Kilosort4Sorter(BaseSorter):
 
     sorter_name: str = "kilosort4"
     requires_locations = True
-    gpu_compatibility = "nvidia-optional"
+    gpu_capability = "nvidia-optional"
 
     _default_params = {
         "nblocks": 1,

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -15,7 +15,7 @@ class Kilosort4Sorter(BaseSorter):
 
     sorter_name: str = "kilosort4"
     requires_locations = True
-    gpu_compatibility = "nvidia-required"
+    gpu_compatibility = "nvidia-optional"
 
     _default_params = {
         "nblocks": 1,


### PR DESCRIPTION
I was trying to run Kilosort4 with docker but it didn't use my GPU.

After some digging I found that `Kilosort4Sorter` only inherits from `BaseSorter` which by default doesn't use the GPU.
I'm not sure if this is the best solution, but adding `gpu_compatibility = "nvidia-required"` seems to have fixed the issue for me.

Might help with #2569