### PR TITLE
Make easier env vars for local testing

### DIFF
--- a/src/spikeinterface/sorters/external/tests/test_docker_containers.py
+++ b/src/spikeinterface/sorters/external/tests/test_docker_containers.py
@@ -15,7 +15,7 @@ else:
     cache_folder = Path("cache_folder") / "sorters"
 
 
-ON_GITHUB = os.getenv("CI")
+ON_GITHUB = bool(os.getenv("GITHUB_ACTIONS"))
 
 
 def check_gh_settings():
@@ -40,6 +40,7 @@ def run_kwargs():
     return generate_run_kwargs()
 
 
+@pytest.skipif()
 def test_spykingcircus(run_kwargs):
     sorting = ss.run_sorter("spykingcircus", output_folder=cache_folder / "spykingcircus", **run_kwargs)
     print("resulting sorting")

--- a/src/spikeinterface/sorters/external/tests/test_docker_containers.py
+++ b/src/spikeinterface/sorters/external/tests/test_docker_containers.py
@@ -40,7 +40,6 @@ def run_kwargs():
     return generate_run_kwargs()
 
 
-@pytest.skipif()
 def test_spykingcircus(run_kwargs):
     sorting = ss.run_sorter("spykingcircus", output_folder=cache_folder / "spykingcircus", **run_kwargs)
     print("resulting sorting")

--- a/src/spikeinterface/sorters/external/tests/test_singularity_containers.py
+++ b/src/spikeinterface/sorters/external/tests/test_singularity_containers.py
@@ -16,7 +16,7 @@ else:
 
 os.environ["SINGULARITY_DISABLE_CACHE"] = "true"
 
-ON_GITHUB = os.getenv("CI")
+ON_GITHUB = os.getenv("GITHUB_ACTIONS")
 
 
 def clean_singularity_cache():

--- a/src/spikeinterface/sorters/external/tests/test_singularity_containers_gpu.py
+++ b/src/spikeinterface/sorters/external/tests/test_singularity_containers_gpu.py
@@ -10,7 +10,7 @@ import spikeinterface.sorters as ss
 
 os.environ["SINGULARITY_DISABLE_CACHE"] = "true"
 
-ON_GITHUB = os.getenv("CI")
+ON_GITHUB = bool(os.getenv("GITHUB_ACTIONS"))
 
 
 def clean_singularity_cache():

--- a/src/spikeinterface/widgets/tests/test_widgets.py
+++ b/src/spikeinterface/widgets/tests/test_widgets.py
@@ -31,6 +31,7 @@ else:
 
 ON_GITHUB = bool(os.getenv("GITHUB_ACTIONS"))
 KACHERY_CLOUD_SET = bool(os.getenv("KACHERY_CLOUD_CLIENT_ID")) and bool(os.getenv("KACHERY_CLOUD_PRIVATE_KEY"))
+SKIP_SORTINGVIEW = bool(os.getenv("SKIP_SORTINGVIEW"))
 
 
 class TestWidgets(unittest.TestCase):
@@ -98,7 +99,7 @@ class TestWidgets(unittest.TestCase):
         cls.skip_backends = ["ipywidgets", "ephyviewer", "spikeinterface_gui"]
         # cls.skip_backends = ["ipywidgets", "ephyviewer", "sortingview"]
 
-        if ON_GITHUB and not KACHERY_CLOUD_SET:
+        if (ON_GITHUB and not KACHERY_CLOUD_SET) or (SKIP_SORTINGVIEW):
             cls.skip_backends.append("sortingview")
 
         print(f"Widgets tests: skipping backends - {cls.skip_backends}")


### PR DESCRIPTION
As discussed the link between KACHERY and Sortingview is not super clear so this provides an easier to discover env-var for skipping sortingview tests for local development of widgets.