### PR TITLE
Improve documentation for excess spikes error in `FrameSliceSorting`.

### DIFF
--- a/src/spikeinterface/core/frameslicesorting.py
+++ b/src/spikeinterface/core/frameslicesorting.py
@@ -56,8 +56,9 @@ class FrameSliceSorting(BaseSorting):
             ), "`start_frame` should be smaller than the sortings' total number of samples."
             if check_spike_frames and has_exceeding_spikes(parent_sorting._recording, parent_sorting):
                 raise ValueError(
-                    "The sorting object has spikes exceeding the recording duration. You have to remove those spikes "
-                    "with the `spikeinterface.curation.remove_excess_spikes()` function"
+                    "The sorting object has spikes whose times go beyond the recording duration."
+                    "This could indicate a bug in the sorter. Double check the time of both objects"
+                    "To remove those spikes, you can use `spikeinterface.curation.remove_excess_spikes()`."
                 )
         else:
             # Pull df end_frame from spikes

--- a/src/spikeinterface/core/frameslicesorting.py
+++ b/src/spikeinterface/core/frameslicesorting.py
@@ -57,7 +57,7 @@ class FrameSliceSorting(BaseSorting):
             if check_spike_frames and has_exceeding_spikes(parent_sorting._recording, parent_sorting):
                 raise ValueError(
                     "The sorting object has spikes whose times go beyond the recording duration."
-                    "This could indicate a bug in the sorter. Double check the time of both objects"
+                    "This could indicate a bug in the sorter. "
                     "To remove those spikes, you can use `spikeinterface.curation.remove_excess_spikes()`."
                 )
         else:


### PR DESCRIPTION
From the discussion here:
https://github.com/SpikeInterface/spikeinterface/issues/2573#issuecomment-1995993813

I was kind of recluctanct to add "could indicate a bug on the sorter" as this is a very general function but I guess a sorting object can only come from sorter so...
