### PR TITLE
SortingAnalyzer: `get_extension_default_params`

### DIFF
--- a/src/spikeinterface/core/__init__.py
+++ b/src/spikeinterface/core/__init__.py
@@ -144,7 +144,15 @@ from .sparsity import ChannelSparsity, compute_sparsity, estimate_sparsity
 from .template import Templates
 
 # SortingAnalyzer and AnalyzerExtension
-from .sortinganalyzer import SortingAnalyzer, AnalyzerExtension, create_sorting_analyzer, load_sorting_analyzer
+from .sortinganalyzer import (
+    SortingAnalyzer,
+    AnalyzerExtension,
+    create_sorting_analyzer,
+    load_sorting_analyzer,
+    get_available_analyzer_extensions,
+    get_default_anlyzer_extension_params,
+)
+
 from .analyzer_extension_core import (
     SelectRandomSpikes,
     compute_select_random_spikes,

--- a/src/spikeinterface/core/__init__.py
+++ b/src/spikeinterface/core/__init__.py
@@ -150,7 +150,7 @@ from .sortinganalyzer import (
     create_sorting_analyzer,
     load_sorting_analyzer,
     get_available_analyzer_extensions,
-    get_default_anlyzer_extension_params,
+    get_default_analyzer_extension_params,
 )
 
 from .analyzer_extension_core import (

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1025,6 +1025,37 @@ class SortingAnalyzer:
         else:
             return False
 
+    def get_computable_extensions(self):
+        """
+        Get all extensions that can be computed by the analyzer.
+        """
+        return list(_builtin_extensions.keys())
+
+    def get_default_extension_params(self, extension_name: str):
+        """
+        Get the default params for an extension.
+
+        Parameters
+        ----------
+        extension_name: str
+            The extension name
+
+        Returns
+        -------
+        default_params: dict
+            The default parameters for the extension
+        """
+        import inspect
+
+        extension_class = get_extension_class(extension_name)
+
+        sig = inspect.signature(extension_class._set_params)
+        default_params = {
+            k: v.default for k, v in sig.parameters.items() if k != "self" and v.default != inspect.Parameter.empty
+        }
+
+        return default_params
+
 
 global _possible_extensions
 _possible_extensions = []

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1045,7 +1045,7 @@ class SortingAnalyzer:
         default_params: dict
             The default parameters for the extension
         """
-        return get_default_anlyzer_extension_params(extension_name)
+        return get_default_analyzer_extension_params(extension_name)
 
 
 global _possible_extensions
@@ -1120,7 +1120,7 @@ def get_available_analyzer_extensions():
     return list(_builtin_extensions.keys())
 
 
-def get_default_anlyzer_extension_params(extension_name: str):
+def get_default_analyzer_extension_params(extension_name: str):
     """
     Get the default params for an extension.
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1029,7 +1029,7 @@ class SortingAnalyzer:
         """
         Get all extensions that can be computed by the analyzer.
         """
-        return list(_builtin_extensions.keys())
+        return get_available_analyzer_extensions()
 
     def get_default_extension_params(self, extension_name: str):
         """
@@ -1045,16 +1045,7 @@ class SortingAnalyzer:
         default_params: dict
             The default parameters for the extension
         """
-        import inspect
-
-        extension_class = get_extension_class(extension_name)
-
-        sig = inspect.signature(extension_class._set_params)
-        default_params = {
-            k: v.default for k, v in sig.parameters.items() if k != "self" and v.default != inspect.Parameter.empty
-        }
-
-        return default_params
+        return get_default_anlyzer_extension_params(extension_name)
 
 
 global _possible_extensions
@@ -1120,6 +1111,39 @@ def get_extension_class(extension_name: str, auto_import=True):
 
     ext_class = extensions_dict[extension_name]
     return ext_class
+
+
+def get_available_analyzer_extensions():
+    """
+    Get all extensions that can be computed by the analyzer.
+    """
+    return list(_builtin_extensions.keys())
+
+
+def get_default_anlyzer_extension_params(extension_name: str):
+    """
+    Get the default params for an extension.
+
+    Parameters
+    ----------
+    extension_name: str
+        The extension name
+
+    Returns
+    -------
+    default_params: dict
+        The default parameters for the extension
+    """
+    import inspect
+
+    extension_class = get_extension_class(extension_name)
+
+    sig = inspect.signature(extension_class._set_params)
+    default_params = {
+        k: v.default for k, v in sig.parameters.items() if k != "self" and v.default != inspect.Parameter.empty
+    }
+
+    return default_params
 
 
 class AnalyzerExtension:

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -156,11 +156,11 @@ def test_extension_params():
     for ext, mod in _builtin_extensions.items():
         assert ext in computable_extension
         if mod == "spikeinterface.core":
-            default_params = get_default_anlyzer_extension_params(ext)
+            default_params = get_default_analyzer_extension_params(ext)
             print(ext, default_params)
         else:
             try:
-                default_params = get_default_anlyzer_extension_params(ext)
+                default_params = get_default_analyzer_extension_params(ext)
                 print(ext, default_params)
             except:
                 print(f"Failed to import {ext}")

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -143,6 +143,26 @@ def _check_sorting_analyzers(sorting_analyzer, original_sorting):
         assert np.all(~np.isin(data["result_two"], [1, 3]))
 
 
+def test_extension_params():
+    from spikeinterface.core.sortinganalyzer import _builtin_extensions
+
+    recording, sorting = get_dataset()
+    sorting_analyzer = create_sorting_analyzer(sorting, recording, format="memory", sparse=False, sparsity=None)
+    computable_extension = sorting_analyzer.get_computable_extensions()
+
+    for ext, mod in _builtin_extensions.items():
+        assert ext in computable_extension
+        if mod == "spikeinterface.core":
+            default_params = sorting_analyzer.get_default_extension_params(ext)
+            print(ext, default_params)
+        else:
+            try:
+                default_params = sorting_analyzer.get_default_extension_params(ext)
+                print(ext, default_params)
+            except:
+                print(f"Failed to import {ext}")
+
+
 class DummyAnalyzerExtension(AnalyzerExtension):
     extension_name = "dummy"
     depend_on = []
@@ -201,3 +221,4 @@ if __name__ == "__main__":
     test_SortingAnalyzer_binary_folder()
     test_SortingAnalyzer_zarr()
     test_extension()
+    test_extension_params()

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -4,7 +4,12 @@ from pathlib import Path
 import shutil
 
 from spikeinterface.core import generate_ground_truth_recording
-from spikeinterface.core import SortingAnalyzer, create_sorting_analyzer, load_sorting_analyzer
+from spikeinterface.core import (
+    create_sorting_analyzer,
+    load_sorting_analyzer,
+    get_available_analyzer_extensions,
+    get_default_anlyzer_extension_params,
+)
 from spikeinterface.core.sortinganalyzer import register_result_extension, AnalyzerExtension
 
 import numpy as np
@@ -146,18 +151,16 @@ def _check_sorting_analyzers(sorting_analyzer, original_sorting):
 def test_extension_params():
     from spikeinterface.core.sortinganalyzer import _builtin_extensions
 
-    recording, sorting = get_dataset()
-    sorting_analyzer = create_sorting_analyzer(sorting, recording, format="memory", sparse=False, sparsity=None)
-    computable_extension = sorting_analyzer.get_computable_extensions()
+    computable_extension = get_available_analyzer_extensions()
 
     for ext, mod in _builtin_extensions.items():
         assert ext in computable_extension
         if mod == "spikeinterface.core":
-            default_params = sorting_analyzer.get_default_extension_params(ext)
+            default_params = get_default_anlyzer_extension_params(ext)
             print(ext, default_params)
         else:
             try:
-                default_params = sorting_analyzer.get_default_extension_params(ext)
+                default_params = get_default_anlyzer_extension_params(ext)
                 print(ext, default_params)
             except:
                 print(f"Failed to import {ext}")

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -8,7 +8,7 @@ from spikeinterface.core import (
     create_sorting_analyzer,
     load_sorting_analyzer,
     get_available_analyzer_extensions,
-    get_default_anlyzer_extension_params,
+    get_default_analyzer_extension_params,
 )
 from spikeinterface.core.sortinganalyzer import register_result_extension, AnalyzerExtension
 

--- a/src/spikeinterface/postprocessing/tests/test_unit_localization.py
+++ b/src/spikeinterface/postprocessing/tests/test_unit_localization.py
@@ -6,11 +6,13 @@ from spikeinterface.postprocessing import ComputeUnitLocations
 class UnitLocationsExtensionTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
     extension_class = ComputeUnitLocations
     extension_function_params_list = [
-        dict(method="center_of_mass", radius_um=100),
-        dict(method="grid_convolution", radius_um=50),
-        dict(method="grid_convolution", radius_um=150, weight_method={"mode": "gaussian_2d"}),
-        dict(method="monopolar_triangulation", radius_um=150),
-        dict(method="monopolar_triangulation", radius_um=150, optimizer="minimize_with_log_penality"),
+        dict(method="center_of_mass", method_kwargs=dict(radius_um=100)),
+        dict(method="grid_convolution", method_kwargs=dict(radius_um=50)),
+        dict(method="grid_convolution", method_kwargs=dict(radius_um=150, weight_method={"mode": "gaussian_2d"})),
+        dict(method="monopolar_triangulation", method_kwargs=dict(radius_um=150)),
+        dict(
+            method="monopolar_triangulation", method_kwargs=dict(radius_um=150, optimizer="minimize_with_log_penality")
+        ),
     ]
 
 

--- a/src/spikeinterface/postprocessing/unit_localization.py
+++ b/src/spikeinterface/postprocessing/unit_localization.py
@@ -37,9 +37,7 @@ class ComputeUnitLocations(AnalyzerExtension):
         A SortingAnalyzer object
     method: "center_of_mass" | "monopolar_triangulation" | "grid_convolution", default: "center_of_mass"
         The method to use for localization
-    outputs: "numpy" | "by_unit", default: "numpy"
-        The output format
-    method_kwargs:
+    method_kwargs: dict, default: {}
         Other kwargs depending on the method
 
     Returns
@@ -59,7 +57,7 @@ class ComputeUnitLocations(AnalyzerExtension):
     def __init__(self, sorting_analyzer):
         AnalyzerExtension.__init__(self, sorting_analyzer)
 
-    def _set_params(self, method="monopolar_triangulation", **method_kwargs):
+    def _set_params(self, method="monopolar_triangulation", method_kwargs={}):
         params = dict(method=method, method_kwargs=method_kwargs)
         return params
 


### PR DESCRIPTION
and `get_computable_extensions()`

@samuelgarcia @h-mayorquin @zm711 couldn't come up with a better name for the latter. Any suggestion?

At one point, we will make the switch and define proper pydantic models (at least for extension, sorters, quality metrics, template metrics params)


**NOTE:** I changed the `unit_locations` `**method_kwargs` to a `method_kwargs` dict, which is better for inspection