### PR TITLE
Add more container dependency checks in `run_sorter`

### DIFF
--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -181,13 +181,11 @@ def run_sorter(
 
             if not has_docker():
                 raise RuntimeError(
-                    "Docker is not installed. Install docker " "on this machine to run sorting with docker."
+                    "Docker is not installed. Install docker on this machine to run sorting with docker."
                 )
 
             if not has_docker_python():
-                raise RuntimeError(
-                    "The python `docker` package must be installed. " "Install with `pip install docker`"
-                )
+                raise RuntimeError("The python `docker` package must be installed. Install with `pip install docker`")
 
         else:
             mode = "singularity"

--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -169,6 +169,15 @@ def run_sorter(
                 container_image = None
             else:
                 container_image = docker_image
+
+            if not has_docker():
+                raise RuntimeError("Docker is not installed. Install docker "
+                                   "on this machine to run sorting with docker.")
+
+            if not has_docker_python():
+                raise RuntimeError("The python `docker` package must be installed."
+                                   "Install with `pip install docker`")
+
         else:
             mode = "singularity"
             assert not docker_image
@@ -176,6 +185,15 @@ def run_sorter(
                 container_image = None
             else:
                 container_image = singularity_image
+
+            if not has_singularity():
+                raise RuntimeError("Singularity is not installed. Install singularity "
+                                   "on this machine to run sorting with singularity.")
+
+            if not has_spython():
+                raise RuntimeError("The python singularity package must be installed."
+                                   "Install with `pip install spython`")
+
         return run_sorter_container(
             container_image=container_image,
             mode=mode,

--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -494,7 +494,7 @@ if __name__ == '__main__':
             assert has_nvidia(), "The container requires a NVIDIA GPU capability, but it is not available"
             extra_kwargs["container_requires_gpu"] = True
 
-            if platform.system() == "Linux" and has_docker_nvidia_installed():
+            if platform.system() == "Linux" and not has_docker_nvidia_installed():
                 warn(
                     f"nvidia-required but none of \n{get_nvidia_docker_dependecies()}\n were found. "
                     f"This may result in an error being raised during sorting. Try "

--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -19,7 +19,7 @@ from .. import __version__ as si_version
 from ..core import BaseRecording, NumpySorting, load_extractor
 from ..core.core_tools import check_json, is_editable_mode
 from .sorterlist import sorter_dict
-from .utils import SpikeSortingError, has_nvidia
+from .utils import SpikeSortingError, has_nvidia, has_docker, has_docker_python, has_singularity, has_spython, has_docker_nvidia_installed, get_nvidia_docker_dependecies
 from .container_tools import (
     find_recording_folders,
     path_to_unix,
@@ -175,7 +175,7 @@ def run_sorter(
                                    "on this machine to run sorting with docker.")
 
             if not has_docker_python():
-                raise RuntimeError("The python `docker` package must be installed."
+                raise RuntimeError("The python `docker` package must be installed. "
                                    "Install with `pip install docker`")
 
         else:
@@ -191,8 +191,8 @@ def run_sorter(
                                    "on this machine to run sorting with singularity.")
 
             if not has_spython():
-                raise RuntimeError("The python singularity package must be installed."
-                                   "Install with `pip install spython`")
+                raise RuntimeError("The python `spython` package must be installed to "
+                                   "run singularity. Install with `pip install spython`")
 
         return run_sorter_container(
             container_image=container_image,
@@ -480,6 +480,15 @@ if __name__ == '__main__':
         if gpu_capability == "nvidia-required":
             assert has_nvidia(), "The container requires a NVIDIA GPU capability, but it is not available"
             extra_kwargs["container_requires_gpu"] = True
+
+            if platform.system() == "Linux" and has_docker_nvidia_installed():
+                warn(
+                    f"nvidia-required but none of \n{get_nvidia_docker_dependecies()}\n were found. "
+                    f"This may result in an error being raised during sorting. Try "
+                    "installing `nvidia-container-toolkit`, including setting the "
+                    "configuration steps, if running into errors."
+                )
+
         elif gpu_capability == "nvidia-optional":
             if has_nvidia():
                 extra_kwargs["container_requires_gpu"] = True

--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -19,7 +19,18 @@ from .. import __version__ as si_version
 from ..core import BaseRecording, NumpySorting, load_extractor
 from ..core.core_tools import check_json, is_editable_mode
 from .sorterlist import sorter_dict
-from .utils import SpikeSortingError, has_nvidia, has_docker, has_docker_python, has_singularity, has_spython, has_docker_nvidia_installed, get_nvidia_docker_dependecies
+
+# full import required for monkeypatch testing.
+from spikeinterface.sorters.utils import (
+    SpikeSortingError,
+    has_nvidia,
+    has_docker,
+    has_docker_python,
+    has_singularity,
+    has_spython,
+    has_docker_nvidia_installed,
+    get_nvidia_docker_dependecies,
+)
 from .container_tools import (
     find_recording_folders,
     path_to_unix,
@@ -171,12 +182,14 @@ def run_sorter(
                 container_image = docker_image
 
             if not has_docker():
-                raise RuntimeError("Docker is not installed. Install docker "
-                                   "on this machine to run sorting with docker.")
+                raise RuntimeError(
+                    "Docker is not installed. Install docker " "on this machine to run sorting with docker."
+                )
 
             if not has_docker_python():
-                raise RuntimeError("The python `docker` package must be installed. "
-                                   "Install with `pip install docker`")
+                raise RuntimeError(
+                    "The python `docker` package must be installed. " "Install with `pip install docker`"
+                )
 
         else:
             mode = "singularity"
@@ -187,12 +200,16 @@ def run_sorter(
                 container_image = singularity_image
 
             if not has_singularity():
-                raise RuntimeError("Singularity is not installed. Install singularity "
-                                   "on this machine to run sorting with singularity.")
+                raise RuntimeError(
+                    "Singularity is not installed. Install singularity "
+                    "on this machine to run sorting with singularity."
+                )
 
             if not has_spython():
-                raise RuntimeError("The python `spython` package must be installed to "
-                                   "run singularity. Install with `pip install spython`")
+                raise RuntimeError(
+                    "The python `spython` package must be installed to "
+                    "run singularity. Install with `pip install spython`"
+                )
 
         return run_sorter_container(
             container_image=container_image,

--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -19,9 +19,7 @@ from .. import __version__ as si_version
 from ..core import BaseRecording, NumpySorting, load_extractor
 from ..core.core_tools import check_json, is_editable_mode
 from .sorterlist import sorter_dict
-
-# full import required for monkeypatch testing.
-from spikeinterface.sorters.utils import (
+from .utils import (
     SpikeSortingError,
     has_nvidia,
     has_docker,

--- a/src/spikeinterface/sorters/tests/test_runsorter_dependency_checks.py
+++ b/src/spikeinterface/sorters/tests/test_runsorter_dependency_checks.py
@@ -13,7 +13,7 @@ import copy
 
 def _monkeypatch_return_false():
     """
-    A function to monkeypatch the `has_<dependecy>` functions,
+    A function to monkeypatch the `has_<dependency>` functions,
     ensuring the always return `False` at runtime.
     """
     return False
@@ -61,12 +61,12 @@ class TestRunersorterDependencyChecks:
     @pytest.fixture(scope="function")
     def uninstall_python_dependency(self, request):
         """
-        This python fixture mocks python modules not been importable
+        This python fixture mocks python modules not being importable
         by setting the relevant `sys.modules` dict entry to `None`.
-        It uses `yeild` so that the function can tear-down the test
+        It uses `yield` so that the function can tear-down the test
         (even if it failed) and replace the patched `sys.module` entry.
 
-        This function uses an `indirect` parameterisation, meaning the
+        This function uses an `indirect` parameterization, meaning the
         `request.param` is passed to the fixture at the start of the
         test function. This is used to reuse code for nearly identical
         `spython` and `docker` python dependency tests.

--- a/src/spikeinterface/sorters/tests/test_runsorter_dependency_checks.py
+++ b/src/spikeinterface/sorters/tests/test_runsorter_dependency_checks.py
@@ -1,0 +1,144 @@
+import os
+import pytest
+from pathlib import Path
+import shutil
+import platform
+from spikeinterface import generate_ground_truth_recording
+from spikeinterface.sorters.utils import has_spython, has_docker_python
+from spikeinterface.sorters import run_sorter
+import subprocess
+import sys
+import copy
+
+
+def _monkeypatch_return_false():
+    return False
+
+
+class TestRunersorterDependencyChecks:
+    """
+    This class performs tests to check whether expected
+    dependency checks prior to sorting are run. The
+    run_sorter function should raise an error if:
+        - singularity is not installed
+        - spython is not installed (python package)
+        - docker is not installed
+        - docker is not installed (python package)
+    when running singularity / docker respectively.
+
+    Two separate checks should be run. First, that the
+    relevant `has_<dependency>` function (indicating if the dependency
+    is installed) is working. Unfortunately it is not possible to
+    easily test this core singularity and docker installs, so this is not done.
+    `uninstall_python_dependency()` allows a test to check if the
+    `has_spython()` and `has_docker_dependency()` return `False` as expected
+    when these python modules are not installed.
+
+    Second, the `run_sorters()` function should return the appropriate error
+    when these functions return that the dependency is not available. This is
+    easier to test as these `has_<dependency>` reporting functions can be
+    monkeypatched to return False at runtime. This is done for these 4
+    dependency checks, and tests check the expected error is raised.
+
+    Notes
+    ----
+    `has_nvidia()` and `has_docker_nvidia_installed()` are not tested
+    as these are complex GPU-related dependencies which are difficult to mock.
+    """
+
+    @pytest.fixture(scope="function")
+    def uninstall_python_dependency(self, request):
+        """
+        This python fixture mocks python modules not been importable
+        by setting the relevant `sys.modules` dict entry to `None`.
+        It uses `yeild` so that the function can tear-down the test
+        (even if it failed) and replace the patched `sys.module` entry.
+
+        This function uses an `indirect` parameterisation, meaning the
+        `request.param` is passed to the fixture at the start of the
+        test function. This is used to reuse code for nearly identical
+        `spython` and `docker` python dependency tests.
+        """
+        dep_name = request.param
+        assert dep_name in ["spython", "docker"]
+
+        try:
+            if dep_name == "spython":
+                import spython
+            else:
+                import docker
+            dependency_installed = True
+        except:
+            dependency_installed = False
+
+        if dependency_installed:
+            copy_import = sys.modules[dep_name]
+            sys.modules[dep_name] = None
+        yield
+        if dependency_installed:
+            sys.modules[dep_name] = copy_import
+
+    @pytest.fixture(scope="session")
+    def recording(self):
+        """
+        Make a small recording to have something to pass to the sorter.
+        """
+        recording, _ = generate_ground_truth_recording(durations=[10])
+        return recording
+
+    @pytest.mark.skipif(platform.system() != "Linux", reason="spython install only for Linux.")
+    @pytest.mark.parametrize("uninstall_python_dependency", ["spython"], indirect=True)
+    def test_has_spython(self, recording, uninstall_python_dependency):
+        """
+        Test the `has_spython()` function, see class docstring and
+        `uninstall_python_dependency()` for details.
+        """
+        assert has_spython() is False
+
+    @pytest.mark.parametrize("uninstall_python_dependency", ["docker"], indirect=True)
+    def test_has_docker_python(self, recording, uninstall_python_dependency):
+        """
+        Test the `has_docker_python()` function, see class docstring and
+        `uninstall_python_dependency()` for details.
+        """
+        assert has_docker_python() is False
+
+    @pytest.mark.parametrize("dependency", ["singularity", "spython"])
+    def test_has_singularity_and_spython(self, recording, monkeypatch, dependency):
+        """
+        When running a sorting, if singularity dependencies (singularity
+        itself or the `spython` package`) are not installed, an error is raised.
+        Beacause it is hard to actually uninstall these dependencies, the
+        `has_<dependency>` functions that let `run_sorter` know if the dependency
+        are installed are monkeypatched. This is done so at runtime these always
+        return False. Then, test the expected error is raised when the dependency
+        is not found.
+        """
+        test_func = f"has_{dependency}"
+
+        monkeypatch.setattr(f"spikeinterface.sorters.runsorter.{test_func}", _monkeypatch_return_false)
+        with pytest.raises(RuntimeError) as e:
+            run_sorter("kilosort2_5", recording, singularity_image=True)
+
+        if dependency == "spython":
+            assert "The python `spython` package must be installed" in str(e)
+        else:
+            assert "Singularity is not installed." in str(e)
+
+    @pytest.mark.parametrize("dependency", ["docker", "docker_python"])
+    def test_has_docker_and_docker_python(self, recording, monkeypatch, dependency):
+        """
+        See `test_has_singularity_and_spython()` for details. This test
+        is almost identical, but with some key changes for Docker.
+        """
+        test_func = f"has_{dependency}"
+
+        monkeypatch.setattr(f"spikeinterface.sorters.runsorter.{test_func}", _monkeypatch_return_false)
+
+        with pytest.raises(RuntimeError) as e:
+            run_sorter("kilosort2_5", recording, docker_image=True)
+
+        if dependency == "docker_python":
+            assert "The python `docker` package must be installed" in str(e)
+        else:
+            assert "Docker is not installed." in str(e)

--- a/src/spikeinterface/sorters/tests/test_runsorter_dependency_checks.py
+++ b/src/spikeinterface/sorters/tests/test_runsorter_dependency_checks.py
@@ -12,6 +12,10 @@ import copy
 
 
 def _monkeypatch_return_false():
+    """
+    A function to monkeypatch the `has_<dependecy>` functions,
+    ensuring the always return `False` at runtime.
+    """
     return False
 
 

--- a/src/spikeinterface/sorters/tests/test_runsorter_dependency_checks.py
+++ b/src/spikeinterface/sorters/tests/test_runsorter_dependency_checks.py
@@ -20,14 +20,18 @@ def _monkeypatch_return_false():
 
 
 def _monkeypatch_return_true():
+    """
+    Monkeypatch for some `has_<dependency>` functions to
+    return `True` so functions that are later in the
+    `runsorter` code can be checked.
+    """
     return True
 
 
 class TestRunersorterDependencyChecks:
     """
-    This class performs tests to check whether expected
-    dependency checks prior to sorting are run. The
-    run_sorter function should raise an error if:
+    This class tests whether expected dependency checks prior to sorting are run.
+    The run_sorter function should raise an error if:
         - singularity is not installed
         - spython is not installed (python package)
         - docker is not installed

--- a/src/spikeinterface/sorters/tests/test_runsorter_dependency_checks.py
+++ b/src/spikeinterface/sorters/tests/test_runsorter_dependency_checks.py
@@ -95,7 +95,6 @@ class TestRunersorterDependencyChecks:
         return recording
 
     @pytest.mark.skipif(platform.system() != "Linux", reason="spython install only for Linux.")
-    @pytest.mark.skipif(not has_singularity(), reason="singularity required for this test.")
     @pytest.mark.parametrize("uninstall_python_dependency", ["spython"], indirect=True)
     def test_has_spython(self, recording, uninstall_python_dependency):
         """
@@ -105,7 +104,6 @@ class TestRunersorterDependencyChecks:
         assert has_spython() is False
 
     @pytest.mark.parametrize("uninstall_python_dependency", ["docker"], indirect=True)
-    @pytest.mark.skipif(not has_docker(), reason="docker required for this test.")
     def test_has_docker_python(self, recording, uninstall_python_dependency):
         """
         Test the `has_docker_python()` function, see class docstring and

--- a/src/spikeinterface/sorters/utils/__init__.py
+++ b/src/spikeinterface/sorters/utils/__init__.py
@@ -1,2 +1,2 @@
 from .shellscript import ShellScript
-from .misc import SpikeSortingError, get_git_commit, has_nvidia, get_matlab_shell_name, get_bash_path
+from .misc import SpikeSortingError, get_git_commit, has_nvidia, get_matlab_shell_name, get_bash_path, has_docker, has_docker_python, has_singularity, has_spython, has_docker_nvidia_installed, get_nvidia_docker_dependecies

--- a/src/spikeinterface/sorters/utils/__init__.py
+++ b/src/spikeinterface/sorters/utils/__init__.py
@@ -1,2 +1,14 @@
 from .shellscript import ShellScript
-from .misc import SpikeSortingError, get_git_commit, has_nvidia, get_matlab_shell_name, get_bash_path, has_docker, has_docker_python, has_singularity, has_spython, has_docker_nvidia_installed, get_nvidia_docker_dependecies
+from .misc import (
+    SpikeSortingError,
+    get_git_commit,
+    has_nvidia,
+    get_matlab_shell_name,
+    get_bash_path,
+    has_docker,
+    has_docker_python,
+    has_singularity,
+    has_spython,
+    has_docker_nvidia_installed,
+    get_nvidia_docker_dependecies,
+)

--- a/src/spikeinterface/sorters/utils/misc.py
+++ b/src/spikeinterface/sorters/utils/misc.py
@@ -96,7 +96,10 @@ def has_docker():
 
 
 def has_singularity():
-    return _run_subprocess_silently("singularity --version").returncode == 0 or _run_subprocess_silently("apptainer --version").returncode == 0
+    return (
+        _run_subprocess_silently("singularity --version").returncode == 0
+        or _run_subprocess_silently("apptainer --version").returncode == 0
+    )
 
 
 def has_docker_nvidia_installed():

--- a/src/spikeinterface/sorters/utils/misc.py
+++ b/src/spikeinterface/sorters/utils/misc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess  # TODO: decide best format for this
 from subprocess import check_output, CalledProcessError
 from typing import List, Union
 
@@ -79,4 +80,34 @@ def has_nvidia():
         cu_result_device_count, device_count = cuda.cuDeviceGetCount()
         return device_count > 0
     except RuntimeError:  #  Failed to dlopen libcuda.so
+        return False
+
+def _run_subprocess_silently(command):
+    output = subprocess.run(
+        command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+    return output
+
+
+def has_docker():
+    return self._run_subprocess_silently("docker --version").returncode == 0
+
+
+def has_singularity():
+    return self._run_subprocess_silently("singularity --version").returncode == 0
+
+
+def has_docker_python():
+    try:
+        import docker
+        return True
+    except ImportError:
+        return False
+
+
+def has_spython():
+    try:
+        import spython
+        return True
+    except ImportError:
         return False

--- a/src/spikeinterface/sorters/utils/misc.py
+++ b/src/spikeinterface/sorters/utils/misc.py
@@ -119,7 +119,7 @@ def has_docker_nvidia_installed():
     has_dep = []
     for dep in all_dependencies:
         has_dep.append(_run_subprocess_silently(f"{dep} --version").returncode == 0)
-    return not any(has_dep)
+    return any(has_dep)
 
 
 def get_nvidia_docker_dependecies():

--- a/src/spikeinterface/sorters/utils/misc.py
+++ b/src/spikeinterface/sorters/utils/misc.py
@@ -96,7 +96,7 @@ def has_docker():
 
 
 def has_singularity():
-    return _run_subprocess_silently("singularity --version").returncode == 0
+    return _run_subprocess_silently("singularity --version").returncode == 0 or _run_subprocess_silently("apptainer --version").returncode == 0
 
 
 def has_docker_nvidia_installed():

--- a/src/spikeinterface/sorters/utils/misc.py
+++ b/src/spikeinterface/sorters/utils/misc.py
@@ -82,6 +82,7 @@ def has_nvidia():
     except RuntimeError:  #  Failed to dlopen libcuda.so
         return False
 
+
 def _run_subprocess_silently(command):
     output = subprocess.run(
         command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
@@ -90,12 +91,27 @@ def _run_subprocess_silently(command):
 
 
 def has_docker():
-    return self._run_subprocess_silently("docker --version").returncode == 0
+    return _run_subprocess_silently("docker --version").returncode == 0
 
 
 def has_singularity():
-    return self._run_subprocess_silently("singularity --version").returncode == 0
+    return _run_subprocess_silently("singularity --version").returncode == 0
 
+def get_nvidia_docker_dependecies():
+    return [
+        "nvidia-docker",
+        "nvidia-docker2",
+        "nvidia-container-toolkit",
+    ]
+
+def has_docker_nvidia_installed():
+    all_dependencies = get_nvidia_docker_dependecies()
+    has_dep = []
+    for dep in all_dependencies:
+        has_dep.append(
+            _run_subprocess_silently(f"{dep} --version").returncode == 0
+        )
+    return not any(has_dep)
 
 def has_docker_python():
     try:


### PR DESCRIPTION
This PR closes #2855 by adding in additional checks on container and GPU dependencies when running `run_sorter()`. 

It adds checks that `docker` or `singularity` are installed (if running sorter with `docker` or `singularity` respectively) and also that the corresponding python packages `docker` and `spython` are installed. It also show a warning if, on Linux, some nvidia-docker tools are not available, which  are usually necessary. See #2855 for a disucssion, but these nvidia-docker dependencies are a little complex so instead of raising an error, only a warning is shown.

I tested all locally and they work okay. It is not easy to test these nvidia-docker checks in code and so have left these, they raise only a warning anyway. The tests are a little bit 'extra', in particulary testing `has_docker_python()` and `has_spython()`. This patches `sys.module` to pretend like these modules are not available, then checks these `has_<dependency>`  functions return `False`. However, these tests are a little bit complex and add a reasonable amount of code to check what is basically a try/except function so although it's nice to test as much as possible, would be happy to remove if the maintenance burden is too high.

The other tests check that at runtime, `run_sorter` raises the appropriate error when the `has_<dependency>` functions return `False`. This is achieved by 'monkeypatching' these `has_<dependency>` functions so they return `False` at runtime. Then it can be checked that `run_sorter` is raising the correct error. I think these tests are more valuable, are less complex that the tests discussed above.
