### PR TITLE
Fix typo in fast templates test

### DIFF
--- a/src/spikeinterface/core/tests/test_analyzer_extension_core.py
+++ b/src/spikeinterface/core/tests/test_analyzer_extension_core.py
@@ -221,10 +221,10 @@ def test_ComputeFastTemplates_versus_ComputeTemplates():
     templates_fast = sorting_analyzer.get_extension("fast_templates").get_templates()
     templates_fast_std = sorting_analyzer.get_extension("fast_templates").get_templates(operator="std")
     templates = sorting_analyzer.get_extension("templates").get_templates()
-    templates_std = sorting_analyzer.get_extension("fast_templates").get_templates(operator="std")
+    templates_std = sorting_analyzer.get_extension("templates").get_templates(operator="std")
 
     np.testing.assert_almost_equal(templates_fast, templates)
-    np.testing.assert_almost_equal(templates_fast_std, templates_std)
+    np.testing.assert_almost_equal(templates_fast_std, templates_std, decimal=4)
 
 
 def test_get_children_dependencies():

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -864,7 +864,7 @@ def estimate_templates_with_accumulator(
 
     # average
     waveforms_sum = np.sum(waveform_accumulator_per_worker, axis=0)
-    template_means = waveforms_sum
+    template_means = waveforms_sum.copy()
     unit_indices, spike_count = np.unique(spikes["unit_index"], return_counts=True)
     template_means[unit_indices, :, :] /= spike_count[:, np.newaxis, np.newaxis]
 
@@ -874,7 +874,7 @@ def estimate_templates_with_accumulator(
         template_stds = np.zeros_like(template_means)
         for i, (unit_index, count) in enumerate(zip(unit_indices, spike_count)):
             residuals = (
-                waveforms_squared_sum[unit_index] - 2 * count * template_means[unit_index] * waveforms_sum[unit_index]
+                waveforms_squared_sum[unit_index] - 2 * template_means[unit_index] * waveforms_sum[unit_index]
             ) + count * template_means[unit_index] ** 2
             template_stds[unit_index] = np.sqrt(residuals / count)
         assert np.all(template_stds >= 0)

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -872,7 +872,7 @@ def estimate_templates_with_accumulator(
         waveforms_squared_sum = np.sum(waveform_squared_accumulator_per_worker, axis=0)
         # standard deviation
         template_stds = np.zeros_like(template_means)
-        for i, (unit_index, count) in enumerate(zip(unit_indices, spike_count)):
+        for unit_index, count in zip(unit_indices, spike_count):
             residuals = (
                 waveforms_squared_sum[unit_index] - 2 * template_means[unit_index] * waveforms_sum[unit_index]
             ) + count * template_means[unit_index] ** 2

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -867,6 +867,8 @@ def estimate_templates_with_accumulator(
     if return_std:
         # we need a copy here because we will use the means to cpmpute the stds
         template_means = waveforms_sum.copy()
+    else:
+        template_means = waveforms_sum
 
     unit_indices, spike_count = np.unique(spikes["unit_index"], return_counts=True)
     template_means[unit_indices, :, :] /= spike_count[:, np.newaxis, np.newaxis]

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -864,7 +864,10 @@ def estimate_templates_with_accumulator(
 
     # average
     waveforms_sum = np.sum(waveform_accumulator_per_worker, axis=0)
-    template_means = waveforms_sum.copy()
+    if return_std:
+        # we need a copy here because we will use the means to cpmpute the stds
+        template_means = waveforms_sum.copy()
+
     unit_indices, spike_count = np.unique(spikes["unit_index"], return_counts=True)
     template_means[unit_indices, :, :] /= spike_count[:, np.newaxis, np.newaxis]
 

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -876,8 +876,8 @@ def estimate_templates_with_accumulator(
             residuals = (
                 waveforms_squared_sum[unit_index] - 2 * template_means[unit_index] * waveforms_sum[unit_index]
             ) + count * template_means[unit_index] ** 2
+            residuals[residuals < 0] = 0
             template_stds[unit_index] = np.sqrt(residuals / count)
-        assert np.all(template_stds >= 0)
         del waveform_squared_accumulator_per_worker
         shm_squared.unlink()
         shm_squared.close()

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -865,9 +865,10 @@ def estimate_templates_with_accumulator(
     # average
     waveforms_sum = np.sum(waveform_accumulator_per_worker, axis=0)
     if return_std:
-        # we need a copy here because we will use the means to cpmpute the stds
+        # we need a copy here because we will use the means to compute the stds
         template_means = waveforms_sum.copy()
     else:
+        # waveforms_sum will also be changed in this case when acting on template_means
         template_means = waveforms_sum
 
     unit_indices, spike_count = np.unique(spikes["unit_index"], return_counts=True)


### PR DESCRIPTION
@DradeAW there was a typo in the tests, but still fast and normal templates give the same stds down to the 4th decimal (which I think it's ok)