### PR TITLE
Remove get_template_extremum_channel from spikelocations init

### DIFF
--- a/src/spikeinterface/postprocessing/spike_locations.py
+++ b/src/spikeinterface/postprocessing/spike_locations.py
@@ -59,9 +59,6 @@ class ComputeSpikeLocations(AnalyzerExtension):
     def __init__(self, sorting_analyzer):
         AnalyzerExtension.__init__(self, sorting_analyzer)
 
-        extremum_channel_inds = get_template_extremum_channel(self.sorting_analyzer, outputs="index")
-        self.spikes = self.sorting_analyzer.sorting.to_spike_vector(extremum_channel_inds=extremum_channel_inds)
-
     def _set_params(
         self,
         ms_before=0.5,
@@ -89,8 +86,9 @@ class ComputeSpikeLocations(AnalyzerExtension):
     def _select_extension_data(self, unit_ids):
         old_unit_ids = self.sorting_analyzer.unit_ids
         unit_inds = np.flatnonzero(np.isin(old_unit_ids, unit_ids))
+        spikes = self.sorting_analyzer.sorting.to_spike_vector()
 
-        spike_mask = np.isin(self.spikes["unit_index"], unit_inds)
+        spike_mask = np.isin(spikes["unit_index"], unit_inds)
         new_spike_locations = self.data["spike_locations"][spike_mask]
         return dict(spike_locations=new_spike_locations)
 


### PR DESCRIPTION
Fixes #3010

Removes `get_template_extremum_channel`, and hence the dependency on the `templates` extension, from the `SpikeLocations` init. It looks like we don't need to saves `spikes` at all in the extensions, I completely removed this line (this is similar to `ComputeSpikeAmplitudes`). @samuelgarcia can you double check this?

Note for #2984, on how to test this. The problem here was that `SpikeLocations` couldn't be initialised without `Templates` being present. To test this we could add something to the `AnalyzerExtensionCommonTestSuite`. Perhaps at the end, we could delete all extensions except the one we're interested in, then save it and load it. This would test that each extension can be saved loaded independent of what other extensions exist? @JoeZiminski thoughts?