### PR TITLE
Make sure we check `is_filtered()` rather than bound method during run basesorter

### DIFF
--- a/src/spikeinterface/sorters/basesorter.py
+++ b/src/spikeinterface/sorters/basesorter.py
@@ -183,7 +183,7 @@ class BaseSorter:
         # custom check params
         params = cls._check_params(recording, output_folder, params)
         # common check : filter warning
-        if recording.is_filtered and cls._check_apply_filter_in_params(params) and verbose:
+        if recording.is_filtered() and cls._check_apply_filter_in_params(params) and verbose:
             print(f"Warning! The recording is already filtered, but {cls.sorter_name} filter is enabled")
 
         # dump parameters inside the folder with json

--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -120,7 +120,6 @@ class Mountainsort5Sorter(BaseSorter):
     @classmethod
     def _run_from_folder(cls, sorter_output_folder, params, verbose):
         import mountainsort5 as ms5
-        from mountainsort5.util import create_cached_recording
 
         recording = cls.load_recording_from_folder(sorter_output_folder.parent, with_warnings=False)
         if recording is None:


### PR DESCRIPTION
This is a bug that has both bothered me and not been annoying enough for me to hunt it down until now.  :)

also cleaned up an import in mountainsort.



Since we just check that the `is_filtered` method exists it always returns `True` even if a recording is not filtered and then says that the sorter is filtered over the filter. This switches it to the actual check instead :)