### PR TITLE
Mcsh5 offsets and proper scaling in uV for return_scaled

### DIFF
--- a/src/spikeinterface/extractors/mcsh5extractors.py
+++ b/src/spikeinterface/extractors/mcsh5extractors.py
@@ -108,9 +108,9 @@ def openMCSH5File(filename, stream_id):
     Specs can be found online
     https://www.multichannelsystems.com/downloads/documentation?page=3
     """
-   
+
     import h5py
-    
+
     rf = h5py.File(filename, "r")
 
     stream_name = "Stream_" + str(stream_id)

--- a/src/spikeinterface/extractors/mcsh5extractors.py
+++ b/src/spikeinterface/extractors/mcsh5extractors.py
@@ -124,8 +124,8 @@ def openMCSH5File(filename, stream_id):
     Tick = info["Tick"][0] / 1e6
     exponent = info["Exponent"][0]
     convFact = info["ConversionFactor"][0]
-    gain_uV = 1e6*(convFact.astype(float) * (10.0**exponent))
-    offset_uV = 1e6*(info['ADZero'].astype(float) * (10.0**exponent))
+    gain_uV = 1e6 * (convFact.astype(float) * (10.0**exponent))
+    offset_uV = 1e6 * (info["ADZero"].astype(float) * (10.0**exponent))
 
     nRecCh, nFrames = data.shape
     channel_ids = [f"Ch{ch}" for ch in info["ChannelID"]]
@@ -155,7 +155,7 @@ def openMCSH5File(filename, stream_id):
         "electrode_labels": electrodeLabels,
         "gain": gain_uV,
         "dtype": dtype,
-        "offset" : offset_uV
+        "offset": offset_uV,
     }
 
     return mcs_info

--- a/src/spikeinterface/extractors/mcsh5extractors.py
+++ b/src/spikeinterface/extractors/mcsh5extractors.py
@@ -124,8 +124,8 @@ def openMCSH5File(filename, stream_id):
     Tick = info["Tick"][0] / 1e6
     exponent = info["Exponent"][0]
     convFact = info["ConversionFactor"][0]
-    gain = convFact.astype(float) * (10.0**exponent)
-    offset = info['ADZero'].astype(float) * (10.0**exponent)
+    gain_uV = 1e6*(convFact.astype(float) * (10.0**exponent))
+    offset_uV = 1e6*(info['ADZero'].astype(float) * (10.0**exponent))
 
     nRecCh, nFrames = data.shape
     channel_ids = [f"Ch{ch}" for ch in info["ChannelID"]]
@@ -153,9 +153,9 @@ def openMCSH5File(filename, stream_id):
         "num_channels": nRecCh,
         "channel_ids": channel_ids,
         "electrode_labels": electrodeLabels,
-        "gain": gain,
+        "gain": gain_uV,
         "dtype": dtype,
-        "offset" : offset
+        "offset" : offset_uV
     }
 
     return mcs_info

--- a/src/spikeinterface/extractors/mcsh5extractors.py
+++ b/src/spikeinterface/extractors/mcsh5extractors.py
@@ -130,7 +130,7 @@ def openMCSH5File(filename, stream_id):
     exponent = info["Exponent"][0]
     convFact = info["ConversionFactor"][0]
     gain_uV = 1e6 * (convFact.astype(float) * (10.0**exponent))
-    offset_uV = -1e6 * (info["ADZero"].astype(float) * (10.0**exponent))
+    offset_uV = -1e6 * (info["ADZero"].astype(float) * (10.0**exponent)) / gain_uV
 
     nRecCh, nFrames = data.shape
     channel_ids = [f"Ch{ch}" for ch in info["ChannelID"]]

--- a/src/spikeinterface/extractors/mcsh5extractors.py
+++ b/src/spikeinterface/extractors/mcsh5extractors.py
@@ -130,7 +130,7 @@ def openMCSH5File(filename, stream_id):
     exponent = info["Exponent"][0]
     convFact = info["ConversionFactor"][0]
     gain_uV = 1e6 * (convFact.astype(float) * (10.0**exponent))
-    offset_uV = -1e6 * (info["ADZero"].astype(float) * (10.0**exponent)) / gain_uV
+    offset_uV = -1e6 * (info["ADZero"].astype(float) * (10.0**exponent)) * gain_uV
 
     nRecCh, nFrames = data.shape
     channel_ids = [f"Ch{ch}" for ch in info["ChannelID"]]

--- a/src/spikeinterface/extractors/mcsh5extractors.py
+++ b/src/spikeinterface/extractors/mcsh5extractors.py
@@ -105,9 +105,9 @@ class MCSH5RecordingSegment(BaseRecordingSegment):
 
 
 def openMCSH5File(filename, stream_id):
-    """Open an MCS hdf5 file, read and return the recording info. 
-       Specs can be found online 
-       https://www.multichannelsystems.com/downloads/documentation?page=3
+    """Open an MCS hdf5 file, read and return the recording info.
+    Specs can be found online
+    https://www.multichannelsystems.com/downloads/documentation?page=3
     """
     rf = h5py.File(filename, "r")
 
@@ -128,7 +128,7 @@ def openMCSH5File(filename, stream_id):
     exponent = info["Exponent"][0]
     convFact = info["ConversionFactor"][0]
     gain_uV = 1e6 * (convFact.astype(float) * (10.0**exponent))
-    offset_uV = - 1e6 * (info["ADZero"].astype(float) * (10.0**exponent))
+    offset_uV = -1e6 * (info["ADZero"].astype(float) * (10.0**exponent))
 
     nRecCh, nFrames = data.shape
     channel_ids = [f"Ch{ch}" for ch in info["ChannelID"]]

--- a/src/spikeinterface/extractors/mcsh5extractors.py
+++ b/src/spikeinterface/extractors/mcsh5extractors.py
@@ -105,7 +105,10 @@ class MCSH5RecordingSegment(BaseRecordingSegment):
 
 
 def openMCSH5File(filename, stream_id):
-    """Open an MCS hdf5 file, read and return the recording info."""
+    """Open an MCS hdf5 file, read and return the recording info. 
+       Specs can be found online 
+       https://www.multichannelsystems.com/downloads/documentation?page=3
+    """
     rf = h5py.File(filename, "r")
 
     stream_name = "Stream_" + str(stream_id)
@@ -125,7 +128,7 @@ def openMCSH5File(filename, stream_id):
     exponent = info["Exponent"][0]
     convFact = info["ConversionFactor"][0]
     gain_uV = 1e6 * (convFact.astype(float) * (10.0**exponent))
-    offset_uV = 1e6 * (info["ADZero"].astype(float) * (10.0**exponent))
+    offset_uV = - 1e6 * (info["ADZero"].astype(float) * (10.0**exponent))
 
     nRecCh, nFrames = data.shape
     channel_ids = [f"Ch{ch}" for ch in info["ChannelID"]]

--- a/src/spikeinterface/extractors/mcsh5extractors.py
+++ b/src/spikeinterface/extractors/mcsh5extractors.py
@@ -63,6 +63,9 @@ class MCSH5RecordingExtractor(BaseRecording):
         # set gain
         self.set_channel_gains(mcs_info["gain"])
 
+        # set offsets
+        self.set_channel_offsets(mcs_info["offset"])
+
         # set other properties
         self.set_property("electrode_labels", mcs_info["electrode_labels"])
 
@@ -122,6 +125,7 @@ def openMCSH5File(filename, stream_id):
     exponent = info["Exponent"][0]
     convFact = info["ConversionFactor"][0]
     gain = convFact.astype(float) * (10.0**exponent)
+    offset = info['ADZero'].astype(float) * (10.0**exponent)
 
     nRecCh, nFrames = data.shape
     channel_ids = [f"Ch{ch}" for ch in info["ChannelID"]]
@@ -151,6 +155,7 @@ def openMCSH5File(filename, stream_id):
         "electrode_labels": electrodeLabels,
         "gain": gain,
         "dtype": dtype,
+        "offset" : offset
     }
 
     return mcs_info


### PR DESCRIPTION
Adding the offsets from the mcs5h header in order to have a recording with offset_to_UV and gain_to_UV. In addition, the gain was entered in V, and thus the scaling was not really making sense. As far as I understand, we want to have return_scaled returning values in uV, am I right? If yes, this is doing the job here, given the documentation that can be found online

https://www.multichannelsystems.com/sites/multichannelsystems.com/files/documents/manuals/HDF5%20MCS%20Raw%20Data%20Definition.pdf