### PR TITLE
Remove upper bound in scipy dependency for full install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ full = [
     "h5py",
     "pandas",
     "xarray",
-    "scipy<1.13",
+    "scipy",
     "scikit-learn",
     "networkx",
     "distinctipy",


### PR DESCRIPTION
This is something that @samuelgarcia asked me to do here https://github.com/SpikeInterface/spikeinterface/pull/2665#discussion_r1552037196 but got lost.


Hopefully the tests pass.