### PR TITLE
Update cron job for `installation_tips`

### DIFF
--- a/.github/workflows/installation-tips-test.yml
+++ b/.github/workflows/installation-tips-test.yml
@@ -28,8 +28,9 @@ jobs:
       with:
         python-version: '3.10'
     - name: Test Conda Environment Creation
-      uses: conda-incubator/setup-miniconda@v2.2.0
+      uses: conda-incubator/setup-miniconda@v3
       with:
+        miniconda-version: "latest"
         environment-file: ./installation_tips/full_spikeinterface_environment_${{ matrix.label }}.yml
         activate-environment: si_env
     - name: Check Installation Tips


### PR DESCRIPTION
The mac install has been failing for the past few months.... Based on the instructions it seems like the solution is to 
provide miniconda version so it is downloaded for safety on Mac.

https://github.com/conda-incubator/setup-miniconda

Also updated to v3. Not sure if we want me to switch to push to test or if we just want to merge and then fix after the next cron job if there is a problem? 