### PR TITLE
Move "return_scaled" options global to SortingAnalyzer.

### DIFF
--- a/src/spikeinterface/core/analyzer_extension_core.py
+++ b/src/spikeinterface/core/analyzer_extension_core.py
@@ -122,8 +122,6 @@ class ComputeWaveforms(AnalyzerExtension):
         The number of ms to extract before the spike events
     ms_after: float, default: 2.0
         The number of ms to extract after the spike events
-    return_scaled: bool, default: True
-        If True, the waveforms are scaled to uV (if the recording has scaling)
     dtype: None | dtype, default: None
         The dtype of the waveforms. If None, the dtype of the recording is used.
 
@@ -179,7 +177,7 @@ class ComputeWaveforms(AnalyzerExtension):
             self.nbefore,
             self.nafter,
             mode=mode,
-            return_scaled=self.params["return_scaled"],
+            return_scaled=self.sorting_analyzer.return_scaled,
             file_path=file_path,
             dtype=self.params["dtype"],
             sparsity_mask=sparsity_mask,
@@ -194,20 +192,13 @@ class ComputeWaveforms(AnalyzerExtension):
         self,
         ms_before: float = 1.0,
         ms_after: float = 2.0,
-        return_scaled: bool = True,
         dtype=None,
     ):
         recording = self.sorting_analyzer.recording
         if dtype is None:
             dtype = recording.get_dtype()
 
-        if return_scaled:
-            # check if has scaled values:
-            if not recording.has_scaled() and recording.get_dtype().kind == "i":
-                print("Setting 'return_scaled' to False")
-                return_scaled = False
-
-        if np.issubdtype(dtype, np.integer) and return_scaled:
+        if np.issubdtype(dtype, np.integer) and self.sorting_analyzer.return_scaled:
             dtype = "float32"
 
         dtype = np.dtype(dtype)
@@ -215,7 +206,6 @@ class ComputeWaveforms(AnalyzerExtension):
         params = dict(
             ms_before=float(ms_before),
             ms_after=float(ms_after),
-            return_scaled=return_scaled,
             dtype=dtype.str,
         )
         return params
@@ -296,7 +286,7 @@ class ComputeTemplates(AnalyzerExtension):
     need_job_kwargs = True
 
     def _set_params(
-        self, ms_before: float = 1.0, ms_after: float = 2.0, return_scaled: bool = True, operators=["average", "std"]
+        self, ms_before: float = 1.0, ms_after: float = 2.0,operators=["average", "std"]
     ):
         assert isinstance(operators, list)
         for operator in operators:
@@ -311,7 +301,6 @@ class ComputeTemplates(AnalyzerExtension):
         if waveforms_extension is not None:
             nbefore = waveforms_extension.nbefore
             nafter = waveforms_extension.nafter
-            return_scaled = waveforms_extension.params["return_scaled"]
         else:
             nbefore = int(ms_before * self.sorting_analyzer.sampling_frequency / 1000.0)
             nafter = int(ms_after * self.sorting_analyzer.sampling_frequency / 1000.0)
@@ -320,7 +309,6 @@ class ComputeTemplates(AnalyzerExtension):
             operators=operators,
             nbefore=nbefore,
             nafter=nafter,
-            return_scaled=return_scaled,
         )
         return params
 
@@ -341,7 +329,7 @@ class ComputeTemplates(AnalyzerExtension):
             # retrieve spike vector and the sampling
             some_spikes = self.sorting_analyzer.get_extension("random_spikes").get_random_spikes()
 
-            return_scaled = self.params["return_scaled"]
+            return_scaled = self.sorting_analyzer.return_scaled
 
             self.data["average"], self.data["std"] = estimate_templates_with_accumulator(
                 recording,
@@ -570,9 +558,9 @@ class ComputeNoiseLevels(AnalyzerExtension):
     def __init__(self, sorting_analyzer):
         AnalyzerExtension.__init__(self, sorting_analyzer)
 
-    def _set_params(self, num_chunks_per_segment=20, chunk_size=10000, return_scaled=True, seed=None):
+    def _set_params(self, num_chunks_per_segment=20, chunk_size=10000, seed=None):
         params = dict(
-            num_chunks_per_segment=num_chunks_per_segment, chunk_size=chunk_size, return_scaled=return_scaled, seed=seed
+            num_chunks_per_segment=num_chunks_per_segment, chunk_size=chunk_size, seed=seed
         )
         return params
 
@@ -581,7 +569,7 @@ class ComputeNoiseLevels(AnalyzerExtension):
         return self.data
 
     def _run(self):
-        self.data["noise_levels"] = get_noise_levels(self.sorting_analyzer.recording, **self.params)
+        self.data["noise_levels"] = get_noise_levels(self.sorting_analyzer.recording, return_scaled=self.sorting_analyzer.return_scaled, **self.params)
 
     def _get_data(self):
         return self.data["noise_levels"]

--- a/src/spikeinterface/core/analyzer_extension_core.py
+++ b/src/spikeinterface/core/analyzer_extension_core.py
@@ -285,9 +285,7 @@ class ComputeTemplates(AnalyzerExtension):
     use_nodepipeline = False
     need_job_kwargs = True
 
-    def _set_params(
-        self, ms_before: float = 1.0, ms_after: float = 2.0,operators=["average", "std"]
-    ):
+    def _set_params(self, ms_before: float = 1.0, ms_after: float = 2.0, operators=["average", "std"]):
         assert isinstance(operators, list)
         for operator in operators:
             if isinstance(operator, str):
@@ -559,9 +557,7 @@ class ComputeNoiseLevels(AnalyzerExtension):
         AnalyzerExtension.__init__(self, sorting_analyzer)
 
     def _set_params(self, num_chunks_per_segment=20, chunk_size=10000, seed=None):
-        params = dict(
-            num_chunks_per_segment=num_chunks_per_segment, chunk_size=chunk_size, seed=seed
-        )
+        params = dict(num_chunks_per_segment=num_chunks_per_segment, chunk_size=chunk_size, seed=seed)
         return params
 
     def _select_extension_data(self, unit_ids):
@@ -569,7 +565,9 @@ class ComputeNoiseLevels(AnalyzerExtension):
         return self.data
 
     def _run(self):
-        self.data["noise_levels"] = get_noise_levels(self.sorting_analyzer.recording, return_scaled=self.sorting_analyzer.return_scaled, **self.params)
+        self.data["noise_levels"] = get_noise_levels(
+            self.sorting_analyzer.recording, return_scaled=self.sorting_analyzer.return_scaled, **self.params
+        )
 
     def _get_data(self):
         return self.data["noise_levels"]

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -62,7 +62,7 @@ def create_sorting_analyzer(
         You can control `estimate_sparsity()` : all extra arguments are propagated to it (included job_kwargs)
     sparsity: ChannelSparsity or None, default: None
         The sparsity used to compute waveforms. If this is given, `sparse` is ignored.
-    return_scaled: bool, default True
+    return_scaled: bool, default: True
         All extensions that play with traces will use this global return_scaled: "waveforms", "noise_levels", "templates".
         This prevent return_scaled being differents from different extensions and having wrong snr for instance.
 
@@ -122,7 +122,7 @@ def create_sorting_analyzer(
         sparsity = None
 
     if return_scaled and not recording.has_scaled_traces() and recording.get_dtype().kind == "i":
-        print("create_sorting_analyzer: recording do not have scale to uV, force return_scaled=False")
+        print("create_sorting_analyzer: recording does not have scaling to uV, forcing return_scaled=False")
         return_scaled = False
 
     sorting_analyzer = SortingAnalyzer.create(sorting, recording, format=format, folder=folder, sparsity=sparsity, return_scaled=return_scaled)

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -32,7 +32,15 @@ from .node_pipeline import run_node_pipeline
 
 # high level function
 def create_sorting_analyzer(
-    sorting, recording, format="memory", folder=None, sparse=True, sparsity=None, return_scaled=True, overwrite=False, **sparsity_kwargs
+    sorting,
+    recording,
+    format="memory",
+    folder=None,
+    sparse=True,
+    sparsity=None,
+    return_scaled=True,
+    overwrite=False,
+    **sparsity_kwargs,
 ):
     """
     Create a SortingAnalyzer by pairing a Sorting and the corresponding Recording.
@@ -125,7 +133,9 @@ def create_sorting_analyzer(
         print("create_sorting_analyzer: recording does not have scaling to uV, forcing return_scaled=False")
         return_scaled = False
 
-    sorting_analyzer = SortingAnalyzer.create(sorting, recording, format=format, folder=folder, sparsity=sparsity, return_scaled=return_scaled)
+    sorting_analyzer = SortingAnalyzer.create(
+        sorting, recording, format=format, folder=folder, sparsity=sparsity, return_scaled=return_scaled
+    )
 
     return sorting_analyzer
 
@@ -289,7 +299,12 @@ class SortingAnalyzer:
         # a copy of sorting is created directly in shared memory format to avoid further duplication of spikes.
         sorting_copy = SharedMemorySorting.from_sorting(sorting, with_metadata=True)
         sorting_analyzer = SortingAnalyzer(
-            sorting=sorting_copy, recording=recording, rec_attributes=rec_attributes, format="memory", sparsity=sparsity, return_scaled=return_scaled,
+            sorting=sorting_copy,
+            recording=recording,
+            rec_attributes=rec_attributes,
+            format="memory",
+            sparsity=sparsity,
+            return_scaled=return_scaled,
         )
         return sorting_analyzer
 
@@ -355,7 +370,6 @@ class SortingAnalyzer:
         with open(settings_file, mode="w") as f:
             json.dump(check_json(settings), f, indent=4)
 
-
     @classmethod
     def load_from_binary_folder(cls, folder, recording=None):
         folder = Path(folder)
@@ -402,7 +416,6 @@ class SortingAnalyzer:
         else:
             sparsity = None
 
-        
         settings_file = folder / f"settings.json"
         with open(settings_file, "r") as f:
             settings = json.load(f)
@@ -444,11 +457,8 @@ class SortingAnalyzer:
         info = dict(version=spikeinterface.__version__, dev_mode=spikeinterface.DEV_MODE, object="SortingAnalyzer")
         zarr_root.attrs["spikeinterface_info"] = check_json(info)
 
-        settings = dict(
-            return_scaled=return_scaled
-        )
+        settings = dict(return_scaled=return_scaled)
         zarr_root.attrs["settings"] = check_json(settings)
-        
 
         # the recording
         rec_dict = recording.to_dict(relative_to=folder, recursive=True)
@@ -601,7 +611,9 @@ class SortingAnalyzer:
             # create  a new folder
             assert folder is not None, "For format='binary_folder' folder must be provided"
             folder = Path(folder)
-            SortingAnalyzer.create_binary_folder(folder, sorting_provenance, recording, sparsity, self.return_scaled, self.rec_attributes)
+            SortingAnalyzer.create_binary_folder(
+                folder, sorting_provenance, recording, sparsity, self.return_scaled, self.rec_attributes
+            )
             new_sorting_analyzer = SortingAnalyzer.load_from_binary_folder(folder, recording=recording)
             new_sorting_analyzer.folder = folder
 
@@ -610,7 +622,9 @@ class SortingAnalyzer:
             folder = Path(folder)
             if folder.suffix != ".zarr":
                 folder = folder.parent / f"{folder.stem}.zarr"
-            SortingAnalyzer.create_zarr(folder, sorting_provenance, recording, sparsity, self.return_scaled, self.rec_attributes)
+            SortingAnalyzer.create_zarr(
+                folder, sorting_provenance, recording, sparsity, self.return_scaled, self.rec_attributes
+            )
             new_sorting_analyzer = SortingAnalyzer.load_from_zarr(folder, recording=recording)
             new_sorting_analyzer.folder = folder
         else:

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -327,9 +327,6 @@ class ChannelSparsity:
         if isinstance(templates_or_sorting_analyzer, SortingAnalyzer):
             ext = templates_or_sorting_analyzer.get_extension("noise_levels")
             assert ext is not None, "To compute sparsity from snr you need to compute 'noise_levels' first"
-            # assert ext.params[
-            #     "return_scaled"
-            # ], "To compute sparsity from snr you need return_scaled=True for extensions"
             noise_levels = ext.data["noise_levels"]
             return_scaled = templates_or_sorting_analyzer.return_scaled
         elif isinstance(templates_or_sorting_analyzer, Templates):

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -368,9 +368,6 @@ class ChannelSparsity:
         if isinstance(templates_or_sorting_analyzer, SortingAnalyzer):
             ext = templates_or_sorting_analyzer.get_extension("noise_levels")
             assert ext is not None, "To compute sparsity from snr you need to compute 'noise_levels' first"
-            # assert ext.params[
-            #     "return_scaled"
-            # ], "To compute sparsity from snr you need return_scaled=True for extensions"
             noise_levels = ext.data["noise_levels"]
             return_scaled = templates_or_sorting_analyzer.return_scaled
         elif isinstance(templates_or_sorting_analyzer, Templates):
@@ -402,7 +399,6 @@ class ChannelSparsity:
         # noise_levels
         ext = sorting_analyzer.get_extension("noise_levels")
         assert ext is not None, "To compute sparsity from ptp you need to compute 'noise_levels' first"
-        # assert ext.params["return_scaled"], "To compute sparsity from snr you need return_scaled=True for extensions"
         noise_levels = ext.data["noise_levels"]
 
         # waveforms

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -327,17 +327,19 @@ class ChannelSparsity:
         if isinstance(templates_or_sorting_analyzer, SortingAnalyzer):
             ext = templates_or_sorting_analyzer.get_extension("noise_levels")
             assert ext is not None, "To compute sparsity from snr you need to compute 'noise_levels' first"
-            assert ext.params[
-                "return_scaled"
-            ], "To compute sparsity from snr you need return_scaled=True for extensions"
+            # assert ext.params[
+            #     "return_scaled"
+            # ], "To compute sparsity from snr you need return_scaled=True for extensions"
             noise_levels = ext.data["noise_levels"]
+            return_scaled = templates_or_sorting_analyzer.return_scaled
         elif isinstance(templates_or_sorting_analyzer, Templates):
             assert noise_levels is not None
+            return_scaled = True
 
         mask = np.zeros((unit_ids.size, channel_ids.size), dtype="bool")
 
         peak_values = get_template_amplitudes(
-            templates_or_sorting_analyzer, peak_sign=peak_sign, mode="extremum", return_scaled=True
+            templates_or_sorting_analyzer, peak_sign=peak_sign, mode="extremum", return_scaled=return_scaled
         )
 
         for unit_ind, unit_id in enumerate(unit_ids):
@@ -366,18 +368,20 @@ class ChannelSparsity:
         if isinstance(templates_or_sorting_analyzer, SortingAnalyzer):
             ext = templates_or_sorting_analyzer.get_extension("noise_levels")
             assert ext is not None, "To compute sparsity from snr you need to compute 'noise_levels' first"
-            assert ext.params[
-                "return_scaled"
-            ], "To compute sparsity from snr you need return_scaled=True for extensions"
+            # assert ext.params[
+            #     "return_scaled"
+            # ], "To compute sparsity from snr you need return_scaled=True for extensions"
             noise_levels = ext.data["noise_levels"]
+            return_scaled = templates_or_sorting_analyzer.return_scaled
         elif isinstance(templates_or_sorting_analyzer, Templates):
             assert noise_levels is not None
+            return_scaled = True
 
         from .template_tools import get_dense_templates_array
 
         mask = np.zeros((unit_ids.size, channel_ids.size), dtype="bool")
 
-        templates_array = get_dense_templates_array(templates_or_sorting_analyzer, return_scaled=True)
+        templates_array = get_dense_templates_array(templates_or_sorting_analyzer, return_scaled=return_scaled)
         templates_ptps = np.ptp(templates_array, axis=1)
 
         for unit_ind, unit_id in enumerate(unit_ids):
@@ -398,7 +402,7 @@ class ChannelSparsity:
         # noise_levels
         ext = sorting_analyzer.get_extension("noise_levels")
         assert ext is not None, "To compute sparsity from ptp you need to compute 'noise_levels' first"
-        assert ext.params["return_scaled"], "To compute sparsity from snr you need return_scaled=True for extensions"
+        # assert ext.params["return_scaled"], "To compute sparsity from snr you need return_scaled=True for extensions"
         noise_levels = ext.data["noise_levels"]
 
         # waveforms

--- a/src/spikeinterface/core/template_tools.py
+++ b/src/spikeinterface/core/template_tools.py
@@ -27,7 +27,9 @@ def get_dense_templates_array(one_object: Templates | SortingAnalyzer, return_sc
         templates_array = one_object.get_dense_templates()
     elif isinstance(one_object, SortingAnalyzer):
         if return_scaled != one_object.return_scaled:
-            raise ValueError(f"get_dense_templates_array: return_scaled={return_scaled} is not possible SortingAnalyzer has the reverse")
+            raise ValueError(
+                f"get_dense_templates_array: return_scaled={return_scaled} is not possible SortingAnalyzer has the reverse"
+            )
         ext = one_object.get_extension("templates")
         if ext is not None:
             templates_array = ext.data["average"]

--- a/src/spikeinterface/core/template_tools.py
+++ b/src/spikeinterface/core/template_tools.py
@@ -26,12 +26,11 @@ def get_dense_templates_array(one_object: Templates | SortingAnalyzer, return_sc
     if isinstance(one_object, Templates):
         templates_array = one_object.get_dense_templates()
     elif isinstance(one_object, SortingAnalyzer):
+        if return_scaled != one_object.return_scaled:
+            raise ValueError(f"get_dense_templates_array: return_scaled={return_scaled} is not possible SortingAnalyzer has the reverse")
         ext = one_object.get_extension("templates")
         if ext is not None:
             templates_array = ext.data["average"]
-            assert (
-                return_scaled == ext.params["return_scaled"]
-            ), f"templates have been extracted with return_scaled={not return_scaled} you cannot get then with return_scaled={return_scaled}"
         else:
             raise ValueError("SortingAnalyzer need extension 'templates' to be computed to retrieve templates")
     else:

--- a/src/spikeinterface/core/tests/test_analyzer_extension_core.py
+++ b/src/spikeinterface/core/tests/test_analyzer_extension_core.py
@@ -189,7 +189,7 @@ def test_ComputeTemplates(format, sparse):
 def test_ComputeNoiseLevels(format, sparse):
     sorting_analyzer = get_sorting_analyzer(format=format, sparse=sparse)
 
-    sorting_analyzer.compute("noise_levels", return_scaled=True)
+    sorting_analyzer.compute("noise_levels")
     print(sorting_analyzer)
 
     noise_levels = sorting_analyzer.get_extension("noise_levels").data["noise_levels"]
@@ -218,15 +218,15 @@ def test_delete_on_recompute():
 
 if __name__ == "__main__":
 
-    # test_ComputeWaveforms(format="memory", sparse=True)
-    # test_ComputeWaveforms(format="memory", sparse=False)
-    # test_ComputeWaveforms(format="binary_folder", sparse=True)
-    # test_ComputeWaveforms(format="binary_folder", sparse=False)
-    # test_ComputeWaveforms(format="zarr", sparse=True)
-    # test_ComputeWaveforms(format="zarr", sparse=False)
-    # test_ComputeRandomSpikes(format="memory", sparse=True)
+    test_ComputeWaveforms(format="memory", sparse=True)
+    test_ComputeWaveforms(format="memory", sparse=False)
+    test_ComputeWaveforms(format="binary_folder", sparse=True)
+    test_ComputeWaveforms(format="binary_folder", sparse=False)
+    test_ComputeWaveforms(format="zarr", sparse=True)
+    test_ComputeWaveforms(format="zarr", sparse=False)
+    test_ComputeRandomSpikes(format="memory", sparse=True)
     test_ComputeTemplates(format="memory", sparse=True)
-    # test_ComputeNoiseLevels(format="memory", sparse=False)
+    test_ComputeNoiseLevels(format="memory", sparse=False)
 
     test_get_children_dependencies()
     test_delete_on_recompute()

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -41,13 +41,16 @@ def test_SortingAnalyzer_memory():
     sorting_analyzer = create_sorting_analyzer(sorting, recording, format="memory", sparse=True, sparsity=None)
     _check_sorting_analyzers(sorting_analyzer, sorting)
 
-    sorting_analyzer = create_sorting_analyzer(sorting, recording, format="memory", sparse=False, return_scaled=True, sparsity=None)
+    sorting_analyzer = create_sorting_analyzer(
+        sorting, recording, format="memory", sparse=False, return_scaled=True, sparsity=None
+    )
     assert sorting_analyzer.return_scaled
     _check_sorting_analyzers(sorting_analyzer, sorting)
 
-    sorting_analyzer = create_sorting_analyzer(sorting, recording, format="memory", sparse=False, return_scaled=False, sparsity=None)
+    sorting_analyzer = create_sorting_analyzer(
+        sorting, recording, format="memory", sparse=False, return_scaled=False, sparsity=None
+    )
     assert not sorting_analyzer.return_scaled
-    
 
 
 def test_SortingAnalyzer_binary_folder():
@@ -68,12 +71,16 @@ def test_SortingAnalyzer_binary_folder():
         shutil.rmtree(folder)
 
     sorting_analyzer = create_sorting_analyzer(
-        sorting, recording, format="binary_folder", folder=folder, sparse=False, sparsity=None, return_scaled=False,
+        sorting,
+        recording,
+        format="binary_folder",
+        folder=folder,
+        sparse=False,
+        sparsity=None,
+        return_scaled=False,
     )
     assert not sorting_analyzer.return_scaled
     _check_sorting_analyzers(sorting_analyzer, sorting)
-    
-
 
 
 def test_SortingAnalyzer_zarr():
@@ -95,7 +102,6 @@ def test_SortingAnalyzer_zarr():
     sorting_analyzer = create_sorting_analyzer(
         sorting, recording, format="zarr", folder=folder, sparse=False, sparsity=None, return_scaled=False
     )
-
 
 
 def _check_sorting_analyzers(sorting_analyzer, original_sorting):

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -41,6 +41,14 @@ def test_SortingAnalyzer_memory():
     sorting_analyzer = create_sorting_analyzer(sorting, recording, format="memory", sparse=True, sparsity=None)
     _check_sorting_analyzers(sorting_analyzer, sorting)
 
+    sorting_analyzer = create_sorting_analyzer(sorting, recording, format="memory", sparse=False, return_scaled=True, sparsity=None)
+    assert sorting_analyzer.return_scaled
+    _check_sorting_analyzers(sorting_analyzer, sorting)
+
+    sorting_analyzer = create_sorting_analyzer(sorting, recording, format="memory", sparse=False, return_scaled=False, sparsity=None)
+    assert not sorting_analyzer.return_scaled
+    
+
 
 def test_SortingAnalyzer_binary_folder():
     recording, sorting = get_dataset()
@@ -55,6 +63,18 @@ def test_SortingAnalyzer_binary_folder():
     sorting_analyzer = load_sorting_analyzer(folder, format="auto")
     _check_sorting_analyzers(sorting_analyzer, sorting)
 
+    folder = cache_folder / "test_SortingAnalyzer_binary_folder"
+    if folder.exists():
+        shutil.rmtree(folder)
+
+    sorting_analyzer = create_sorting_analyzer(
+        sorting, recording, format="binary_folder", folder=folder, sparse=False, sparsity=None, return_scaled=False,
+    )
+    assert not sorting_analyzer.return_scaled
+    _check_sorting_analyzers(sorting_analyzer, sorting)
+    
+
+
 
 def test_SortingAnalyzer_zarr():
     recording, sorting = get_dataset()
@@ -68,6 +88,14 @@ def test_SortingAnalyzer_zarr():
     )
     sorting_analyzer = load_sorting_analyzer(folder, format="auto")
     _check_sorting_analyzers(sorting_analyzer, sorting)
+
+    folder = cache_folder / "test_SortingAnalyzer_zarr.zarr"
+    if folder.exists():
+        shutil.rmtree(folder)
+    sorting_analyzer = create_sorting_analyzer(
+        sorting, recording, format="zarr", folder=folder, sparse=False, sparsity=None, return_scaled=False
+    )
+
 
 
 def _check_sorting_analyzers(sorting_analyzer, original_sorting):
@@ -123,6 +151,8 @@ def _check_sorting_analyzers(sorting_analyzer, original_sorting):
         data = sorting_analyzer2.get_extension("dummy").data
         assert "result_one" in data
         assert data["result_two"].size == original_sorting.to_spike_vector().size
+
+        assert sorting_analyzer2.return_scaled == sorting_analyzer.return_scaled
 
     # select unit_ids to several format
     for format in ("memory", "binary_folder", "zarr"):

--- a/src/spikeinterface/core/tests/test_sparsity.py
+++ b/src/spikeinterface/core/tests/test_sparsity.py
@@ -199,11 +199,11 @@ def test_estimate_sparsity():
 def test_compute_sparsity():
     recording, sorting = get_dataset()
 
-    sorting_analyzer = create_sorting_analyzer(sorting=sorting, recording=recording, sparse=False)
+    sorting_analyzer = create_sorting_analyzer(sorting=sorting, recording=recording, sparse=False, return_scaled=True)
     sorting_analyzer.compute("random_spikes")
-    sorting_analyzer.compute("waveforms", return_scaled=True)
-    sorting_analyzer.compute("templates", return_scaled=True)
-    sorting_analyzer.compute("noise_levels", return_scaled=True)
+    sorting_analyzer.compute("waveforms", )
+    sorting_analyzer.compute("templates")
+    sorting_analyzer.compute("noise_levels")
     # this is needed for method="energy"
 
     # using object SortingAnalyzer

--- a/src/spikeinterface/core/tests/test_sparsity.py
+++ b/src/spikeinterface/core/tests/test_sparsity.py
@@ -201,7 +201,9 @@ def test_compute_sparsity():
 
     sorting_analyzer = create_sorting_analyzer(sorting=sorting, recording=recording, sparse=False, return_scaled=True)
     sorting_analyzer.compute("random_spikes")
-    sorting_analyzer.compute("waveforms", )
+    sorting_analyzer.compute(
+        "waveforms",
+    )
     sorting_analyzer.compute("templates")
     sorting_analyzer.compute("noise_levels")
     # this is needed for method="energy"

--- a/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
+++ b/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
@@ -368,7 +368,7 @@ def _read_old_waveforms_extractor_binary(folder):
     with open(params_file, "r") as f:
         params = json.load(f)
 
-    return_scaled = (params["return_scaled"],)
+    return_scaled = params["return_scaled"]
 
     sparsity_file = folder / "sparsity.json"
     if sparsity_file.exists():

--- a/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
+++ b/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
@@ -93,12 +93,19 @@ def extract_waveforms(
         **job_kwargs,
     )
     sorting_analyzer = create_sorting_analyzer(
-        sorting, recording, format=format, folder=folder, sparse=sparse, sparsity=sparsity, return_scaled=return_scaled, **sparsity_kwargs
+        sorting,
+        recording,
+        format=format,
+        folder=folder,
+        sparse=sparse,
+        sparsity=sparsity,
+        return_scaled=return_scaled,
+        **sparsity_kwargs,
     )
 
     sorting_analyzer.compute("random_spikes", max_spikes_per_unit=max_spikes_per_unit, seed=seed)
 
-    waveforms_params = dict(ms_before=ms_before, ms_after=ms_after,  dtype=dtype)
+    waveforms_params = dict(ms_before=ms_before, ms_after=ms_after, dtype=dtype)
     sorting_analyzer.compute("waveforms", **waveforms_params, **job_kwargs)
 
     templates_params = dict(operators=list(precompute_template))
@@ -360,8 +367,8 @@ def _read_old_waveforms_extractor_binary(folder):
         raise ValueError(f"This folder is not a WaveformsExtractor folder {folder}")
     with open(params_file, "r") as f:
         params = json.load(f)
-    
-    return_scaled = params["return_scaled"],
+
+    return_scaled = (params["return_scaled"],)
 
     sparsity_file = folder / "sparsity.json"
     if sparsity_file.exists():
@@ -400,7 +407,9 @@ def _read_old_waveforms_extractor_binary(folder):
     elif (folder / "sorting.pickle").exists():
         sorting = load_extractor(folder / "sorting.pickle", base_folder=folder)
 
-    sorting_analyzer = SortingAnalyzer.create_memory(sorting, recording, sparsity=sparsity, return_scaled=return_scaled, rec_attributes=rec_attributes)
+    sorting_analyzer = SortingAnalyzer.create_memory(
+        sorting, recording, sparsity=sparsity, return_scaled=return_scaled, rec_attributes=rec_attributes
+    )
 
     # waveforms
     # need to concatenate all waveforms in one unique buffer
@@ -449,7 +458,6 @@ def _read_old_waveforms_extractor_binary(folder):
         ext.params = dict(
             ms_before=params["ms_before"],
             ms_after=params["ms_after"],
-            
             dtype=params["dtype"],
         )
         ext.data["waveforms"] = waveforms
@@ -464,9 +472,7 @@ def _read_old_waveforms_extractor_binary(folder):
             templates[mode] = np.load(template_file)
     if len(templates) > 0:
         ext = ComputeTemplates(sorting_analyzer)
-        ext.params = dict(
-            nbefore=nbefore, nafter=nafter, operators=list(templates.keys())
-        )
+        ext.params = dict(nbefore=nbefore, nafter=nafter, operators=list(templates.keys()))
         for mode, arr in templates.items():
             ext.data[mode] = arr
         sorting_analyzer.extensions["templates"] = ext

--- a/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
+++ b/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
@@ -93,12 +93,12 @@ def extract_waveforms(
         **job_kwargs,
     )
     sorting_analyzer = create_sorting_analyzer(
-        sorting, recording, format=format, folder=folder, sparse=sparse, sparsity=sparsity, **sparsity_kwargs
+        sorting, recording, format=format, folder=folder, sparse=sparse, sparsity=sparsity, return_scaled=return_scaled, **sparsity_kwargs
     )
 
     sorting_analyzer.compute("random_spikes", max_spikes_per_unit=max_spikes_per_unit, seed=seed)
 
-    waveforms_params = dict(ms_before=ms_before, ms_after=ms_after, return_scaled=return_scaled, dtype=dtype)
+    waveforms_params = dict(ms_before=ms_before, ms_after=ms_after,  dtype=dtype)
     sorting_analyzer.compute("waveforms", **waveforms_params, **job_kwargs)
 
     templates_params = dict(operators=list(precompute_template))
@@ -360,6 +360,8 @@ def _read_old_waveforms_extractor_binary(folder):
         raise ValueError(f"This folder is not a WaveformsExtractor folder {folder}")
     with open(params_file, "r") as f:
         params = json.load(f)
+    
+    return_scaled = params["return_scaled"],
 
     sparsity_file = folder / "sparsity.json"
     if sparsity_file.exists():
@@ -398,7 +400,7 @@ def _read_old_waveforms_extractor_binary(folder):
     elif (folder / "sorting.pickle").exists():
         sorting = load_extractor(folder / "sorting.pickle", base_folder=folder)
 
-    sorting_analyzer = SortingAnalyzer.create_memory(sorting, recording, sparsity, rec_attributes=rec_attributes)
+    sorting_analyzer = SortingAnalyzer.create_memory(sorting, recording, sparsity=sparsity, return_scaled=return_scaled, rec_attributes=rec_attributes)
 
     # waveforms
     # need to concatenate all waveforms in one unique buffer
@@ -447,7 +449,7 @@ def _read_old_waveforms_extractor_binary(folder):
         ext.params = dict(
             ms_before=params["ms_before"],
             ms_after=params["ms_after"],
-            return_scaled=params["return_scaled"],
+            
             dtype=params["dtype"],
         )
         ext.data["waveforms"] = waveforms
@@ -463,7 +465,7 @@ def _read_old_waveforms_extractor_binary(folder):
     if len(templates) > 0:
         ext = ComputeTemplates(sorting_analyzer)
         ext.params = dict(
-            nbefore=nbefore, nafter=nafter, return_scaled=params["return_scaled"], operators=list(templates.keys())
+            nbefore=nbefore, nafter=nafter, operators=list(templates.keys())
         )
         for mode, arr in templates.items():
             ext.data[mode] = arr

--- a/src/spikeinterface/postprocessing/amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/amplitude_scalings.py
@@ -107,8 +107,7 @@ class ComputeAmplitudeScalings(AnalyzerExtension):
         recording = self.sorting_analyzer.recording
         sorting = self.sorting_analyzer.sorting
 
-        # TODO return_scaled is not any more a property of SortingAnalyzer this is hard coded for now
-        return_scaled = True
+        return_scaled = self.sorting_analyzer.return_scaled
 
         all_templates = get_dense_templates_array(self.sorting_analyzer, return_scaled=return_scaled)
         nbefore = _get_nbefore(self.sorting_analyzer)

--- a/src/spikeinterface/postprocessing/spike_amplitudes.py
+++ b/src/spikeinterface/postprocessing/spike_amplitudes.py
@@ -66,8 +66,8 @@ class ComputeSpikeAmplitudes(AnalyzerExtension):
 
         self._all_spikes = None
 
-    def _set_params(self, peak_sign="neg", return_scaled=True):
-        params = dict(peak_sign=str(peak_sign), return_scaled=bool(return_scaled))
+    def _set_params(self, peak_sign="neg"):
+        params = dict(peak_sign=peak_sign)
         return params
 
     def _select_extension_data(self, unit_ids):
@@ -87,18 +87,12 @@ class ComputeSpikeAmplitudes(AnalyzerExtension):
         sorting = self.sorting_analyzer.sorting
 
         peak_sign = self.params["peak_sign"]
-        return_scaled = self.params["return_scaled"]
+        return_scaled = self.sorting_analyzer.return_scaled
 
         extremum_channels_indices = get_template_extremum_channel(
             self.sorting_analyzer, peak_sign=peak_sign, outputs="index"
         )
         peak_shifts = get_template_extremum_channel_peak_shift(self.sorting_analyzer, peak_sign=peak_sign)
-
-        if return_scaled:
-            # check if has scaled values:
-            if not recording.has_scaled_traces() and recording.get_dtype().kind == "i":
-                warnings.warn("Recording doesn't have scaled traces! Setting 'return_scaled' to False")
-                return_scaled = False
 
         spike_retriever_node = SpikeRetriever(
             recording, sorting, channel_from_template=True, extremum_channel_inds=extremum_channels_indices

--- a/src/spikeinterface/postprocessing/template_similarity.py
+++ b/src/spikeinterface/postprocessing/template_similarity.py
@@ -43,7 +43,7 @@ class ComputeTemplateSimilarity(AnalyzerExtension):
         return dict(similarity=new_similarity)
 
     def _run(self):
-        templates_array = get_dense_templates_array(self.sorting_analyzer, return_scaled=True)
+        templates_array = get_dense_templates_array(self.sorting_analyzer, return_scaled=self.sorting_analyzer.return_scaled)
         similarity = compute_similarity_with_templates_array(
             templates_array, templates_array, method=self.params["method"]
         )

--- a/src/spikeinterface/postprocessing/template_similarity.py
+++ b/src/spikeinterface/postprocessing/template_similarity.py
@@ -43,7 +43,9 @@ class ComputeTemplateSimilarity(AnalyzerExtension):
         return dict(similarity=new_similarity)
 
     def _run(self):
-        templates_array = get_dense_templates_array(self.sorting_analyzer, return_scaled=self.sorting_analyzer.return_scaled)
+        templates_array = get_dense_templates_array(
+            self.sorting_analyzer, return_scaled=self.sorting_analyzer.return_scaled
+        )
         similarity = compute_similarity_with_templates_array(
             templates_array, templates_array, method=self.params["method"]
         )

--- a/src/spikeinterface/postprocessing/tests/test_spike_amplitudes.py
+++ b/src/spikeinterface/postprocessing/tests/test_spike_amplitudes.py
@@ -8,8 +8,7 @@ from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerE
 class ComputeSpikeAmplitudesTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
     extension_class = ComputeSpikeAmplitudes
     extension_function_params_list = [
-        dict(return_scaled=True),
-        dict(return_scaled=False),
+        dict(),
     ]
 
 

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -1428,13 +1428,13 @@ def compute_sd_ratio(
         return {unit_id: np.nan for unit_id in unit_ids}
 
     noise_levels = get_noise_levels(
-        sorting_analyzer.recording, return_scaled=amplitudes_ext.params["return_scaled"], method="std"
+        sorting_analyzer.recording, return_scaled=sorting_analyzer.return_scaled, method="std"
     )
     best_channels = get_template_extremum_channel(sorting_analyzer, outputs="index", **kwargs)
     n_spikes = sorting.count_num_spikes_per_unit()
 
     if correct_for_template_itself:
-        tamplates_array = get_dense_templates_array(sorting_analyzer, return_scaled=True)
+        tamplates_array = get_dense_templates_array(sorting_analyzer, return_scaled=sorting_analyzer.return_scaled)
 
     spikes = sorting.to_spike_vector()
     sd_ratio = {}

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -668,7 +668,7 @@ def nearest_neighbors_noise_overlap(
         recording = sorting_analyzer.recording
         noise_cluster = get_random_data_chunks(
             recording,
-            return_scaled=waveforms_ext.params["return_scaled"],
+            return_scaled=sorting_analyzer.return_scaled,
             num_chunks_per_segment=max_spikes,
             chunk_size=nsamples,
             seed=seed,


### PR DESCRIPTION
Move "return_scaled" options global to SortingAnalyzer.

Having a unique and global option for this is less dangerous, for instance to compute snr which depends on 2 options.