### PR TITLE
Add template `generate_recording_from_template_database`

### DIFF
--- a/src/spikeinterface/core/template.py
+++ b/src/spikeinterface/core/template.py
@@ -229,12 +229,13 @@ class Templates:
         The `templates_array` dataset is saved with a chunk size that has a single unit per chunk
         to optimize read/write operations for individual units.
         """
+        import numcodecs
 
         # Saves one chunk per unit
         arrays_chunk = (1, None, None)
         zarr_group.create_dataset("templates_array", data=self.templates_array, chunks=arrays_chunk)
-        zarr_group.create_dataset("channel_ids", data=self.channel_ids)
-        zarr_group.create_dataset("unit_ids", data=self.unit_ids)
+        zarr_group.create_dataset("channel_ids", data=self.channel_ids, object_codec=numcodecs.MsgPack())
+        zarr_group.create_dataset("unit_ids", data=self.unit_ids, object_codec=numcodecs.MsgPack())
 
         zarr_group.attrs["sampling_frequency"] = self.sampling_frequency
         zarr_group.attrs["nbefore"] = self.nbefore

--- a/src/spikeinterface/generation/__init__.py
+++ b/src/spikeinterface/generation/__init__.py
@@ -11,3 +11,8 @@ from .drifting_generator import (
     generate_displacement_vector,
     generate_drifting_recording,
 )
+
+from ._template_database import (
+    fetch_templates_from_database,
+    generate_recording_from_template_database,
+)

--- a/src/spikeinterface/generation/_template_database.py
+++ b/src/spikeinterface/generation/_template_database.py
@@ -1,0 +1,47 @@
+from spikeinterface.core.template import Templates
+from spikeinterface.core import generate_sorting, InjectTemplatesRecording
+import zarr
+
+
+def fetch_templates_from_database(dataset="test_templates"):
+
+    import s3fs
+
+    s3 = s3fs.S3FileSystem(anon=False, client_kwargs={"region_name": "us-east-2"})
+
+    # Specify the S3 bucket and path where your Zarr dataset is stored
+    store = s3fs.S3Map(root=f"spikeinterface-template-database/{dataset}", s3=s3)
+
+    # Load the Zarr group from S3
+    zarr_group = zarr.open(store, mode="r")
+
+    templates_object = Templates.from_zarr_group(zarr_group)
+
+    return templates_object
+
+
+def generate_recording_from_template_database(selected_unit_inidces=None, dataset="test_templates", durations=None):
+
+    durations = durations or [10.0]
+
+    templates_object = fetch_templates_from_database(dataset=dataset)
+
+    if selected_unit_inidces:
+        selected_templates = templates_object.templates_array[selected_unit_inidces, :, :]
+    else:
+        selected_templates = templates_object.templates_array
+
+    num_units = selected_templates.shape[0]
+    sampling_frequency = templates_object.sampling_frequency
+    sorting = generate_sorting(num_units=num_units, sampling_frequency=sampling_frequency, durations=durations)
+
+    nbefore = templates_object.nbefore
+    num_samples = durations[0] * sampling_frequency
+    recording = InjectTemplatesRecording(
+        sorting=sorting,
+        templates=selected_templates,
+        nbefore=nbefore,
+        num_samples=[num_samples],
+    )
+
+    return recording


### PR DESCRIPTION
Thisi s a request for the hybrid project to fetch templates from the s3 database and generate recordings. I addded a pure function that allows to fetch teh template data and a convinence function that wraps this and generates a recording.


How to use:

```python
from spikeinterface.generation import generate_recording_from_template_database

selected_unit_inidces = [0, 23, 44 , 55]
durations = [1.0]

#from spikeinterface.hybrid import generate_recording_from_template_database
selected_unit_inidces  = [0, 1, 2, 3] # Here value from selectedUnitIndices
durations = [1.0] # To be determined by the user
dataset = "test_templates" # The dataset name
recording = generate_recording_from_template_database(selected_unit_inidces, durations=durations, dataset=dataset)
recording
```

Right now I only have `test_templates` as a dataset. This comes from real data but I have not done the whole batch because I am getting a memory leak. I need to test this.