### PR TITLE
Improve caching of MS5 sorter

### DIFF
--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -190,15 +190,14 @@ class Mountainsort5Sorter(BaseSorter):
         else:
             recording_cached = recording
 
-        scheme = p["scheme"]
-        if scheme == "1":
+        if p["scheme"] == "1":
             sorting = ms5.sorting_scheme1(recording=recording_cached, sorting_parameters=scheme1_sorting_parameters)
         elif p["scheme"] == "2":
             sorting = ms5.sorting_scheme2(recording=recording_cached, sorting_parameters=scheme2_sorting_parameters)
         elif p["scheme"] == "3":
             sorting = ms5.sorting_scheme3(recording=recording_cached, sorting_parameters=scheme3_sorting_parameters)
         else:
-            raise ValueError(f"Invalid scheme: {scheme} given. scheme must be one of '1', '2' or '3'")
+            raise ValueError(f"Invalid scheme: {p['scheme']} given. scheme must be one of '1', '2' or '3'")
 
         if p["delete_temporary_recording"]:
             if not recording.is_binary_compatible():

--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -9,7 +9,7 @@ import numpy as np
 from spikeinterface.preprocessing import bandpass_filter, whiten
 
 from spikeinterface.core.baserecording import BaseRecording
-from ..basesorter import BaseSorter
+from ..basesorter import BaseSorter, get_job_kwargs
 
 from spikeinterface.extractors import NpzSortingExtractor
 
@@ -20,6 +20,7 @@ class Mountainsort5Sorter(BaseSorter):
     sorter_name = "mountainsort5"
     requires_locations = False
     compatible_with_parallel = {"loky": False, "multiprocessing": False, "threading": False}
+    requires_binary_data = True
 
     _default_params = {
         "scheme": "2",  # '1', '2', '3'
@@ -42,7 +43,6 @@ class Mountainsort5Sorter(BaseSorter):
         "freq_max": 6000,
         "filter": True,
         "whiten": True,  # Important to do whitening
-        "n_jobs_for_preprocessing": -1,
         "delete_temporary_recording": True,
     }
 
@@ -186,9 +186,7 @@ class Mountainsort5Sorter(BaseSorter):
         )
 
         if not recording.is_binary_compatible():
-            recording_cached = recording.save(
-                folder=sorter_output_folder / "recording", n_jobs=p["n_jobs_for_preprocessing"], progress_bar=verbose
-            )
+            recording_cached = recording.save(folder=sorter_output_folder / "recording", **get_job_kwargs(p, verbose))
         else:
             recording_cached = recording
 


### PR DESCRIPTION
Uses the internal `save` function and gets rid of the `tmp_dir`.

Should fix #2670 #2607