### PR TITLE
Replace toy_example by generate_ground_truth_recording in sorters folder

### DIFF
--- a/src/spikeinterface/preprocessing/tests/test_phase_shift.py
+++ b/src/spikeinterface/preprocessing/tests/test_phase_shift.py
@@ -13,13 +13,6 @@ from spikeinterface.preprocessing.phase_shift import apply_fshift
 
 import scipy.fft
 
-if hasattr(pytest, "global_test_folder"):
-    cache_folder = pytest.global_test_folder / "preprocessing"
-else:
-    cache_folder = Path("cache_folder") / "preprocessing"
-
-set_global_tmp_folder(cache_folder)
-
 
 def create_shifted_channel():
     duration = 5.0

--- a/src/spikeinterface/sorters/external/tests/test_docker_containers.py
+++ b/src/spikeinterface/sorters/external/tests/test_docker_containers.py
@@ -4,6 +4,7 @@ import shutil
 import pytest
 from pathlib import Path
 
+from spikeinterface import generate_ground_truth_recording
 from spikeinterface.core.core_tools import is_editable_mode
 import spikeinterface.extractors as se
 import spikeinterface.sorters as ss
@@ -23,7 +24,7 @@ def check_gh_settings():
 
 
 def generate_run_kwargs():
-    test_recording, _ = se.toy_example(duration=30, seed=0, num_channels=64, num_segments=1)
+    test_recording, _ = generate_ground_truth_recording(durations=[30], seed=0, num_channels=64)
     test_recording = test_recording.save(name="toy")
     test_recording.set_channel_gains(1)
     test_recording.set_channel_offsets(0)

--- a/src/spikeinterface/sorters/external/tests/test_docker_containers.py
+++ b/src/spikeinterface/sorters/external/tests/test_docker_containers.py
@@ -4,7 +4,7 @@ import shutil
 import pytest
 from pathlib import Path
 
-from spikeinterface import generate_ground_truth_recording
+from spikeinterface import generate_ground_truth_recording, generate_recording
 from spikeinterface.core.core_tools import is_editable_mode
 import spikeinterface.extractors as se
 import spikeinterface.sorters as ss
@@ -24,7 +24,7 @@ def check_gh_settings():
 
 
 def generate_run_kwargs():
-    test_recording, _ = generate_ground_truth_recording(durations=[30], seed=0, num_channels=64)
+    test_recording = generate_recording(durations=[30], seed=0, num_channels=64)
     test_recording = test_recording.save(name="toy")
     test_recording.set_channel_gains(1)
     test_recording.set_channel_offsets(0)

--- a/src/spikeinterface/sorters/external/tests/test_docker_containers.py
+++ b/src/spikeinterface/sorters/external/tests/test_docker_containers.py
@@ -4,7 +4,7 @@ import shutil
 import pytest
 from pathlib import Path
 
-from spikeinterface import generate_ground_truth_recording, generate_recording
+from spikeinterface import generate_ground_truth_recording
 from spikeinterface.core.core_tools import is_editable_mode
 import spikeinterface.extractors as se
 import spikeinterface.sorters as ss
@@ -24,7 +24,7 @@ def check_gh_settings():
 
 
 def generate_run_kwargs():
-    test_recording = generate_recording(durations=[30], seed=0, num_channels=64)
+    test_recording, _ = generate_ground_truth_recording(durations=[30], seed=0, num_channels=64)
     test_recording = test_recording.save(name="toy")
     test_recording.set_channel_gains(1)
     test_recording.set_channel_offsets(0)

--- a/src/spikeinterface/sorters/external/tests/test_kilosort4.py
+++ b/src/spikeinterface/sorters/external/tests/test_kilosort4.py
@@ -2,8 +2,7 @@ import unittest
 import pytest
 from pathlib import Path
 
-from spikeinterface import load_extractor
-from spikeinterface.extractors import toy_example
+from spikeinterface import load_extractor, generate_ground_truth_recording
 from spikeinterface.sorters import Kilosort4Sorter, run_sorter
 from spikeinterface.sorters.tests.common_tests import SorterCommonTestSuite
 
@@ -23,7 +22,7 @@ class Kilosort4SorterCommonTestSuite(SorterCommonTestSuite, unittest.TestCase):
         if (cache_folder / "rec").is_dir():
             recording = load_extractor(cache_folder / "rec")
         else:
-            recording, _ = toy_example(num_channels=32, duration=60, seed=0, num_segments=1)
+            recording, _ = generate_ground_truth_recording(num_channels=32, durations=[60], seed=0)
             recording = recording.save(folder=cache_folder / "rec", verbose=False, format="binary")
         self.recording = recording
         print(self.recording)

--- a/src/spikeinterface/sorters/external/tests/test_kilosort4.py
+++ b/src/spikeinterface/sorters/external/tests/test_kilosort4.py
@@ -2,7 +2,7 @@ import unittest
 import pytest
 from pathlib import Path
 
-from spikeinterface import load_extractor, generate_ground_truth_recording, generate_recording
+from spikeinterface import load_extractor, generate_ground_truth_recording
 from spikeinterface.sorters import Kilosort4Sorter, run_sorter
 from spikeinterface.sorters.tests.common_tests import SorterCommonTestSuite
 
@@ -22,7 +22,7 @@ class Kilosort4SorterCommonTestSuite(SorterCommonTestSuite, unittest.TestCase):
         if (cache_folder / "rec").is_dir():
             recording = load_extractor(cache_folder / "rec")
         else:
-            recording = generate_recording(num_channels=32, durations=[60], seed=0)
+            recording, _ = generate_ground_truth_recording(num_channels=32, durations=[60], seed=0)
             recording = recording.save(folder=cache_folder / "rec", verbose=False, format="binary")
         self.recording = recording
         print(self.recording)

--- a/src/spikeinterface/sorters/external/tests/test_kilosort4.py
+++ b/src/spikeinterface/sorters/external/tests/test_kilosort4.py
@@ -2,7 +2,7 @@ import unittest
 import pytest
 from pathlib import Path
 
-from spikeinterface import load_extractor, generate_ground_truth_recording
+from spikeinterface import load_extractor, generate_ground_truth_recording, generate_recording
 from spikeinterface.sorters import Kilosort4Sorter, run_sorter
 from spikeinterface.sorters.tests.common_tests import SorterCommonTestSuite
 
@@ -22,7 +22,7 @@ class Kilosort4SorterCommonTestSuite(SorterCommonTestSuite, unittest.TestCase):
         if (cache_folder / "rec").is_dir():
             recording = load_extractor(cache_folder / "rec")
         else:
-            recording, _ = generate_ground_truth_recording(num_channels=32, durations=[60], seed=0)
+            recording = generate_recording(num_channels=32, durations=[60], seed=0)
             recording = recording.save(folder=cache_folder / "rec", verbose=False, format="binary")
         self.recording = recording
         print(self.recording)

--- a/src/spikeinterface/sorters/external/tests/test_pykilosort.py
+++ b/src/spikeinterface/sorters/external/tests/test_pykilosort.py
@@ -1,7 +1,6 @@
 import unittest
 
 import pytest
-from spikeinterface.extractors import toy_example
 from spikeinterface.sorters import PyKilosortSorter
 from spikeinterface.sorters.tests.common_tests import SorterCommonTestSuite
 

--- a/src/spikeinterface/sorters/external/tests/test_singularity_containers.py
+++ b/src/spikeinterface/sorters/external/tests/test_singularity_containers.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from pathlib import Path
 
+from spikeinterface import generate_ground_truth_recording
 from spikeinterface.core.core_tools import is_editable_mode
 import spikeinterface.extractors as se
 import spikeinterface.sorters as ss
@@ -29,7 +30,7 @@ def check_gh_settings():
 
 
 def generate_run_kwargs():
-    test_recording, _ = se.toy_example(duration=30, seed=0, num_channels=64, num_segments=1)
+    test_recording, _ = generate_ground_truth_recording(durations=[30], seed=0, num_channels=64)
     test_recording = test_recording.save(name="toy")
     test_recording.set_channel_gains(1)
     test_recording.set_channel_offsets(0)

--- a/src/spikeinterface/sorters/external/tests/test_singularity_containers.py
+++ b/src/spikeinterface/sorters/external/tests/test_singularity_containers.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from pathlib import Path
 
-from spikeinterface import generate_ground_truth_recording
+from spikeinterface import generate_ground_truth_recording, generate_recording
 from spikeinterface.core.core_tools import is_editable_mode
 import spikeinterface.extractors as se
 import spikeinterface.sorters as ss
@@ -30,7 +30,7 @@ def check_gh_settings():
 
 
 def generate_run_kwargs():
-    test_recording, _ = generate_ground_truth_recording(durations=[30], seed=0, num_channels=64)
+    test_recording = generate_recording(durations=[30], seed=0, num_channels=64)
     test_recording = test_recording.save(name="toy")
     test_recording.set_channel_gains(1)
     test_recording.set_channel_offsets(0)

--- a/src/spikeinterface/sorters/external/tests/test_singularity_containers.py
+++ b/src/spikeinterface/sorters/external/tests/test_singularity_containers.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from pathlib import Path
 
-from spikeinterface import generate_ground_truth_recording, generate_recording
+from spikeinterface import generate_ground_truth_recording
 from spikeinterface.core.core_tools import is_editable_mode
 import spikeinterface.extractors as se
 import spikeinterface.sorters as ss
@@ -30,7 +30,7 @@ def check_gh_settings():
 
 
 def generate_run_kwargs():
-    test_recording = generate_recording(durations=[30], seed=0, num_channels=64)
+    test_recording, _ = generate_ground_truth_recording(durations=[30], seed=0, num_channels=64)
     test_recording = test_recording.save(name="toy")
     test_recording.set_channel_gains(1)
     test_recording.set_channel_offsets(0)

--- a/src/spikeinterface/sorters/external/tests/test_singularity_containers_gpu.py
+++ b/src/spikeinterface/sorters/external/tests/test_singularity_containers_gpu.py
@@ -3,7 +3,7 @@ import shutil
 
 import pytest
 
-from spikeinterface import generate_ground_truth_recording, generate_recording
+from spikeinterface import generate_ground_truth_recording
 from spikeinterface.core.core_tools import is_editable_mode
 
 import spikeinterface.sorters as ss
@@ -24,7 +24,7 @@ def check_gh_settings():
 
 
 def generate_run_kwargs():
-    test_recording = generate_recording(durations=[30], seed=0, num_channels=64)
+    test_recording, _ = generate_ground_truth_recording(durations=[30], seed=0, num_channels=64)
     test_recording = test_recording.save(name="toy")
     test_recording.set_channel_gains(1)
     test_recording.set_channel_offsets(0)

--- a/src/spikeinterface/sorters/external/tests/test_singularity_containers_gpu.py
+++ b/src/spikeinterface/sorters/external/tests/test_singularity_containers_gpu.py
@@ -3,6 +3,7 @@ import shutil
 
 import pytest
 
+from spikeinterface import generate_ground_truth_recording
 from spikeinterface.core.core_tools import is_editable_mode
 import spikeinterface.extractors as se
 import spikeinterface.sorters as ss
@@ -23,7 +24,7 @@ def check_gh_settings():
 
 
 def generate_run_kwargs():
-    test_recording, _ = se.toy_example(duration=30, seed=0, num_channels=64, num_segments=1)
+    test_recording, _ = generate_ground_truth_recording(durations=[30], seed=0, num_channels=64)
     test_recording = test_recording.save(name="toy")
     test_recording.set_channel_gains(1)
     test_recording.set_channel_offsets(0)

--- a/src/spikeinterface/sorters/external/tests/test_singularity_containers_gpu.py
+++ b/src/spikeinterface/sorters/external/tests/test_singularity_containers_gpu.py
@@ -3,9 +3,9 @@ import shutil
 
 import pytest
 
-from spikeinterface import generate_ground_truth_recording
+from spikeinterface import generate_ground_truth_recording, generate_recording
 from spikeinterface.core.core_tools import is_editable_mode
-import spikeinterface.extractors as se
+
 import spikeinterface.sorters as ss
 
 os.environ["SINGULARITY_DISABLE_CACHE"] = "true"
@@ -24,7 +24,7 @@ def check_gh_settings():
 
 
 def generate_run_kwargs():
-    test_recording, _ = generate_ground_truth_recording(durations=[30], seed=0, num_channels=64)
+    test_recording = generate_recording(durations=[30], seed=0, num_channels=64)
     test_recording = test_recording.save(name="toy")
     test_recording.set_channel_gains(1)
     test_recording.set_channel_offsets(0)

--- a/src/spikeinterface/sorters/external/yass.py
+++ b/src/spikeinterface/sorters/external/yass.py
@@ -96,7 +96,7 @@ class YassSorter(BaseSorter):
 
                             1.  Retraining Neural Networks (Default)
 
-                            rec, sort = se.toy_example(duration=300)
+                            rec, sort = generate_ground_truth_recording(durations=[300])
                             sorting_yass = ss.run_yass(rec, '/home/cat/Downloads/test2')
 
 

--- a/src/spikeinterface/sorters/tests/common_tests.py
+++ b/src/spikeinterface/sorters/tests/common_tests.py
@@ -4,7 +4,7 @@ import pytest
 from pathlib import Path
 import shutil
 
-from spikeinterface.extractors import toy_example
+from spikeinterface import generate_ground_truth_recording
 from spikeinterface.sorters import run_sorter
 from spikeinterface.core.snippets_tools import snippets_from_sorting
 
@@ -24,7 +24,7 @@ class SorterCommonTestSuite:
     SorterClass = None
 
     def setUp(self):
-        recording, sorting_gt = toy_example(num_channels=4, duration=60, seed=0, num_segments=1)
+        recording, sorting_gt = generate_ground_truth_recording(num_channels=4, durations=[60], seed=0)
         rec_folder = cache_folder / "rec"
         if rec_folder.is_dir():
             shutil.rmtree(rec_folder)
@@ -80,7 +80,7 @@ class SnippetsSorterCommonTestSuite:
     SorterClass = None
 
     def setUp(self):
-        recording, sorting_gt = toy_example(num_channels=4, duration=60, seed=0, num_segments=1)
+        recording, sorting_gt = generate_ground_truth_recording(num_channels=4, durations=[60], seed=0)
         snippets_folder = cache_folder / "snippets"
         if snippets_folder.is_dir():
             shutil.rmtree(snippets_folder)

--- a/src/spikeinterface/sorters/tests/test_container_tools.py
+++ b/src/spikeinterface/sorters/tests/test_container_tools.py
@@ -5,7 +5,8 @@ import shutil
 import os
 
 import spikeinterface as si
-from spikeinterface.extractors import toy_example
+from spikeinterface import generate_ground_truth_recording
+
 from spikeinterface.sorters.container_tools import find_recording_folders, ContainerClient, install_package_in_container
 
 ON_GITHUB = bool(os.getenv("GITHUB_ACTIONS"))
@@ -21,10 +22,10 @@ def setup_module():
     for test_dir in test_dirs:
         if test_dir.exists():
             shutil.rmtree(test_dir)
-    rec1, _ = toy_example(num_segments=1)
+    rec1, _ = generate_ground_truth_recording(durations=[10])
     rec1 = rec1.save(folder=cache_folder / "mono")
 
-    rec2, _ = toy_example(num_segments=3)
+    rec2, _ = generate_ground_truth_recording(durations=[10, 10, 10])
     rec2 = rec2.save(folder=cache_folder / "multi")
 
 

--- a/src/spikeinterface/sorters/tests/test_container_tools.py
+++ b/src/spikeinterface/sorters/tests/test_container_tools.py
@@ -22,10 +22,10 @@ def setup_module():
     for test_dir in test_dirs:
         if test_dir.exists():
             shutil.rmtree(test_dir)
-    rec1 = generate_recording(durations=[10])
+    rec1, _ = generate_ground_truth_recording(durations=[10])
     rec1 = rec1.save(folder=cache_folder / "mono")
 
-    rec2 = generate_recording(durations=[10, 10, 10])
+    rec2, _ = generate_ground_truth_recording(durations=[10, 10, 10])
     rec2 = rec2.save(folder=cache_folder / "multi")
 
 

--- a/src/spikeinterface/sorters/tests/test_container_tools.py
+++ b/src/spikeinterface/sorters/tests/test_container_tools.py
@@ -5,7 +5,7 @@ import shutil
 import os
 
 import spikeinterface as si
-from spikeinterface import generate_ground_truth_recording, generate_recording
+from spikeinterface import generate_ground_truth_recording
 
 from spikeinterface.sorters.container_tools import find_recording_folders, ContainerClient, install_package_in_container
 

--- a/src/spikeinterface/sorters/tests/test_container_tools.py
+++ b/src/spikeinterface/sorters/tests/test_container_tools.py
@@ -5,7 +5,7 @@ import shutil
 import os
 
 import spikeinterface as si
-from spikeinterface import generate_ground_truth_recording
+from spikeinterface import generate_ground_truth_recording, generate_recording
 
 from spikeinterface.sorters.container_tools import find_recording_folders, ContainerClient, install_package_in_container
 
@@ -22,10 +22,10 @@ def setup_module():
     for test_dir in test_dirs:
         if test_dir.exists():
             shutil.rmtree(test_dir)
-    rec1, _ = generate_ground_truth_recording(durations=[10])
+    rec1 = generate_recording(durations=[10])
     rec1 = rec1.save(folder=cache_folder / "mono")
 
-    rec2, _ = generate_ground_truth_recording(durations=[10, 10, 10])
+    rec2 = generate_recording(durations=[10, 10, 10])
     rec2 = rec2.save(folder=cache_folder / "multi")
 
 

--- a/src/spikeinterface/sorters/tests/test_launcher.py
+++ b/src/spikeinterface/sorters/tests/test_launcher.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from spikeinterface.core import load_extractor
 
-from spikeinterface import generate_ground_truth_recording
+from spikeinterface import generate_ground_truth_recording, generate_recording
 from spikeinterface.sorters import run_sorter_jobs, run_sorter_by_property
 
 
@@ -27,7 +27,7 @@ sorters = ["tridesclous2"]
 def setup_module():
     base_seed = 42
     for i in range(num_recordings):
-        rec, _ = generate_ground_truth_recording(num_channels=8, durations=[10.0], seed=base_seed + i)
+        rec = generate_recording(num_channels=8, durations=[10.0], seed=base_seed + i)
         rec_folder = cache_folder / f"toy_rec_{i}"
         if rec_folder.is_dir():
             shutil.rmtree(rec_folder)

--- a/src/spikeinterface/sorters/tests/test_launcher.py
+++ b/src/spikeinterface/sorters/tests/test_launcher.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from spikeinterface.core import load_extractor
 
-from spikeinterface import generate_ground_truth_recording, generate_recording
+from spikeinterface import generate_ground_truth_recording
 from spikeinterface.sorters import run_sorter_jobs, run_sorter_by_property
 
 
@@ -27,7 +27,7 @@ sorters = ["tridesclous2"]
 def setup_module():
     base_seed = 42
     for i in range(num_recordings):
-        rec = generate_recording(num_channels=8, durations=[10.0], seed=base_seed + i)
+        rec, _ = generate_ground_truth_recording(num_channels=8, durations=[10.0], seed=base_seed + i)
         rec_folder = cache_folder / f"toy_rec_{i}"
         if rec_folder.is_dir():
             shutil.rmtree(rec_folder)

--- a/src/spikeinterface/sorters/tests/test_launcher.py
+++ b/src/spikeinterface/sorters/tests/test_launcher.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 from spikeinterface.core import load_extractor
 
-# from spikeinterface.extractors import toy_example
 from spikeinterface import generate_ground_truth_recording
 from spikeinterface.sorters import run_sorter_jobs, run_sorter_by_property
 


### PR DESCRIPTION
This PR replaces toy_example with generate_ground_truth_recording in the sorters folder, it is part of a group of PRs removing toy_example decided during the hackathon 2024