### PR TITLE
Avoid `np.prod` in `make_shared_array`

### DIFF
--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -163,6 +163,7 @@ def make_shared_array(shape, dtype):
     from multiprocessing.shared_memory import SharedMemory
 
     dtype = np.dtype(dtype)
+    shape = (int(x) for x in shape)  # We need to be sure that shape comes in int and not number scalars
     nbytes = prod(shape) * dtype.itemsize
     shm = SharedMemory(name=None, create=True, size=nbytes)
     arr = np.ndarray(shape=shape, dtype=dtype, buffer=shm.buf)

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -163,7 +163,7 @@ def make_shared_array(shape, dtype):
     from multiprocessing.shared_memory import SharedMemory
 
     dtype = np.dtype(dtype)
-    shape = tuple(int(x) for x in shape)  # We need to be sure that shape comes in int and numpy number scalars
+    shape = tuple(int(x) for x in shape)  # We need to be sure that shape comes in int and numpy scalars
     nbytes = prod(shape) * dtype.itemsize
     shm = SharedMemory(name=None, create=True, size=nbytes)
     arr = np.ndarray(shape=shape, dtype=dtype, buffer=shm.buf)

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -163,7 +163,7 @@ def make_shared_array(shape, dtype):
     from multiprocessing.shared_memory import SharedMemory
 
     dtype = np.dtype(dtype)
-    shape = (int(x) for x in shape)  # We need to be sure that shape comes in int and not number scalars
+    shape = tuple(int(x) for x in shape)  # We need to be sure that shape comes in int and not number scalars
     nbytes = prod(shape) * dtype.itemsize
     shm = SharedMemory(name=None, create=True, size=nbytes)
     arr = np.ndarray(shape=shape, dtype=dtype, buffer=shm.buf)

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -163,7 +163,7 @@ def make_shared_array(shape, dtype):
     from multiprocessing.shared_memory import SharedMemory
 
     dtype = np.dtype(dtype)
-    shape = tuple(int(x) for x in shape)  # We need to be sure that shape comes in int and numpy scalars
+    shape = tuple(int(x) for x in shape)  # We need to be sure that shape comes in int instead of numpy scalars
     nbytes = prod(shape) * dtype.itemsize
     shm = SharedMemory(name=None, create=True, size=nbytes)
     arr = np.ndarray(shape=shape, dtype=dtype, buffer=shm.buf)

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -163,7 +163,7 @@ def make_shared_array(shape, dtype):
     from multiprocessing.shared_memory import SharedMemory
 
     dtype = np.dtype(dtype)
-    shape = tuple(int(x) for x in shape)  # We need to be sure that shape comes in int and not number scalars
+    shape = tuple(int(x) for x in shape)  # We need to be sure that shape comes in int and numpy number scalars
     nbytes = prod(shape) * dtype.itemsize
     shm = SharedMemory(name=None, create=True, size=nbytes)
     arr = np.ndarray(shape=shape, dtype=dtype, buffer=shm.buf)

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -6,7 +6,7 @@ import sys
 import datetime
 import json
 from copy import deepcopy
-
+from math import prod
 
 import numpy as np
 from tqdm import tqdm
@@ -163,7 +163,7 @@ def make_shared_array(shape, dtype):
     from multiprocessing.shared_memory import SharedMemory
 
     dtype = np.dtype(dtype)
-    nbytes = int(np.prod(shape) * dtype.itemsize)
+    nbytes = prod(shape) * dtype.itemsize
     shm = SharedMemory(name=None, create=True, size=nbytes)
     arr = np.ndarray(shape=shape, dtype=dtype, buffer=shm.buf)
     arr[:] = 0

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -483,7 +483,7 @@ def extract_waveforms_to_single_buffer(
     if sparsity_mask is None:
         num_chans = recording.get_num_channels()
     else:
-        num_chans = max(np.sum(sparsity_mask, axis=1))
+        num_chans = int(max(np.sum(sparsity_mask, axis=1)))  # This is a numpy scalar, so we cast to int
     shape = (num_spikes, nsamples, num_chans)
 
     if mode == "memmap":


### PR DESCRIPTION
np.prod produces a numpy scalars (not integers or floats!). 

Numpy scalars behave like numpy values and can overflow. Example:

```python
In [1]: a_billion_int = 1_000_000_000

In [2]: np.prod((a_billion_int, a_billion_int, a_billion_int, a_billion_int))
Out[2]: -5527149226598858752
```

Python integers on the other hand do not overflow. 

This PR changes this so overflow errors do not happen.

This error appear to a user here:
https://github.com/SpikeInterface/spikeinterface/issues/1871#issuecomment-1947957281

