### PR TITLE
Handle ms_before and ms_after difference between waveforms and template extensions

### DIFF
--- a/src/spikeinterface/core/analyzer_extension_core.py
+++ b/src/spikeinterface/core/analyzer_extension_core.py
@@ -298,6 +298,12 @@ class ComputeTemplates(AnalyzerExtension):
 
         waveforms_extension = self.sorting_analyzer.get_extension("waveforms")
         if waveforms_extension is not None:
+
+            if ms_before != waveforms_extension.ms_before or ms_after != waveforms_extension.ms_after:
+                raise ValueError(
+                    "ComputeTemplates: ms_before and ms_after must be the same as the ones used for the 'waveforms' extension"
+                )
+
             nbefore = waveforms_extension.nbefore
             nafter = waveforms_extension.nafter
         else:


### PR DESCRIPTION
They might be different, we can either raise an error like here or change to a warning and priviledge the ones of the waveform as we are doing right now.

What do you guys think?