### PR TITLE
[0.100.x-bug-fixes] Fix waveforms save in recordingless mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "numpy",
     "threadpoolctl>=3.0.0",
     "tqdm",
-    "zarr>=0.2.16",
+    "zarr>=2.16,<2.18",
     "neo>=0.13.0",
     "probeinterface>=0.2.21",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ full = [
 ]
 
 widgets = [
-    "matplotlib",
+    "matplotlib<3.9",
     "ipympl",
     "ipywidgets",
     "sortingview>=0.12.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ full = [
 ]
 
 widgets = [
-    "matplotlib<3.9",
+    "matplotlib",
     "ipympl",
     "ipywidgets",
     "sortingview>=0.12.0",

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -1928,10 +1928,16 @@ class BaseWaveformExtractorExtension:
             params = cls.load_params_from_folder(folder)
 
         if "sparsity" in params and params["sparsity"] is not None:
+            sparsity_params = params["sparsity"]
+            # handle old sparsity version
+            if "unit_ids" not in params["sparsity"]:
+                sparsity_params = {}
+                sparsity_params["unit_ids"] = waveform_extractor.unit_ids
+                sparsity_params["channel_ids"] = waveform_extractor.channel_ids
+                sparsity_params["unit_id_to_channel_ids"] = params["sparsity"]
+            else:
+                sparsity_params = params["sparsity"]
             params["sparsity"] = ChannelSparsity.from_dict(params["sparsity"])
-
-        # if waveform_extractor is None:
-        #     waveform_extractor = WaveformExtractor.load(folder)
 
         # make instance with params
         ext = cls(waveform_extractor)

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -1937,7 +1937,7 @@ class BaseWaveformExtractorExtension:
                 sparsity_params["unit_id_to_channel_ids"] = params["sparsity"]
             else:
                 sparsity_params = params["sparsity"]
-            params["sparsity"] = ChannelSparsity.from_dict(params["sparsity"])
+            params["sparsity"] = ChannelSparsity.from_dict(sparsity_params)
 
         # make instance with params
         ext = cls(waveform_extractor)

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -913,7 +913,7 @@ class WaveformExtractor:
                 probegroup = self.recording.get_probegroup()
         else:
             rec_attributes = deepcopy(self._rec_attributes)
-            probegroup = rec_attributes["probegroup"]
+            probegroup = rec_attributes.pop("probegroup")
 
         if self.is_sparse():
             assert sparsity is None, "WaveformExtractor is already sparse!"

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -1028,7 +1028,7 @@ class WaveformExtractor:
                         name=f"sampled_index_{unit_id}", data=sampled_indices, compressor=compressor
                     )
 
-        new_we = WaveformExtractor.load(folder, with_recording=)
+        new_we = WaveformExtractor.load(folder, with_recording=with_recording)
 
         # save waveform extensions
         for ext_name in self.get_available_extension_names():

--- a/src/spikeinterface/core/waveform_extractor.py
+++ b/src/spikeinterface/core/waveform_extractor.py
@@ -911,9 +911,11 @@ class WaveformExtractor:
             )
             if self.recording.get_probegroup() is not None:
                 probegroup = self.recording.get_probegroup()
+            with_recording = True
         else:
             rec_attributes = deepcopy(self._rec_attributes)
             probegroup = rec_attributes.pop("probegroup")
+            with_recording = False
 
         if self.is_sparse():
             assert sparsity is None, "WaveformExtractor is already sparse!"
@@ -1026,7 +1028,7 @@ class WaveformExtractor:
                         name=f"sampled_index_{unit_id}", data=sampled_indices, compressor=compressor
                     )
 
-        new_we = WaveformExtractor.load(folder)
+        new_we = WaveformExtractor.load(folder, with_recording=)
 
         # save waveform extensions
         for ext_name in self.get_available_extension_names():


### PR DESCRIPTION
This small PR fixes the `WaveformExtractor.save()` in recordingless mode