### PR TITLE
Switch `Visualise` to `Visualize`

### DIFF
--- a/doc/how_to/viewers.rst
+++ b/doc/how_to/viewers.rst
@@ -1,4 +1,4 @@
-Visualise Data
+Visualize Data
 ==============
 
 There are several ways to plot signals (raw, preprocessed) and spikes.


### PR DESCRIPTION
Related to the decision to use US spelling.

Last fix we need to make is analyse_neuropixel to analyze_neuropixel. But I don't have access to the raw data to fix that one.

@chrishalcrow  :) 