### PR TITLE
Fix to impose sorting of the peaks in from_peaks()

### DIFF
--- a/src/spikeinterface/core/numpyextractors.py
+++ b/src/spikeinterface/core/numpyextractors.py
@@ -457,7 +457,8 @@ class NumpySorting(BaseSorting):
         spikes["sample_index"] = peaks["sample_index"]
         spikes["unit_index"] = peaks["channel_index"]
         spikes["segment_index"] = peaks["segment_index"]
-
+        order = np.argsort(spikes["sample_index"])
+        spikes = spikes[order]
         sorting = NumpySorting(spikes, sampling_frequency, unit_ids)
 
         return sorting


### PR DESCRIPTION
As discussed with Sam, we should impose a sorting of the peaks while creating a sorting, to avoid posible bugs downstream