### PR TITLE
Fix #2972

### DIFF
--- a/src/spikeinterface/core/node_pipeline.py
+++ b/src/spikeinterface/core/node_pipeline.py
@@ -647,7 +647,7 @@ class GatherToNpy:
         self.shapes0 = []
         self.final_shapes = []
         for name in names:
-            filename = folder / (name + ".npy")
+            filename = self.folder / (name + ".npy")
             f = open(filename, "wb+")
             f.seek(npy_header_size)
             self.files.append(f)


### PR DESCRIPTION
This fixes the problem of user passing path as string and using the input directly instead of the self.folder which is already converted to Path:

https://github.com/h-mayorquin/spikeinterface/blob/316769382adef9148eaf9d7fb010bb602bddd881/src/spikeinterface/core/node_pipeline.py#L636-L640