### PR TITLE
Remove unused imports in ibl test

### DIFF
--- a/src/spikeinterface/extractors/tests/test_iblextractors.py
+++ b/src/spikeinterface/extractors/tests/test_iblextractors.py
@@ -1,5 +1,4 @@
 from re import escape
-from tkinter import ON
 from unittest import TestCase
 
 import numpy as np
@@ -8,8 +7,6 @@ import pytest
 import requests
 
 from spikeinterface.extractors import read_ibl_recording, read_ibl_sorting, IblRecordingExtractor
-from spikeinterface.extractors import read_ibl_sorting
-from spikeinterface.core import generate_sorting
 
 EID = "e2b845a1-e313-4a08-bc61-a5f662ed295e"
 PID = "80f6ffdd-f692-450f-ab19-cd6d45bfd73e"


### PR DESCRIPTION
Remove unused tkinter import on ibl that is breaking tests on mac.