### PR TITLE
Modify CI for new dev version criteria

### DIFF
--- a/.github/actions/build-test-environment/action.yml
+++ b/.github/actions/build-test-environment/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Force installation of latest dev from key-packages when running dev (not release)
       run: |
         source ${{ github.workspace }}/test_env/bin/activate
-        spikeinterface_is_dev_version=$(python -c "import importlib.metadata; version = importlib.metadata.version('spikeinterface'); print(version.endswith('dev0'))")
+        spikeinterface_is_dev_version=$(python -c "import spikeinterface; print(spikeinterface.DEV_MODE)")
         if [ $spikeinterface_is_dev_version = "True" ]; then
           echo "Running spikeinterface dev version"
           pip install --no-cache-dir git+https://github.com/NeuralEnsemble/python-neo


### PR DESCRIPTION
Uses the new attribute on the `__init__` to determine whether to install neo and probe from their latest github versions.