### PR TITLE
Add more helpful error when a non-existent id is passed to extractors

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -56,7 +56,7 @@ class BaseExtractor:
 
         # "main_ids" will either be channel_ids or units_ids
         # They are used for properties
-        self._main_ids = np.array(main_ids)
+        self._main_ids = np.asarray(main_ids)
         if len(self._main_ids) > 0:
             assert (
                 self._main_ids.dtype.kind in "uiSU"
@@ -128,8 +128,18 @@ class BaseExtractor:
                 indices = np.arange(len(self._main_ids))
         else:
             assert isinstance(ids, (list, np.ndarray, tuple)), "'ids' must be a list, np.ndarray or tuple"
+
+            non_existent_ids = [id for id in ids if id not in self._main_ids]
+            if non_existent_ids:
+                error_msg = (
+                    f"IDs {non_existent_ids} are not channel ids of the extractor. \n"
+                    f"Available ids are {self._main_ids} with dtype {self._main_ids.dtype}"
+                )
+                raise ValueError(error_msg)
+
             _main_ids = self._main_ids.tolist()
-            indices = np.array([_main_ids.index(id) for id in ids], dtype=int)
+            indices = np.array([_main_ids.index(id) for id in ids], dtype=np.int)
+
             if prefer_slice:
                 if np.all(np.diff(indices) == 1):
                     indices = slice(indices[0], indices[-1] + 1)

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -56,7 +56,7 @@ class BaseExtractor:
 
         # "main_ids" will either be channel_ids or units_ids
         # They are used for properties
-        self._main_ids = np.asarray(main_ids)
+        self._main_ids = np.array(main_ids)
         if len(self._main_ids) > 0:
             assert (
                 self._main_ids.dtype.kind in "uiSU"

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -138,7 +138,7 @@ class BaseExtractor:
                 raise ValueError(error_msg)
 
             _main_ids = self._main_ids.tolist()
-            indices = np.array([_main_ids.index(id) for id in ids], dtype=np.int)
+            indices = np.array([_main_ids.index(id) for id in ids], dtype=int)
 
             if prefer_slice:
                 if np.all(np.diff(indices) == 1):


### PR DESCRIPTION
As in the title, related to 

https://github.com/SpikeInterface/spikeinterface/issues/3049

Looks like this:
![image](https://github.com/SpikeInterface/spikeinterface/assets/6429509/d7a1f356-beda-4000-8664-6f8bd59f2201)
