### PR TITLE
Remove randomness of order in _get_children_dependencies

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1187,7 +1187,7 @@ def _get_children_dependencies(extension_name):
             names.append(child)
         grand_children = _get_children_dependencies(child)
         names.extend(grand_children)
-    return list(set(names))
+    return list(names)
 
 
 def register_result_extension(extension_class):

--- a/src/spikeinterface/core/tests/test_analyzer_extension_core.py
+++ b/src/spikeinterface/core/tests/test_analyzer_extension_core.py
@@ -205,9 +205,13 @@ def test_ComputeNoiseLevels(format, sparse):
 def test_get_children_dependencies():
     assert "waveforms" in _extension_children["random_spikes"]
 
-    children = _get_children_dependencies("random_spikes")
-    assert "waveforms" in children
-    assert "templates" in children
+    rs_children = _get_children_dependencies("random_spikes")
+    assert "waveforms" in rs_children
+    assert "templates" in rs_children
+
+    assert rs_children.index('waveforms') < rs_children.index('templates')
+
+
 
 
 def test_delete_on_recompute():

--- a/src/spikeinterface/core/tests/test_analyzer_extension_core.py
+++ b/src/spikeinterface/core/tests/test_analyzer_extension_core.py
@@ -209,9 +209,7 @@ def test_get_children_dependencies():
     assert "waveforms" in rs_children
     assert "templates" in rs_children
 
-    assert rs_children.index('waveforms') < rs_children.index('templates')
-
-
+    assert rs_children.index("waveforms") < rs_children.index("templates")
 
 
 def test_delete_on_recompute():


### PR DESCRIPTION
Fixes #2745 , bug discovered and solution discovered by @zm711 

The function `_get_children_dependencies` randomised the list of children, through the `set` function. This is a problem when using this function to delete extensions, since this has an ordering to it. Solution is simply to delete `set`, which didn't do anything (as far as I can tell, from playing with more complicated dependencies in the postprocessing module).

Added test to check that ordering is correct for the core extensions. Note: the test randomly passes or fails randomly for past versions. Test always passes now 😎