### PR TITLE
Provide useful message if sorting used instead of analyzer for remove_duplicate_units

### DIFF
--- a/src/spikeinterface/curation/remove_redundant.py
+++ b/src/spikeinterface/curation/remove_redundant.py
@@ -71,7 +71,7 @@ def remove_redundant_units(
     else:
         assert not align, "The 'align' option is only available when a SortingAnalyzer is used as input"
         # other remove strategies rely on sorting analyzer looking at templates
-        assert remove_strategy == "max_spikes", "For sorting the remove_strategy must be 'max_spikes'"
+        assert remove_strategy == "max_spikes", "For a Sorting input the remove_strategy must be 'max_spikes'"
         sorting = sorting_or_sorting_analyzer
         sorting_analyzer = None
 

--- a/src/spikeinterface/curation/remove_redundant.py
+++ b/src/spikeinterface/curation/remove_redundant.py
@@ -71,7 +71,7 @@ def remove_redundant_units(
     else:
         assert not align, "The 'align' option is only available when a SortingAnalyzer is used as input"
         # other remove strategies rely on sorting analyzer looking at templates
-        assert remove_strategy == "max_spikes"
+        assert remove_strategy == "max_spikes", "For sorting the remove_strategy must be 'max_spikes'"
         sorting = sorting_or_sorting_analyzer
         sorting_analyzer = None
 

--- a/src/spikeinterface/curation/remove_redundant.py
+++ b/src/spikeinterface/curation/remove_redundant.py
@@ -70,6 +70,8 @@ def remove_redundant_units(
         sorting_analyzer = sorting_or_sorting_analyzer
     else:
         assert not align, "The 'align' option is only available when a SortingAnalyzer is used as input"
+        # other remove strategies rely on sorting analyzer looking at templates
+        assert remove_strategy == "max_spikes"
         sorting = sorting_or_sorting_analyzer
         sorting_analyzer = None
 


### PR DESCRIPTION
Current error message if using a `Sorting` with `remove_redundant_units` and `remove_strategy != max_spikes` is 

```python
AttributeError: 'NoneType' object has no attribute 'unit_ids'
```

This is because the other strategies rely on Templates from the `SortingAnalyzer`. This just adds an extra assert at the beginning indicating that for a sorting input only `max_spikes` is possible. If there is a better solution also happy to adapt.