### PR TITLE
Add extra check in fix_job_kwargs

### DIFF
--- a/src/spikeinterface/core/job_tools.py
+++ b/src/spikeinterface/core/job_tools.py
@@ -85,16 +85,18 @@ def fix_job_kwargs(runtime_job_kwargs):
 
     # if n_jobs is -1, set to os.cpu_count() (n_jobs is always in global job_kwargs)
     n_jobs = job_kwargs["n_jobs"]
-    assert isinstance(n_jobs, (float, np.integer, int))
-    if isinstance(n_jobs, float):
-        # if n_jobs is > 1 then it is something like 4.0 cast to int
-        if n_jobs >= 1.0:
-            n_jobs = int(n_jobs)
-        # otherwise it is a fraction so we should do the fraction of os.cpu_count()
-        else:
-            n_jobs = int(n_jobs * os.cpu_count())
+    assert isinstance(n_jobs, (float, np.integer, int)) and n_jobs != 0, "n_jobs must be a non-zero int or float"
+
+    # for a fraction we do fraction of total cores
+    if isinstance(n_jobs, float) and 0 < n_jobs <= 1:
+        n_jobs = int(n_jobs * os.cpu_count())
+    # for negative numbers we count down from total cores (with -1 being all)
     elif n_jobs < 0:
         n_jobs = int(os.cpu_count() + 1 + n_jobs)
+    # otherwise we just take the value given
+    else:
+        n_jobs = int(n_jobs)
+
     job_kwargs["n_jobs"] = max(n_jobs, 1)
 
     return job_kwargs

--- a/src/spikeinterface/core/job_tools.py
+++ b/src/spikeinterface/core/job_tools.py
@@ -87,7 +87,12 @@ def fix_job_kwargs(runtime_job_kwargs):
     n_jobs = job_kwargs["n_jobs"]
     assert isinstance(n_jobs, (float, np.integer, int))
     if isinstance(n_jobs, float):
-        n_jobs = int(n_jobs * os.cpu_count())
+        # if n_jobs is > 1 then it is something like 4.0 cast to int
+        if n_jobs > 1:
+            n_jobs = int(n_jobs)
+        # otherwise it is a fraction so we should do the fraction of os.cpu_count()
+        else:
+            n_jobs = int(n_jobs * os.cpu_count())
     elif n_jobs < 0:
         n_jobs = os.cpu_count() + 1 + n_jobs
     job_kwargs["n_jobs"] = max(n_jobs, 1)

--- a/src/spikeinterface/core/job_tools.py
+++ b/src/spikeinterface/core/job_tools.py
@@ -88,13 +88,13 @@ def fix_job_kwargs(runtime_job_kwargs):
     assert isinstance(n_jobs, (float, np.integer, int))
     if isinstance(n_jobs, float):
         # if n_jobs is > 1 then it is something like 4.0 cast to int
-        if n_jobs > 1:
+        if n_jobs >= 1.0:
             n_jobs = int(n_jobs)
         # otherwise it is a fraction so we should do the fraction of os.cpu_count()
         else:
             n_jobs = int(n_jobs * os.cpu_count())
     elif n_jobs < 0:
-        n_jobs = os.cpu_count() + 1 + n_jobs
+        n_jobs = int(os.cpu_count() + 1 + n_jobs)
     job_kwargs["n_jobs"] = max(n_jobs, 1)
 
     return job_kwargs

--- a/src/spikeinterface/core/tests/test_job_tools.py
+++ b/src/spikeinterface/core/tests/test_job_tools.py
@@ -180,10 +180,10 @@ def test_fix_job_kwargs():
     else:
         assert fixed_job_kwargs["n_jobs"] == 1
 
-    # test minimum n_jobs
-    job_kwargs = dict(n_jobs=0, progress_bar=False, chunk_duration="1s")
+    # test float value > 1 is cast to correct int
+    job_kwargs = dict(n_jobs=4.0, progress_bar=False, chunk_duration="1s")
     fixed_job_kwargs = fix_job_kwargs(job_kwargs)
-    assert fixed_job_kwargs["n_jobs"] == 1
+    assert fixed_job_kwargs["n_jobs"] == 4
 
     # test wrong keys
     with pytest.raises(AssertionError):


### PR DESCRIPTION
For functions that take in an `n_jobs` argument they all run `fix_job_kwargs`, but if the user gives something like 4.0 to mean 4 jobs they end up with (if they have 4 cores)

int(4.0 * 4.0) = 16

So instead we should cast 4.0 -> 4 and just make it 4 jobs no? 

What do you think @alejoe91 ?