### PR TITLE
Improve error log to json in run_sorter

### DIFF
--- a/src/spikeinterface/sorters/basesorter.py
+++ b/src/spikeinterface/sorters/basesorter.py
@@ -262,7 +262,12 @@ class BaseSorter:
             has_error = True
             run_time = None
             log["error"] = True
-            log["error_trace"] = traceback.format_exc()
+            error_log_to_display = traceback.format_exc()
+            trace_lines = error_log_to_display.strip().split("\n")
+            error_to_json = ["Traceback (most recent call last):"] + [
+                f"  {line}" if not line.startswith(" ") else line for line in trace_lines[1:]
+            ]
+            log["error_trace"] = error_to_json
 
         log["error"] = has_error
         log["run_time"] = run_time
@@ -290,7 +295,7 @@ class BaseSorter:
 
         if has_error and raise_error:
             raise SpikeSortingError(
-                f"Spike sorting error trace:\n{log['error_trace']}\n"
+                f"Spike sorting error trace:\n{error_log_to_display}\n"
                 f"Spike sorting failed. You can inspect the runtime trace in {output_folder}/spikeinterface_log.json."
             )
 


### PR DESCRIPTION
As in the title.

In the current PR:

```json
{
    "sorter_name": "kilosort3",
    "sorter_version": "compiled",
    "datetime": "2024-06-20T19:08:55.934035",
    "runtime_trace": [
        "Warning: X does not support locale C.UTF-8",
        "Time   0s. Computing whitening matrix..",
        "Getting channel whitening matrix...",
        "Channel-whitening matrix computed.",
        "Time   2s. Loading raw data and applying filters...",
        "Time   2s. Finished preprocessing 4 batches.",
        "Drift correction ENABLED",
        "vertical pitch size is 20",
        "horizontal pitch size is 20",
        "0    10    20",
        "",
        "6",
        "",
        "----------------------------------------Index in position 1 exceeds array bounds. Index must not exceed 4."
    ],
    "error": true,
    "error_trace": [
        "Traceback (most recent call last):",
        "  File \"/root/.local/lib/python3.9/site-packages/spikeinterface/sorters/basesorter.py\", line 257, in run_from_folder",
        "    SorterClass._run_from_folder(sorter_output_folder, sorter_params, verbose)",
        "  File \"/root/.local/lib/python3.9/site-packages/spikeinterface/sorters/external/kilosortbase.py\", line 217, in _run_from_folder",
        "    raise Exception(f\"{cls.sorter_name} returned a non-zero exit code\")",
        "  Exception: kilosort3 returned a non-zero exit code"
    ],
    "run_time": null
}
```

Vs what is on main:

```json
{
    "sorter_name": "kilosort3",
    "sorter_version": "compiled",
    "datetime": "2024-06-20T19:16:49.436576",
    "runtime_trace": [
        "Warning: X does not support locale C.UTF-8",
        "Time   0s. Computing whitening matrix..",
        "Getting channel whitening matrix...",
        "Channel-whitening matrix computed.",
        "Time   2s. Loading raw data and applying filters...",
        "Time   2s. Finished preprocessing 4 batches.",
        "Drift correction ENABLED",
        "vertical pitch size is 20",
        "horizontal pitch size is 20",
        "0    10    20",
        "",
        "6",
        "",
        "----------------------------------------Index in position 1 exceeds array bounds. Index must not exceed 4."
    ],
    "error": true,
    "error_trace": "Traceback (most recent call last):\n  File \"/root/.local/lib/python3.9/site-packages/spikeinterface/sorters/basesorter.py\", line 257, in run_from_folder\n    SorterClass._run_from_folder(sorter_output_folder, sorter_params, verbose)\n  File \"/root/.local/lib/python3.9/site-packages/spikeinterface/sorters/external/kilosortbase.py\", line 217, in _run_from_folder\n    raise Exception(f\"{cls.sorter_name} returned a non-zero exit code\")\nException: kilosort3 returned a non-zero exit code\n",
    "run_time": null
}
```