### PR TITLE
Allowing to bypass the random_spikes_selection to estimate sparsity

### DIFF
--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -602,16 +602,17 @@ def estimate_sparsity(
     nafter = int(ms_after * recording.sampling_frequency / 1000.0)
 
     num_samples = [recording.get_num_samples(seg_index) for seg_index in range(recording.get_num_segments())]
-    random_spikes_indices = random_spikes_selection(
-        sorting,
-        num_samples,
-        method="uniform",
-        max_spikes_per_unit=num_spikes_for_sparsity,
-        margin_size=max(nbefore, nafter),
-        seed=2205,
-    )
     spikes = sorting.to_spike_vector()
-    spikes = spikes[random_spikes_indices]
+    if num_spikes_for_sparsity is not None:
+        random_spikes_indices = random_spikes_selection(
+            sorting,
+            num_samples,
+            method="uniform",
+            max_spikes_per_unit=num_spikes_for_sparsity,
+            margin_size=max(nbefore, nafter),
+            seed=2205,
+        )
+        spikes = spikes[random_spikes_indices]
 
     templates_array = estimate_templates_with_accumulator(
         recording,


### PR DESCRIPTION
Currently, the random_spikes_selection() function is really slow for large number of spikes/units. Therefore, the sorting analyzer is not operational when you have lots of neurons. This PR allows to bypass such a selection if num_spikes_for_sparsity is set to None. This is a temp fix, while @samuelgarcia will optimize the random_spikes_selection() function