### PR TITLE
Remove scipy upper bound for streaming extractors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ extractors = [
     "pyedflib>=0.1.30",
     "sonpy;python_version<'3.10'",
     "lxml", # lxml for neuroscope
-    "scipy<1.13",
+    "scipy",
     "ONE-api>=2.7.0", # alf sorter and streaming IBL
     "ibllib>=2.32.5", # streaming IBL
     "pymatreader>=0.0.32", # For cell explorer matlab files
@@ -75,8 +75,6 @@ extractors = [
 streaming_extractors = [
     "ONE-api>=2.7.0", # alf sorter and streaming IBL
     "ibllib>=2.32.5", # streaming IBL
-    "scipy<1.13", # ibl has a dependency on scipy but it does not have an upper bound
-    # Remove this once https://github.com/int-brain-lab/ibllib/issues/753
     # Following dependencies are for streaming with nwb files
     "pynwb>=2.6.0",
     "fsspec",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ extractors = [
     "lxml", # lxml for neuroscope
     "scipy",
     "ONE-api>=2.7.0", # alf sorter and streaming IBL
-    "ibllib>=2.32.5", # streaming IBL
+    "ibllib>=2.36.0", # streaming IBL
     "pymatreader>=0.0.32", # For cell explorer matlab files
     "zugbruecke>=0.2; sys_platform!='win32'", # For plexon2
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ extractors = [
 
 streaming_extractors = [
     "ONE-api>=2.7.0", # alf sorter and streaming IBL
-    "ibllib>=2.32.5", # streaming IBL
+    "ibllib>=2.36.0", # streaming IBL
     # Following dependencies are for streaming with nwb files
     "pynwb>=2.6.0",
     "fsspec",


### PR DESCRIPTION
This was solved:
https://github.com/int-brain-lab/ibllib/issues/753#event-13133745384