### PR TITLE
Add documentation to `frame_slice` in recording and drop redundant inheritance

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -657,7 +657,23 @@ class BaseRecording(BaseRecordingSnippets):
         sub_recording = ChannelSliceRecording(self, new_channel_ids)
         return sub_recording
 
-    def _frame_slice(self, start_frame, end_frame):
+    def frame_slice(self, start_frame: int, end_frame: int) -> BaseRecording:
+        """
+        Returns a new recording with sliced frames. Note that this operation is not in place.
+
+        Parameters
+        ----------
+        start_frame : int
+            The start frame
+        end_frame : int
+            The end frame
+
+        Returns
+        -------
+        BaseRecording
+            The object with sliced frames
+        """
+
         from .frameslicerecording import FrameSliceRecording
 
         sub_recording = FrameSliceRecording(self, start_frame=start_frame, end_frame=end_frame)

--- a/src/spikeinterface/core/baserecordingsnippets.py
+++ b/src/spikeinterface/core/baserecordingsnippets.py
@@ -78,9 +78,6 @@ class BaseRecordingSnippets(BaseExtractor):
     def _channel_slice(self, channel_ids, renamed_channel_ids=None):
         raise NotImplementedError
 
-    def _frame_slice(self, channel_ids, renamed_channel_ids=None):
-        raise NotImplementedError
-
     def set_probe(self, probe, group_mode="by_probe", in_place=False):
         """
         Attach a list of Probe object to a recording.
@@ -513,7 +510,7 @@ class BaseRecordingSnippets(BaseExtractor):
         BaseRecordingSnippets
             The object with sliced frames
         """
-        return self._frame_slice(start_frame, end_frame)
+        raise NotImplementedError
 
     def select_segments(self, segment_indices):
         """

--- a/src/spikeinterface/core/basesnippets.py
+++ b/src/spikeinterface/core/basesnippets.py
@@ -142,6 +142,7 @@ class BaseSnippets(BaseRecordingSnippets):
 
     def _channel_slice(self, channel_ids, renamed_channel_ids=None):
         from .channelslice import ChannelSliceSnippets
+        import warnings
 
         warnings.warn(
             "Snippets.channel_slice will be removed in version 0.103, use `select_channels` or `rename_channels` instead.",
@@ -157,9 +158,6 @@ class BaseSnippets(BaseRecordingSnippets):
         new_channel_ids = self.channel_ids[~np.isin(self.channel_ids, remove_channel_ids)]
         sub_recording = ChannelSliceSnippets(self, new_channel_ids)
         return sub_recording
-
-    def _frame_slice(self, start_frame, end_frame):
-        raise NotImplementedError
 
     def _select_segments(self, segment_indices):
         from .segmentutils import SelectSegmentSnippets


### PR DESCRIPTION
From a comment in https://github.com/SpikeInterface/spikeinterface/pull/2977#issuecomment-2154864078 but for frame_slice.
 
This method is defined is only for base recording but then it points to `BaseRecordingSnippets` where the method is not implemented. This makes it harder for navigation when reading the code base for no benefit.

This PR defined overides the method in `BaseRecording` keeping the behavior in `BaseSnipets` and `BaseRecordingSnippets` the same as before. It also adds documentation to the function.


