### PR TITLE
Add force_recompute to SortingAnalyzer.compute

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -957,8 +957,8 @@ class SortingAnalyzer:
             If not then the extension will only live in memory as long as the object is deleted.
             save=False is convenient to try some parameters without changing an already saved extension.
 
-        **kwargs:
-            All other kwargs are transmitted to extension.set_params() or job_kwargs
+        **kwargs: keyword arguments
+            All other keyword arguments are transmitted to extension.set_params() or job_kwargs
 
         Returns
         -------
@@ -1033,7 +1033,7 @@ class SortingAnalyzer:
             If True, the extension is recomputed even if it has already been computed with the provided parameters.
             If False, the extension is not recomputed if it has already been computed with the provided parameters.
         **job_kwargs : keyword arguments
-            All other kwargs are transmitted to job_kwargs
+            All other keyword arguments are transmitted to job_kwargs
 
         Returns
         -------

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -887,7 +887,7 @@ class SortingAnalyzer:
             If True, the extension is recomputed even if it has already been computed with the provided parameters.
             If False, the extension is not recomputed if it has already been computed with the provided parameters.
         **kwargs:
-            All other kwargs are transmitted to extension.set_params() (if input is a string) or job_kwargs
+            All other keyword arguments are transmitted to extension.set_params() (if input is a string) or job_kwargs
 
         Returns
         -------

--- a/src/spikeinterface/core/tests/test_analyzer_extension_core.py
+++ b/src/spikeinterface/core/tests/test_analyzer_extension_core.py
@@ -218,7 +218,7 @@ def test_delete_on_recompute(create_cache_folder):
     sorting_analyzer.compute("templates")
 
     # re compute random_spikes should delete waveforms and templates
-    sorting_analyzer.compute("random_spikes")
+    sorting_analyzer.compute("random_spikes", force_recompute=True)
     assert sorting_analyzer.get_extension("templates") is None
     assert sorting_analyzer.get_extension("waveforms") is None
 

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -108,6 +108,20 @@ def test_SortingAnalyzer_zarr(tmp_path, dataset):
     )
 
 
+def test_recompute(dataset):
+    recording, sorting = dataset
+    sorting_analyzer = create_sorting_analyzer(sorting, recording, format="memory", sparse=False)
+
+    ext1 = sorting_analyzer.compute("dummy", param1=5.5)
+    ext2 = sorting_analyzer.compute("dummy", param1=5.5)
+    assert id(ext1) == id(ext2)
+
+    ext3 = sorting_analyzer.compute("dummy", param1=5.6)
+    assert id(ext1) != id(ext3)
+    ext4 = sorting_analyzer.compute("dummy", param1=5.6, force_recompute=True)
+    assert id(ext3) == id(ext4)
+
+
 def test_SortingAnalyzer_tmp_recording(dataset):
     recording, sorting = dataset
     recording_cached = recording.save(mode="memory")

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -119,7 +119,7 @@ def test_recompute(dataset):
     ext3 = sorting_analyzer.compute("dummy", param1=5.6)
     assert id(ext1) != id(ext3)
     ext4 = sorting_analyzer.compute("dummy", param1=5.6, force_recompute=True)
-    assert id(ext3) == id(ext4)
+    assert id(ext3) != id(ext4)
 
 
 def test_SortingAnalyzer_tmp_recording(dataset):


### PR DESCRIPTION
This is for avoiding recomputing extensions when they are:
- already computed
- have the same parameters
This also avoids deleting dependent extensions by mistake!

A `force_recompute` option is added to  override this behavior

Partially addresses #3031