### PR TITLE
Remove numba type signature to prevent compilation of numba functions at import

### DIFF
--- a/src/spikeinterface/core/sorting_tools.py
+++ b/src/spikeinterface/core/sorting_tools.py
@@ -108,7 +108,7 @@ def get_numba_vector_to_list_of_spiketrain():
 
     import numba
 
-    @numba.jit((numba.int64[::1], numba.int64[::1], numba.int64), nopython=True, nogil=True, cache=False)
+    @numba.jit(nopython=True, nogil=True, cache=False)
     def vector_to_list_of_spiketrain_numba(sample_indices, unit_indices, num_units):
         """
         Fast implementation of vector_to_dict using numba loop.

--- a/src/spikeinterface/postprocessing/correlograms.py
+++ b/src/spikeinterface/postprocessing/correlograms.py
@@ -316,7 +316,7 @@ def compute_correlograms_numba(sorting, window_size, bin_size):
 
 if HAVE_NUMBA:
 
-    @numba.jit((numba.int64[::1], numba.int32, numba.int32), nopython=True, nogil=True, cache=False)
+    @numba.jit(nopython=True, nogil=True, cache=False)
     def _compute_autocorr_numba(spike_times, window_size, bin_size):
         num_half_bins = window_size // bin_size
         num_bins = 2 * num_half_bins
@@ -341,7 +341,7 @@ if HAVE_NUMBA:
 
         return auto_corr
 
-    @numba.jit((numba.int64[::1], numba.int64[::1], numba.int32, numba.int32), nopython=True, nogil=True, cache=False)
+    @numba.jit(nopython=True, nogil=True, cache=False)
     def _compute_crosscorr_numba(spike_times1, spike_times2, window_size, bin_size):
         num_half_bins = window_size // bin_size
         num_bins = 2 * num_half_bins
@@ -367,7 +367,6 @@ if HAVE_NUMBA:
         return cross_corr
 
     @numba.jit(
-        (numba.int64[:, :, ::1], numba.int64[::1], numba.int32[::1], numba.int32, numba.int32),
         nopython=True,
         nogil=True,
         cache=False,

--- a/src/spikeinterface/postprocessing/isi.py
+++ b/src/spikeinterface/postprocessing/isi.py
@@ -159,7 +159,6 @@ def compute_isi_histograms_numba(sorting, window_ms: float = 50.0, bin_ms: float
 if HAVE_NUMBA:
 
     @numba.jit(
-        (numba.int64[:, ::1], numba.int64[::1], numba.int32[::1], numba.int64[::1]),
         nopython=True,
         nogil=True,
         cache=False,

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -1363,7 +1363,7 @@ def _compute_violations(obs_viol, firing_rate, spike_count, ref_period_dur, cont
 
 if HAVE_NUMBA:
 
-    @numba.jit((numba.int64[::1], numba.int32), nopython=True, nogil=True, cache=False)
+    @numba.jit(nopython=True, nogil=True, cache=False)
     def _compute_nb_violations_numba(spike_train, t_r):
         n_v = 0
         N = len(spike_train)
@@ -1383,7 +1383,6 @@ if HAVE_NUMBA:
         return n_v
 
     @numba.jit(
-        (numba.int64[::1], numba.int64[::1], numba.int32[::1], numba.int32, numba.int32),
         nopython=True,
         nogil=True,
         cache=False,


### PR DESCRIPTION
https://numba.discourse.group/t/reducing-import-time/1072/8 

This discussion says that providing type signatures gives type checking, but then leads to eager compilation. This PR tests removing that to see if it speeds import time.