### PR TITLE
Fix intan kwargs

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/intan.py
+++ b/src/spikeinterface/extractors/neoextractors/intan.py
@@ -53,12 +53,8 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         )
 
         self._kwargs.update(dict(file_path=str(Path(file_path).absolute())))
-        import packaging
-        import neo
-
-        neo_version = packaging.version.parse(neo.__version__)
-        if neo_version > packaging.version.parse("0.13.1"):
-            self._kwargs.update(dict(ignore_integrity_checks=ignore_integrity_checks))
+        if "ignore_integrity_checks" in neo_kwargs:
+            self._kwargs["ignore_integrity_checks"] = neo_kwargs["ignore_integrity_checks"]
 
     @classmethod
     def map_to_neo_kwargs(cls, file_path, ignore_integrity_checks: bool = False):

--- a/src/spikeinterface/extractors/neoextractors/intan.py
+++ b/src/spikeinterface/extractors/neoextractors/intan.py
@@ -53,6 +53,12 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         )
 
         self._kwargs.update(dict(file_path=str(Path(file_path).absolute())))
+        import packaging
+        import neo
+
+        neo_version = packaging.version.parse(neo.__version__)
+        if neo_version > packaging.version.parse("0.13.1"):
+            self._kwargs.update(dict(ignore_integrity_checks=ignore_integrity_checks))
 
     @classmethod
     def map_to_neo_kwargs(cls, file_path, ignore_integrity_checks: bool = False):

--- a/src/spikeinterface/widgets/traces.py
+++ b/src/spikeinterface/widgets/traces.py
@@ -277,7 +277,7 @@ class TracesWidget(BaseWidget):
 
     def plot_matplotlib(self, data_plot, **backend_kwargs):
         import matplotlib.pyplot as plt
-        from matplotlib.ticker import MaxNLocator
+        from matplotlib.ticker import MaxNLocator, FuncFormatter
         from .utils_matplotlib import make_mpl_figure
 
         dp = to_attr(data_plot)

--- a/src/spikeinterface/widgets/traces.py
+++ b/src/spikeinterface/widgets/traces.py
@@ -277,7 +277,7 @@ class TracesWidget(BaseWidget):
 
     def plot_matplotlib(self, data_plot, **backend_kwargs):
         import matplotlib.pyplot as plt
-        from matplotlib.ticker import MaxNLocator, FuncFormatter
+        from matplotlib.ticker import MaxNLocator
         from .utils_matplotlib import make_mpl_figure
 
         dp = to_attr(data_plot)


### PR DESCRIPTION
The `ignore_integrity_checks` keyword that was added recently was not propagated to the kwargs. So running thing in parallel with a context other than fork was not working. This PR fixes it.

This also indicates that there are some missing tests there if this behavior was missing. I will think on how to add a general test to see that al kwargs are catched in another PR. 