### PR TITLE
Zarr: extract time vector once and for all!

### DIFF
--- a/src/spikeinterface/core/zarrextractors.py
+++ b/src/spikeinterface/core/zarrextractors.py
@@ -72,7 +72,7 @@ class ZarrRecordingExtractor(BaseRecording):
             time_kwargs = {}
             time_vector = self._root.get(f"times_seg{segment_index}", None)
             if time_vector is not None:
-                time_kwargs["time_vector"] = time_vector
+                time_kwargs["time_vector"] = time_vector[:]
             else:
                 if t_starts is None:
                     t_start = None

--- a/src/spikeinterface/generation/template_database.py
+++ b/src/spikeinterface/generation/template_database.py
@@ -2,7 +2,7 @@ from spikeinterface.core.template import Templates
 import zarr
 
 
-def fetch_templates_from_database(dataset="test_templates") -> Templates:
+def fetch_templates_from_database(dataset="test_templates.zarr") -> Templates:
 
     s3_path = f"s3://spikeinterface-template-database/{dataset}/"
     zarr_group = zarr.open_consolidated(s3_path, storage_options={"anon": True})


### PR DESCRIPTION
If the zarr folder has timestamps, they were re-extracted and uncompressed every time the `get_times()` was called. 

This PR loads the zarr array as a numpy array at instantiation to speed things up