### PR TITLE
Add a jQuery extension to enable search

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -67,6 +67,7 @@ extensions = [
     'numpydoc',
     'sphinx.ext.autosectionlabel',
     'sphinx_design',
+    'sphinxcontrib.jquery',
     "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
     "IPython.sphinxext.ipython_directive",


### PR DESCRIPTION
Sphinx removed JQuery dependency in v6. To keep using ReadTheDocs we need to add an extension.

Should fix #2961, wait till documentation has built to see!