### PR TITLE
Correct segment counting in SpikeAmpltiudes and SpikeLocations get_data

### DIFF
--- a/src/spikeinterface/postprocessing/spike_amplitudes.py
+++ b/src/spikeinterface/postprocessing/spike_amplitudes.py
@@ -127,13 +127,20 @@ class ComputeSpikeAmplitudes(AnalyzerExtension):
         elif outputs == "by_unit":
             unit_ids = self.sorting_analyzer.unit_ids
             spike_vector = self.sorting_analyzer.sorting.to_spike_vector(concatenated=False)
+            segment_cum_count = np.insert(
+                np.cumsum([len(spike_vector[a]) for a in range(0, self.sorting_analyzer.sorting.get_num_segments())]),
+                0,
+                0,
+            )
             spike_indices = spike_vector_to_indices(spike_vector, unit_ids)
             amplitudes_by_units = {}
             for segment_index in range(self.sorting_analyzer.sorting.get_num_segments()):
                 amplitudes_by_units[segment_index] = {}
                 for unit_id in unit_ids:
                     inds = spike_indices[segment_index][unit_id]
-                    amplitudes_by_units[segment_index][unit_id] = all_amplitudes[inds]
+                    amplitudes_by_units[segment_index][unit_id] = all_amplitudes[
+                        segment_cum_count[segment_index] + inds
+                    ]
             return amplitudes_by_units
         else:
             raise ValueError(f"Wrong .get_data(outputs={outputs})")

--- a/src/spikeinterface/postprocessing/spike_locations.py
+++ b/src/spikeinterface/postprocessing/spike_locations.py
@@ -140,13 +140,20 @@ class ComputeSpikeLocations(AnalyzerExtension):
         elif outputs == "by_unit":
             unit_ids = self.sorting_analyzer.unit_ids
             spike_vector = self.sorting_analyzer.sorting.to_spike_vector(concatenated=False)
+            segment_cum_count = np.insert(
+                np.cumsum([len(spike_vector[a]) for a in range(0, self.sorting_analyzer.sorting.get_num_segments())]),
+                0,
+                0,
+            )
             spike_indices = spike_vector_to_indices(spike_vector, unit_ids)
             spike_locations_by_units = {}
             for segment_index in range(self.sorting_analyzer.sorting.get_num_segments()):
                 spike_locations_by_units[segment_index] = {}
                 for unit_id in unit_ids:
                     inds = spike_indices[segment_index][unit_id]
-                    spike_locations_by_units[segment_index][unit_id] = all_spike_locations[inds]
+                    spike_locations_by_units[segment_index][unit_id] = all_spike_locations[
+                        segment_cum_count[segment_index] + inds
+                    ]
             return spike_locations_by_units
         else:
             raise ValueError(f"Wrong .get_data(outputs={outputs})")

--- a/src/spikeinterface/postprocessing/tests/test_spike_amplitudes.py
+++ b/src/spikeinterface/postprocessing/tests/test_spike_amplitudes.py
@@ -2,7 +2,11 @@ import unittest
 import numpy as np
 
 from spikeinterface.postprocessing import ComputeSpikeAmplitudes
-from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
+from spikeinterface.postprocessing.tests.common_extension_tests import (
+    AnalyzerExtensionCommonTestSuite,
+    get_sorting_analyzer,
+    get_dataset,
+)
 
 
 class ComputeSpikeAmplitudesTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
@@ -10,6 +14,36 @@ class ComputeSpikeAmplitudesTest(AnalyzerExtensionCommonTestSuite, unittest.Test
     extension_function_params_list = [
         dict(),
     ]
+
+
+def test_getdata_by_unit():
+    recording, sorting = get_dataset()
+    sorting_analyzer = get_sorting_analyzer(recording=recording, sorting=sorting)
+    sorting_analyzer.compute(["random_spikes", "templates", "spike_amplitudes"])
+
+    amp_ext = sorting_analyzer.get_extension("spike_amplitudes")
+
+    amps_by_unit = amp_ext.get_data(outputs="by_unit")
+    all_amps = amp_ext.get_data()
+
+    spikes = sorting_analyzer.sorting.to_spike_vector()
+
+    # check the number of amplitudes matches the number of spikes for each segment and unit
+    for segment_index in range(sorting_analyzer.get_num_segments()):
+        for unit_id in sorting_analyzer.unit_ids:
+            unit_index = sorting_analyzer.unit_ids[unit_id]
+
+            num_spikes_in_unit_and_segment = sum(
+                (spikes["unit_index"] == unit_index) & (spikes["segment_index"] == segment_index)
+            )
+            num_amps_in_unit_and_segment = len(amps_by_unit[segment_index][unit_id])
+
+            assert num_spikes_in_unit_and_segment == num_amps_in_unit_and_segment
+
+    # check the spike amplitude is in the correct place, for some random spikes
+    for spike_ind in [0, 50, 100, 150]:
+        _, unit_index, segment_index = spikes[spike_ind]
+        assert all_amps[spike_ind] in amps_by_unit[segment_index][sorting_analyzer.unit_ids[unit_index]]
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/postprocessing/tests/test_spike_locations.py
+++ b/src/spikeinterface/postprocessing/tests/test_spike_locations.py
@@ -2,7 +2,11 @@ import unittest
 import numpy as np
 
 from spikeinterface.postprocessing import ComputeSpikeLocations
-from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
+from spikeinterface.postprocessing.tests.common_extension_tests import (
+    AnalyzerExtensionCommonTestSuite,
+    get_dataset,
+    get_sorting_analyzer,
+)
 
 
 class SpikeLocationsExtensionTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
@@ -18,6 +22,36 @@ class SpikeLocationsExtensionTest(AnalyzerExtensionCommonTestSuite, unittest.Tes
         dict(method="monopolar_triangulation"),  # , chunk_size=10000, n_jobs=1
         dict(method="grid_convolution"),  # , chunk_size=10000, n_jobs=1
     ]
+
+
+def test_getdata_by_unit():
+    recording, sorting = get_dataset()
+    sorting_analyzer = get_sorting_analyzer(recording=recording, sorting=sorting)
+    sorting_analyzer.compute(["random_spikes", "templates", "spike_locations"])
+
+    ext_loc = sorting_analyzer.get_extension("spike_locations")
+
+    locations_by_unit = ext_loc.get_data(outputs="by_unit")
+    all_locations = ext_loc.get_data()
+
+    spikes = sorting_analyzer.sorting.to_spike_vector()
+
+    # check the number of locations matches the number of spikes for each segment and unit
+    for segment_index in range(sorting_analyzer.get_num_segments()):
+        for unit_id in sorting_analyzer.unit_ids:
+            unit_index = sorting_analyzer.unit_ids[unit_id]
+
+            num_spikes_in_unit_and_segment = sum(
+                (spikes["unit_index"] == unit_index) & (spikes["segment_index"] == segment_index)
+            )
+            num_locations_in_unit_and_segment = len(locations_by_unit[segment_index][unit_id])
+
+            assert num_spikes_in_unit_and_segment == num_locations_in_unit_and_segment
+
+    # check the spike location is in the correct place, for some random spikes
+    for spike_ind in [0, 50, 100, 150]:
+        _, unit_index, segment_index = spikes[spike_ind]
+        assert all_locations[spike_ind] in locations_by_unit[segment_index][sorting_analyzer.unit_ids[unit_index]]
 
 
 if __name__ == "__main__":

--- a/src/spikeinterface/postprocessing/tests/test_unit_localization.py
+++ b/src/spikeinterface/postprocessing/tests/test_unit_localization.py
@@ -1,5 +1,9 @@
 import unittest
-from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
+from spikeinterface.postprocessing.tests.common_extension_tests import (
+    AnalyzerExtensionCommonTestSuite,
+    get_dataset,
+    get_sorting_analyzer,
+)
 from spikeinterface.postprocessing import ComputeUnitLocations
 
 
@@ -12,6 +16,20 @@ class UnitLocationsExtensionTest(AnalyzerExtensionCommonTestSuite, unittest.Test
         dict(method="monopolar_triangulation", radius_um=150),
         dict(method="monopolar_triangulation", radius_um=150, optimizer="minimize_with_log_penality"),
     ]
+
+
+def test_getdata_by_unit():
+    recording, sorting = get_dataset()
+    sorting_analyzer = get_sorting_analyzer(recording=recording, sorting=sorting)
+    sorting_analyzer.compute(["random_spikes", "templates", "unit_locations"])
+
+    ext_unit_loc = sorting_analyzer.get_extension("unit_locations")
+
+    locations_by_unit = ext_unit_loc.get_data(outputs="by_unit")
+    all_locations = ext_unit_loc.get_data()
+
+    for unit_location in locations_by_unit.items():
+        assert unit_location[1] in all_locations[unit_location[0]]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #2975, without losing speed.

The `all_amplitudes` and `all_locations` vectors are flattened, so don't take account of segment index. This PR adds a cumulative sum which keeps track of where each segments begins.

In draft until tests are added.