### PR TITLE
Allow for `remove_excess_spikes` to remove negative spike times

### DIFF
--- a/src/spikeinterface/curation/remove_excess_spikes.py
+++ b/src/spikeinterface/curation/remove_excess_spikes.py
@@ -79,8 +79,9 @@ class RemoveExcessSpikesSortingSegment(BaseSortingSegment):
     ) -> np.ndarray:
         spike_train = self._parent_segment.get_unit_spike_train(unit_id, start_frame=start_frame, end_frame=end_frame)
         max_spike = np.searchsorted(spike_train, self._num_samples, side="left")
+        min_spike = np.searchsorted(spike_train, 0, side="left")
 
-        return spike_train[:max_spike]
+        return spike_train[min_spike:max_spike]
 
 
 def remove_excess_spikes(sorting, recording):

--- a/src/spikeinterface/curation/tests/test_remove_excess_spikes.py
+++ b/src/spikeinterface/curation/tests/test_remove_excess_spikes.py
@@ -14,6 +14,7 @@ def test_remove_excess_spikes():
     num_spikes = 100
     num_num_samples_spikes_per_segment = 5
     num_excess_spikes_per_segment = 5
+    num_neg_spike_times_per_segment = 2
     times = []
     labels = []
     for segment_index in range(recording.get_num_segments()):
@@ -21,12 +22,15 @@ def test_remove_excess_spikes():
         times_segment = np.array([], dtype=int)
         labels_segment = np.array([], dtype=int)
         for unit in range(num_units):
+            neg_spike_times = np.random.randint(-50, 0, num_neg_spike_times_per_segment)
             spike_times = np.random.randint(0, num_samples, num_spikes)
             last_samples_spikes = (num_samples - 1) * np.ones(num_num_samples_spikes_per_segment, dtype=int)
             num_samples_spike_times = num_samples * np.ones(num_num_samples_spikes_per_segment, dtype=int)
             excess_spikes = np.random.randint(num_samples, num_samples + 100, num_excess_spikes_per_segment)
             spike_times = np.sort(
-                np.concatenate((spike_times, last_samples_spikes, num_samples_spike_times, excess_spikes))
+                np.concatenate(
+                    (neg_spike_times, spike_times, last_samples_spikes, num_samples_spike_times, excess_spikes)
+                )
             )
             spike_labels = unit * np.ones_like(spike_times)
             times_segment = np.concatenate((times_segment, spike_times))
@@ -47,7 +51,10 @@ def test_remove_excess_spikes():
 
             assert (
                 len(spike_train_corrected)
-                == len(spike_train_excess) - num_num_samples_spikes_per_segment - num_excess_spikes_per_segment
+                == len(spike_train_excess)
+                - num_num_samples_spikes_per_segment
+                - num_excess_spikes_per_segment
+                - num_neg_spike_times_per_segment
             )
 
 


### PR DESCRIPTION
Fixes #2710.

Remove negative spikes (a known bug in KS4) and update tests to test removing negative times.