### PR TITLE
Remove unittest from postprocessing

### DIFF
--- a/src/spikeinterface/postprocessing/tests/common_extension_tests.py
+++ b/src/spikeinterface/postprocessing/tests/common_extension_tests.py
@@ -136,7 +136,7 @@ class AnalyzerExtensionCommonTestSuite:
 
         ext = sorting_analyzer.compute(extension_class.extension_name, **params, **job_kwargs)
         assert len(ext.data) > 0
-        main_data = ext.get_data()
+        assert len(main_data) > 0
 
         ext = sorting_analyzer.get_extension(extension_class.extension_name)
         assert ext is not None

--- a/src/spikeinterface/postprocessing/tests/common_extension_tests.py
+++ b/src/spikeinterface/postprocessing/tests/common_extension_tests.py
@@ -61,13 +61,27 @@ def get_sorting_analyzer(recording, sorting, format="memory", sparsity=None, nam
 
 class AnalyzerExtensionCommonTestSuite:
     """
-    Common tests with class approach to compute extension on several cases (3 format x 2 sparsity)
+    Common tests with class approach to compute extension on several cases,
+    format ("memory", "binary_folder", "zarr") and sparsity (True, False).
+    Extensions refer to the extension classes that handle the postprocessing,
+    for example extracting principal components or amplitude scalings.
 
-    This is done a a list of differents parameters (extension_function_params_list).
+    This base class provides a fixture which sets a recording
+    and sorting object onto itself, which are set up once each time
+    the base class is subclassed in a test environment. The recording
+    and sorting object are used in the creation of the `sorting_analyzer`
+    object used to run postprocessing routines.
 
-    This automatically precompute extension dependencies with default params before running computation.
+    When subclassed, a test function that parametrises arguments
+    that are passed to the `sorting_analyzer.compute()` can be setup.
+    This must call `run_extension_tests()`  which sets up a `sorting_analyzer`
+    with the relevant format and sparsity. This also automatically precomputes
+    extension dependencies with default params, Then, `check_one()` is called
+    which runs the compute function with the passed params and tests that:
 
-    This also test the select_units() ability.
+    1) the returned extractor object has data on it
+    2) check `sorting_analyzer.get_extension()` does not return None
+    3) the correct units are sliced with the `select_units()` function.
     """
 
     @pytest.fixture(autouse=True, scope="class")
@@ -90,20 +104,31 @@ class AnalyzerExtensionCommonTestSuite:
         )
 
     def _prepare_sorting_analyzer(self, format, sparse, extension_class):
-        """prepare a SortingAnalyzer object with depencies already computed"""
+        """
+        Prepare a SortingAnalyzer object with dependencies already computed
+        according to format (e.g. "memory", "binary_folder", "zarr")
+        and sparsity (e.g. True, False).
+        """
         sparsity_ = self.sparsity if sparse else None
+
         sorting_analyzer = get_sorting_analyzer(
             self.recording, self.sorting, format=format, sparsity=sparsity_, name=extension_class.extension_name
         )
         sorting_analyzer.compute("random_spikes", max_spikes_per_unit=50, seed=2205)
+
         for dependency_name in extension_class.depend_on:
             if "|" in dependency_name:
                 dependency_name = dependency_name.split("|")[0]
             sorting_analyzer.compute(dependency_name)
+
         return sorting_analyzer
 
     def _check_one(self, sorting_analyzer, extension_class, params):
-        """"""
+        """
+        Take a prepared sorting analyzer object, compute the extension of interest
+        with the passed parameters, and check the output is not empty, the extension
+        exists and `select_units()` method works.
+        """
         if extension_class.need_job_kwargs:
             job_kwargs = dict(n_jobs=2, chunk_duration="1s", progress_bar=True)
         else:
@@ -121,6 +146,11 @@ class AnalyzerExtensionCommonTestSuite:
         assert np.array_equal(sliced.unit_ids, sorting_analyzer.unit_ids[::2])
 
     def run_extension_tests(self, extension_class, params):
+        """
+        Convenience function to perform all checks on the extension
+        of interest with the passed parameters. Will perform tests
+        for sparsity and format.
+        """
         for sparse in (True, False):
             for format in ("memory", "binary_folder", "zarr"):
                 print("sparse", sparse, format)

--- a/src/spikeinterface/postprocessing/tests/common_extension_tests.py
+++ b/src/spikeinterface/postprocessing/tests/common_extension_tests.py
@@ -115,6 +115,8 @@ class AnalyzerExtensionCommonTestSuite:
         else:
             job_kwargs = dict()
 
+        # TODO: a downside of this approach is each parameterisation does
+        # not get it's own test, but all falls under the same test.
         for params in self.extension_function_params_list:
             print("  params", params)
             ext = sorting_analyzer.compute(self.extension_name, **params, **job_kwargs)

--- a/src/spikeinterface/postprocessing/tests/test_align_sorting.py
+++ b/src/spikeinterface/postprocessing/tests/test_align_sorting.py
@@ -1,5 +1,3 @@
-import pytest
-import shutil
 from pathlib import Path
 
 import pytest
@@ -18,8 +16,16 @@ else:
 
 
 def test_align_sorting():
+    """
+    `align_sorting()` shifts, in time, the spikes belonging to a unit.
+    For each unit, an offset is provided and the spike peak index is shifted.
+
+    This test creates a sorting object, then creates an 'unaligned' sorting
+    object in which the peaks for some of the units are shifted. Next, the `align_sorting()`
+    function is unused to unshift them, and the original sorting spike train
+    peak times compared with the corrected sorting train.
+    """
     sorting = generate_sorting(durations=[10.0], seed=0)
-    print(sorting)
 
     unit_ids = sorting.unit_ids
 
@@ -27,16 +33,27 @@ def test_align_sorting():
     unit_peak_shifts[unit_ids[-1]] = 5
     unit_peak_shifts[unit_ids[-2]] = -5
 
-    # sorting to dict
-    d = {unit_id: sorting.get_unit_spike_train(unit_id) + unit_peak_shifts[unit_id] for unit_id in sorting.unit_ids}
-    sorting_unaligned = NumpySorting.from_unit_dict(d, sampling_frequency=sorting.get_sampling_frequency())
-    print(sorting_unaligned)
+    shifted_unit_dict = {
+        unit_id: sorting.get_unit_spike_train(unit_id) + unit_peak_shifts[unit_id] for unit_id in sorting.unit_ids
+    }
+    sorting_unaligned = NumpySorting.from_unit_dict(
+        shifted_unit_dict, sampling_frequency=sorting.get_sampling_frequency()
+    )
 
     sorting_aligned = align_sorting(sorting_unaligned, unit_peak_shifts)
-    print(sorting_aligned)
 
-    for start_frame, end_frame in [(None, None), (10000, 50000)]:
-        for unit_id in unit_ids[-2:]:
-            st = sorting.get_unit_spike_train(unit_id)
-            st_clean = sorting_aligned.get_unit_spike_train(unit_id)
-            assert np.array_equal(st, st_clean)
+    for unit_id in unit_ids:
+        spiketrain_orig = sorting.get_unit_spike_train(unit_id)
+        spiketrain_aligned = sorting_aligned.get_unit_spike_train(unit_id)
+        spiketrain_unaligned = sorting_unaligned.get_unit_spike_train(unit_id)
+
+        # check the shift induced in the test has changed the
+        # spiketrain as expected.
+        if unit_peak_shifts[unit_id] == 0:
+            assert np.array_equal(spiketrain_orig, spiketrain_unaligned)
+        else:
+            assert not np.array_equal(spiketrain_orig, spiketrain_unaligned)
+
+        # Perform the key test, that after correction the spiketrain
+        # matches the original spiketrain for all units (shifted and unshifted).
+        assert np.array_equal(spiketrain_orig, spiketrain_aligned)

--- a/src/spikeinterface/postprocessing/tests/test_align_sorting.py
+++ b/src/spikeinterface/postprocessing/tests/test_align_sorting.py
@@ -40,7 +40,3 @@ def test_align_sorting():
             st = sorting.get_unit_spike_train(unit_id)
             st_clean = sorting_aligned.get_unit_spike_train(unit_id)
             assert np.array_equal(st, st_clean)
-
-
-if __name__ == "__main__":
-    test_align_sorting()

--- a/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
@@ -33,10 +33,3 @@ class TestAmplitudeScalingsExtension(AnalyzerExtensionCommonTestSuite):
         # fig, ax = plt.subplots()
         # ax.hist(ext.data["amplitude_scalings"])
         # plt.show()
-
-
-if __name__ == "__main__":
-    test = TestAmplitudeScalingsExtension()
-    test.setUpClass()
-    test.test_extension()
-    test.test_scaling_values()

--- a/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
@@ -7,7 +7,7 @@ from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerE
 from spikeinterface.postprocessing import ComputeAmplitudeScalings
 
 
-class AmplitudeScalingsExtensionTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
+class TestAmplitudeScalingsExtension(AnalyzerExtensionCommonTestSuite):
     extension_class = ComputeAmplitudeScalings
     extension_function_params_list = [
         dict(handle_collisions=True),
@@ -36,7 +36,7 @@ class AmplitudeScalingsExtensionTest(AnalyzerExtensionCommonTestSuite, unittest.
 
 
 if __name__ == "__main__":
-    test = AmplitudeScalingsExtensionTest()
+    test = TestAmplitudeScalingsExtension()
     test.setUpClass()
     test.test_extension()
     test.test_scaling_values()

--- a/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
@@ -1,6 +1,5 @@
-import unittest
 import numpy as np
-
+import pytest
 
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
 
@@ -8,14 +7,13 @@ from spikeinterface.postprocessing import ComputeAmplitudeScalings
 
 
 class TestAmplitudeScalingsExtension(AnalyzerExtensionCommonTestSuite):
-    extension_class = ComputeAmplitudeScalings
-    extension_function_params_list = [
-        dict(handle_collisions=True),
-        dict(handle_collisions=False),
-    ]
+
+    @pytest.mark.parametrize("params", [dict(handle_collisions=True), dict(handle_collisions=False)])
+    def test_extension(self, params):
+        self.run_extension_tests(ComputeAmplitudeScalings, params)
 
     def test_scaling_values(self):
-        sorting_analyzer = self._prepare_sorting_analyzer("memory", True)
+        sorting_analyzer = self._prepare_sorting_analyzer("memory", True, ComputeAmplitudeScalings)
         sorting_analyzer.compute("amplitude_scalings", handle_collisions=False)
 
         spikes = sorting_analyzer.sorting.to_spike_vector()
@@ -26,7 +24,6 @@ class TestAmplitudeScalingsExtension(AnalyzerExtensionCommonTestSuite):
             mask = spikes["unit_index"] == unit_index
             scalings = ext.data["amplitude_scalings"][mask]
             median_scaling = np.median(scalings)
-            # print(unit_index, median_scaling)
             np.testing.assert_array_equal(np.round(median_scaling), 1)
 
         # import matplotlib.pyplot as plt

--- a/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
@@ -35,8 +35,3 @@ class TestAmplitudeScalingsExtension(AnalyzerExtensionCommonTestSuite):
             scalings = ext.data["amplitude_scalings"][mask]
             median_scaling = np.median(scalings)
             np.testing.assert_array_equal(np.round(median_scaling), 1)
-
-        # import matplotlib.pyplot as plt
-        # fig, ax = plt.subplots()
-        # ax.hist(ext.data["amplitude_scalings"])
-        # plt.show()

--- a/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
@@ -13,7 +13,17 @@ class TestAmplitudeScalingsExtension(AnalyzerExtensionCommonTestSuite):
         self.run_extension_tests(ComputeAmplitudeScalings, params)
 
     def test_scaling_values(self):
-        sorting_analyzer = self._prepare_sorting_analyzer("memory", True, ComputeAmplitudeScalings)
+        """
+        Amplitude finds the scaling factor for each waveform
+        to best match its unit template. In this test, amplitude scalings
+        are calculated from the `sorting_analyzer`. In the test environment,
+        injected waveforms are not scaled from the template and so
+        should only differ by Gaussian noise. Therefore the median
+        scaling should be close to 1.
+        """
+        sorting_analyzer = self._prepare_sorting_analyzer(
+            "memory", sparse=True, extension_class=ComputeAmplitudeScalings
+        )
         sorting_analyzer.compute("amplitude_scalings", handle_collisions=False)
 
         spikes = sorting_analyzer.sorting.to_spike_vector()

--- a/src/spikeinterface/postprocessing/tests/test_correlograms.py
+++ b/src/spikeinterface/postprocessing/tests/test_correlograms.py
@@ -199,6 +199,6 @@ if __name__ == "__main__":
     # test_auto_equal_cross_correlograms()
     # test_detect_injected_correlation()
 
-    test = ComputeCorrelogramsTest()
+    test = TestComputeCorrelograms()
     test.setUpClass()
     test.test_extension()

--- a/src/spikeinterface/postprocessing/tests/test_correlograms.py
+++ b/src/spikeinterface/postprocessing/tests/test_correlograms.py
@@ -93,20 +93,12 @@ def test_flat_cross_correlogram():
     if HAVE_NUMBA:
         methods.append("numba")
 
-    # ~ import matplotlib.pyplot as plt
-    # ~ fig, ax = plt.subplots()
-
     for method in methods:
         correlograms, bins = compute_correlograms_on_sorting(sorting, window_ms=50.0, bin_ms=1.0, method=method)
         cc = correlograms[0, 1, :].copy()
         m = np.mean(cc)
         assert np.all(cc > (m * 0.90))
         assert np.all(cc < (m * 1.10))
-
-        # ~ ax.plot(bins[:-1], cc, label=method)
-    # ~ ax.legend()
-    # ~ ax.set_ylim(0, np.max(correlograms) * 1.1)
-    # ~ plt.show()
 
 
 def test_auto_equal_cross_correlograms():
@@ -145,16 +137,6 @@ def test_auto_equal_cross_correlograms():
             assert np.array_equal(cc_corrected[num_half_bins + 1 :], ac[num_half_bins + 1 :])
         else:
             assert np.array_equal(cc_corrected, ac)
-
-        # ~ import matplotlib.pyplot as plt
-        # ~ fig, ax = plt.subplots()
-        # ~ ax.plot(bins[:-1], cc, marker='*',  color='red', label='cross-corr')
-        # ~ ax.plot(bins[:-1], cc_corrected, marker='*', color='orange', label='cross-corr corrected')
-        # ~ ax.plot(bins[:-1], ac, marker='*', color='green', label='auto-corr')
-        # ~ ax.set_title(method)
-        # ~ ax.legend()
-        # ~ ax.set_ylim(0, np.max(correlograms) * 1.1)
-        # ~ plt.show()
 
 
 def test_detect_injected_correlation():
@@ -195,12 +177,3 @@ def test_detect_injected_correlation():
         sampling_period_ms = 1000.0 / sampling_frequency
         assert abs(peak_location_01_ms) - injected_delta_ms < sampling_period_ms
         assert abs(peak_location_02_ms) - injected_delta_ms < sampling_period_ms
-
-    #     import matplotlib.pyplot as plt
-    #     fig, ax = plt.subplots()
-    #     half_bin_ms = np.mean(np.diff(bins)) / 2.
-    #     ax.plot(bins[:-1]+half_bin_ms, cc_01, marker='*',  color='red', label='cross-corr 0>1')
-    #     ax.plot(bins[:-1]+half_bin_ms, cc_10, marker='*',  color='orange', label='cross-corr 1>0')
-    #     ax.set_title(method)
-    #     ax.legend()
-    # plt.show()

--- a/src/spikeinterface/postprocessing/tests/test_correlograms.py
+++ b/src/spikeinterface/postprocessing/tests/test_correlograms.py
@@ -190,15 +190,3 @@ def test_detect_injected_correlation():
     #     ax.set_title(method)
     #     ax.legend()
     # plt.show()
-
-
-if __name__ == "__main__":
-    # test_make_bins()
-    # test_equal_results_correlograms()
-    # test_flat_cross_correlogram()
-    # test_auto_equal_cross_correlograms()
-    # test_detect_injected_correlation()
-
-    test = TestComputeCorrelograms()
-    test.setUpClass()
-    test.test_extension()

--- a/src/spikeinterface/postprocessing/tests/test_correlograms.py
+++ b/src/spikeinterface/postprocessing/tests/test_correlograms.py
@@ -22,7 +22,7 @@ class TestComputeCorrelograms(AnalyzerExtensionCommonTestSuite):
         [
             dict(method="numpy"),
             dict(method="auto"),
-            pytest.param(dict(method="numba"), marks=pytest.mark.skipif("not HAVE_NUMBA")),
+            pytest.param(dict(method="numba"), marks=pytest.mark.skipif(not HAVE_NUMBA, reason="Numba not available")),
         ],
     )
     def test_extension(self, params):

--- a/src/spikeinterface/postprocessing/tests/test_correlograms.py
+++ b/src/spikeinterface/postprocessing/tests/test_correlograms.py
@@ -1,6 +1,4 @@
-import unittest
 import numpy as np
-from typing import List
 
 try:
     import numba
@@ -38,13 +36,11 @@ def test_make_bins():
     bin_ms = 1.6421
     bins, window_size, bin_size = _make_bins(sorting, window_ms, bin_ms)
     assert bins.size == np.floor(window_ms / bin_ms) + 1
-    # print(bins, window_size, bin_size)
 
     window_ms = 60.0
     bin_ms = 2.0
     bins, window_size, bin_size = _make_bins(sorting, window_ms, bin_ms)
     assert bins.size == np.floor(window_ms / bin_ms) + 1
-    # print(bins, window_size, bin_size)
 
 
 def _test_correlograms(sorting, window_ms, bin_ms, methods):

--- a/src/spikeinterface/postprocessing/tests/test_correlograms.py
+++ b/src/spikeinterface/postprocessing/tests/test_correlograms.py
@@ -30,6 +30,10 @@ class TestComputeCorrelograms(AnalyzerExtensionCommonTestSuite):
 
 
 def test_make_bins():
+    """
+    Check the `_make_bins()` function that generates time bins (lags) for
+    the correllogram creates the expected number of bins.
+    """
     sorting = generate_sorting(num_units=5, sampling_frequency=30000.0, durations=[10.325, 3.5], seed=0)
 
     window_ms = 43.57
@@ -79,6 +83,10 @@ def test_equal_results_correlograms():
 
 
 def test_flat_cross_correlogram():
+    """
+    Check that the correlogram (num_units x num_units x num_bins) does not
+    vary too much across time bins (lags), for entries representing two different units.
+    """
     sorting = generate_sorting(num_units=2, sampling_frequency=10000.0, durations=[100000.0], seed=0)
 
     methods = ["numpy"]
@@ -150,6 +158,11 @@ def test_auto_equal_cross_correlograms():
 
 
 def test_detect_injected_correlation():
+    """
+    Inject 1.44 ms of correlation every 13 spikes and compute
+    cross-correlation. Check that the time bin lag with the peak
+    correlation lag is 1.44 ms (within tolerance of a sampling period).
+    """
     methods = ["numpy"]
     if HAVE_NUMBA:
         methods.append("numba")

--- a/src/spikeinterface/postprocessing/tests/test_correlograms.py
+++ b/src/spikeinterface/postprocessing/tests/test_correlograms.py
@@ -14,16 +14,21 @@ from spikeinterface import NumpySorting, generate_sorting
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
 from spikeinterface.postprocessing import ComputeCorrelograms
 from spikeinterface.postprocessing.correlograms import compute_correlograms_on_sorting, _make_bins
+import pytest
 
 
 class TestComputeCorrelograms(AnalyzerExtensionCommonTestSuite):
-    extension_class = ComputeCorrelograms
-    extension_function_params_list = [
-        dict(method="numpy"),
-        dict(method="auto"),
-    ]
-    if HAVE_NUMBA:
-        extension_function_params_list.append(dict(method="numba"))
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            dict(method="numpy"),
+            dict(method="auto"),
+            pytest.param(dict(method="numba"), marks=pytest.mark.skipif("not HAVE_NUMBA")),
+        ],
+    )
+    def test_extension(self, params):
+        self.run_extension_tests(ComputeCorrelograms, params)
 
 
 def test_make_bins():

--- a/src/spikeinterface/postprocessing/tests/test_correlograms.py
+++ b/src/spikeinterface/postprocessing/tests/test_correlograms.py
@@ -16,7 +16,7 @@ from spikeinterface.postprocessing import ComputeCorrelograms
 from spikeinterface.postprocessing.correlograms import compute_correlograms_on_sorting, _make_bins
 
 
-class ComputeCorrelogramsTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
+class TestComputeCorrelograms(AnalyzerExtensionCommonTestSuite):
     extension_class = ComputeCorrelograms
     extension_function_params_list = [
         dict(method="numpy"),

--- a/src/spikeinterface/postprocessing/tests/test_correlograms.py
+++ b/src/spikeinterface/postprocessing/tests/test_correlograms.py
@@ -51,22 +51,8 @@ def _test_correlograms(sorting, window_ms, bin_ms, methods):
     for method in methods:
         correlograms, bins = compute_correlograms_on_sorting(sorting, window_ms=window_ms, bin_ms=bin_ms, method=method)
         if method == "numpy":
-            ref_correlograms = correlograms
             ref_bins = bins
         else:
-            # ~ import matplotlib.pyplot as plt
-            # ~ for i in range(ref_correlograms.shape[1]):
-            # ~ for j in range(ref_correlograms.shape[1]):
-            # ~ fig, ax = plt.subplots()
-            # ~ ax.plot(bins[:-1], ref_correlograms[i, j, :], color='green', label='numpy')
-            # ~ ax.plot(bins[:-1], correlograms[i, j, :], color='red', label=method)
-            # ~ ax.legend()
-            # ~ ax.set_title(f'{i} {j}')
-            # ~ plt.show()
-
-            # numba and numyp do not have exactly the same output
-            # assert np.all(correlograms == ref_correlograms), f"Failed with method={method}"
-
             assert np.allclose(bins, ref_bins, atol=1e-10), f"Failed with method={method}"
 
 

--- a/src/spikeinterface/postprocessing/tests/test_isi.py
+++ b/src/spikeinterface/postprocessing/tests/test_isi.py
@@ -1,10 +1,9 @@
-import unittest
 import numpy as np
 from typing import List
 
 
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
-from spikeinterface.postprocessing import compute_isi_histograms, ComputeISIHistograms
+from spikeinterface.postprocessing import ComputeISIHistograms
 from spikeinterface.postprocessing.isi import _compute_isi_histograms
 import pytest
 

--- a/src/spikeinterface/postprocessing/tests/test_isi.py
+++ b/src/spikeinterface/postprocessing/tests/test_isi.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError as err:
     HAVE_NUMBA = False
 
 
-class ComputeISIHistogramsTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
+class TestComputeISIHistograms(AnalyzerExtensionCommonTestSuite):
     extension_class = ComputeISIHistograms
     extension_function_params_list = [
         dict(method="numpy"),

--- a/src/spikeinterface/postprocessing/tests/test_isi.py
+++ b/src/spikeinterface/postprocessing/tests/test_isi.py
@@ -30,8 +30,10 @@ class TestComputeISIHistograms(AnalyzerExtensionCommonTestSuite):
 
     def test_compute_ISI(self):
         """
-        Requires as list because everything tested against Numpy.
-        But numpy is not tested against anything.
+        This test checks the creation of ISI histograms matches across
+        "numpy", "auto" and "numba" methods. Does not parameterize as requires
+        as list because everything tested against Numpy. The Numpy result is not
+        explicitly tested.
         """
         methods = ["numpy", "auto"]
         if HAVE_NUMBA:

--- a/src/spikeinterface/postprocessing/tests/test_isi.py
+++ b/src/spikeinterface/postprocessing/tests/test_isi.py
@@ -47,7 +47,7 @@ def _test_ISI(sorting, window_ms: float, bin_ms: float, methods: List[str]):
 
 
 if __name__ == "__main__":
-    test = ComputeISIHistogramsTest()
+    test = TestComputeISIHistograms()
     test.setUpClass()
     test.test_extension()
     test.test_compute_ISI()

--- a/src/spikeinterface/postprocessing/tests/test_isi.py
+++ b/src/spikeinterface/postprocessing/tests/test_isi.py
@@ -22,7 +22,7 @@ class TestComputeISIHistograms(AnalyzerExtensionCommonTestSuite):
         [
             dict(method="numpy"),
             dict(method="auto"),
-            pytest.param(dict(method="numba"), marks=pytest.mark.skipif("not HAVE_NUMBA")),
+            pytest.param(dict(method="numba"), marks=pytest.mark.skipif(not HAVE_NUMBA, reason="Numba not available")),
         ],
     )
     def test_extension(self, params):

--- a/src/spikeinterface/postprocessing/tests/test_isi.py
+++ b/src/spikeinterface/postprocessing/tests/test_isi.py
@@ -44,10 +44,3 @@ def _test_ISI(sorting, window_ms: float, bin_ms: float, methods: List[str]):
         else:
             assert np.all(ISI == ref_ISI), f"Failed with method={method}"
             assert np.allclose(bins, ref_bins, atol=1e-10), f"Failed with method={method}"
-
-
-if __name__ == "__main__":
-    test = TestComputeISIHistograms()
-    test.setUpClass()
-    test.test_extension()
-    test.test_compute_ISI()

--- a/src/spikeinterface/postprocessing/tests/test_isi.py
+++ b/src/spikeinterface/postprocessing/tests/test_isi.py
@@ -6,7 +6,7 @@ from typing import List
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
 from spikeinterface.postprocessing import compute_isi_histograms, ComputeISIHistograms
 from spikeinterface.postprocessing.isi import _compute_isi_histograms
-
+import pytest
 
 try:
     import numba
@@ -17,30 +17,37 @@ except ModuleNotFoundError as err:
 
 
 class TestComputeISIHistograms(AnalyzerExtensionCommonTestSuite):
-    extension_class = ComputeISIHistograms
-    extension_function_params_list = [
-        dict(method="numpy"),
-        dict(method="auto"),
-    ]
-    if HAVE_NUMBA:
-        extension_function_params_list.append(dict(method="numba"))
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            dict(method="numpy"),
+            dict(method="auto"),
+            pytest.param(dict(method="numba"), marks=pytest.mark.skipif("not HAVE_NUMBA")),
+        ],
+    )
+    def test_extension(self, params):
+        self.run_extension_tests(ComputeISIHistograms, params)
 
     def test_compute_ISI(self):
+        """
+        Requires as list because everything tested against Numpy.
+        But numpy is not tested against anything.
+        """
         methods = ["numpy", "auto"]
         if HAVE_NUMBA:
             methods.append("numba")
 
-        _test_ISI(self.sorting, window_ms=60.0, bin_ms=1.0, methods=methods)
-        _test_ISI(self.sorting, window_ms=43.57, bin_ms=1.6421, methods=methods)
+        self._test_ISI(self.sorting, window_ms=60.0, bin_ms=1.0, methods=methods)
+        self._test_ISI(self.sorting, window_ms=43.57, bin_ms=1.6421, methods=methods)
 
+    def _test_ISI(self, sorting, window_ms: float, bin_ms: float, methods: List[str]):
+        for method in methods:
+            ISI, bins = _compute_isi_histograms(sorting, window_ms=window_ms, bin_ms=bin_ms, method=method)
 
-def _test_ISI(sorting, window_ms: float, bin_ms: float, methods: List[str]):
-    for method in methods:
-        ISI, bins = _compute_isi_histograms(sorting, window_ms=window_ms, bin_ms=bin_ms, method=method)
-
-        if method == "numpy":
-            ref_ISI = ISI
-            ref_bins = bins
-        else:
-            assert np.all(ISI == ref_ISI), f"Failed with method={method}"
-            assert np.allclose(bins, ref_bins, atol=1e-10), f"Failed with method={method}"
+            if method == "numpy":
+                ref_ISI = ISI
+                ref_bins = bins
+            else:
+                assert np.all(ISI == ref_ISI), f"Failed with method={method}"
+                assert np.allclose(bins, ref_bins, atol=1e-10), f"Failed with method={method}"

--- a/src/spikeinterface/postprocessing/tests/test_noise_levels.py
+++ b/src/spikeinterface/postprocessing/tests/test_noise_levels.py
@@ -1,1 +1,3 @@
 # "noise_levels" extensions is now in core
+
+# TODO: can this page now be deleted?

--- a/src/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/src/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -133,7 +133,7 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
 
 
 if __name__ == "__main__":
-    test = PrincipalComponentsExtensionTest()
+    test = TestPrincipalComponentsExtension()
     test.setUpClass()
     test.test_extension()
     test.test_mode_concatenated()

--- a/src/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/src/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -1,14 +1,7 @@
-import unittest
 import pytest
-from pathlib import Path
-
 import numpy as np
-
-from spikeinterface.postprocessing import ComputePrincipalComponents, compute_principal_components
+from spikeinterface.postprocessing import ComputePrincipalComponents
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite, cache_folder
-
-
-DEBUG = False
 
 
 class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):

--- a/src/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/src/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -12,17 +12,23 @@ DEBUG = False
 
 
 class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
-    extension_class = ComputePrincipalComponents
-    extension_function_params_list = [
-        dict(mode="by_channel_local"),
-        dict(mode="by_channel_global"),
-        # mode concatenated cannot be tested here because it do not work with sparse=True
-    ]
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            dict(mode="by_channel_local"),
+            dict(mode="by_channel_global"),
+            # mode concatenated cannot be tested here because it do not work with sparse=True
+        ],
+    )
+    def test_extension(self, params):
+        self.run_extension_tests(ComputePrincipalComponents, params=params)
 
     def test_mode_concatenated(self):
         # this is tested outside "extension_function_params_list" because it do not support sparsity!
-
-        sorting_analyzer = self._prepare_sorting_analyzer(format="memory", sparse=False)
+        sorting_analyzer = self._prepare_sorting_analyzer(
+            format="memory", sparse=False, extension_class=ComputePrincipalComponents
+        )
 
         n_components = 3
         sorting_analyzer.compute("principal_components", mode="concatenated", n_components=n_components)
@@ -33,93 +39,98 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
         assert pca.ndim == 2
         assert pca.shape[1] == n_components
 
-    def test_get_projections(self):
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_get_projections(self, sparse):
 
-        for sparse in (False, True):
+        sorting_analyzer = self._prepare_sorting_analyzer(
+            format="memory", sparse=sparse, extension_class=ComputePrincipalComponents
+        )
+        num_chans = sorting_analyzer.get_num_channels()
+        n_components = 2
 
-            sorting_analyzer = self._prepare_sorting_analyzer(format="memory", sparse=sparse)
-            num_chans = sorting_analyzer.get_num_channels()
-            n_components = 2
+        sorting_analyzer.compute("principal_components", mode="by_channel_global", n_components=n_components)
+        ext = sorting_analyzer.get_extension("principal_components")
 
-            sorting_analyzer.compute("principal_components", mode="by_channel_global", n_components=n_components)
-            ext = sorting_analyzer.get_extension("principal_components")
+        for unit_id in sorting_analyzer.unit_ids:
+            if not sparse:
+                one_proj = ext.get_projections_one_unit(unit_id, sparse=False)
+                assert one_proj.shape[1] == n_components
+                assert one_proj.shape[2] == num_chans
+            else:
+                one_proj = ext.get_projections_one_unit(unit_id, sparse=False)
+                assert one_proj.shape[1] == n_components
+                assert one_proj.shape[2] == num_chans
 
-            for unit_id in sorting_analyzer.unit_ids:
-                if not sparse:
-                    one_proj = ext.get_projections_one_unit(unit_id, sparse=False)
-                    assert one_proj.shape[1] == n_components
-                    assert one_proj.shape[2] == num_chans
-                else:
-                    one_proj = ext.get_projections_one_unit(unit_id, sparse=False)
-                    assert one_proj.shape[1] == n_components
-                    assert one_proj.shape[2] == num_chans
+                one_proj, chan_inds = ext.get_projections_one_unit(unit_id, sparse=True)
+                assert one_proj.shape[1] == n_components
+                assert one_proj.shape[2] < num_chans
+                assert one_proj.shape[2] == chan_inds.size
 
-                    one_proj, chan_inds = ext.get_projections_one_unit(unit_id, sparse=True)
-                    assert one_proj.shape[1] == n_components
-                    assert one_proj.shape[2] < num_chans
-                    assert one_proj.shape[2] == chan_inds.size
+        some_unit_ids = sorting_analyzer.unit_ids[::2]
+        some_channel_ids = sorting_analyzer.channel_ids[::2]
 
-            some_unit_ids = sorting_analyzer.unit_ids[::2]
-            some_channel_ids = sorting_analyzer.channel_ids[::2]
+        random_spikes_indices = sorting_analyzer.get_extension("random_spikes").get_data()
 
-            random_spikes_indices = sorting_analyzer.get_extension("random_spikes").get_data()
+        # this should be all spikes all channels
+        some_projections, spike_unit_index = ext.get_some_projections(channel_ids=None, unit_ids=None)
+        assert some_projections.shape[0] == spike_unit_index.shape[0]
+        assert spike_unit_index.shape[0] == random_spikes_indices.size
+        assert some_projections.shape[1] == n_components
+        assert some_projections.shape[2] == num_chans
 
-            # this should be all spikes all channels
-            some_projections, spike_unit_index = ext.get_some_projections(channel_ids=None, unit_ids=None)
-            assert some_projections.shape[0] == spike_unit_index.shape[0]
-            assert spike_unit_index.shape[0] == random_spikes_indices.size
-            assert some_projections.shape[1] == n_components
-            assert some_projections.shape[2] == num_chans
+        # this should be some spikes all channels
+        some_projections, spike_unit_index = ext.get_some_projections(channel_ids=None, unit_ids=some_unit_ids)
+        assert some_projections.shape[0] == spike_unit_index.shape[0]
+        assert spike_unit_index.shape[0] < random_spikes_indices.size
+        assert some_projections.shape[1] == n_components
+        assert some_projections.shape[2] == num_chans
+        assert 1 not in spike_unit_index
 
-            # this should be some spikes all channels
-            some_projections, spike_unit_index = ext.get_some_projections(channel_ids=None, unit_ids=some_unit_ids)
-            assert some_projections.shape[0] == spike_unit_index.shape[0]
-            assert spike_unit_index.shape[0] < random_spikes_indices.size
-            assert some_projections.shape[1] == n_components
-            assert some_projections.shape[2] == num_chans
-            assert 1 not in spike_unit_index
+        # this should be some spikes some channels
+        some_projections, spike_unit_index = ext.get_some_projections(
+            channel_ids=some_channel_ids, unit_ids=some_unit_ids
+        )
+        assert some_projections.shape[0] == spike_unit_index.shape[0]
+        assert spike_unit_index.shape[0] < random_spikes_indices.size
+        assert some_projections.shape[1] == n_components
+        assert some_projections.shape[2] == some_channel_ids.size
+        assert 1 not in spike_unit_index
 
-            # this should be some spikes some channels
-            some_projections, spike_unit_index = ext.get_some_projections(
-                channel_ids=some_channel_ids, unit_ids=some_unit_ids
-            )
-            assert some_projections.shape[0] == spike_unit_index.shape[0]
-            assert spike_unit_index.shape[0] < random_spikes_indices.size
-            assert some_projections.shape[1] == n_components
-            assert some_projections.shape[2] == some_channel_ids.size
-            assert 1 not in spike_unit_index
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_compute_for_all_spikes(self, sparse):
 
-    def test_compute_for_all_spikes(self):
+        sorting_analyzer = self._prepare_sorting_analyzer(
+            format="memory", sparse=sparse, extension_class=ComputePrincipalComponents
+        )
 
-        for sparse in (True, False):
-            sorting_analyzer = self._prepare_sorting_analyzer(format="memory", sparse=sparse)
+        num_spikes = sorting_analyzer.sorting.to_spike_vector().size
 
-            num_spikes = sorting_analyzer.sorting.to_spike_vector().size
+        n_components = 3
+        sorting_analyzer.compute("principal_components", mode="by_channel_local", n_components=n_components)
+        ext = sorting_analyzer.get_extension("principal_components")
 
-            n_components = 3
-            sorting_analyzer.compute("principal_components", mode="by_channel_local", n_components=n_components)
-            ext = sorting_analyzer.get_extension("principal_components")
+        pc_file1 = cache_folder / "all_pc1.npy"
+        ext.run_for_all_spikes(pc_file1, chunk_size=10000, n_jobs=1)
+        all_pc1 = np.load(pc_file1)
+        assert all_pc1.shape[0] == num_spikes
 
-            pc_file1 = cache_folder / "all_pc1.npy"
-            ext.run_for_all_spikes(pc_file1, chunk_size=10000, n_jobs=1)
-            all_pc1 = np.load(pc_file1)
-            assert all_pc1.shape[0] == num_spikes
+        pc_file2 = cache_folder / "all_pc2.npy"
+        ext.run_for_all_spikes(pc_file2, chunk_size=10000, n_jobs=2)
+        all_pc2 = np.load(pc_file2)
 
-            pc_file2 = cache_folder / "all_pc2.npy"
-            ext.run_for_all_spikes(pc_file2, chunk_size=10000, n_jobs=2)
-            all_pc2 = np.load(pc_file2)
-
-            assert np.array_equal(all_pc1, all_pc2)
+        assert np.array_equal(all_pc1, all_pc2)
 
     def test_project_new(self):
 
-        sorting_analyzer = self._prepare_sorting_analyzer(format="memory", sparse=False)
+        sorting_analyzer = self._prepare_sorting_analyzer(
+            format="memory", sparse=False, extension_class=ComputePrincipalComponents
+        )
 
         waveforms = sorting_analyzer.get_extension("waveforms").data["waveforms"]
 
         n_components = 3
         sorting_analyzer.compute("principal_components", mode="by_channel_local", n_components=n_components)
-        ext_pca = sorting_analyzer.get_extension(self.extension_name)
+        ext_pca = sorting_analyzer.get_extension(ComputePrincipalComponents.extension_name)
 
         num_spike = 100
         new_spikes = sorting_analyzer.sorting.to_spike_vector()[:num_spike]

--- a/src/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/src/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -11,7 +11,7 @@ from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerE
 DEBUG = False
 
 
-class PrincipalComponentsExtensionTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
+class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
     extension_class = ComputePrincipalComponents
     extension_function_params_list = [
         dict(mode="by_channel_local"),

--- a/src/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/src/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -18,7 +18,12 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
         self.run_extension_tests(ComputePrincipalComponents, params=params)
 
     def test_mode_concatenated(self):
-        # this is tested outside "extension_function_params_list" because it do not support sparsity!
+        """
+        Replicate the "extension_function_params_list" test outside of
+        AnalyzerExtensionCommonTestSuite because it does not support sparsity.
+
+        Also, add two additional checks on the dimension and n components of the output.
+        """
         sorting_analyzer = self._prepare_sorting_analyzer(
             format="memory", sparse=False, extension_class=ComputePrincipalComponents
         )
@@ -34,7 +39,13 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
 
     @pytest.mark.parametrize("sparse", [True, False])
     def test_get_projections(self, sparse):
-
+        """
+        Test the shape of output projection score matrices are
+        correct when adjusting sparsity and using the
+        `get_some_projections()` function. We expect them
+        to hold, for each spike and each channel, the loading
+        for each of the specified number of components.
+        """
         sorting_analyzer = self._prepare_sorting_analyzer(
             format="memory", sparse=sparse, extension_class=ComputePrincipalComponents
         )
@@ -44,6 +55,8 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
         sorting_analyzer.compute("principal_components", mode="by_channel_global", n_components=n_components)
         ext = sorting_analyzer.get_extension("principal_components")
 
+        # First, check the created projections have the expected number
+        # of components and the expected number of channels based on sparsity.
         for unit_id in sorting_analyzer.unit_ids:
             if not sparse:
                 one_proj = ext.get_projections_one_unit(unit_id, sparse=False)
@@ -56,13 +69,19 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
 
                 one_proj, chan_inds = ext.get_projections_one_unit(unit_id, sparse=True)
                 assert one_proj.shape[1] == n_components
-                assert one_proj.shape[2] < num_chans
+                num_channels_for_unit = sorting_analyzer.sparsity.unit_id_to_channel_ids[unit_id].size
+                assert one_proj.shape[2] == num_channels_for_unit
                 assert one_proj.shape[2] == chan_inds.size
 
+        # Next, check that the `get_some_projections()` function returns
+        # projections with the expected shapes when selecting subjsets
+        # of channel and unit IDs.
         some_unit_ids = sorting_analyzer.unit_ids[::2]
         some_channel_ids = sorting_analyzer.channel_ids[::2]
 
         random_spikes_indices = sorting_analyzer.get_extension("random_spikes").get_data()
+        all_num_spikes = sorting_analyzer.sorting.get_total_num_spikes()
+        unit_ids_num_spikes = np.sum(all_num_spikes[unit_id] for unit_id in some_unit_ids)
 
         # this should be all spikes all channels
         some_projections, spike_unit_index = ext.get_some_projections(channel_ids=None, unit_ids=None)
@@ -74,7 +93,7 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
         # this should be some spikes all channels
         some_projections, spike_unit_index = ext.get_some_projections(channel_ids=None, unit_ids=some_unit_ids)
         assert some_projections.shape[0] == spike_unit_index.shape[0]
-        assert spike_unit_index.shape[0] < random_spikes_indices.size
+        assert spike_unit_index.shape[0] == unit_ids_num_spikes
         assert some_projections.shape[1] == n_components
         assert some_projections.shape[2] == num_chans
         assert 1 not in spike_unit_index
@@ -84,14 +103,19 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
             channel_ids=some_channel_ids, unit_ids=some_unit_ids
         )
         assert some_projections.shape[0] == spike_unit_index.shape[0]
-        assert spike_unit_index.shape[0] < random_spikes_indices.size
+        assert spike_unit_index.shape[0] == unit_ids_num_spikes
         assert some_projections.shape[1] == n_components
         assert some_projections.shape[2] == some_channel_ids.size
         assert 1 not in spike_unit_index
 
     @pytest.mark.parametrize("sparse", [True, False])
     def test_compute_for_all_spikes(self, sparse):
-
+        """
+        Compute the principal component scores, checking the shape
+        matches the number of spikes as expected. This is re-run
+        with n_jobs=2 and output projection score matrices
+        checked against n_jobs=1.
+        """
         sorting_analyzer = self._prepare_sorting_analyzer(
             format="memory", sparse=sparse, extension_class=ComputePrincipalComponents
         )
@@ -114,7 +138,16 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
         assert np.array_equal(all_pc1, all_pc2)
 
     def test_project_new(self):
+        """
+        `project_new` projects new (unseen) waveforms onto the PCA components.
+        First compute principal components from existing waveforms. Then,
+        generate a new 'spikes' vector that includes sample_index, unit_index
+        and segment_index alongside some waveforms (the spike vector is required
+        to generate some corresponding unit IDs for the generated waveforms following
+        the API of principal_components.py).
 
+        Then, check that the new projection scores matrix is the expected shape.
+        """
         sorting_analyzer = self._prepare_sorting_analyzer(
             format="memory", sparse=False, extension_class=ComputePrincipalComponents
         )

--- a/src/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/src/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -112,7 +112,6 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
             assert np.array_equal(all_pc1, all_pc2)
 
     def test_project_new(self):
-        from sklearn.decomposition import IncrementalPCA
 
         sorting_analyzer = self._prepare_sorting_analyzer(format="memory", sparse=False)
 
@@ -130,16 +129,6 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
         assert new_proj.shape[0] == num_spike
         assert new_proj.shape[1] == n_components
         assert new_proj.shape[2] == ext_pca.data["pca_projection"].shape[2]
-
-
-if __name__ == "__main__":
-    test = TestPrincipalComponentsExtension()
-    test.setUpClass()
-    test.test_extension()
-    test.test_mode_concatenated()
-    test.test_get_projections()
-    test.test_compute_for_all_spikes()
-    test.test_project_new()
 
     # ext = test.sorting_analyzers["sparseTrue_memory"].get_extension("principal_components")
     # pca = ext.data["pca_projection"]

--- a/src/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/src/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -166,10 +166,3 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
         assert new_proj.shape[0] == num_spike
         assert new_proj.shape[1] == n_components
         assert new_proj.shape[2] == ext_pca.data["pca_projection"].shape[2]
-
-    # ext = test.sorting_analyzers["sparseTrue_memory"].get_extension("principal_components")
-    # pca = ext.data["pca_projection"]
-    # import matplotlib.pyplot as plt
-    # fig, ax = plt.subplots()
-    # ax.scatter(pca[:, 0, 0], pca[:, 0, 1])
-    # plt.show()

--- a/src/spikeinterface/postprocessing/tests/test_spike_amplitudes.py
+++ b/src/spikeinterface/postprocessing/tests/test_spike_amplitudes.py
@@ -5,7 +5,7 @@ from spikeinterface.postprocessing import ComputeSpikeAmplitudes
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
 
 
-class ComputeSpikeAmplitudesTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
+class TestComputeSpikeAmplitudes(AnalyzerExtensionCommonTestSuite):
     extension_class = ComputeSpikeAmplitudes
     extension_function_params_list = [
         dict(),
@@ -13,7 +13,7 @@ class ComputeSpikeAmplitudesTest(AnalyzerExtensionCommonTestSuite, unittest.Test
 
 
 if __name__ == "__main__":
-    test = ComputeSpikeAmplitudesTest()
+    test = TestComputeSpikeAmplitudes()
     test.setUpClass()
     test.test_extension()
 

--- a/src/spikeinterface/postprocessing/tests/test_spike_amplitudes.py
+++ b/src/spikeinterface/postprocessing/tests/test_spike_amplitudes.py
@@ -10,13 +10,3 @@ class TestComputeSpikeAmplitudes(AnalyzerExtensionCommonTestSuite):
     extension_function_params_list = [
         dict(),
     ]
-
-
-if __name__ == "__main__":
-    test = TestComputeSpikeAmplitudes()
-    test.setUpClass()
-    test.test_extension()
-
-    # for k, sorting_analyzer in test.sorting_analyzers.items():
-    #     print(sorting_analyzer)
-    #     print(sorting_analyzer.get_extension("spike_amplitudes").data["amplitudes"].shape)

--- a/src/spikeinterface/postprocessing/tests/test_spike_amplitudes.py
+++ b/src/spikeinterface/postprocessing/tests/test_spike_amplitudes.py
@@ -6,7 +6,6 @@ from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerE
 
 
 class TestComputeSpikeAmplitudes(AnalyzerExtensionCommonTestSuite):
-    extension_class = ComputeSpikeAmplitudes
-    extension_function_params_list = [
-        dict(),
-    ]
+
+    def test_extension(self):
+        self.run_extension_tests(ComputeSpikeAmplitudes, params=dict())

--- a/src/spikeinterface/postprocessing/tests/test_spike_amplitudes.py
+++ b/src/spikeinterface/postprocessing/tests/test_spike_amplitudes.py
@@ -1,6 +1,3 @@
-import unittest
-import numpy as np
-
 from spikeinterface.postprocessing import ComputeSpikeAmplitudes
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
 

--- a/src/spikeinterface/postprocessing/tests/test_spike_locations.py
+++ b/src/spikeinterface/postprocessing/tests/test_spike_locations.py
@@ -3,18 +3,20 @@ import numpy as np
 
 from spikeinterface.postprocessing import ComputeSpikeLocations
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
+import pytest
 
 
 class TestSpikeLocationsExtension(AnalyzerExtensionCommonTestSuite):
-    extension_class = ComputeSpikeLocations
-    extension_function_params_list = [
-        dict(
-            method="center_of_mass", spike_retriver_kwargs=dict(channel_from_template=True)
-        ),  # chunk_size=10000, n_jobs=1,
-        dict(method="center_of_mass", spike_retriver_kwargs=dict(channel_from_template=False)),
-        dict(
-            method="center_of_mass",
-        ),
-        dict(method="monopolar_triangulation"),  # , chunk_size=10000, n_jobs=1
-        dict(method="grid_convolution"),  # , chunk_size=10000, n_jobs=1
-    ]
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            dict(method="center_of_mass", spike_retriver_kwargs=dict(channel_from_template=True)),
+            dict(method="center_of_mass", spike_retriver_kwargs=dict(channel_from_template=False)),
+            dict(method="center_of_mass"),
+            dict(method="monopolar_triangulation"),
+            dict(method="grid_convolution"),
+        ],
+    )
+    def test_extension(self, params):
+        self.run_extension_tests(ComputeSpikeLocations, params)

--- a/src/spikeinterface/postprocessing/tests/test_spike_locations.py
+++ b/src/spikeinterface/postprocessing/tests/test_spike_locations.py
@@ -1,6 +1,3 @@
-import unittest
-import numpy as np
-
 from spikeinterface.postprocessing import ComputeSpikeLocations
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
 import pytest

--- a/src/spikeinterface/postprocessing/tests/test_spike_locations.py
+++ b/src/spikeinterface/postprocessing/tests/test_spike_locations.py
@@ -5,7 +5,7 @@ from spikeinterface.postprocessing import ComputeSpikeLocations
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
 
 
-class SpikeLocationsExtensionTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
+class TestSpikeLocationsExtension(AnalyzerExtensionCommonTestSuite):
     extension_class = ComputeSpikeLocations
     extension_function_params_list = [
         dict(
@@ -21,6 +21,6 @@ class SpikeLocationsExtensionTest(AnalyzerExtensionCommonTestSuite, unittest.Tes
 
 
 if __name__ == "__main__":
-    test = SpikeLocationsExtensionTest()
+    test = TestSpikeLocationsExtension()
     test.setUpClass()
     test.test_extension()

--- a/src/spikeinterface/postprocessing/tests/test_spike_locations.py
+++ b/src/spikeinterface/postprocessing/tests/test_spike_locations.py
@@ -18,9 +18,3 @@ class TestSpikeLocationsExtension(AnalyzerExtensionCommonTestSuite):
         dict(method="monopolar_triangulation"),  # , chunk_size=10000, n_jobs=1
         dict(method="grid_convolution"),  # , chunk_size=10000, n_jobs=1
     ]
-
-
-if __name__ == "__main__":
-    test = TestSpikeLocationsExtension()
-    test.setUpClass()
-    test.test_extension()

--- a/src/spikeinterface/postprocessing/tests/test_template_metrics.py
+++ b/src/spikeinterface/postprocessing/tests/test_template_metrics.py
@@ -5,7 +5,7 @@ from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerE
 from spikeinterface.postprocessing import ComputeTemplateMetrics
 
 
-class TemplateMetricsTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
+class TestTemplateMetrics(AnalyzerExtensionCommonTestSuite):
     extension_class = ComputeTemplateMetrics
     extension_function_params_list = [
         dict(),
@@ -15,6 +15,6 @@ class TemplateMetricsTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
 
 
 if __name__ == "__main__":
-    test = TemplateMetricsTest()
+    test = TestTemplateMetrics()
     test.setUpClass()
     test.test_extension()

--- a/src/spikeinterface/postprocessing/tests/test_template_metrics.py
+++ b/src/spikeinterface/postprocessing/tests/test_template_metrics.py
@@ -1,6 +1,3 @@
-import unittest
-
-
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
 from spikeinterface.postprocessing import ComputeTemplateMetrics
 import pytest

--- a/src/spikeinterface/postprocessing/tests/test_template_metrics.py
+++ b/src/spikeinterface/postprocessing/tests/test_template_metrics.py
@@ -12,9 +12,3 @@ class TestTemplateMetrics(AnalyzerExtensionCommonTestSuite):
         dict(upsampling_factor=2),
         dict(include_multi_channel_metrics=True),
     ]
-
-
-if __name__ == "__main__":
-    test = TestTemplateMetrics()
-    test.setUpClass()
-    test.test_extension()

--- a/src/spikeinterface/postprocessing/tests/test_template_metrics.py
+++ b/src/spikeinterface/postprocessing/tests/test_template_metrics.py
@@ -3,12 +3,18 @@ import unittest
 
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
 from spikeinterface.postprocessing import ComputeTemplateMetrics
+import pytest
 
 
 class TestTemplateMetrics(AnalyzerExtensionCommonTestSuite):
-    extension_class = ComputeTemplateMetrics
-    extension_function_params_list = [
-        dict(),
-        dict(upsampling_factor=2),
-        dict(include_multi_channel_metrics=True),
-    ]
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            dict(),
+            dict(upsampling_factor=2),
+            dict(include_multi_channel_metrics=True),
+        ],
+    )
+    def test_extension(self, params):
+        self.run_extension_tests(ComputeTemplateMetrics, params)

--- a/src/spikeinterface/postprocessing/tests/test_template_similarity.py
+++ b/src/spikeinterface/postprocessing/tests/test_template_similarity.py
@@ -1,9 +1,5 @@
-import unittest
-
 from spikeinterface.postprocessing.tests.common_extension_tests import (
     AnalyzerExtensionCommonTestSuite,
-    get_sorting_analyzer,
-    get_dataset,
 )
 
 from spikeinterface.postprocessing import check_equal_template_with_distribution_overlap, ComputeTemplateSimilarity

--- a/src/spikeinterface/postprocessing/tests/test_template_similarity.py
+++ b/src/spikeinterface/postprocessing/tests/test_template_similarity.py
@@ -11,7 +11,12 @@ class TestSimilarityExtension(AnalyzerExtensionCommonTestSuite):
         self.run_extension_tests(ComputeTemplateSimilarity, params=dict(method="cosine_similarity"))
 
     def test_check_equal_template_with_distribution_overlap(self):
-
+        """
+        Create a sorting object, extract its waveforms. Compare waveforms
+        from all pairs of units (excluding a unit against itself)
+        and check `check_equal_template_with_distribution_overlap()`
+        correctly determines they are different.
+        """
         sorting_analyzer = self._prepare_sorting_analyzer("memory", None, ComputeTemplateSimilarity)
         sorting_analyzer.compute("random_spikes")
         sorting_analyzer.compute("waveforms")
@@ -25,4 +30,5 @@ class TestSimilarityExtension(AnalyzerExtensionCommonTestSuite):
                 if unit_id0 == unit_id1:
                     continue
                 waveforms1 = wf_ext.get_waveforms_one_unit(unit_id1)
-                check_equal_template_with_distribution_overlap(waveforms0, waveforms1)
+
+                assert not check_equal_template_with_distribution_overlap(waveforms0, waveforms1)

--- a/src/spikeinterface/postprocessing/tests/test_template_similarity.py
+++ b/src/spikeinterface/postprocessing/tests/test_template_similarity.py
@@ -9,7 +9,7 @@ from spikeinterface.postprocessing.tests.common_extension_tests import (
 from spikeinterface.postprocessing import check_equal_template_with_distribution_overlap, ComputeTemplateSimilarity
 
 
-class SimilarityExtensionTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
+class TestSimilarityExtension(AnalyzerExtensionCommonTestSuite):
     extension_class = ComputeTemplateSimilarity
     extension_function_params_list = [
         dict(method="cosine_similarity"),

--- a/src/spikeinterface/postprocessing/tests/test_template_similarity.py
+++ b/src/spikeinterface/postprocessing/tests/test_template_similarity.py
@@ -10,27 +10,23 @@ from spikeinterface.postprocessing import check_equal_template_with_distribution
 
 
 class TestSimilarityExtension(AnalyzerExtensionCommonTestSuite):
-    extension_class = ComputeTemplateSimilarity
-    extension_function_params_list = [
-        dict(method="cosine_similarity"),
-    ]
 
+    def test_extension(self):
+        self.run_extension_tests(ComputeTemplateSimilarity, params=dict(method="cosine_similarity"))
 
-def test_check_equal_template_with_distribution_overlap():
+    def test_check_equal_template_with_distribution_overlap(self):
 
-    recording, sorting = get_dataset()
+        sorting_analyzer = self._prepare_sorting_analyzer("memory", None, ComputeTemplateSimilarity)
+        sorting_analyzer.compute("random_spikes")
+        sorting_analyzer.compute("waveforms")
+        sorting_analyzer.compute("templates")
 
-    sorting_analyzer = get_sorting_analyzer(recording, sorting, sparsity=None)
-    sorting_analyzer.compute("random_spikes")
-    sorting_analyzer.compute("waveforms")
-    sorting_analyzer.compute("templates")
+        wf_ext = sorting_analyzer.get_extension("waveforms")
 
-    wf_ext = sorting_analyzer.get_extension("waveforms")
-
-    for unit_id0 in sorting_analyzer.unit_ids:
-        waveforms0 = wf_ext.get_waveforms_one_unit(unit_id0)
-        for unit_id1 in sorting_analyzer.unit_ids:
-            if unit_id0 == unit_id1:
-                continue
-            waveforms1 = wf_ext.get_waveforms_one_unit(unit_id1)
-            check_equal_template_with_distribution_overlap(waveforms0, waveforms1)
+        for unit_id0 in sorting_analyzer.unit_ids:
+            waveforms0 = wf_ext.get_waveforms_one_unit(unit_id0)
+            for unit_id1 in sorting_analyzer.unit_ids:
+                if unit_id0 == unit_id1:
+                    continue
+                waveforms1 = wf_ext.get_waveforms_one_unit(unit_id1)
+                check_equal_template_with_distribution_overlap(waveforms0, waveforms1)

--- a/src/spikeinterface/postprocessing/tests/test_template_similarity.py
+++ b/src/spikeinterface/postprocessing/tests/test_template_similarity.py
@@ -34,11 +34,3 @@ def test_check_equal_template_with_distribution_overlap():
                 continue
             waveforms1 = wf_ext.get_waveforms_one_unit(unit_id1)
             check_equal_template_with_distribution_overlap(waveforms0, waveforms1)
-
-
-if __name__ == "__main__":
-    # test = SimilarityExtensionTest()
-    # test.setUpClass()
-    # test.test_extension()
-
-    test_check_equal_template_with_distribution_overlap()

--- a/src/spikeinterface/postprocessing/tests/test_unit_localization.py
+++ b/src/spikeinterface/postprocessing/tests/test_unit_localization.py
@@ -12,10 +12,3 @@ class TestUnitLocationsExtension(AnalyzerExtensionCommonTestSuite):
         dict(method="monopolar_triangulation", radius_um=150),
         dict(method="monopolar_triangulation", radius_um=150, optimizer="minimize_with_log_penality"),
     ]
-
-
-if __name__ == "__main__":
-    test = TestUnitLocationsExtension()
-    test.setUpClass()
-    test.test_extension()
-    # test.tearDown()

--- a/src/spikeinterface/postprocessing/tests/test_unit_localization.py
+++ b/src/spikeinterface/postprocessing/tests/test_unit_localization.py
@@ -1,4 +1,3 @@
-import unittest
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
 from spikeinterface.postprocessing import ComputeUnitLocations
 import pytest

--- a/src/spikeinterface/postprocessing/tests/test_unit_localization.py
+++ b/src/spikeinterface/postprocessing/tests/test_unit_localization.py
@@ -1,14 +1,20 @@
 import unittest
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
 from spikeinterface.postprocessing import ComputeUnitLocations
+import pytest
 
 
 class TestUnitLocationsExtension(AnalyzerExtensionCommonTestSuite):
-    extension_class = ComputeUnitLocations
-    extension_function_params_list = [
-        dict(method="center_of_mass", radius_um=100),
-        dict(method="grid_convolution", radius_um=50),
-        dict(method="grid_convolution", radius_um=150, weight_method={"mode": "gaussian_2d"}),
-        dict(method="monopolar_triangulation", radius_um=150),
-        dict(method="monopolar_triangulation", radius_um=150, optimizer="minimize_with_log_penality"),
-    ]
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            dict(method="center_of_mass", radius_um=100),
+            dict(method="grid_convolution", radius_um=50),
+            dict(method="grid_convolution", radius_um=150, weight_method={"mode": "gaussian_2d"}),
+            dict(method="monopolar_triangulation", radius_um=150),
+            dict(method="monopolar_triangulation", radius_um=150, optimizer="minimize_with_log_penality"),
+        ],
+    )
+    def test_extension(self, params):
+        self.run_extension_tests(ComputeUnitLocations, params=params)

--- a/src/spikeinterface/postprocessing/tests/test_unit_localization.py
+++ b/src/spikeinterface/postprocessing/tests/test_unit_localization.py
@@ -3,7 +3,7 @@ from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerE
 from spikeinterface.postprocessing import ComputeUnitLocations
 
 
-class UnitLocationsExtensionTest(AnalyzerExtensionCommonTestSuite, unittest.TestCase):
+class TestUnitLocationsExtension(AnalyzerExtensionCommonTestSuite):
     extension_class = ComputeUnitLocations
     extension_function_params_list = [
         dict(method="center_of_mass", radius_um=100),
@@ -15,7 +15,7 @@ class UnitLocationsExtensionTest(AnalyzerExtensionCommonTestSuite, unittest.Test
 
 
 if __name__ == "__main__":
-    test = UnitLocationsExtensionTest()
+    test = TestUnitLocationsExtension()
     test.setUpClass()
     test.test_extension()
     # test.tearDown()


### PR DESCRIPTION
This PR removes `unittest` from the tests in the `postprocessing` module. Overall it:

1) Removes `unittest` and changes the `setUpClass` (the running of which was handlded by `unittest`) to a pytest fixture. This still is setup only once-per-subclass instantiation and the run-time of the `postprocessing` tests is within a few seconds of the old runtime.
2) Slightly reworks how `test_extension` is called. Now each subclass has its own `test_extension` function that calls the base class `run_extension_tests`, and the parameters are parameterised which means `pytest` runs 1 test per parameter set. This gives a bit more granulatiry to the test output.
3) In a couple of places add `sparsity` as a test parameterization rather than a loop, for the benefit for separating the tests in the output.
3) This now breaks the existing `if __name__ == "__main__"` blocks which can no longer be run with python. However, all the equivilent functionality can be gained through making plots / interacting with tests from inside test functions, so I removed for now. But please let me know if this will mess with your workflows.
4) In some small places, extended tests by checking for direct equivilency with an expected value rather than over / under an expected bounds.
5) Extended docstrings, removed a few stray `print()` functions.
6) I removed some (but not all) of the commented code that was used for debugging. In this case I tried to remove only the simple cases that I roughly thought would be quicker to rewrite on the fly than look through the commented code and figure out what it is doing. But let me know if it's a problem!

