### PR TITLE
Avoid duplicating channel names as property in neo base extractor when `all_annotations=True`

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -179,6 +179,7 @@ class NeoBaseRecordingExtractor(_NeoBaseExtractor, BaseRecording):
             If True, include all annotations in the extracted data.
         use_names_as_ids : Optional[bool], default: None
             If True, use channel names as IDs. Otherwise, use default IDs.
+            In NEO the ids are guaranteed to be unique. Names are user defined and can be duplicated.
         neo_kwargs : Dict[str, Any]
             Additional keyword arguments to pass to the NeoBaseExtractor for initialization.
 
@@ -275,8 +276,8 @@ class NeoBaseRecordingExtractor(_NeoBaseExtractor, BaseRecording):
 
         self.set_property("gain_to_uV", final_gains)
         self.set_property("offset_to_uV", final_offsets)
-        if not use_names_as_ids:
-            self.set_property("channel_name", signal_channels["name"])
+        if not use_names_as_ids and not all_annotations:
+            self.set_property("channel_names", signal_channels["name"])
 
         if all_annotations:
             block_ann = self.neo_reader.raw_annotations["blocks"][self.block_index]


### PR DESCRIPTION
As in the title. 

There is always a `channel_names` annotation in neo that we can load with `all_annotations=True`:

https://github.com/h-mayorquin/python-neo/blob/223e22edb917d8ad5ef8aff4fe7197afc414d5f6/neo/rawio/baserawio.py#L282-L293

This PR modifieds the code so when `all_annotations=True` the property is not duplicated. 

Plus, I am changing the name of the property to `channel_names` because that's how it is neo and I think is more consistent overall. Another option is to instead change the property  name to "channel_name" when loaded from neo annotations so we don't duplicate. I think that the first approach is better.