### PR TITLE
Multiple verbose arguments fix

### DIFF
--- a/src/spikeinterface/core/recording_tools.py
+++ b/src/spikeinterface/core/recording_tools.py
@@ -336,6 +336,9 @@ def write_memory_recording(recording, dtype=None, verbose=False, auto_cast_uint=
     else:
         init_args = (recording, arrays, None, None, dtype, cast_unsigned)
 
+    if "verbose" in job_kwargs:
+        del job_kwargs["verbose"]
+
     executor = ChunkRecordingExecutor(
         recording, func, init_func, init_args, verbose=verbose, job_name="write_memory_recording", **job_kwargs
     )


### PR DESCRIPTION
I know that the goal is to remove `verbose` from the job_kwargs (see #2602).

But until this is done, can we implement this quick fix? (this bug is the reason why lussac has been crashing for 3 weeks...)