### PR TITLE
Patch unit location

### DIFF
--- a/src/spikeinterface/postprocessing/unit_localization.py
+++ b/src/spikeinterface/postprocessing/unit_localization.py
@@ -239,7 +239,7 @@ def compute_monopolar_triangulation(
     contact_locations = sorting_analyzer.get_channel_locations()
 
     sparsity = compute_sparsity(sorting_analyzer, method="radius", radius_um=radius_um)
-    templates = get_dense_templates_array(sorting_analyzer)
+    templates = get_dense_templates_array(sorting_analyzer, return_scaled=sorting_analyzer.return_scaled)
     nbefore = _get_nbefore(sorting_analyzer)
 
     if enforce_decrease:
@@ -303,7 +303,7 @@ def compute_center_of_mass(sorting_analyzer, peak_sign="neg", radius_um=75, feat
     assert feature in ["ptp", "mean", "energy", "peak_voltage"], f"{feature} is not a valid feature"
 
     sparsity = compute_sparsity(sorting_analyzer, peak_sign=peak_sign, method="radius", radius_um=radius_um)
-    templates = get_dense_templates_array(sorting_analyzer)
+    templates = get_dense_templates_array(sorting_analyzer, return_scaled=sorting_analyzer.return_scaled)
     nbefore = _get_nbefore(sorting_analyzer)
 
     unit_location = np.zeros((unit_ids.size, 2), dtype="float64")
@@ -374,7 +374,7 @@ def compute_grid_convolution(
     contact_locations = sorting_analyzer.get_channel_locations()
     unit_ids = sorting_analyzer.unit_ids
 
-    templates = get_dense_templates_array(sorting_analyzer)
+    templates = get_dense_templates_array(sorting_analyzer, return_scaled=sorting_analyzer.return_scaled)
     nbefore = _get_nbefore(sorting_analyzer)
     nafter = templates.shape[1] - nbefore
 

--- a/src/spikeinterface/sortingcomponents/clustering/circus.py
+++ b/src/spikeinterface/sortingcomponents/clustering/circus.py
@@ -56,13 +56,13 @@ class CircusClustering:
             "recursive_depth": 3,
             "returns_split_count": True,
         },
-        "radius_um": 50,
+        "radius_um": 100,
         "n_svd": [5, 2],
-        "ms_before": 2,
-        "ms_after": 2,
+        "ms_before": 0.5,
+        "ms_after": 0.5,
         "rank": 5,
         "noise_levels": None,
-        "tmp_folder": "test",
+        "tmp_folder": None,
         "job_kwargs": {},
         "verbose": True,
     }
@@ -187,26 +187,9 @@ class CircusClustering:
             neighbours_mask = get_channel_distances(recording) < radius_um
 
             # np.save(features_folder / "sparse_mask.npy", sparse_mask)
-            # np.save(features_folder / "peaks.npy", peaks)
-            # np.save(features_folder / "mask.npy", neighbours_mask)
-            # np.save(features_folder / "distances.npy", get_channel_distances(recording))
+            np.save(features_folder / "peaks.npy", peaks)
 
-            # features = np.load(tmp_folder / 'tsvd_features/sparse_tsvd.npy')
-            # positions = recording.get_channel_locations()
-            # m = len(peaks)
-            # dense_features = np.zeros((m, 5, len(positions)), dtype=np.float32)
-            # for i in range(m):
-            #     main_channel = peaks["channel_index"][i]
-            #     chan_inds = np.flatnonzero(neighbours_mask[main_channel])
-            #     dense_features[i, :, chan_inds] = (features[i][:, :len(chan_inds)]).T
-            
-            # energy_pca = np.linalg.norm(dense_features, axis=1)
-            # estimated_positions = energy_pca.dot(positions)/(energy_pca.sum(axis=1)[:, None])
-
-            # dist = np.linalg.norm(estimated_positions[:, np.newaxis] - positions[np.newaxis, :], axis=2)
-            # original_labels = np.argmin(dist, axis=1)
             original_labels = peaks["channel_index"]
-
             from spikeinterface.sortingcomponents.clustering.split import split_clusters
 
             peak_labels, _ = split_clusters(

--- a/src/spikeinterface/sortingcomponents/clustering/circus.py
+++ b/src/spikeinterface/sortingcomponents/clustering/circus.py
@@ -56,13 +56,13 @@ class CircusClustering:
             "recursive_depth": 3,
             "returns_split_count": True,
         },
-        "radius_um": 100,
+        "radius_um": 50,
         "n_svd": [5, 2],
-        "ms_before": 0.5,
-        "ms_after": 0.5,
+        "ms_before": 2,
+        "ms_after": 2,
         "rank": 5,
         "noise_levels": None,
-        "tmp_folder": None,
+        "tmp_folder": "test",
         "job_kwargs": {},
         "verbose": True,
     }
@@ -187,9 +187,26 @@ class CircusClustering:
             neighbours_mask = get_channel_distances(recording) < radius_um
 
             # np.save(features_folder / "sparse_mask.npy", sparse_mask)
-            np.save(features_folder / "peaks.npy", peaks)
+            # np.save(features_folder / "peaks.npy", peaks)
+            # np.save(features_folder / "mask.npy", neighbours_mask)
+            # np.save(features_folder / "distances.npy", get_channel_distances(recording))
 
+            # features = np.load(tmp_folder / 'tsvd_features/sparse_tsvd.npy')
+            # positions = recording.get_channel_locations()
+            # m = len(peaks)
+            # dense_features = np.zeros((m, 5, len(positions)), dtype=np.float32)
+            # for i in range(m):
+            #     main_channel = peaks["channel_index"][i]
+            #     chan_inds = np.flatnonzero(neighbours_mask[main_channel])
+            #     dense_features[i, :, chan_inds] = (features[i][:, :len(chan_inds)]).T
+            
+            # energy_pca = np.linalg.norm(dense_features, axis=1)
+            # estimated_positions = energy_pca.dot(positions)/(energy_pca.sum(axis=1)[:, None])
+
+            # dist = np.linalg.norm(estimated_positions[:, np.newaxis] - positions[np.newaxis, :], axis=2)
+            # original_labels = np.argmin(dist, axis=1)
             original_labels = peaks["channel_index"]
+
             from spikeinterface.sortingcomponents.clustering.split import split_clusters
 
             peak_labels, _ = split_clusters(


### PR DESCRIPTION
Currently, unit_locations can not be properly computed for return_scaled=False, because the argument (inherited from the analyzer) is not propage to the get_dense_template() local call