### PR TITLE
Add error message and tests for `plot_motion`.

### DIFF
--- a/src/spikeinterface/widgets/motion.py
+++ b/src/spikeinterface/widgets/motion.py
@@ -178,13 +178,14 @@ class MotionWidget(BaseWidget):
         # Plot the Motion Vectors ---------------------------------------------
 
         if dp.motion_lim is None:
-            motion_lim = np.max(np.abs(dp.motion)) * 1.05
+            max_motion_lim = np.max(np.abs(dp.motion)) * 1.05
+            motion_lim = (-max_motion_lim, max_motion_lim)
         else:
             motion_lim = dp.motion_lim
 
         ax2.plot(temporal_bins_plot, dp.motion, alpha=0.2, color="black")
         ax2.plot(temporal_bins_plot, np.mean(dp.motion, axis=1), color="C0")
-        ax2.set_ylim(-motion_lim, motion_lim)
+        ax2.set_ylim(motion_lim)
         ax2.set_xlabel("Time [s]")
         ax2.set_ylabel("Motion [μm]")
         ax2.set_title("Motion vectors")
@@ -204,7 +205,7 @@ class MotionWidget(BaseWidget):
                     dp.spatial_bins[-1],
                 ),
             )
-            im.set_clim(-motion_lim, motion_lim)
+            im.set_clim(motion_lim)
             cbar = fig.colorbar(im)
             cbar.ax.set_xlabel("motion [μm]")
             ax3.set_xlabel("Time [s]")

--- a/src/spikeinterface/widgets/motion.py
+++ b/src/spikeinterface/widgets/motion.py
@@ -97,7 +97,8 @@ class MotionWidget(BaseWidget):
 
         # Setup figures and axes ----------------------------------------------
 
-        self.figure, self.axes, self.ax = make_mpl_figure(**backend_kwargs)
+        self.ax = None
+        self.figure, self.axes, _ = make_mpl_figure(**backend_kwargs)
         fig = self.figure
         fig.clear()
 

--- a/src/spikeinterface/widgets/motion.py
+++ b/src/spikeinterface/widgets/motion.py
@@ -11,10 +11,10 @@ class MotionWidget(BaseWidget):
 
     1) 'Peak depth' plot displaying the peak location for all detected spikes over time
        before motion correction.
-    2) 'Corrected peak depth' displayed the peak location for all detected spikes
+    2) 'Corrected peak depth' displays the peak location for all detected spikes
        over time after motion correction.
-    3) 'Motion vectors' plot shows the estimated displacement per channel
-       across time. The average displacement is shown in blue.
+    3) 'Motion vectors' plot shows the estimated displacement per spatial
+        bin across time. The average displacement is shown in blue.
     4) 'Motion vectors nonrigid' plot shows a heatmap of the estimated
        motion across the depth of the probe and time.
 

--- a/src/spikeinterface/widgets/motion.py
+++ b/src/spikeinterface/widgets/motion.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import numpy as np
 
 from .base import BaseWidget, to_attr
-from spikeinterface.sortingcomponents.motion_interpolation import correct_motion_on_peaks
 
 
 class MotionWidget(BaseWidget):
@@ -84,6 +83,7 @@ class MotionWidget(BaseWidget):
         import matplotlib.pyplot as plt
         from .utils_matplotlib import make_mpl_figure
         from matplotlib.colors import Normalize
+        from spikeinterface.sortingcomponents.motion_interpolation import correct_motion_on_peaks
 
         dp = to_attr(data_plot)
 

--- a/src/spikeinterface/widgets/tests/test_motion_widgets.py
+++ b/src/spikeinterface/widgets/tests/test_motion_widgets.py
@@ -1,0 +1,254 @@
+import copy
+
+import spikeinterface.extractors as si_extractors
+import spikeinterface.preprocessing as si_preprocess
+import spikeinterface.widgets as si_widgets
+import matplotlib.pyplot as plt
+import pytest
+import numpy as np
+import time
+
+
+class TestMotionWidgets:
+    """
+    Tests the functionality and parameters of `plot_motion`
+    function.
+
+    Currently there are not tests covering
+    that the corrected peak depth is correct, as
+    in the `plot_motion` function the (tested) peak depth
+    is passed directly to the correction function.
+
+    Also, `amplitude_clim` is not tested.
+
+    These tests use a `motion_data` fixture that runs
+    only once per tests ("class scope"), as well as
+    a fixture that closes the widget figure after
+    each test to avoid a strange tkinkter bug that
+    was appearing unpredictably.
+    """
+
+    @pytest.fixture(scope="class")
+    def motion_data(self, tmp_path_factory):
+        """
+        Fixture to create a test recording and run
+        motion correction (nonrigid).
+        """
+        rec, _ = si_extractors.toy_example(
+            num_segments=1,
+            duration=30.0,
+            num_units=10,
+            num_channels=12,
+        )
+
+        folder = tmp_path_factory.mktemp("test_motion_widgets")
+
+        rec_corrected = si_preprocess.correct_motion(rec, folder=folder)
+        motion_info = si_preprocess.load_motion_info(folder)
+
+        motion_data = {"rec": rec, "rec_corrected": rec_corrected, "motion_info": motion_info}
+
+        return motion_data
+
+    @pytest.fixture(scope="function")
+    def close_figures(self):
+        """
+        Closing figures after each test, and including a short pause,
+        is required to avoid tkinter "init.tcl" access error that
+        can randomly occur.
+        """
+        yield
+        plt.close("all")
+
+    # Check plots are shown as expected
+    # -------------------------------------------------------------------------
+
+    def test_plot_motion(self, motion_data, close_figures):
+        """
+        Test the expected axis (along with title and x/y labels)
+        are created for nonrigid motion correction.
+        """
+        widget = si_widgets.plot_motion(
+            motion_data["motion_info"],
+            motion_data["rec_corrected"],
+        )
+
+        self.check_all_plot_labels(widget)
+
+    def test_plot_motion_rigid(self, motion_data, tmp_path, close_figures):
+        """
+        Text the expected axes as above but for rigid motion correction.
+        """
+        rec_corrected = si_preprocess.correct_motion(motion_data["rec"], preset="rigid_fast", folder=tmp_path)
+
+        motion_info = si_preprocess.load_motion_info(tmp_path)
+
+        widget = si_widgets.plot_motion(
+            motion_info,
+            rec_corrected,
+        )
+        self.check_all_plot_labels(widget, rigid=True)
+
+    def check_all_plot_labels(self, widget, rigid=False):
+        """
+        Helper function to check the expected axes along
+        with title and x/y labels are contained
+        a created widget.
+        """
+        first_plot = widget.axes[0]
+        assert first_plot.get_title() == "Peak depth"
+        assert first_plot.get_xlabel() == "Time [s]"
+        assert first_plot.get_ylabel() == "Depth [μm]"
+
+        second_plot = widget.axes[1]
+        assert second_plot.get_title() == "Corrected peak depth"
+        assert second_plot.get_xlabel() == "Time [s]"
+        assert second_plot.get_ylabel() == "Depth [μm]"
+
+        third_plot = widget.axes[2]
+        assert third_plot.get_title() == "Motion vectors"
+        assert third_plot.get_ylabel() == "Motion [μm]"
+        assert third_plot.get_xlabel() == "Time [s]"
+
+        if rigid:
+            assert len(widget.axes) == 3
+        else:
+            fourth_plot = widget.axes[3]
+            assert fourth_plot.get_title() == "Motion vectors"
+            assert fourth_plot.get_ylabel() == "Depth [μm]"
+            assert fourth_plot.get_xlabel() == "Time [s]"
+
+    def test_peak_depth(self, motion_data, close_figures):
+        """
+        Check that the plot peak depth matches the
+        actual peak locations of the `motion_info`.
+        """
+        widget = si_widgets.plot_motion(
+            motion_data["motion_info"],
+            motion_data["rec_corrected"],
+        )
+
+        assert np.array_equal(
+            motion_data["motion_info"]["peak_locations"]["y"],
+            widget.axes[0].collections[0].get_offsets().data[:, 1],
+        ), "Peak depth does not match motion_info locations."
+
+    def test_motion(self, motion_data, close_figures):
+        """
+        Check that the motion plots reflect the actual
+        motion in `motion_info` (tested first channel only).
+        """
+        widget = si_widgets.plot_motion(
+            motion_data["motion_info"],
+            motion_data["rec_corrected"],
+        )
+        assert np.array_equal(
+            motion_data["motion_info"]["motion"][:, 0], widget.axes[2].lines[0].get_ydata()
+        ), "motion of first channel does not match plot."
+
+    # Check plots are shown as expected
+    # -------------------------------------------------------------------------
+
+    def test_axis_limit_arguments(self, motion_data, close_figures):
+        """
+        Test the axis limits change as expected when set.
+        """
+        widget = si_widgets.plot_motion(
+            motion_data["motion_info"],
+            motion_data["rec_corrected"],
+            depth_lim=(-200, 200),
+            motion_lim=1.5,
+        )
+        for i in range(2):
+            assert widget.axes[i].get_ylim() == (-200.0, 200.0), f"Plot {i} failed depth lim."
+
+        assert widget.axes[2].get_ylim() == (-1.5, 1.5), "Failed motion lim."
+
+    def test_decimate(self, motion_data, close_figures):
+        """
+        Test data is displayed as expected on the
+        scatter plot if downsampled.
+        """
+        widget = si_widgets.plot_motion(
+            motion_data["motion_info"],
+            motion_data["rec_corrected"],
+            scatter_decimate=10,
+        )
+        assert np.array_equal(
+            motion_data["motion_info"]["peak_locations"]["y"][::10],
+            widget.axes[0].collections[0].get_offsets().data[:, 1],
+        ), "Peak depth does not match motion_info locations."
+
+    def test_color_amplitude(self, motion_data, close_figures):
+        """
+        Test the color amplitude argument. This will color the
+        scatter plot depending on the amplitude of the AP.
+
+        This is a little tricky to test as the cmap is not 1:1
+        based on amplitude but binned. Therefore, it is tested
+        just to ensure that no amplitude in a color bin are
+        larger than in the preceeding (lighter) bin.
+        """
+        decimate = 2
+        alpha = 0.8
+
+        widget = si_widgets.plot_motion(
+            motion_data["motion_info"],
+            motion_data["rec_corrected"],
+            color_amplitude=True,
+            scatter_decimate=decimate,
+            amplitude_alpha=alpha,
+            amplitude_cmap="grey",
+        )
+
+        amplitudes = motion_data["motion_info"]["peaks"]["amplitude"][::decimate]
+
+        # Get the color bin and color bin id for each AP. Iterate through
+        # the bins and check the intensity increaes with amplitude as
+        # expected.
+        uniques, color_bin_id = np.unique(widget.axes[0].collections[0].get_facecolors()[:, 0], return_inverse=True)
+
+        for i in range(1, uniques.size):
+
+            amp_this_level = amplitudes[np.where(color_bin_id == i)]
+            amp_prev_level = amplitudes[np.where(color_bin_id == i - 1)]
+
+            assert (np.abs(amp_prev_level).min() < np.abs(amp_this_level)).all()
+
+        # Check alpha
+        assert (widget.axes[0].collections[0].get_facecolors()[:, 3 == alpha]).all()
+
+    def test_times(self, motion_data, close_figures):
+        """
+        Time can be set based on the recording or
+        just assuming the time starts at zero. Test that time
+        is displayed properly when the recording time does not
+        start at zero.
+        """
+        orig_start = 0
+        orig_end = motion_data["rec_corrected"].get_times()[-1]
+
+        new_start = 10
+        new_end = 20
+
+        new_times = np.linspace(new_start, new_end, motion_data["rec_corrected"].get_num_samples())
+        rec = copy.deepcopy(motion_data["rec_corrected"])
+        rec.set_times(new_times)
+
+        widget_with_times = si_widgets.plot_motion(motion_data["motion_info"], rec)
+
+        widget_no_times = si_widgets.plot_motion(
+            motion_data["motion_info"],
+        )
+
+        for i in range(2):
+            test_new_start, test_new_end = widget_with_times.axes[i].get_xlim()
+
+            assert np.isclose(test_new_start, new_start, rtol=0, atol=1)
+            assert np.isclose(test_new_end, new_end, rtol=0, atol=1)
+
+            test_orig_start, test_orig_end = widget_no_times.axes[2].get_xlim()
+            assert not np.isclose(test_new_start, test_orig_start, rtol=0, atol=1)
+
+            assert np.isclose(test_orig_start, orig_start, rtol=0, atol=1)
+            assert np.isclose(test_orig_end, orig_end, rtol=0, atol=1)

--- a/src/spikeinterface/widgets/tests/test_motion_widgets.py
+++ b/src/spikeinterface/widgets/tests/test_motion_widgets.py
@@ -157,7 +157,7 @@ class TestMotionWidgets:
             motion_data["motion_info"],
             motion_data["rec_corrected"],
             depth_lim=(-200, 200),
-            motion_lim=1.5,
+            motion_lim=(-1.5, 1.5),
         )
         for i in range(2):
             assert widget.axes[i].get_ylim() == (-200.0, 200.0), f"Plot {i} failed depth lim."

--- a/src/spikeinterface/widgets/tests/test_motion_widgets.py
+++ b/src/spikeinterface/widgets/tests/test_motion_widgets.py
@@ -252,3 +252,30 @@ class TestMotionWidgets:
 
             assert np.isclose(test_orig_start, orig_start, rtol=0, atol=1)
             assert np.isclose(test_orig_end, orig_end, rtol=0, atol=1)
+
+    def test_axes_ax_asserts(self, motion_data):
+        """
+        Check that expected error message raised when
+        `ax` or `axes` passed, which is not supported.
+        """
+        _, ax = plt.subplots()
+
+        error_message = "`ax` and `axes` arguments are not permitted"
+
+        with pytest.raises(ValueError) as e:
+            si_widgets.plot_motion(
+                motion_data["motion_info"],
+                motion_data["rec_corrected"],
+                ax=ax,
+            )
+
+        assert error_message in str(e.value)
+
+        with pytest.raises(ValueError) as e:
+            si_widgets.plot_motion(
+                motion_data["motion_info"],
+                motion_data["rec_corrected"],
+                axes=[ax],
+            )
+
+        assert error_message in str(e.value)


### PR DESCRIPTION
This PR closes #2725 by adding an error message when `ax` or `axes` arguments are passed, these are `backend_kwargs` which are not supported for this function.

This is slightly suboptimal as the documentation still says they are accepted, but at least it is clear what to do when it does go wrong. I looked into making the function support passing `axes` but it would make things very complicated for (I don't think?) not too much benefit. 

I also added tests for the function and made a couple of minor changes:
- Added a little more explanation to the docstrings..
- renamed the variables `x` and `y` to make slightly more descriptive.
- renamed x-axis label `Times [s]` to `Time [s]`.

I had a couple of questions:
- The `motion_lim` is documented as `Tuple` or `None` but it actually expects an `int`.  I guess this could be changed to accept a `Tuple` similar to `depth_lim`?
- at the moment the widget object `.ax` is set to an empty `Axes` object. Maybe it would be clearer to set this to `None` as it is unused?

Also a more general question, the `matplotlib` and `scipy` imports are not at the top of the file, and I see the tests do not expect `scipy` to be installed. I guess the logic is the same for `matplotlib` which is why it is not top of file? Personally I would add any 'core' python modules to the general dependencies and then there is less maintenance required to have to workaround users potentially not having them installed. I don't think anyone will have trouble installing `matplotlib` or `scipy` unlike heavier modules such as `numba`. However may there are other considerations (e.g. docker images?).
