### PR TITLE
Put get_extension (to trigger auto-import) before get_children_dependencies for deleting Analyzer extensions to prevent KeyError

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -921,10 +921,10 @@ class SortingAnalyzer:
         >>> wfs = compute_waveforms(sorting_analyzer, **some_params)
 
         """
+        extension_class = get_extension_class(extension_name)
+
         for child in _get_children_dependencies(extension_name):
             self.delete_extension(child)
-
-        extension_class = get_extension_class(extension_name)
 
         if extension_class.need_job_kwargs:
             params, job_kwargs = split_job_kwargs(kwargs)


### PR DESCRIPTION
Fixes #2887 

## Issue

See #2887. But the issue is delete on recompute won't work for non-core extensions since the get_child_dependencies won't have the other extensions registered. We either need to flip the order (which I want to test with this PR) or fix the error messaging for this case.

Logic is that getting the class_extension should register it, which would allow us to delete on recompute.