### PR TITLE
Pin matplotlib dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ full = [
     "scikit-learn",
     "networkx",
     "distinctipy",
-    "matplotlib",
+    "matplotlib<3.9.",  # See https://github.com/SpikeInterface/spikeinterface/issues/2863
     "cuda-python; platform_system != 'Darwin'",
     "numba",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ full = [
     "scikit-learn",
     "networkx",
     "distinctipy",
-    "matplotlib<3.9.",  # See https://github.com/SpikeInterface/spikeinterface/issues/2863
+    "matplotlib<3.9",  # See https://github.com/SpikeInterface/spikeinterface/issues/2863
     "cuda-python; platform_system != 'Darwin'",
     "numba",
 ]


### PR DESCRIPTION
Should fix https://github.com/SpikeInterface/spikeinterface/issues/2863 while someone goes and ensures that the library works with the newest version of matplotlib