### PR TITLE
Changing the generation of fake template with a decaying exponential and fix torch locally exclusive

### DIFF
--- a/src/spikeinterface/core/tests/test_analyzer_extension_core.py
+++ b/src/spikeinterface/core/tests/test_analyzer_extension_core.py
@@ -111,7 +111,7 @@ def test_ComputeWaveforms(format, sparse):
 def test_ComputeTemplates(format, sparse):
     sorting_analyzer = get_sorting_analyzer(format=format, sparse=sparse)
 
-    sorting_analyzer.compute("random_spikes", max_spikes_per_unit=500, seed=2205)
+    sorting_analyzer.compute("random_spikes", max_spikes_per_unit=50, seed=2205)
 
     job_kwargs = dict(n_jobs=2, chunk_duration="1s", progress_bar=True)
 
@@ -162,12 +162,10 @@ def test_ComputeTemplates(format, sparse):
         sparsity_mask = np.ones((sorting_analyzer.unit_ids.size, sorting_analyzer.channel_ids.size), dtype=bool)
     for unit_index, unit_id in enumerate(sorting_analyzer.unit_ids):
         unit_mask = sparsity_mask[unit_index, :]
-        np.testing.assert_array_almost_equal(
-            fast_avg[unit_index][:, unit_mask], temp_ext.data["average"][unit_index][:, unit_mask], decimal=2
+        assert np.allclose(
+            fast_avg[unit_index][:, unit_mask], temp_ext.data["average"][unit_index][:, unit_mask], atol=0.01
         )
-        np.testing.assert_array_almost_equal(
-            fast_std[unit_index][:, unit_mask], temp_ext.data["std"][unit_index][:, unit_mask], decimal=1
-        )
+        assert np.allclose(fast_std[unit_index][:, unit_mask], temp_ext.data["std"][unit_index][:, unit_mask], atol=0.5)
 
     templates = temp_ext.get_templates(outputs="Templates")
     assert isinstance(templates, Templates)

--- a/src/spikeinterface/core/tests/test_analyzer_extension_core.py
+++ b/src/spikeinterface/core/tests/test_analyzer_extension_core.py
@@ -111,7 +111,7 @@ def test_ComputeWaveforms(format, sparse):
 def test_ComputeTemplates(format, sparse):
     sorting_analyzer = get_sorting_analyzer(format=format, sparse=sparse)
 
-    sorting_analyzer.compute("random_spikes", max_spikes_per_unit=20, seed=2205)
+    sorting_analyzer.compute("random_spikes", max_spikes_per_unit=500, seed=2205)
 
     job_kwargs = dict(n_jobs=2, chunk_duration="1s", progress_bar=True)
 
@@ -162,11 +162,11 @@ def test_ComputeTemplates(format, sparse):
         sparsity_mask = np.ones((sorting_analyzer.unit_ids.size, sorting_analyzer.channel_ids.size), dtype=bool)
     for unit_index, unit_id in enumerate(sorting_analyzer.unit_ids):
         unit_mask = sparsity_mask[unit_index, :]
-        np.testing.assert_almost_equal(
-            fast_avg[unit_index][:, unit_mask], temp_ext.data["average"][unit_index][:, unit_mask], decimal=4
+        np.testing.assert_array_almost_equal(
+            fast_avg[unit_index][:, unit_mask], temp_ext.data["average"][unit_index][:, unit_mask], decimal=2
         )
-        np.testing.assert_almost_equal(
-            fast_std[unit_index][:, unit_mask], temp_ext.data["std"][unit_index][:, unit_mask], decimal=4
+        np.testing.assert_array_almost_equal(
+            fast_std[unit_index][:, unit_mask], temp_ext.data["std"][unit_index][:, unit_mask], decimal=1
         )
 
     templates = temp_ext.get_templates(outputs="Templates")

--- a/src/spikeinterface/postprocessing/tests/common_extension_tests.py
+++ b/src/spikeinterface/postprocessing/tests/common_extension_tests.py
@@ -34,7 +34,7 @@ def get_dataset():
         ),
         generate_templates_kwargs=dict(
             unit_params_range=dict(
-                alpha=(9_000.0, 12_000.0),
+                alpha=(100.0, 500.0),
             )
         ),
         noise_kwargs=dict(noise_level=5.0, strategy="tile_pregenerated"),

--- a/src/spikeinterface/sortingcomponents/peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/peak_detection.py
@@ -743,6 +743,8 @@ if HAVE_TORCH:
         # this will be adjusted based on: num jobs, num gpus, num neighbors
         MAXCOPY = 8
 
+        # center traces by excluding the sweep size
+        traces = traces[exclude_sweep_size:-exclude_sweep_size, :]
         num_samples, num_channels = traces.shape
         dtype = torch.float32
         empty_return_value = (torch.tensor([], dtype=dtype), torch.tensor([], dtype=dtype))
@@ -825,7 +827,7 @@ if HAVE_TORCH:
             ).squeeze()
             if not deduplication_indices.numel():
                 return empty_return_value
-            sample_indices = sample_indices[deduplication_indices]
+            sample_indices = sample_indices[deduplication_indices] + exclude_sweep_size
             channel_indices = channel_indices[deduplication_indices]
             amplitudes = amplitudes[deduplication_indices]
 

--- a/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/tests/test_peak_detection.py
@@ -26,11 +26,6 @@ from spikeinterface.core.node_pipeline import run_node_pipeline
 from spikeinterface.sortingcomponents.tests.common import make_dataset
 
 
-if hasattr(pytest, "global_test_folder"):
-    cache_folder = pytest.global_test_folder / "sortingcomponents"
-else:
-    cache_folder = Path("cache_folder") / "sortingcomponents"
-
 try:
     import pyopencl
 
@@ -345,7 +340,7 @@ def test_peak_sign_consistency(recording, job_kwargs, detection_class):
         assert all_peaks.size > 0
 
 
-def test_peak_detection_with_pipeline(recording, job_kwargs, torch_job_kwargs):
+def test_peak_detection_with_pipeline(recording, job_kwargs, torch_job_kwargs, tmp_path):
     extract_dense_waveforms = ExtractDenseWaveforms(recording, ms_before=1.0, ms_after=1.0, return_output=False)
 
     pipeline_nodes = [
@@ -367,7 +362,7 @@ def test_peak_detection_with_pipeline(recording, job_kwargs, torch_job_kwargs):
     assert "x" in peak_locations.dtype.fields
 
     # same pipeline but saved to npy
-    folder = cache_folder / "peak_detection_folder"
+    folder = tmp_path / "peak_detection_folder"
     if folder.is_dir():
         shutil.rmtree(folder)
     peaks2, ptp2, peak_locations2 = detect_peaks(
@@ -467,6 +462,7 @@ def test_peak_detection_with_pipeline(recording, job_kwargs, torch_job_kwargs):
 
 if __name__ == "__main__":
     recording, sorting = make_dataset()
+    tmp_path = Path(tempfile.mkdtemp())
 
     job_kwargs_main = job_kwargs()
     torch_job_kwargs_main = torch_job_kwargs(job_kwargs_main)
@@ -479,4 +475,5 @@ if __name__ == "__main__":
     #     recording, job_kwargs_main, pca_model_folder_path_main, peak_detector_kwargs_main
     # )
 
-    test_peak_sign_consistency(recording, torch_job_kwargs_main, DetectPeakLocallyExclusiveTorch)
+    # test_peak_sign_consistency(recording, torch_job_kwargs_main, DetectPeakLocallyExclusiveTorch)
+    test_peak_detection_with_pipeline(recording, job_kwargs_main, torch_job_kwargs_main, tmp_path)


### PR DESCRIPTION
In this PR, we change the way fake templates are generated. Instead of a powerlaw for the decay of the amplitudes as function of the distances, we use a decaying exponential with a spatial_constant. This seems to be more biophysically plausible, and it introduces less artefacts