### PR TITLE
Add errors to `ensure` functions  in `Base` of widgets

### DIFF
--- a/src/spikeinterface/widgets/base.py
+++ b/src/spikeinterface/widgets/base.py
@@ -109,17 +109,17 @@ class BaseWidget:
 
     @classmethod
     def ensure_sorting_analyzer(cls, input):
-        # internal help to accept both SortingAnalyzer or MockWaveformExtractor for a ploter
+        # internal help to accept both SortingAnalyzer or MockWaveformExtractor for a plotter
         if isinstance(input, SortingAnalyzer):
             return input
         elif isinstance(input, MockWaveformExtractor):
             return input.sorting_analyzer
         else:
-            return input
+            raise TypeError("input must be a SortingAnalyzer or MockWaveformExtractor")
 
     @classmethod
     def ensure_sorting(cls, input):
-        # internal help to accept both Sorting or SortingAnalyzer or MockWaveformExtractor for a ploter
+        # internal help to accept both Sorting or SortingAnalyzer or MockWaveformExtractor for a plotter
         if isinstance(input, BaseSorting):
             return input
         elif isinstance(input, SortingAnalyzer):
@@ -127,7 +127,7 @@ class BaseWidget:
         elif isinstance(input, MockWaveformExtractor):
             return input.sorting_analyzer.sorting
         else:
-            return input
+            raise TypeError("input must be a SortingAnalyzer, MockWaveformExtractor, or of type BaseSorting")
 
     @staticmethod
     def check_extensions(sorting_analyzer, extensions):

--- a/src/spikeinterface/widgets/crosscorrelograms.py
+++ b/src/spikeinterface/widgets/crosscorrelograms.py
@@ -46,7 +46,9 @@ class CrossCorrelogramsWidget(BaseWidget):
         backend=None,
         **backend_kwargs,
     ):
-        sorting_analyzer_or_sorting = self.ensure_sorting_analyzer(sorting_analyzer_or_sorting)
+
+        if not isinstance(sorting_analyzer_or_sorting, BaseSorting):
+            sorting_analyzer_or_sorting = self.ensure_sorting_analyzer(sorting_analyzer_or_sorting)
 
         if min_similarity_for_correlograms is None:
             min_similarity_for_correlograms = 0


### PR DESCRIPTION
This came up during talking in #2782, but I think `TypeError` instead of `ValueError` no? @alejoe91 ? 

And was there a reason you didn't want an error here originally @samuelgarcia @alejoe91 ? 