### PR TITLE
Use names as channel ids in plexon2

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/plexon2.py
+++ b/src/spikeinterface/extractors/neoextractors/plexon2.py
@@ -19,6 +19,13 @@ class Plexon2RecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name : str, default: None
         If there are several streams, specify the stream name you want to load.
+    use_names_as_ids:
+        If True, the names of the signals are used as channel ids. If False, the channel ids are a combination of the
+        source id and the channel index.
+
+        Example for widegain signals:
+            names: ["WB01", "WB02", "WB03", "WB04"]
+            ids: ["source3.1" , "source3.2", "source3.3", "source3.4"]
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
     """
@@ -27,14 +34,14 @@ class Plexon2RecordingExtractor(NeoBaseRecordingExtractor):
     NeoRawIOClass = "Plexon2RawIO"
     name = "plexon2"
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, use_names_as_ids=True, all_annotations=False):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(
             self,
             stream_id=stream_id,
             stream_name=stream_name,
             all_annotations=all_annotations,
-            use_names_as_ids=True,
+            use_names_as_ids=use_names_as_ids,
             **neo_kwargs,
         )
         self._kwargs.update({"file_path": str(file_path)})

--- a/src/spikeinterface/extractors/neoextractors/plexon2.py
+++ b/src/spikeinterface/extractors/neoextractors/plexon2.py
@@ -30,7 +30,12 @@ class Plexon2RecordingExtractor(NeoBaseRecordingExtractor):
     def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(
-            self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
+            self,
+            stream_id=stream_id,
+            stream_name=stream_name,
+            all_annotations=all_annotations,
+            use_names_as_ids=True,
+            **neo_kwargs,
         )
         self._kwargs.update({"file_path": str(file_path)})
 


### PR DESCRIPTION
The header for signals in plexon data:

```python
 'signal_channels': array([('WB01', 'source3.1', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB02', 'source3.2', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB03', 'source3.3', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB04', 'source3.4', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB05', 'source3.5', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB06', 'source3.6', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB07', 'source3.7', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB08', 'source3.8', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB09', 'source3.9', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB10', 'source3.10', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB11', 'source3.11', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB12', 'source3.12', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB13', 'source3.13', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB14', 'source3.14', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB15', 'source3.15', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('WB16', 'source3.16', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '3'),
        ('SPKC01', 'source4.1', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC02', 'source4.2', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC03', 'source4.3', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC04', 'source4.4', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC05', 'source4.5', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC06', 'source4.6', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC07', 'source4.7', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC08', 'source4.8', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC09', 'source4.9', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC10', 'source4.10', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC11', 'source4.11', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC12', 'source4.12', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC13', 'source4.13', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC14', 'source4.14', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC15', 'source4.15', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('SPKC16', 'source4.16', 40000., 'int16', 'Volts', 1.52587891e-07, 0., '4'),
        ('FP01', 'source7.1',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP02', 'source7.2',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP03', 'source7.3',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP04', 'source7.4',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP05', 'source7.5',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP06', 'source7.6',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP07', 'source7.7',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP08', 'source7.8',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP09', 'source7.9',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP10', 'source7.10',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP11', 'source7.11',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP12', 'source7.12',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP13', 'source7.13',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP14', 'source7.14',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP15', 'source7.15',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('FP16', 'source7.16',  1000., 'int16', 'Volts', 1.52587891e-07, 0., '7'),
        ('AI01', 'source12.1',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI02', 'source12.2',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI03', 'source12.3',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI04', 'source12.4',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI05', 'source12.5',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI06', 'source12.6',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI07', 'source12.7',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI08', 'source12.8',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI09', 'source12.9',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI10', 'source12.10',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI11', 'source12.11',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI12', 'source12.12',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI13', 'source12.13',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI14', 'source12.14',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI15', 'source12.15',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI16', 'source12.16',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI17', 'source12.17',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI18', 'source12.18',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI19', 'source12.19',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI20', 'source12.20',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI21', 'source12.21',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI22', 'source12.22',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI23', 'source12.23',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI24', 'source12.24',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI25', 'source12.25',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI26', 'source12.26',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI27', 'source12.27',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI28', 'source12.28',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI29', 'source12.29',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI30', 'source12.30',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI31', 'source12.31',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12'),
        ('AI32', 'source12.32',  1000., 'int16', 'Volts', 1.52587891e-04, 0., '12')],
       dtype=[('name', '<U64'), ('id', '<U64'), ('sampling_rate', '<f8'), ('dtype', '<U16'), ('units', '<U64'), ('gain', '<f8'), ('offset', '<f8'), ('stream_id', '<U64')]),
 'spike_channels': array([('SPK02.0', 'unit2.0', 'Volts', 1.52587891e-07, 0., 8, 40000.),
```

As you can see the names are unique and way more clear than the ids in neo. I think it would be better to use names as channel_ids. This is the PR.

Tested this against: https://github.com/catalystneuro/neuroconv/pull/918 in neuroconv
