### PR TITLE
Fix bug with nan values

### DIFF
--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -173,9 +173,11 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
                     # pandas loads strings as objects
                     if cluster_info[prop_name].values.dtype.kind == "O":
                         for value in cluster_info[prop_name].values:
-                            if isinstance(value, (np.floating, float)) and np.isnan(value):  # Blank values are encoded as 'NaN'.
+                            if isinstance(value, (np.floating, float)) and np.isnan(
+                                value
+                            ):  # Blank values are encoded as 'NaN'.
                                 continue
-                                
+
                             prop_dtype = type(value)
                             break
                         values_ = cluster_info[prop_name].values.astype(prop_dtype)

--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -172,7 +172,12 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
                 if load_all_cluster_properties:
                     # pandas loads strings as objects
                     if cluster_info[prop_name].values.dtype.kind == "O":
-                        prop_dtype = type(cluster_info[prop_name].values[0])
+                        for value in cluster_info[prop_name].values:
+                            if isinstance(value, (np.floating, float)) and np.isnan(value):  # Blank values are encoded as 'NaN'.
+                                continue
+                                
+                            prop_dtype = type(value)
+                            break
                         values_ = cluster_info[prop_name].values.astype(prop_dtype)
                     else:
                         values_ = cluster_info[prop_name].values

--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -170,7 +170,8 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
                 self.set_property(key="quality", values=cluster_info[prop_name])
             else:
                 if load_all_cluster_properties:
-                    # pandas loads strings as objects
+                    # pandas loads strings with empty values as objects with NaNs
+                    prop_dtype = None
                     if cluster_info[prop_name].values.dtype.kind == "O":
                         for value in cluster_info[prop_name].values:
                             if isinstance(value, (np.floating, float)) and np.isnan(
@@ -180,7 +181,11 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
 
                             prop_dtype = type(value)
                             break
-                        values_ = cluster_info[prop_name].values.astype(prop_dtype)
+                        if prop_dtype is not None:
+                            values_ = cluster_info[prop_name].values.astype(prop_dtype)
+                        else:
+                            # Could not find a valid dtype for the column. Skip it.
+                            continue
                     else:
                         values_ = cluster_info[prop_name].values
                     self.set_property(key=prop_name, values=values_)


### PR DESCRIPTION
When the first value was a `nan` (because of no value), we ended up with the wrong dtype (e.g. should have been `str`)