### PR TITLE
Load `is_scaled` in from zarr Template representation

### DIFF
--- a/src/spikeinterface/core/template.py
+++ b/src/spikeinterface/core/template.py
@@ -301,10 +301,7 @@ class Templates:
         nbefore = zarr_group.attrs["nbefore"]
 
         # TODO: Consider eliminating this and make it required
-        if "is_scaled" not in zarr_group.attrs:
-            is_scaled = True
-        else:
-            is_scaled = zarr_group.attrs["is_scaled"]
+         is_scaled = zarr_group.attrs.get("is_scaled", True)
 
         sparsity_mask = None
         if "sparsity_mask" in zarr_group:

--- a/src/spikeinterface/core/template.py
+++ b/src/spikeinterface/core/template.py
@@ -300,8 +300,8 @@ class Templates:
         sampling_frequency = zarr_group.attrs["sampling_frequency"]
         nbefore = zarr_group.attrs["nbefore"]
 
-        # TODO: Consider eliminating this and make it required
-         is_scaled = zarr_group.attrs.get("is_scaled", True)
+        # TODO: Consider eliminating the True and make it required
+        is_scaled = zarr_group.attrs.get("is_scaled", True)
 
         sparsity_mask = None
         if "sparsity_mask" in zarr_group:

--- a/src/spikeinterface/core/template.py
+++ b/src/spikeinterface/core/template.py
@@ -299,7 +299,12 @@ class Templates:
         unit_ids = zarr_group["unit_ids"]
         sampling_frequency = zarr_group.attrs["sampling_frequency"]
         nbefore = zarr_group.attrs["nbefore"]
-        is_scaled = zarr_group.attrs["is_scaled"]
+
+        # TODO: Consider eliminating this and make it required
+        if "is_scaled" not in zarr_group.attrs:
+            is_scaled = True
+        else:
+            is_scaled = zarr_group.attrs["is_scaled"]
 
         sparsity_mask = None
         if "sparsity_mask" in zarr_group:

--- a/src/spikeinterface/core/template.py
+++ b/src/spikeinterface/core/template.py
@@ -299,6 +299,7 @@ class Templates:
         unit_ids = zarr_group["unit_ids"]
         sampling_frequency = zarr_group.attrs["sampling_frequency"]
         nbefore = zarr_group.attrs["nbefore"]
+        is_scaled = zarr_group.attrs["is_scaled"]
 
         sparsity_mask = None
         if "sparsity_mask" in zarr_group:
@@ -316,6 +317,7 @@ class Templates:
             channel_ids=channel_ids,
             unit_ids=unit_ids,
             probe=probe,
+            is_scaled=is_scaled,
         )
 
     @staticmethod


### PR DESCRIPTION
This was missing. Added a test to catch this type of error.