### PR TITLE
Protect zarr properties of type object

### DIFF
--- a/src/spikeinterface/core/zarrextractors.py
+++ b/src/spikeinterface/core/zarrextractors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 import numpy as np
 import zarr
@@ -315,6 +316,12 @@ def add_properties_and_annotations(
     prop_group = zarr_group.create_group("properties")
     for key in recording_or_sorting.get_property_keys():
         values = recording_or_sorting.get_property(key)
+        if values.dtype.kind == "O":
+            try:
+                values = values.astype("str")
+            except Exception as e:
+                warnings.warn(f"Property {key} not saved because it is a python Object type")
+                continue
         prop_group.create_dataset(name=key, data=values, compressor=None)
 
     # save annotations

--- a/src/spikeinterface/core/zarrextractors.py
+++ b/src/spikeinterface/core/zarrextractors.py
@@ -309,9 +309,7 @@ def get_default_zarr_compressor(clevel: int = 5):
     return Blosc(cname="zstd", clevel=clevel, shuffle=Blosc.BITSHUFFLE)
 
 
-def add_properties_and_annotations(
-    zarr_group: zarr.hierarchy.Group, recording_or_sorting: BaseRecording | BaseSorting
-):
+def add_properties_and_annotations(zarr_group: zarr.hierarchy.Group, recording_or_sorting: BaseRecording | BaseSorting):
     # save properties
     prop_group = zarr_group.create_group("properties")
     for key in recording_or_sorting.get_property_keys():

--- a/src/spikeinterface/core/zarrextractors.py
+++ b/src/spikeinterface/core/zarrextractors.py
@@ -310,18 +310,15 @@ def get_default_zarr_compressor(clevel: int = 5):
 
 
 def add_properties_and_annotations(
-    zarr_group: zarr.hierarchy.Group, recording_or_sorting: Union[BaseRecording, BaseSorting]
+    zarr_group: zarr.hierarchy.Group, recording_or_sorting: BaseRecording | BaseSorting
 ):
     # save properties
     prop_group = zarr_group.create_group("properties")
     for key in recording_or_sorting.get_property_keys():
         values = recording_or_sorting.get_property(key)
         if values.dtype.kind == "O":
-            try:
-                values = values.astype("str")
-            except Exception as e:
-                warnings.warn(f"Property {key} not saved because it is a python Object type")
-                continue
+            warnings.warn(f"Property {key} not saved because it is a python Object type")
+            continue
         prop_group.create_dataset(name=key, data=values, compressor=None)
 
     # save annotations

--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -168,11 +168,14 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
             elif prop_name == "group":
                 # rename group property to 'quality'
                 self.set_property(key="quality", values=cluster_info[prop_name])
-            elif prop_name != "group":
+            else:
                 if load_all_cluster_properties:
                     # pandas loads strings as objects
-                    prop_dtype = type(cluster_info[prop_name].values[0])
-                    values_ = cluster_info[prop_name].values.astype(prop_dtype)
+                    if isinstance(cluster_info[prop_name].values, object):
+                        prop_dtype = type(cluster_info[prop_name].values[0])
+                        values_ = cluster_info[prop_name].values.astype(prop_dtype)
+                    else:
+                        values_ = cluster_info[prop_name].values
                     self.set_property(key=prop_name, values=values_)
 
         self.annotate(phy_folder=str(phy_folder.resolve()))

--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -172,7 +172,15 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
                 self.set_property(key="quality", values=cluster_info[prop_name])
             else:
                 if load_all_cluster_properties:
-                    self.set_property(key=prop_name, values=cluster_info[prop_name])
+                    # pandas loads strings as objects
+                    if isinstance(cluster_info[prop_name].values[0], object):
+                        try:
+                            values_ = cluster_info[prop_name].values.astype(str)
+                        except:
+                            continue
+                    else:
+                        values_ = cluster_info[prop_name].values
+                    self.set_property(key=prop_name, values=values_)
 
         self.annotate(phy_folder=str(phy_folder.resolve()))
 

--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -165,21 +165,14 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
                 self.set_property(key="group", values=cluster_info[prop_name])
             elif prop_name == "cluster_id":
                 self.set_property(key="original_cluster_id", values=cluster_info[prop_name])
-            elif prop_name != "group":
-                self.set_property(key=prop_name, values=cluster_info[prop_name])
             elif prop_name == "group":
                 # rename group property to 'quality'
                 self.set_property(key="quality", values=cluster_info[prop_name])
-            else:
+            elif prop_name != "group":
                 if load_all_cluster_properties:
                     # pandas loads strings as objects
-                    if isinstance(cluster_info[prop_name].values[0], object):
-                        try:
-                            values_ = cluster_info[prop_name].values.astype(str)
-                        except:
-                            continue
-                    else:
-                        values_ = cluster_info[prop_name].values
+                    prop_dtype = type(cluster_info[prop_name].values[0])
+                    values_ = cluster_info[prop_name].values.astype(prop_dtype)
                     self.set_property(key=prop_name, values=values_)
 
         self.annotate(phy_folder=str(phy_folder.resolve()))

--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -171,7 +171,7 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
             else:
                 if load_all_cluster_properties:
                     # pandas loads strings as objects
-                    if isinstance(cluster_info[prop_name].values, object):
+                    if cluster_info[prop_name].values.dtype.kind == "O":
                         prop_dtype = type(cluster_info[prop_name].values[0])
                         values_ = cluster_info[prop_name].values.astype(prop_dtype)
                     else:


### PR DESCRIPTION
When loading phy/kilosort folders, string array properties are cast to python `Object`. This results in a failure when writing to zarr.

This simple PR protects against Object dtypes and tries to cast the array as str.