### PR TITLE
Clarify status of main and Sortinganalyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 > :warning::warning::warning:
 > **New features under construction!** 🚧🚧🚧: after the 0.100.0 release (and related bug fixes), the next release will contain
 > a major API improvement: the `SortingAnalyzer`. To read more about this, checkout the
-> [enhancement proposal](https://github.com/SpikeInterface/spikeinterface/issues/2282)
+> [enhancement proposal](https://github.com/SpikeInterface/spikeinterface/issues/2282).
 > Please refer to the stable documentation [here](https://spikeinterface.readthedocs.io/en/0.100.1)
 
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@
 [![Twitter](https://img.shields.io/badge/@spikeinterface-%231DA1F2.svg?style=for-the-badge&logo=Twitter&logoColor=white)](https://twitter.com/spikeinterface) [![Mastodon](https://img.shields.io/badge/-@spikeinterface-%232B90D9?style=for-the-badge&logo=mastodon&logoColor=white)](https://fosstodon.org/@spikeinterface)
 
 
-> :warning::warning::warning: **PRs with new features are frozen!**: after the 0.100.0 release, we will not accept PRs with new features (only bug fixes) until February 21st 2024.
+> :warning::warning::warning:
+> **New features under construction!** 🚧🚧🚧: after the 0.100.0 release (and related bug fixes), the next release will contain
+> a major API improvement: the `SortingAnalyzer`. To read more about this, checkout the
+> [enhancement proposal](https://github.com/SpikeInterface/spikeinterface/issues/2282)
+> Please refer to the stable documentation [here](https://spikeinterface.readthedocs.io/en/0.100.1)
 
 
 SpikeInterface is a Python framework designed to unify preexisting spike sorting technologies into a single code base.
@@ -70,7 +74,7 @@ With SpikeInterface, users can:
 
 ## Documentation
 
-Detailed documentation of the latest PyPI release of SpikeInterface can be found [here](https://spikeinterface.readthedocs.io/en/0.100.0).
+Detailed documentation of the latest PyPI release of SpikeInterface can be found [here](https://spikeinterface.readthedocs.io/en/0.100.1).
 
 Detailed documentation of the development version of SpikeInterface can be found [here](https://spikeinterface.readthedocs.io/en/latest).
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,7 +17,7 @@ state-of-the-art spike sorters, post-process and curate the output, compute qual
 
     **New features under construction!** 🚧🚧🚧: after the 0.100.0 release (and related bug fixes), the next release will contain
     a major API improvement: the :code:`SortingAnalyzer`. To read more about this, checkout the
-    `enhancement proposal <https://github.com/SpikeInterface/spikeinterface/issues/2282>`_
+    `enhancement proposal <https://github.com/SpikeInterface/spikeinterface/issues/2282>`_.
     Please refer to the stable documentation `here <https://spikeinterface.readthedocs.io/en/0.100.1>`_
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,6 +13,14 @@ With a few lines of code, SpikeInterface enables you to load and pre-process the
 state-of-the-art spike sorters, post-process and curate the output, compute quality metrics, and visualize the results.
 
 
+.. warning::
+
+    **New features under construction!** 🚧🚧🚧: after the 0.100.0 release (and related bug fixes), the next release will contain
+    a major API improvement: the :code:`SortingAnalyzer`. To read more about this, checkout the
+    `enhancement proposal <https://github.com/SpikeInterface/spikeinterface/issues/2282>`_
+    Please refer to the stable documentation `here <https://spikeinterface.readthedocs.io/en/0.100.1>`_
+
+
 Overview of SpikeInterface modules
 ----------------------------------
 


### PR DESCRIPTION
It could be very confusing for a user to understand the status of the `SortingAnalyzer` in the docs.

Added a comment in the README and docs, so that landing on `latest` will explain briefly what's going on and where to find the stable docs.