### PR TITLE
Add html representation for recording objects

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -45,26 +45,11 @@ class BaseRecording(BaseRecordingSnippets):
         self.annotate(is_filtered=False)
 
     def __repr__(self):
+
         extractor_name = self.__class__.__name__
         num_segments = self.get_num_segments()
-        num_channels = self.get_num_channels()
-        sf_khz = self.get_sampling_frequency() / 1000.0
-        dtype = self.get_dtype()
 
-        total_samples = self.get_total_samples()
-        total_duration = self.get_total_duration()
-        total_memory_size = self.get_total_memory_size()
-
-        txt = (
-            f"{extractor_name}: "
-            f"{num_channels} channels - "
-            f"{sf_khz:0.1f}kHz - "
-            f"{num_segments} segments - "
-            f"{total_samples:,} samples - "
-            f"{convert_seconds_to_str(total_duration)} - "
-            f"{dtype} dtype - "
-            f"{convert_bytes_to_str(total_memory_size)}"
-        )
+        txt = self._repr_header()
 
         # Split if too long
         if len(txt) > 100:
@@ -109,6 +94,70 @@ class BaseRecording(BaseRecordingSnippets):
             txt += f"\n  file_path: {self._kwargs['file_path']}"
 
         return txt
+
+    def _repr_header(self):
+        extractor_name = self.__class__.__name__
+        num_segments = self.get_num_segments()
+        num_channels = self.get_num_channels()
+        sf_khz = self.get_sampling_frequency() / 1000.0
+        dtype = self.get_dtype()
+
+        total_samples = self.get_total_samples()
+        total_duration = self.get_total_duration()
+        total_memory_size = self.get_total_memory_size()
+
+        txt = (
+            f"{extractor_name}: "
+            f"{num_channels} channels - "
+            f"{sf_khz:0.1f}kHz - "
+            f"{num_segments} segments - "
+            f"{total_samples:,} samples - "
+            f"{convert_seconds_to_str(total_duration)} - "
+            f"{dtype} dtype - "
+            f"{convert_bytes_to_str(total_memory_size)}"
+        )
+
+        return txt
+
+    def _repr_html_(self):
+        common_style = "margin-left: 10px;"
+        border_style = "border:1px solid #ddd; padding:10px;"
+
+        html_header = f"<div style='{border_style}'><strong>{self._repr_header()}</strong></div>"
+
+        html_segments = ""
+        if self.get_num_segments() > 1:
+            html_segments += f"<details style='{common_style}'>  <summary><strong>Segments</strong></summary><ol>"
+            for segment_index in range(self.get_num_segments()):
+                samples = self.get_num_samples(segment_index)
+                duration = self.get_duration(segment_index)
+                memory_size = self.get_memory_size(segment_index)
+                samples_str = f"{samples:,}"
+                duration_str = convert_seconds_to_str(duration)
+                memory_size_str = convert_bytes_to_str(memory_size)
+                html_segments += (
+                    f"<li> Samples: {samples_str}, Duration: {duration_str}, Memory: {memory_size_str}</li>"
+                )
+
+            html_segments += "</ol></details>"
+
+        html_channel_ids = f"<details style='{common_style}'>  <summary><strong>Channel IDs</strong></summary><ul>"
+        html_channel_ids += f"{self.channel_ids} </details>"
+
+        html_annotations = f"<details style='{common_style}'>  <summary><strong>Annotations</strong></summary><ul>"
+        for key, value in self._annotations.items():
+            html_annotations += f"<li> <strong> {key} </strong>: {value}</li>"
+        html_annotations += "</ul> </details>"
+
+        html_properties = f"<details style='{common_style}'><summary><strong>Channel Properties</strong></summary><ul>"
+        for key, value in self._properties.items():
+            # Add a further indent for each property
+            value_formatted = np.asarray(value)
+            html_properties += f"<details><summary> <strong> {key} </strong> </summary>{value_formatted}</details>"
+        html_properties += "</ul></details>"
+
+        html_repr = html_header + html_segments + html_channel_ids + html_annotations + html_properties
+        return html_repr
 
     def get_num_segments(self) -> int:
         """


### PR DESCRIPTION
Similar to #2747 but for recording objects

![image](https://github.com/SpikeInterface/spikeinterface/assets/6429509/a4fd5842-8880-40e3-99b9-e5ea36e4ad7c)

Note that this avoids the problem that once bothered @samuelgarcia about displaying too much. This displays less than the string representation by making the segment representation optional (you need to click).

Here an interactive version you can click:

<div style='border:1px solid #ddd; padding:10px;'><strong>NoiseGeneratorRecording: 4 channels - 30.0kHz - 3 segments - 6,300,000 samples - 210.00s (3.50 minutes) - float32 dtype - 96.13 MiB</strong></div><details style='margin-left: 10px;'>  <summary><strong>Segments</strong></summary><ol><li> Samples: 300,000, Duration: 10.00s, Memory: 4.58 MiB</li><li> Samples: 600,000, Duration: 20.00s, Memory: 9.16 MiB</li><li> Samples: 5,400,000, Duration: 180.00s (3.00 minutes), Memory: 82.40 MiB</li></ol></details><details style='margin-left: 10px;'>  <summary><strong>Channel IDs</strong></summary><ul>[0 1 2 3] </details><details style='margin-left: 10px;'>  <summary><strong>Annotations</strong></summary><ul><li> <strong> is_filtered </strong>: True</li><li> <strong> probe_0_planar_contour </strong>: [[ -25.   85.]
 [ -25.  -25.]
 [   0. -125.]
 [  25.  -25.]
 [  25.   85.]]</li><li> <strong> probes_info </strong>: [{}]</li></ul> </details><details style='margin-left: 10px;'><summary><strong>Channel Properties</strong></summary><ul><details><summary> <strong> contact_vector </strong> </summary>[(0, 0.,  0., 'circle', 6., '', '0', 0, 'um', 1., 0., 0., 1.)
 (0, 0., 20., 'circle', 6., '', '1', 1, 'um', 1., 0., 0., 1.)
 (0, 0., 40., 'circle', 6., '', '2', 2, 'um', 1., 0., 0., 1.)
 (0, 0., 60., 'circle', 6., '', '3', 3, 'um', 1., 0., 0., 1.)]</details><details><summary> <strong> location </strong> </summary>[[ 0.  0.]
 [ 0. 20.]
 [ 0. 40.]
 [ 0. 60.]]</details><details><summary> <strong> group </strong> </summary>[0 0 0 0]</details></ul></details>
