### PR TITLE
Protect hdbscan import in `TdCClustering`

### DIFF
--- a/src/spikeinterface/sortingcomponents/clustering/tdc.py
+++ b/src/spikeinterface/sortingcomponents/clustering/tdc.py
@@ -37,8 +37,6 @@ from spikeinterface.sortingcomponents.clustering.tools import compute_template_f
 
 from sklearn.decomposition import TruncatedSVD
 
-import hdbscan
-
 
 class TdcClustering:
     """
@@ -63,6 +61,8 @@ class TdcClustering:
 
     @classmethod
     def main_function(cls, recording, peaks, params):
+        import hdbscan
+
         job_kwargs = params["job_kwargs"]
 
         if params["folder"] is None:


### PR DESCRIPTION
This is causing some problems on import tests. 

Would that work like this?