### PR TITLE
Fix timestamps access in NWB extractor

### DIFF
--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -731,7 +731,7 @@ class NwbRecordingExtractor(BaseRecording):
             sampling_frequency = 1.0 / np.median(np.diff(timestamps[:samples_for_rate_estimation]))
 
         if load_time_vector and timestamps is not None:
-            times_kwargs = dict(time_vector=electrical_series.timestamps)
+            times_kwargs = dict(time_vector=electrical_series['timestamps'])
         else:
             times_kwargs = dict(sampling_frequency=sampling_frequency, t_start=t_start)
 

--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -731,7 +731,7 @@ class NwbRecordingExtractor(BaseRecording):
             sampling_frequency = 1.0 / np.median(np.diff(timestamps[:samples_for_rate_estimation]))
 
         if load_time_vector and timestamps is not None:
-            times_kwargs = dict(time_vector=electrical_series['timestamps'])
+            times_kwargs = dict(time_vector=electrical_series["timestamps"])
         else:
             times_kwargs = dict(sampling_frequency=sampling_frequency, t_start=t_start)
 


### PR DESCRIPTION
I'm getting `AttributeError: 'Group' object has no attribute 'timestamps'` error when accessing an NWB recording with explicit timestamps. This seems to resolve the error. 
