### PR TITLE
Set correct package version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spikeinterface"
-version = "0.101.0"
+version = "0.100.6"
 authors = [
   { name="Alessio Buccino", email="alessiop.buccino@gmail.com" },
   { name="Samuel Garcia", email="sam.garcia.die@gmail.com" },


### PR DESCRIPTION
You are pointing the version of the next version that will release but this is causing troubles for dependency resolution at neuroconv. More concrently, if I install the package from git for testing, like here:

https://github.com/catalystneuro/neuroconv/blob/fa9285b5a09e6c80e8c3011f08b2cd418fb39aff/.github/workflows/dev-testing.yml#L57

  Then I get an incorrect version of spikeinterface that is incompatible with another bounds.