### PR TITLE
Fix remaining verbose clashing

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -491,7 +491,7 @@ class BaseRecording(BaseRecordingSnippets):
         rs = self._recording_segments[segment_index]
         return rs.time_to_sample_index(time_s)
 
-    def _save(self, format="binary", **save_kwargs):
+    def _save(self, format="binary", verbose: bool = False, **save_kwargs):
         # handle t_starts
         t_starts = []
         has_time_vectors = []
@@ -510,7 +510,7 @@ class BaseRecording(BaseRecordingSnippets):
             file_paths = [folder / f"traces_cached_seg{i}.raw" for i in range(self.get_num_segments())]
             dtype = kwargs.get("dtype", None) or self.get_dtype()
 
-            write_binary_recording(self, file_paths=file_paths, dtype=dtype, **job_kwargs)
+            write_binary_recording(self, file_paths=file_paths, dtype=dtype, verbose=verbose, **job_kwargs)
 
             from .binaryrecordingextractor import BinaryRecordingExtractor
 
@@ -540,6 +540,8 @@ class BaseRecording(BaseRecordingSnippets):
 
                 cached = SharedMemoryRecording.from_recording(self, **job_kwargs)
             else:
+                from spikeinterface.core import NumpyRecording
+
                 cached = NumpyRecording.from_recording(self, **job_kwargs)
 
         elif format == "zarr":
@@ -547,7 +549,9 @@ class BaseRecording(BaseRecordingSnippets):
 
             zarr_path = kwargs.pop("zarr_path")
             storage_options = kwargs.pop("storage_options")
-            ZarrRecordingExtractor.write_recording(self, zarr_path, storage_options, **kwargs, **job_kwargs)
+            ZarrRecordingExtractor.write_recording(
+                self, zarr_path, storage_options, verbose=verbose, **kwargs, **job_kwargs
+            )
             cached = ZarrRecordingExtractor(zarr_path, storage_options)
 
         elif format == "nwb":

--- a/src/spikeinterface/core/recording_tools.py
+++ b/src/spikeinterface/core/recording_tools.py
@@ -351,9 +351,6 @@ def write_memory_recording(recording, dtype=None, verbose=False, auto_cast_uint=
     else:
         init_args = (recording, arrays, None, None, dtype, cast_unsigned)
 
-    if "verbose" in job_kwargs:
-        del job_kwargs["verbose"]
-
     executor = ChunkRecordingExecutor(
         recording, func, init_func, init_args, verbose=verbose, job_name="write_memory_recording", **job_kwargs
     )

--- a/src/spikeinterface/core/recording_tools.py
+++ b/src/spikeinterface/core/recording_tools.py
@@ -73,7 +73,7 @@ def write_binary_recording(
     add_file_extension: bool = True,
     byte_offset: int = 0,
     auto_cast_uint: bool = True,
-    verbose: bool = True,
+    verbose: bool = False,
     **job_kwargs,
 ):
     """
@@ -100,7 +100,7 @@ def write_binary_recording(
         If True, unsigned integers are automatically cast to int if the specified dtype is signed
         .. deprecated:: 0.103, use the `unsigned_to_signed` function instead.
     verbose: bool
-        If True, output is verbose
+        This is the verbosity of the ChunkRecordingExecutor
     {}
     """
     job_kwargs = fix_job_kwargs(job_kwargs)


### PR DESCRIPTION
Should close #2847. Following on https://github.com/SpikeInterface/spikeinterface/pull/2898/files. Also removed some comments from https://github.com/SpikeInterface/spikeinterface/pull/2728.

I still think this approach of catching verbose at every point of the call stack is very labor intensive. I mentioned to Sam that we could have more specific verbosity terms:

For the ChunkRecordingExectuor: `display_chunk_info` or `verbose_chunk_executor` 
For the save_to_folder `display_saved_folder`

But he pointed out -correctly I think- that usually verbose is managed in linux like a global option which I think it makes sense. 

Maybe the real work around will be the genera logger as described in https://github.com/SpikeInterface/spikeinterface/pull/2602