### PR TITLE
[Discussion] Add method to force loading Templates into memory

### DIFF
--- a/src/spikeinterface/core/template.py
+++ b/src/spikeinterface/core/template.py
@@ -188,6 +188,19 @@ class Templates:
 
         return are_templates_sparse
 
+    def get_channel_locations(self) -> np.ndarray:
+        assert self.probe is not None, "Templates.get_channel_locations() needs a set probe to be defined."
+        channel_locations = self.probe.contact_positions
+        return channel_locations
+
+    def load_all_arrays_into_memory(self):
+        "This is useful to avoid making requests to the disk when the templates are stored in disk"
+        self.templates_array = np.asarray(self.templates_array)
+        if self.sparsity_mask is not None:
+            self.sparsity_mask = np.asarray(self.sparsity_mask)
+        self.channel_ids = np.asarray(self.channel_ids)
+        self.unit_ids = np.asarray(self.unit_ids.copy())
+
     def to_dict(self):
         return {
             "templates_array": self.templates_array,
@@ -385,8 +398,3 @@ class Templates:
                     return False
 
         return True
-
-    def get_channel_locations(self):
-        assert self.probe is not None, "Templates.get_channel_locations() needs a probe to be set"
-        channel_locations = self.probe.contact_positions
-        return channel_locations


### PR DESCRIPTION
Discussion PR.  @samuelgarcia @alejoe91 

Following on https://github.com/SpikeInterface/spikeinterface/pull/2828 and as alternative to the code in #2436. 

With this, if you are in a scenario (I guess like plotting?) where you are going to be making repeated calls to the functions then you can call this function. We can even add an argument to the signature and call this at post_init. 

The advantage of this vs loading by default is that the `__init__` of the object becomes lighter at the cost of some complexity.

What do you think?