### PR TITLE
Add Mac skip for plexon2 Neo test

### DIFF
--- a/src/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/src/spikeinterface/extractors/tests/test_neoextractors.py
@@ -31,13 +31,12 @@ def has_plexon2_dependencies():
         # On Windows, no need for additional dependencies
         return True
 
-    elif os_type == "Linux":
-        # Check for 'wine' using dpkg
-        try:
-            result_wine = subprocess.run(
-                ["dpkg", "-l", "wine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
-            )
-        except subprocess.CalledProcessError:
+    elif os_type == "Linux" or os_type == "Darwin":
+        # Check for 'wine' using which. "which" works for both mac and linux
+        # if package exists it returns a 0. Anything else is an error code.
+
+        result_wine = subprocess.run(["which", "wine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+        if result_wine.returncode != 0:
             return False
 
         # Check for 'zugbruecke' using pip
@@ -48,7 +47,6 @@ def has_plexon2_dependencies():
         except ImportError:
             return False
     else:
-        # Not sure about MacOS
         raise ValueError(f"Unsupported OS: {os_type}")
 
 


### PR DESCRIPTION
This brings us into line with how Neo does this check which works for both Mac and linux for the wine stuff.