### PR TITLE
Use keyword arguments in all `kilosort4` function calls.

### DIFF
--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -1408,6 +1408,7 @@ default_unit_params_range = dict(
 def _ensure_unit_params(unit_params, num_units, seed):
     rng = np.random.default_rng(seed=seed)
     # check or generate params per units
+
     params = dict()
     for k, default_lims in default_unit_params_range.items():
         v = unit_params.get(k, default_lims)
@@ -1525,7 +1526,7 @@ def generate_templates(
         templates = np.zeros((num_units, width, num_channels), dtype=dtype)
         fs = sampling_frequency
 
-    params = _ensure_unit_params(unit_params, num_units, seed)
+    params = _ensure_unit_params(unit_params, num_units, seed)  # TODO: sort this out
 
     for u in range(num_units):
         wf = generate_single_fake_waveform(

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -243,7 +243,7 @@ class Kilosort4Sorter(BaseSorter):
 
         # Set preprocessing and drift correction parameters
         if not params["skip_kilosort_preprocessing"]:
-            ops = compute_preprocessing(ops, device, tic0=tic0, file_object=file_object)
+            ops = compute_preprocessing(ops=ops, device=device, tic0=tic0, file_object=file_object)
         else:
             print("Skipping kilosort preprocessing.")
             bfile = BinaryFiltered(

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -17,9 +17,6 @@ class Kilosort4Sorter(BaseSorter):
     requires_locations = True
     gpu_capability = "nvidia-optional"
 
-    # Q: Should we take these directly from the KS defaults? https://github.com/MouseLand/Kilosort/blob/59c03b060cc8e8ac75a7f1a972a8b5c5af3f41a6/kilosort/parameters.py#L164
-    # I see these overwrite the `DEFAULT_SETTINGS`. Do we want to do this? There is benefit to fixing on the SI side, but users switching KS version would expect
-    # the defaults to represent the KS version. This could lead to divergence in result between users running KS directly vs. the SI wrapper.
     _default_params = {
         "batch_size": 60000,
         "nblocks": 1,
@@ -28,8 +25,8 @@ class Kilosort4Sorter(BaseSorter):
         "do_CAR": True,
         "invert_sign": False,
         "nt": 61,
-        "shift": None,  # TODO: I don't think these are passed to BinaryFiltered when preprocessing skipped. Need to distinguish version +/ 4.0.9
-        "scale": None,  # TODO: I don't think these are passed to BinaryFiltered when preprocessing skipped. Need to distinguish version +/ 4.0.9
+        "shift": None,
+        "scale": None,
         "artifact_threshold": None,
         "nskip": 25,
         "whitening_range": 32,

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -282,14 +282,28 @@ class Kilosort4Sorter(BaseSorter):
         )
 
         # Sort spikes and save results
-        st, tF, _, _ = detect_spikes(ops, device, bfile, tic0=tic0, progress_bar=progress_bar)
-        clu, Wall = cluster_spikes(st, tF, ops, device, bfile, tic0=tic0, progress_bar=progress_bar)
+        st, tF, _, _ = detect_spikes(ops=ops, device=device, bfile=bfile, tic0=tic0, progress_bar=progress_bar)
+
+        clu, Wall = cluster_spikes(
+            st=st, tF=tF, ops=ops, device=device, bfile=bfile, tic0=tic0, progress_bar=progress_bar
+        )
+
         if params["skip_kilosort_preprocessing"]:
             ops["preprocessing"] = dict(
                 hp_filter=torch.as_tensor(np.zeros(1)), whiten_mat=torch.as_tensor(np.eye(recording.get_num_channels()))
             )
 
-        _ = save_sorting(ops, results_dir, st, clu, tF, Wall, bfile.imin, tic0, save_extra_vars=save_extra_vars)
+        _ = save_sorting(
+            ops=ops,
+            results_dir=results_dir,
+            st=st,
+            clu=clu,
+            tF=tF,
+            Wall=Wall,
+            imin=bfile.imin,
+            tic0=tic0,
+            save_extra_vars=save_extra_vars,
+        )
 
     @classmethod
     def _get_result_from_folder(cls, sorter_output_folder):

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -278,7 +278,7 @@ class Kilosort4Sorter(BaseSorter):
 
         # this function applies both preprocessing and drift correction
         ops, bfile, st0 = compute_drift_correction(
-            ops, device, tic0=tic0, progress_bar=progress_bar, file_object=file_object
+            ops=ops, device=device, tic0=tic0, progress_bar=progress_bar, file_object=file_object
         )
 
         # Sort spikes and save results

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -18,6 +18,8 @@ class Kilosort4Sorter(BaseSorter):
     gpu_capability = "nvidia-optional"
 
     # Q: Should we take these directly from the KS defaults? https://github.com/MouseLand/Kilosort/blob/59c03b060cc8e8ac75a7f1a972a8b5c5af3f41a6/kilosort/parameters.py#L164
+    # I see these overwrite the `DEFAULT_SETTINGS`. Do we want to do this? There is benefit to fixing on the SI side, but users switching KS version would expect
+    # the defaults to represent the KS version. This could lead to divergence in result between users running KS directly vs. the SI wrapper.
     _default_params = {
         "batch_size": 60000,
         "nblocks": 1,

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -216,12 +216,27 @@ class Kilosort4Sorter(BaseSorter):
         )
 
         if version.parse(cls.get_sorter_version()) >= version.parse("4.0.12"):
-            ops = initialize_ops(settings, probe, recording.get_dtype(), do_CAR, invert_sign, device, False)
+            ops = initialize_ops(
+                settings=settings,
+                probe=probe,
+                data_dtype=recording.get_dtype(),
+                do_CAR=do_CAR,
+                invert_sign=invert_sign,
+                device=device,
+                save_preprocessed_copy=False,
+            )
             n_chan_bin, fs, NT, nt, twav_min, chan_map, dtype, do_CAR, invert, _, _, tmin, tmax, artifact, _, _ = (
                 get_run_parameters(ops)
             )
         else:
-            ops = initialize_ops(settings, probe, recording.get_dtype(), do_CAR, invert_sign, device)
+            ops = initialize_ops(
+                settings=settings,
+                probe=probe,
+                data_dtype=recording.get_dtype(),
+                do_CAR=do_CAR,
+                invert_sign=invert_sign,
+                device=device,
+            )
             n_chan_bin, fs, NT, nt, twav_min, chan_map, dtype, do_CAR, invert, _, _, tmin, tmax, artifact = (
                 get_run_parameters(ops)
             )

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -17,6 +17,7 @@ class Kilosort4Sorter(BaseSorter):
     requires_locations = True
     gpu_capability = "nvidia-optional"
 
+    # Q: Should we take these directly from the KS defaults? https://github.com/MouseLand/Kilosort/blob/59c03b060cc8e8ac75a7f1a972a8b5c5af3f41a6/kilosort/parameters.py#L164
     _default_params = {
         "batch_size": 60000,
         "nblocks": 1,
@@ -25,8 +26,8 @@ class Kilosort4Sorter(BaseSorter):
         "do_CAR": True,
         "invert_sign": False,
         "nt": 61,
-        "shift": None,
-        "scale": None,
+        "shift": None,  # TODO: I don't think these are passed to BinaryFiltered when preprocessing skipped. Need to distinguish version +/ 4.0.9
+        "scale": None,  # TODO: I don't think these are passed to BinaryFiltered when preprocessing skipped. Need to distinguish version +/ 4.0.9
         "artifact_threshold": None,
         "nskip": 25,
         "whitening_range": 32,
@@ -247,16 +248,16 @@ class Kilosort4Sorter(BaseSorter):
         else:
             print("Skipping kilosort preprocessing.")
             bfile = BinaryFiltered(
-                ops["filename"],
-                n_chan_bin,
-                fs,
-                NT,
-                nt,
-                twav_min,
-                chan_map,
+                filename=ops["filename"],
+                n_chan_bin=n_chan_bin,
+                fs=fs,
+                nT=NT,
+                nt=nt,
+                nt0min=twav_min,
+                chan_map=chan_map,
                 hp_filter=None,
                 device=device,
-                do_CAR=do_CAR,
+                do_CAR=do_CAR,  # TODO: should this always be False if we are in skipping KS preprocessing land?
                 invert_sign=invert,
                 dtype=dtype,
                 tmin=tmin,

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -205,7 +205,16 @@ class Kilosort4Sorter(BaseSorter):
         # NOTE: Also modifies settings in-place
         data_dir = ""
         results_dir = sorter_output_folder
-        filename, data_dir, results_dir, probe = set_files(settings, filename, probe, probe_name, data_dir, results_dir)
+
+        filename, data_dir, results_dir, probe = set_files(
+            settings=settings,
+            filename=filename,
+            probe=probe,
+            probe_name=probe_name,
+            data_dir=data_dir,
+            results_dir=results_dir,
+        )
+
         if version.parse(cls.get_sorter_version()) >= version.parse("4.0.12"):
             ops = initialize_ops(settings, probe, recording.get_dtype(), do_CAR, invert_sign, device, False)
             n_chan_bin, fs, NT, nt, twav_min, chan_map, dtype, do_CAR, invert, _, _, tmin, tmax, artifact, _, _ = (

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -176,12 +176,12 @@ class Kilosort4Sorter(BaseSorter):
 
         # load probe
         recording = cls.load_recording_from_folder(sorter_output_folder.parent, with_warnings=False)
-        probe = load_probe(probe_filename)
+        probe = load_probe(probe_path=probe_filename)
         probe_name = ""
         filename = ""
 
         # this internally concatenates the recording
-        file_object = RecordingExtractorAsArray(recording)
+        file_object = RecordingExtractorAsArray(recording_extractor=recording)
 
         do_CAR = params["do_CAR"]
         invert_sign = params["invert_sign"]

--- a/src/spikeinterface/sorters/external/tests/test_kilosort4.py
+++ b/src/spikeinterface/sorters/external/tests/test_kilosort4.py
@@ -7,6 +7,49 @@ from spikeinterface.sorters import Kilosort4Sorter, run_sorter
 from spikeinterface.sorters.tests.common_tests import SorterCommonTestSuite
 
 
+_default_params = {
+    "batch_size": 60000,
+    "nblocks": 1,
+    "Th_universal": 9,
+    "Th_learned": 8,
+    "do_CAR": True,
+    "invert_sign": False,
+    "nt": 61,
+    "shift": None,
+    "scale": None,
+    "artifact_threshold": None,
+    "nskip": 25,
+    "whitening_range": 32,
+    "binning_depth": 5,
+    "sig_interp": 20,
+    "drift_smoothing": [0.5, 0.5, 0.5],
+    "nt0min": None,
+    "dmin": None,
+    "dminx": 32,
+    "min_template_size": 10,
+    "template_sizes": 5,
+    "nearest_chans": 10,
+    "nearest_templates": 100,
+    "max_channel_distance": None,
+    "templates_from_data": True,
+    "n_templates": 6,
+    "n_pcs": 6,
+    "Th_single_ch": 6,
+    "acg_threshold": 0.2,
+    "ccg_threshold": 0.25,
+    "cluster_downsampling": 20,
+    "cluster_pcs": 64,
+    "x_centers": None,
+    "duplicate_spike_bins": 7,
+    "do_correction": True,
+    "keep_good_only": False,
+    "save_extra_kwargs": False,
+    "skip_kilosort_preprocessing": False,
+    "scaleproc": None,
+    "torch_device": "auto",
+}
+
+
 # This run several tests
 @pytest.mark.skipif(not Kilosort4Sorter.is_installed(), reason="kilosort4 not installed")
 class Kilosort4SorterCommonTestSuite(SorterCommonTestSuite, unittest.TestCase):
@@ -32,6 +75,7 @@ class Kilosort4SorterCommonTestSuite(SorterCommonTestSuite, unittest.TestCase):
         sorter_params = self.SorterClass.default_params()
         sorter_params["do_correction"] = False
 
+        breakpoint()
         sorting = run_sorter(
             sorter_name,
             recording,
@@ -42,6 +86,7 @@ class Kilosort4SorterCommonTestSuite(SorterCommonTestSuite, unittest.TestCase):
             raise_error=True,
             **sorter_params,
         )
+        breakpoint()
         assert sorting.sorting_info is not None
         assert "recording" in sorting.sorting_info.keys()
         assert "params" in sorting.sorting_info.keys()


### PR DESCRIPTION
This PR updates the `kilosort4.py` wrapper to call kilosort functions using kwargs rather than position arguments, following the discussion [here](https://github.com/SpikeInterface/spikeinterface/pull/3055#pullrequestreview-2132263072).

This is looking okay as-is, will carefully double check tomorrow but might as well wait for an upcoming kilosort testing PR, to make sure it didn't break anything.

Some notes:

in KS v4.0.11 the `shift` and `scale` arguments were added to the `BinaryFiltered` class. I'm not sure exactly what these are doing, but when skipping kilosort preprocessing, should these be passed to from `params` to `BinaryFiltered` for versions >= 4.0.11?

At present, if I understand correctly all of the default params stored in kilosorts [`DEFAULT_SETTINGS`](https://github.com/MouseLand/Kilosort/blob/59c03b060cc8e8ac75a7f1a972a8b5c5af3f41a6/kilosort/parameters.py#L164) are overwritten by the `_default_params` set in SpikeInterface. I'm unsure of the best way to handle this. Would it not be best to always use the KS-set `DEFAULT_SETTINGS` to ensure the wrapper is faithful to the underlying kilosort version? KS may conceivably make important changes to their defaults but as I understand it these would not be propagated to the spikeinterface wrapper.

[EDIT] closing as superceeded by #3085, will transfer comments, thanks!
