### PR TITLE
Remove toy example from test codebase (1)

### DIFF
--- a/src/spikeinterface/comparison/tests/test_groundtruthcomparison.py
+++ b/src/spikeinterface/comparison/tests/test_groundtruthcomparison.py
@@ -3,7 +3,7 @@ from numpy.testing import assert_array_equal
 
 import pandas as pd
 
-from spikeinterface.extractors import NumpySorting, toy_example
+from spikeinterface.extractors import NumpySorting
 from spikeinterface.comparison import compare_sorter_to_ground_truth
 
 

--- a/src/spikeinterface/comparison/tests/test_multisortingcomparison.py
+++ b/src/spikeinterface/comparison/tests/test_multisortingcomparison.py
@@ -5,7 +5,8 @@ from pathlib import Path
 import pytest
 import numpy as np
 
-from spikeinterface.extractors import NumpySorting, toy_example
+from spikeinterface.core import generate_ground_truth_recording
+from spikeinterface.extractors import NumpySorting
 from spikeinterface.comparison import compare_multiple_sorters, MultiSortingComparison
 
 if hasattr(pytest, "global_test_folder"):
@@ -72,7 +73,7 @@ def test_compare_multiple_sorters():
 
 def test_compare_multi_segment():
     num_segments = 3
-    _, sort = toy_example(num_segments=num_segments)
+    _, sort = generate_ground_truth_recording(durations=[10] * num_segments)
 
     cmp_multi = compare_multiple_sorters([sort, sort, sort])
 

--- a/src/spikeinterface/comparison/tests/test_multisortingcomparison.py
+++ b/src/spikeinterface/comparison/tests/test_multisortingcomparison.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 import numpy as np
 
-from spikeinterface.core import generate_ground_truth_recording
+from spikeinterface.core import generate_sorting
 from spikeinterface.extractors import NumpySorting
 from spikeinterface.comparison import compare_multiple_sorters, MultiSortingComparison
 
@@ -73,7 +73,7 @@ def test_compare_multiple_sorters():
 
 def test_compare_multi_segment():
     num_segments = 3
-    _, sort = generate_ground_truth_recording(durations=[10] * num_segments)
+    sort = generate_sorting(durations=[10] * num_segments)
 
     cmp_multi = compare_multiple_sorters([sort, sort, sort])
 

--- a/src/spikeinterface/comparison/tests/test_symmetricsortingcomparison.py
+++ b/src/spikeinterface/comparison/tests/test_symmetricsortingcomparison.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-from spikeinterface.extractors import NumpySorting, toy_example
+from spikeinterface.core import generate_ground_truth_recording
+from spikeinterface.extractors import NumpySorting
 from spikeinterface.comparison import compare_two_sorters
 
 
@@ -29,7 +30,7 @@ def test_compare_two_sorters():
 
 
 def test_compare_multi_segment():
-    _, sort = toy_example(num_segments=2)
+    _, sort = generate_ground_truth_recording(durations=[10, 10])
 
     cmp_multi = compare_two_sorters(sort, sort)
 

--- a/src/spikeinterface/comparison/tests/test_symmetricsortingcomparison.py
+++ b/src/spikeinterface/comparison/tests/test_symmetricsortingcomparison.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from spikeinterface.core import generate_ground_truth_recording
+from spikeinterface.core import generate_sorting
 from spikeinterface.extractors import NumpySorting
 from spikeinterface.comparison import compare_two_sorters
 
@@ -30,7 +30,7 @@ def test_compare_two_sorters():
 
 
 def test_compare_multi_segment():
-    _, sort = generate_ground_truth_recording(durations=[10, 10])
+    sort = generate_sorting(durations=[10, 10])
 
     cmp_multi = compare_two_sorters(sort, sort)
 

--- a/src/spikeinterface/qualitymetrics/tests/test_pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/tests/test_pca_metrics.py
@@ -11,7 +11,6 @@ from spikeinterface.core import (
     create_sorting_analyzer,
 )
 
-# from spikeinterface.extractors.toy_example import toy_example
 from spikeinterface.qualitymetrics.utils import create_ground_truth_pc_distributions
 
 from spikeinterface.qualitymetrics import (


### PR DESCRIPTION
This PR replaces `toy_example` with `generate_recordings` in certain test files (outside of sorter tests). This PR is part of three PRs removing `toy_example` created during the 2024 Hackathon.

TODO:
- [src/spikeinterface/comparison/tests/test_hybrid.py](https://github.com/JoeZiminski/spikeinterface/blob/29ad02bba37426e931902744a3eb68bc6c1ae2f2/src/spikeinterface/comparison/tests/test_hybrid.py#L10) uses a `average_peak_amplitude` argument that is not  included in `generate_ground_truth_recording`. Q: should this functionality be added to `generate_ground_truth_recording`?