### PR TITLE
Allow covariance matrix for noise generation

### DIFF
--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -27,6 +27,7 @@ def _ensure_seed(seed):
         seed = np.random.default_rng(seed=None).integers(0, 2**63)
     return seed
 
+
 def get_distances_from_probe(probe):
     locations = probe.contact_positions
     channel_distances = np.linalg.norm(locations[:, np.newaxis] - locations[np.newaxis, :], axis=2)
@@ -1138,7 +1139,9 @@ class NoiseGeneratorRecordingSegment(BaseRecordingSegment):
                 if self.cov_matrix is None:
                     noise_block = rng.standard_normal(size=(self.noise_block_size, self.num_channels), dtype=self.dtype)
                 else:
-                    noise_block = rng.multivariate_normal(np.zeros(self.num_channels), self.cov_matrix, size=self.noise_block_size)
+                    noise_block = rng.multivariate_normal(
+                        np.zeros(self.num_channels), self.cov_matrix, size=self.noise_block_size
+                    )
                 noise_block *= self.noise_level
 
             if block_index == first_block_index:
@@ -2037,9 +2040,8 @@ def generate_ground_truth_recording(
     else:
         num_channels = probe.get_contact_count()
 
-
     if correlated_noise is not None:
-        distances =  get_distances_from_probe(probe)
+        distances = get_distances_from_probe(probe)
         cov_matrix = np.zeros((num_channels, num_channels), dtype=np.float32)
         for i in range(num_channels):
             for j in range(num_channels):
@@ -2047,7 +2049,7 @@ def generate_ground_truth_recording(
                     cov_matrix[i, j] = (0.5 * correlated_noise) / distances[i, j]
                 else:
                     cov_matrix[i, j] = 1
-        
+
     else:
         cov_matrix = None
 

--- a/src/spikeinterface/sortingcomponents/benchmark/benchmark_matching.py
+++ b/src/spikeinterface/sortingcomponents/benchmark/benchmark_matching.py
@@ -46,7 +46,7 @@ class MatchingBenchmark(Benchmark):
         sorting = self.result["sorting"]
         comp = compare_sorter_to_ground_truth(self.gt_sorting, sorting, exhaustive_gt=True)
         self.result["gt_comparison"] = comp
-        #self.result["gt_collision"] = CollisionGTComparison(self.gt_sorting, sorting, exhaustive_gt=True)
+        # self.result["gt_collision"] = CollisionGTComparison(self.gt_sorting, sorting, exhaustive_gt=True)
 
     _run_key_saved = [
         ("sorting", "sorting"),

--- a/src/spikeinterface/sortingcomponents/benchmark/benchmark_matching.py
+++ b/src/spikeinterface/sortingcomponents/benchmark/benchmark_matching.py
@@ -46,13 +46,13 @@ class MatchingBenchmark(Benchmark):
         sorting = self.result["sorting"]
         comp = compare_sorter_to_ground_truth(self.gt_sorting, sorting, exhaustive_gt=True)
         self.result["gt_comparison"] = comp
-        self.result["gt_collision"] = CollisionGTComparison(self.gt_sorting, sorting, exhaustive_gt=True)
+        #self.result["gt_collision"] = CollisionGTComparison(self.gt_sorting, sorting, exhaustive_gt=True)
 
     _run_key_saved = [
         ("sorting", "sorting"),
         ("templates", "zarr_templates"),
     ]
-    _result_key_saved = [("gt_collision", "pickle"), ("gt_comparison", "pickle")]
+    _result_key_saved = [("gt_comparison", "pickle")]
 
 
 class MatchingStudy(BenchmarkStudy):


### PR DESCRIPTION
We want to make the noise generation more realistic, and to do so, we can allow a covariance matrix in order to make the noise structure more realistic. However, I know that after discussion with @samuelgarcia , the goal is to keep the generation file as simple as possible, so maybe a more complicated object could be put elsewhere. Open to discussion