### PR TITLE
fixed bug in add_suffix and added test

### DIFF
--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -146,7 +146,7 @@ def add_suffix(file_path, possible_suffix):
         possible_suffix = [possible_suffix]
     possible_suffix = [s if s.startswith(".") else "." + s for s in possible_suffix]
     if file_path.suffix not in possible_suffix:
-        file_path = file_path.parent / (file_path.name + "." + possible_suffix[0])
+        file_path = file_path.parent / (file_path.name + possible_suffix[0])
     return file_path
 
 

--- a/src/spikeinterface/core/tests/test_core_tools.py
+++ b/src/spikeinterface/core/tests/test_core_tools.py
@@ -11,7 +11,7 @@ from spikeinterface.core.core_tools import (
     check_paths_relative,
     normal_pdf,
     convert_string_to_bytes,
-    add_suffix
+    add_suffix,
 )
 
 
@@ -20,20 +20,22 @@ if hasattr(pytest, "global_test_folder"):
 else:
     cache_folder = Path("cache_folder") / "core"
 
+
 def test_add_suffix():
     # first case - no dot provided before extension
-    file_path = 'testpath'
-    possible_suffix = ['raw', 'bin', 'path']
+    file_path = "testpath"
+    possible_suffix = ["raw", "bin", "path"]
     file_path_with_suffix = add_suffix(file_path, possible_suffix)
-    expected_path = 'testpath.raw'
+    expected_path = "testpath.raw"
     assert str(file_path_with_suffix) == expected_path
 
     # second case - dot provided before extension
-    file_path = 'testpath'
-    possible_suffix = ['.raw', '.bin', '.path']
+    file_path = "testpath"
+    possible_suffix = [".raw", ".bin", ".path"]
     file_path_with_suffix = add_suffix(file_path, possible_suffix)
-    expected_path = 'testpath.raw'
+    expected_path = "testpath.raw"
     assert str(file_path_with_suffix) == expected_path
+
 
 def test_path_utils_functions():
     if platform.system() != "Windows":

--- a/src/spikeinterface/core/tests/test_core_tools.py
+++ b/src/spikeinterface/core/tests/test_core_tools.py
@@ -11,6 +11,7 @@ from spikeinterface.core.core_tools import (
     check_paths_relative,
     normal_pdf,
     convert_string_to_bytes,
+    add_suffix
 )
 
 
@@ -19,6 +20,20 @@ if hasattr(pytest, "global_test_folder"):
 else:
     cache_folder = Path("cache_folder") / "core"
 
+def test_add_suffix():
+    # first case - no dot provided before extension
+    file_path = 'testpath'
+    possible_suffix = ['raw', 'bin', 'path']
+    file_path_with_suffix = add_suffix(file_path, possible_suffix)
+    expected_path = 'testpath.raw'
+    assert str(file_path_with_suffix) == expected_path
+
+    # second case - dot provided before extension
+    file_path = 'testpath'
+    possible_suffix = ['.raw', '.bin', '.path']
+    file_path_with_suffix = add_suffix(file_path, possible_suffix)
+    expected_path = 'testpath.raw'
+    assert str(file_path_with_suffix) == expected_path
 
 def test_path_utils_functions():
     if platform.system() != "Windows":


### PR DESCRIPTION
I found a bug wherein the add_suffix function was adding two dots to the filename instead of just one. For example, add_suffix('myfile', ['raw','bin','path']) returned "myfile..raw" instead of "myfile.raw". I have corrected this bug and also added a new test in test_core_tools.py.