### PR TITLE
Use the `is_scaled` attribute inside of `template_tools` functions

### DIFF
--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -331,7 +331,7 @@ class ChannelSparsity:
             return_scaled = templates_or_sorting_analyzer.return_scaled
         elif isinstance(templates_or_sorting_analyzer, Templates):
             assert noise_levels is not None
-            return_scaled = True
+            return_scaled = templates_or_sorting_analyzer.is_scaled
 
         mask = np.zeros((unit_ids.size, channel_ids.size), dtype="bool")
 
@@ -369,7 +369,7 @@ class ChannelSparsity:
             return_scaled = templates_or_sorting_analyzer.return_scaled
         elif isinstance(templates_or_sorting_analyzer, Templates):
             assert noise_levels is not None
-            return_scaled = True
+            return_scaled = templates_or_sorting_analyzer.is_scaled
 
         from .template_tools import get_dense_templates_array
 

--- a/src/spikeinterface/core/template_tools.py
+++ b/src/spikeinterface/core/template_tools.py
@@ -148,11 +148,11 @@ def get_template_extremum_channel(
     channel_ids = templates_or_sorting_analyzer.channel_ids
 
     # if SortingAnalyzer need to use global SortingAnalyzer return_scaled otherwise
-    # we just use the previous default of return_scaled=True (for templates)
+    # we use the Templates is_scaled
     if isinstance(templates_or_sorting_analyzer, SortingAnalyzer):
         return_scaled = templates_or_sorting_analyzer.return_scaled
     else:
-        return_scaled = True
+        return_scaled = templates_or_sorting_analyzer.is_scaled
 
     peak_values = get_template_amplitudes(
         templates_or_sorting_analyzer, peak_sign=peak_sign, mode=mode, return_scaled=return_scaled
@@ -196,12 +196,12 @@ def get_template_extremum_channel_peak_shift(templates_or_sorting_analyzer, peak
 
     shifts = {}
 
-    # We need to use the SortingAnalyzer return_scaled if possible
-    # otherwise for Templates default to True
+    # We need to use the SortingAnalyzer return_scaled
+    # We need to use the Templates is_scaled
     if isinstance(templates_or_sorting_analyzer, SortingAnalyzer):
         return_scaled = templates_or_sorting_analyzer.return_scaled
     else:
-        return_scaled = True
+        return_scaled = templates_or_sorting_analyzer.is_scaled
 
     templates_array = get_dense_templates_array(templates_or_sorting_analyzer, return_scaled=return_scaled)
 
@@ -257,7 +257,7 @@ def get_template_extremum_amplitude(
     if isinstance(templates_or_sorting_analyzer, SortingAnalyzer):
         return_scaled = templates_or_sorting_analyzer.return_scaled
     else:
-        return_scaled = True
+        return_scaled = templates_or_sorting_analyzer.is_scaled
 
     extremum_amplitudes = get_template_amplitudes(
         templates_or_sorting_analyzer, peak_sign=peak_sign, mode=mode, return_scaled=return_scaled


### PR DESCRIPTION
Now that #2842 adds an attribute which indicates that the Templates object is scaled we should use that for the functions inside of template_tools no? If the Templates aren't scaled then we can't return scaled.
