### PR TITLE
Remove "waveforms" dependency for compute_quality_metrics().

### DIFF
--- a/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -44,7 +44,7 @@ class ComputeQualityMetrics(AnalyzerExtension):
     """
 
     extension_name = "quality_metrics"
-    depend_on = ["waveforms", "templates", "noise_levels"]
+    depend_on = ["templates", "noise_levels"]
     need_recording = False
     use_nodepipeline = False
     need_job_kwargs = True


### PR DESCRIPTION
Remove "waveforms" dependency for compute_quality_metrics().
This needed only for some metrics that will give wrnings.