### PR TITLE
Speed up test_sorting_s3_nwb_zarr

### DIFF
--- a/src/spikeinterface/extractors/tests/test_nwbextractors_streaming.py
+++ b/src/spikeinterface/extractors/tests/test_nwbextractors_streaming.py
@@ -290,7 +290,15 @@ def test_sorting_s3_nwb_zarr(tmp_path):
 
     # test to/from dict
     sorting_loaded = load_extractor(sorting.to_dict())
-    check_sortings_equal(sorting, sorting_loaded)
+
+    # just take 3 random units to test
+    rng = np.random.default_rng(seed=2205)
+    three_unit_ids = rng.choice(sorting.unit_ids, size=3)
+    sorting_sub = sorting.select_units(unit_ids = three_unit_ids)
+    sorting_loaded_sub = sorting_loaded.select_units(unit_ids = three_unit_ids)
+
+    # test to/from dict
+    check_sortings_equal(sorting_sub, sorting_loaded_sub)
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/extractors/tests/test_nwbextractors_streaming.py
+++ b/src/spikeinterface/extractors/tests/test_nwbextractors_streaming.py
@@ -297,7 +297,6 @@ def test_sorting_s3_nwb_zarr(tmp_path):
     sorting_sub = sorting.select_units(unit_ids = three_unit_ids)
     sorting_loaded_sub = sorting_loaded.select_units(unit_ids = three_unit_ids)
 
-    # test to/from dict
     check_sortings_equal(sorting_sub, sorting_loaded_sub)
 
 

--- a/src/spikeinterface/extractors/tests/test_nwbextractors_streaming.py
+++ b/src/spikeinterface/extractors/tests/test_nwbextractors_streaming.py
@@ -294,8 +294,8 @@ def test_sorting_s3_nwb_zarr(tmp_path):
     # just take 3 random units to test
     rng = np.random.default_rng(seed=2205)
     three_unit_ids = rng.choice(sorting.unit_ids, size=3)
-    sorting_sub = sorting.select_units(unit_ids = three_unit_ids)
-    sorting_loaded_sub = sorting_loaded.select_units(unit_ids = three_unit_ids)
+    sorting_sub = sorting.select_units(unit_ids=three_unit_ids)
+    sorting_loaded_sub = sorting_loaded.select_units(unit_ids=three_unit_ids)
 
     check_sortings_equal(sorting_sub, sorting_loaded_sub)
 


### PR DESCRIPTION
Speed up a very slow test, by only checking some units, cutting the total test run from 33->28 minutes!

A preview of the Great-Test-Speed-Up of 2024: https://github.com/SpikeInterface/SpikeInteface-Hackathon-Edinburgh-May24/issues/8
(This seemed too easy and impactful to wait until the hackathon)

The function `test_sorting_s3_nwb_zarr` downloads a sorting object from s3 and checks some things about it. This has traditionally taken a while because the object is pretty big and has ~450 units. Most of the testing time was spent looping over these 450 units and calculating their spike trains. This is probably overkill, so I propose to only check a random selection of 3/450 units.

You can see the overall speed-up here, from my github page (I realise these are failing, but they are attempting all the tests!!):

<img width="796" alt="Screenshot 2024-04-26 at 12 51 09" src="https://github.com/SpikeInterface/spikeinterface/assets/57948917/f84050a9-45ba-4a08-97ea-133b1cb88dce">
(from https://github.com/chrishalcrow/spikeinterface/actions )
