### PR TITLE
Remove neo top level imports

### DIFF
--- a/.github/import_test.py
+++ b/.github/import_test.py
@@ -45,20 +45,19 @@ for import_statement in import_statement_list:
         time_taken_list.append(time_taken)
 
     for time in time_taken_list:
-        import_time_threshold = 1.0
-        if time > import_time_threshold:
+        import_time_threshold = 2.0  # Most of the times is sub-second but there outliers
+        if time >= import_time_threshold:
             exceptions.append(
-                f"Importing {import_statement} took too long: {time:.2f} seconds. Import time threshold: {import_time_threshold} seconds."
+                f"Importing {import_statement} took: {time:.2f} seconds. Should be <: {import_time_threshold} seconds."
             )
             break
 
     if time_taken_list:
-        avg_time_taken = sum(time_taken_list) / len(time_taken_list)
-        std_dev_time_taken = math.sqrt(sum((x - avg_time_taken) ** 2 for x in time_taken_list) / len(time_taken_list))
+        avg_time = sum(time_taken_list) / len(time_taken_list)
+        std_time = math.sqrt(sum((x - avg_time) ** 2 for x in time_taken_list) / len(time_taken_list))
         times_list_str = ", ".join(f"{time:.2f}" for time in time_taken_list)
-        markdown_output += (
-            f"| `{import_statement}` | {avg_time_taken:.2f} | {std_dev_time_taken:.2f} | {times_list_str} |\n"
-        )
+        markdown_output += f"| `{import_statement}` | {avg_time:.2f} | {std_time:.2f} | {times_list_str} |\n"
+
 
 if exceptions:
     raise Exception("\n".join(exceptions))

--- a/.github/import_test.py
+++ b/.github/import_test.py
@@ -26,18 +26,17 @@ for import_statement in import_statement_list:
     time_taken_list = []
     for _ in range(n_samples):
         script_to_execute = (
-                f"import timeit \n"
-                f"import_statement = '{import_statement}' \n"
-                f"time_taken = timeit.timeit(import_statement, number=1) \n"
-                f"print(time_taken) \n"
-               )
+            f"import timeit \n"
+            f"import_statement = '{import_statement}' \n"
+            f"time_taken = timeit.timeit(import_statement, number=1) \n"
+            f"print(time_taken) \n"
+        )
 
         result = subprocess.run(["python", "-c", script_to_execute], capture_output=True, text=True)
 
         if result.returncode != 0:
-            error_message  = (
-                f"Error when running {import_statement} \n"
-                f"Error in subprocess: {result.stderr.strip()}\n"
+            error_message = (
+                f"Error when running {import_statement} \n" f"Error in subprocess: {result.stderr.strip()}\n"
             )
             exceptions.append(error_message)
             break
@@ -46,15 +45,20 @@ for import_statement in import_statement_list:
         time_taken_list.append(time_taken)
 
     for time in time_taken_list:
-        if time > 1.5:
-            exceptions.append(f"Importing {import_statement} took too long: {time:.2f} seconds")
+        import_time_threshold = 1.0
+        if time > import_time_threshold:
+            exceptions.append(
+                f"Importing {import_statement} took too long: {time:.2f} seconds. Import time threshold: {import_time_threshold} seconds."
+            )
             break
 
     if time_taken_list:
         avg_time_taken = sum(time_taken_list) / len(time_taken_list)
         std_dev_time_taken = math.sqrt(sum((x - avg_time_taken) ** 2 for x in time_taken_list) / len(time_taken_list))
         times_list_str = ", ".join(f"{time:.2f}" for time in time_taken_list)
-        markdown_output += f"| `{import_statement}` | {avg_time_taken:.2f} | {std_dev_time_taken:.2f} | {times_list_str} |\n"
+        markdown_output += (
+            f"| `{import_statement}` | {avg_time_taken:.2f} | {std_dev_time_taken:.2f} | {times_list_str} |\n"
+        )
 
 if exceptions:
     raise Exception("\n".join(exceptions))

--- a/.github/import_test.py
+++ b/.github/import_test.py
@@ -48,9 +48,10 @@ for import_statement in import_statement_list:
         import_time_threshold = 2.0  # Most of the times is sub-second but there outliers
         if time >= import_time_threshold:
             exceptions.append(
-                f"Importing {import_statement} took: {time:.2f} seconds. Should be <: {import_time_threshold} seconds."
+                f"Importing {import_statement} took: {time:.2f} s. Should be <: {import_time_threshold} s."
             )
             break
+
 
     if time_taken_list:
         avg_time = sum(time_taken_list) / len(time_taken_list)
@@ -58,6 +59,11 @@ for import_statement in import_statement_list:
         times_list_str = ", ".join(f"{time:.2f}" for time in time_taken_list)
         markdown_output += f"| `{import_statement}` | {avg_time:.2f} | {std_time:.2f} | {times_list_str} |\n"
 
+        import_time_threshold = 1.0
+        if avg_time > import_time_threshold:
+            exceptions.append(
+                f"Importing {import_statement} took: {avg_time:.2f} s in average. Should be <: {import_time_threshold} s."
+            )
 
 if exceptions:
     raise Exception("\n".join(exceptions))

--- a/src/spikeinterface/extractors/bids.py
+++ b/src/spikeinterface/extractors/bids.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import numpy as np
 
-import neo
 import probeinterface
 
 from .nwbextractors import read_nwb
@@ -47,6 +46,8 @@ def read_bids(folder_path):
             recordings.append(rec)
 
         elif file_path.suffix == ".nix":
+            import neo
+
             neo_reader = neo.rawio.NIXRawIO(file_path)
             neo_reader.parse_header()
             stream_ids = neo_reader.header["signal_streams"]["id"]

--- a/src/spikeinterface/extractors/mcsh5extractors.py
+++ b/src/spikeinterface/extractors/mcsh5extractors.py
@@ -7,13 +7,6 @@ import numpy as np
 from spikeinterface.core import BaseRecording, BaseRecordingSegment
 from spikeinterface.core.core_tools import define_function_from_class
 
-try:
-    import h5py
-
-    HAVE_MCSH5 = True
-except ImportError:
-    HAVE_MCSH5 = False
-
 
 class MCSH5RecordingExtractor(BaseRecording):
     """Load a MCS H5 file as a recording extractor.
@@ -32,7 +25,6 @@ class MCSH5RecordingExtractor(BaseRecording):
     """
 
     extractor_name = "MCSH5Recording"
-    installed = HAVE_MCSH5  # check at class level if installed or not
     mode = "file"
     installation_mesg = (
         "To use the MCSH5RecordingExtractor install h5py: \n\n pip install h5py\n\n"  # error message when not installed
@@ -40,7 +32,14 @@ class MCSH5RecordingExtractor(BaseRecording):
     name = "mcsh5"
 
     def __init__(self, file_path, stream_id=0):
-        assert self.installed, self.installation_mesg
+
+        try:
+            import h5py
+
+            HAVE_MCSH5 = True
+        except ImportError:
+            raise ImportError(self.installation_mesg)
+
         self._file_path = file_path
 
         mcs_info = openMCSH5File(self._file_path, stream_id)
@@ -103,6 +102,8 @@ class MCSH5RecordingSegment(BaseRecordingSegment):
 
 def openMCSH5File(filename, stream_id):
     """Open an MCS hdf5 file, read and return the recording info."""
+    import h5py
+
     rf = h5py.File(filename, "r")
 
     stream_name = "Stream_" + str(stream_id)

--- a/src/spikeinterface/extractors/neoextractors/blackrock.py
+++ b/src/spikeinterface/extractors/neoextractors/blackrock.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from packaging import version
 from typing import Optional
 
-import neo
 
 from spikeinterface.core.core_tools import define_function_from_class
 
@@ -43,9 +42,8 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
         use_names_as_ids=False,
     ):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
-        if version.parse(neo.__version__) > version.parse("0.12.0"):
-            # do not load spike because this is slow but not released yet
-            neo_kwargs["load_nev"] = False
+        neo_kwargs["load_nev"] = False  # Avoid loading spikes release in neo 0.12.0
+
         # trick to avoid to select automatically the correct stream_id
         suffix = Path(file_path).suffix
         if ".ns" in suffix:

--- a/src/spikeinterface/extractors/neoextractors/spikeglx.py
+++ b/src/spikeinterface/extractors/neoextractors/spikeglx.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-from packaging import version
-
-import numpy as np
 from pathlib import Path
 
-import neo
 import probeinterface
 
 from spikeinterface.extractors.neuropixels_utils import get_neuropixels_sample_shifts

--- a/src/spikeinterface/sorters/internal/spyking_circus2.py
+++ b/src/spikeinterface/sorters/internal/spyking_circus2.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
-from operator import is_
 
 from .si_based import ComponentsBasedSorter
 
-import os
 import shutil
 import numpy as np
 
@@ -11,7 +9,6 @@ from spikeinterface.core import NumpySorting
 from spikeinterface.core.job_tools import fix_job_kwargs
 from spikeinterface.core.recording_tools import get_noise_levels
 from spikeinterface.core.template import Templates
-from spikeinterface.core.template_tools import get_template_extremum_amplitude
 from spikeinterface.core.waveform_tools import estimate_templates
 from spikeinterface.preprocessing import common_reference, whiten, bandpass_filter, correct_motion
 from spikeinterface.sortingcomponents.tools import cache_preprocessing

--- a/src/spikeinterface/widgets/utils.py
+++ b/src/spikeinterface/widgets/utils.py
@@ -3,14 +3,6 @@ from __future__ import annotations
 import numpy as np
 
 
-try:
-    import distinctipy
-
-    HAVE_DISTINCTIPY = True
-except ImportError:
-    HAVE_DISTINCTIPY = False
-
-
 def get_some_colors(
     keys, color_engine="auto", map_name="gist_ncar", format="RGBA", shuffle=None, seed=None, margin=None
 ):
@@ -47,6 +39,13 @@ def get_some_colors(
         HAVE_MPL = True
     except ImportError:
         HAVE_MPL = False
+
+    try:
+        import distinctipy
+
+        HAVE_DISTINCTIPY = True
+    except ImportError:
+        HAVE_DISTINCTIPY = False
 
     assert color_engine in ("auto", "distinctipy", "matplotlib", "colorsys")
 


### PR DESCRIPTION
Thanks to @zm711 whose profile helped in this [discussion](https://github.com/SpikeInterface/spikeinterface/issues/2957) to find out that import neo `import neo` imports scipy under the hood.

This should make the imports of the extractors module faster.

This should close #2957.

