### PR TITLE
Add argument to `IntanRecordingExtractor`  for opening files with discontinous timestamps

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/intan.py
+++ b/src/spikeinterface/extractors/neoextractors/intan.py
@@ -52,7 +52,15 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
 
     @classmethod
     def map_to_neo_kwargs(cls, file_path, ignore_integrity_checks: bool = False):
-        neo_kwargs = {"filename": str(file_path), "ignore_integrity_checks": ignore_integrity_checks}
+
+        # Only propagate the argument if the version is greater than 0.13.1
+        import packaging
+        import neo
+
+        if packaging.version.parse(neo.__version__) > packaging.version.parse("0.13.1"):
+            neo_kwargs = {"filename": str(file_path), "ignore_integrity_checks": ignore_integrity_checks}
+        else:
+            neo_kwargs = {"filename": str(file_path)}
         return neo_kwargs
 
 

--- a/src/spikeinterface/extractors/neoextractors/intan.py
+++ b/src/spikeinterface/extractors/neoextractors/intan.py
@@ -23,6 +23,10 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
+    ignore_integrity_checks, bool, default: False.
+        If True, data that violates integrity assumptions will be loaded. At the moment the only integrity
+        check we perform is that timestamps are continuous. Setting this to True will ignore this check and set
+        the attribute `discontinuous_timestamps` to True in the underlying neo object.
     """
 
     mode = "file"
@@ -57,7 +61,8 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         import packaging
         import neo
 
-        if packaging.version.parse(neo.__version__) > packaging.version.parse("0.13.1"):
+        neo_version = packaging.version.parse(neo.__version__)
+        if neo_version > packaging.version.parse("0.13.1"):
             neo_kwargs = {"filename": str(file_path), "ignore_integrity_checks": ignore_integrity_checks}
         else:
             neo_kwargs = {"filename": str(file_path)}

--- a/src/spikeinterface/extractors/neoextractors/intan.py
+++ b/src/spikeinterface/extractors/neoextractors/intan.py
@@ -23,7 +23,7 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
-    ignore_integrity_checks, bool, default: False.
+    ignore_integrity_checks : bool, default: False.
         If True, data that violates integrity assumptions will be loaded. At the moment the only integrity
         check we perform is that timestamps are continuous. Setting this to True will ignore this check and set
         the attribute `discontinuous_timestamps` to True in the underlying neo object.

--- a/src/spikeinterface/extractors/neoextractors/intan.py
+++ b/src/spikeinterface/extractors/neoextractors/intan.py
@@ -29,8 +29,16 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
     NeoRawIOClass = "IntanRawIO"
     name = "intan"
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False, use_names_as_ids=False):
-        neo_kwargs = self.map_to_neo_kwargs(file_path)
+    def __init__(
+        self,
+        file_path,
+        stream_id=None,
+        stream_name=None,
+        all_annotations=False,
+        use_names_as_ids=False,
+        ignore_integrity_checks: bool = False,
+    ):
+        neo_kwargs = self.map_to_neo_kwargs(file_path, ignore_integrity_checks=ignore_integrity_checks)
         NeoBaseRecordingExtractor.__init__(
             self,
             stream_id=stream_id,
@@ -43,8 +51,8 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         self._kwargs.update(dict(file_path=str(Path(file_path).absolute())))
 
     @classmethod
-    def map_to_neo_kwargs(cls, file_path):
-        neo_kwargs = {"filename": str(file_path)}
+    def map_to_neo_kwargs(cls, file_path, ignore_integrity_checks: bool = False):
+        neo_kwargs = {"filename": str(file_path), "ignore_integrity_checks": ignore_integrity_checks}
         return neo_kwargs
 
 


### PR DESCRIPTION
Following on the corresponding neo work:

https://github.com/NeuralEnsemble/python-neo/pull/1470

Comes with a check so the argument is only propagated for the upcoming version of neo and does not break current version.