### PR TITLE
Unpin sphinx and add networkx dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,8 +159,8 @@ test = [
 ]
 
 docs = [
-    "Sphinx==5.1.1",
-    "sphinx_rtd_theme==1.0.0",
+    "Sphinx",
+    "sphinx_rtd_theme",
     "sphinx-gallery",
     "sphinx-design",
     "numpydoc",
@@ -169,6 +169,7 @@ docs = [
     # for notebooks in the gallery
     "MEArec",   # Use as an example
     "datalad==0.16.2",  # Download mearec data, not sure if needed as is installed with conda as well because of git-annex
+    "networkx",
     "pandas", # in the modules gallery comparison tutorial
     "hdbscan>=0.8.33",   # For sorters spykingcircus2 + tridesclous
     "numba", # For many postprocessing functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,8 +159,8 @@ test = [
 ]
 
 docs = [
-    "Sphinx",
-    "sphinx_rtd_theme",
+    "Sphinx==5.1.1",
+    "sphinx_rtd_theme==1.0.0",
     "sphinx-gallery",
     "sphinx-design",
     "numpydoc",
@@ -173,7 +173,6 @@ docs = [
     "hdbscan>=0.8.33",   # For sorters spykingcircus2 + tridesclous
     "numba", # For many postprocessing functions
     "xarray", # For use of SortingAnalyzer zarr format
-    "networkx",
     # for release we need pypi, so this needs to be commented
     "probeinterface @ git+https://github.com/SpikeInterface/probeinterface.git",  # We always build from the latest version
     "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",  # We always build from the latest version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ docs = [
     "hdbscan>=0.8.33",   # For sorters spykingcircus2 + tridesclous
     "numba", # For many postprocessing functions
     "xarray", # For use of SortingAnalyzer zarr format
+    "networkx",
     # for release we need pypi, so this needs to be commented
     "probeinterface @ git+https://github.com/SpikeInterface/probeinterface.git",  # We always build from the latest version
     "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",  # We always build from the latest version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,8 +159,8 @@ test = [
 ]
 
 docs = [
-    "Sphinx==5.1.1",
-    "sphinx_rtd_theme==1.0.0",
+    "Sphinx",
+    "sphinx_rtd_theme",
     "sphinx-gallery",
     "sphinx-design",
     "numpydoc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,6 @@ docs = [
     # for notebooks in the gallery
     "MEArec",   # Use as an example
     "datalad==0.16.2",  # Download mearec data, not sure if needed as is installed with conda as well because of git-annex
-    "networkx",
     "pandas", # in the modules gallery comparison tutorial
     "hdbscan>=0.8.33",   # For sorters spykingcircus2 + tridesclous
     "numba", # For many postprocessing functions

--- a/src/spikeinterface/widgets/multicomparison.py
+++ b/src/spikeinterface/widgets/multicomparison.py
@@ -51,6 +51,7 @@ class MultiCompGraphWidget(BaseWidget):
     def plot_matplotlib(self, data_plot, **backend_kwargs):
         import matplotlib.colors as mpl_colors
         import matplotlib.pyplot as plt
+        import matplotlib.cm
         import networkx as nx
         from .utils_matplotlib import make_mpl_figure
 

--- a/src/spikeinterface/widgets/multicomparison.py
+++ b/src/spikeinterface/widgets/multicomparison.py
@@ -51,7 +51,6 @@ class MultiCompGraphWidget(BaseWidget):
     def plot_matplotlib(self, data_plot, **backend_kwargs):
         import matplotlib.colors as mpl_colors
         import matplotlib.pyplot as plt
-        import matplotlib.cm
         import networkx as nx
         from .utils_matplotlib import make_mpl_figure
 


### PR DESCRIPTION
This PR unpins the Sphinx version dependency from 5.1.1 as well as read the docs from 1.0.0. It also adds `networkx` which from the logs seems to be a dependency on the docs as an build warning was raised.

I can't detect any issues from the upgrade, although it's quite hard to test. I looked through the logs and they look similar, Number of warnings differs by 1. I went through every page and compared with current docs, everything looks the same and seems to have build without issue, but I did skim pages just randomly checking features like 1) links working 2) images rendering 3) generated values the same. The only differences I saw is that in the new version, the API docs typing is written a little neater using the new shortcuts (e.g. "|") and there is a slight stylistic change (the grey boxes around certain text is now gone). It would be great if someone could double check this in case I missed anything. I'm surprised it worked out the box 😅 seems too good to be true...

BTW I am getting a lot of warnings (~143) when building on Windows, does anyone else? If so we can look to address these when we look at further docs revisions. I am also getting random errors when building some of the sphinx galleries (for main also), it seems that when trying to delete some files they are still in use. I guess this is a platform filesystem difference issue, but would be good to hear if anyone else on windows has had this problem.