### PR TITLE
Avoid redirection to not implemented method in `BaseRecording.select_channels`

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -605,7 +605,7 @@ class BaseRecording(BaseRecordingSnippets):
             if time_vector is not None:
                 np.save(folder / f"times_cached_seg{segment_index}.npy", time_vector)
 
-    def _select_channels(self, channel_ids: list | np.array | tuple) -> "BaseRecording":
+    def select_channels(self, channel_ids: list | np.array | tuple) -> "BaseRecording":
         """
         Returns a new recording object with a subset of channels.
 

--- a/src/spikeinterface/core/baserecordingsnippets.py
+++ b/src/spikeinterface/core/baserecordingsnippets.py
@@ -72,9 +72,6 @@ class BaseRecordingSnippets(BaseExtractor):
         # the is_filtered is handle with annotation
         return self._annotations.get("is_filtered", False)
 
-    def _select_channels(self, channel_ids: list | np.array | tuple) -> "BaseRecordingSnippets":
-        raise NotImplementedError
-
     def _channel_slice(self, channel_ids, renamed_channel_ids=None):
         raise NotImplementedError
 
@@ -478,7 +475,7 @@ class BaseRecordingSnippets(BaseExtractor):
         BaseRecordingSnippets
             The object with sliced channels
         """
-        return self._select_channels(channel_ids)
+        raise NotImplementedError
 
     def remove_channels(self, remove_channel_ids):
         """

--- a/src/spikeinterface/core/basesnippets.py
+++ b/src/spikeinterface/core/basesnippets.py
@@ -135,13 +135,14 @@ class BaseSnippets(BaseRecordingSnippets):
     def _save(self, format="binary", **save_kwargs):
         raise NotImplementedError
 
-    def _select_channels(self, channel_ids: list | np.array | tuple) -> "BaseSnippets":
+    def select_channels(self, channel_ids: list | np.array | tuple) -> "BaseSnippets":
         from .channelslice import ChannelSliceSnippets
 
         return ChannelSliceSnippets(self, channel_ids)
 
     def _channel_slice(self, channel_ids, renamed_channel_ids=None):
         from .channelslice import ChannelSliceSnippets
+        import warnings
 
         warnings.warn(
             "Snippets.channel_slice will be removed in version 0.103, use `select_channels` or `rename_channels` instead.",


### PR DESCRIPTION
A continuation from https://github.com/SpikeInterface/spikeinterface/pull/2977 because I did not want to stop @DradeAW aurelien's job which was to get rid of an unfair warning.


As mentioned in the other discussion the current approach has the drawback of making the function harder to document (you don't get the docstring of the function correspondign to BaseRecording) plus it makes navigation harder. You click on the method and instead you get to `BaseRecordingSnippets` where the method is not implemented. All of that for no aparent gain (maybe I am wrong here?).

This PR fixes this.
