### PR TITLE
Propagate FrameSlice default behavior to frame_slice and time_slice

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -45,7 +45,6 @@ class BaseRecording(BaseRecordingSnippets):
         self.annotate(is_filtered=False)
 
     def __repr__(self):
-
         extractor_name = self.__class__.__name__
         num_segments = self.get_num_segments()
 
@@ -182,7 +181,7 @@ class BaseRecording(BaseRecordingSnippets):
         self._recording_segments.append(recording_segment)
         recording_segment.set_parent_extractor(self)
 
-    def get_num_samples(self, segment_index=None) -> int:
+    def get_num_samples(self, segment_index: int | None = None) -> int:
         """
         Returns the number of samples for a segment.
 
@@ -657,21 +656,21 @@ class BaseRecording(BaseRecordingSnippets):
         sub_recording = ChannelSliceRecording(self, new_channel_ids)
         return sub_recording
 
-    def frame_slice(self, start_frame: int, end_frame: int) -> BaseRecording:
+    def frame_slice(self, start_frame: int | None, end_frame: int | None) -> BaseRecording:
         """
         Returns a new recording with sliced frames. Note that this operation is not in place.
 
         Parameters
         ----------
-        start_frame : int
-            The start frame
-        end_frame : int
-            The end frame
+        start_frame : int, optional
+            The start frame, if not provided it is set to 0
+        end_frame : int, optional
+            The end frame, it not provided it is set to the total number of samples
 
         Returns
         -------
         BaseRecording
-            The object with sliced frames
+            A new recording object with only samples between start_frame and end_frame
         """
 
         from .frameslicerecording import FrameSliceRecording
@@ -679,27 +678,27 @@ class BaseRecording(BaseRecordingSnippets):
         sub_recording = FrameSliceRecording(self, start_frame=start_frame, end_frame=end_frame)
         return sub_recording
 
-    def time_slice(self, start_time: float, end_time: float) -> BaseRecording:
+    def time_slice(self, start_time: float | None, end_time: float) -> BaseRecording:
         """
         Returns a new recording with sliced time. Note that this operation is not in place.
 
         Parameters
         ----------
-        start_time : float
-            The start time in seconds.
-        end_time : float
-            The end time in seconds.
+        start_time : float, optional
+            The start time in seconds. If not provided it is set to 0.
+        end_time : float, optional
+            The end time in seconds. If not provided it is set to the total duration.
 
         Returns
         -------
         BaseRecording
-            The object with sliced time.
+            A new recording object with only samples between start_time and end_time
         """
 
         assert self.get_num_segments() == 1, "Time slicing is only supported for single segment recordings."
 
-        start_frame = self.time_to_sample_index(start_time)
-        end_frame = self.time_to_sample_index(end_time)
+        start_frame = self.time_to_sample_index(start_time) if start_time else None
+        end_frame = self.time_to_sample_index(end_time) if end_time else None
 
         return self.frame_slice(start_frame=start_frame, end_frame=end_frame)
 

--- a/src/spikeinterface/core/frameslicerecording.py
+++ b/src/spikeinterface/core/frameslicerecording.py
@@ -30,7 +30,7 @@ class FrameSliceRecording(BaseRecording):
 
         assert parent_recording.get_num_segments() == 1, "FrameSliceRecording only works with one segment"
 
-        parent_size = parent_recording.get_num_samples(0)
+        parent_size = parent_recording.get_num_samples(segment_index=0)
         if start_frame is None:
             start_frame = 0
         else:


### PR DESCRIPTION
`FrameSlice` sets defaults of 0 and num_samples when start_frame and end_frame are not passed respectively:

https://github.com/h-mayorquin/spikeinterface/blob/bd626b0b4fbf4bfa5cfa68e857fb8ea997784c56/src/spikeinterface/core/frameslicerecording.py#L33-L45

But currently, this behavior is not available in frame_slice. This PR propagates this behavior to both frame_slice and time_slice to make it consistent. 