### PR TITLE
Add macos and windows to cache cron jobs

### DIFF
--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/cache@v4
         id: cache-datasets
         with:
-          path: $HOME/spikeinterface_datasets/*
+          path: ~/spikeinterface_datasets/
           key: ${{ runner.os }}-datasets-${{ steps.repo_hash.outputs.dataset_hash }}
           lookup-only: 'true'   # Avoids downloading the data, saving behavior is not affected.
       - name: Cache found?

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -7,10 +7,7 @@ on:
       - main
   schedule:
     - cron: "0 12 * * *"  # Daily at noon UTC
-  pull_request:  # Temporary, will remove this line before merging
-    types: [synchronize, opened, reopened]
-    branches:
-      - main
+
 jobs:
   create-gin-data-cache-if-missing:
     name: Caching data env

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Create the directory to store the data
         run: |
           mkdir -p $HOME/spikeinterface_datasets/behavior_testing_data/
+          chmod -R 777 $HOME/spikeinterface_datasets
           ls -l $HOME/spikeinterface_datasets
         shell: bash
       - name: Get current hash (SHA) of the ephy_testing_data repo

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: '3.11'
       - name: Create the directory to store the data
         run: |
-          mkdir -p $HOME/spikeinterface_datasets/behavior_testing_data/
+          mkdir --parents --verbose $HOME/spikeinterface_datasets/behavior_testing_data/
           chmod -R 777 $HOME/spikeinterface_datasets
           ls -l $HOME/spikeinterface_datasets
         shell: bash

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/cache@v4
         id: cache-datasets
         with:
-          path: $HOME/spikeinterface_datasets/
+          path: $HOME/spikeinterface_datasets/*
           key: ${{ runner.os }}-datasets-${{ steps.repo_hash.outputs.dataset_hash }}
           lookup-only: 'true'   # Avoids downloading the data, saving behavior is not affected.
       - name: Cache found?

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/cache@v4
         id: cache-datasets
         with:
-          path: $HOME/spikeinterface_datasets/*
+          path: $HOME/spikeinterface_datasets/
           key: ${{ runner.os }}-datasets-${{ steps.repo_hash.outputs.dataset_hash }}
           lookup-only: 'true'   # Avoids downloading the data, saving behavior is not affected.
       - name: Cache found?
@@ -68,7 +68,6 @@ jobs:
       - name: Move the downloaded data to the right directory
         if: steps.cache-datasets.outputs.cache-hit != 'true'
         run: |
-          rm -rf $HOME/spikeinterface_datasets/ephy_testing_data/ # Remove existing directory if present
           mv ./ephy_testing_data $HOME/spikeinterface_datasets/
         shell: bash
       - name: Show size of the cache to assert data is downloaded

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: '3.11'
       - name: Create the directory to store the data
         run: |
-          mkdir --parents --verbose $HOME/spikeinterface_datasets/behavior_testing_data/
+          mkdir -p  $HOME/spikeinterface_datasets/behavior_testing_data/
           chmod -R 777 $HOME/spikeinterface_datasets
           ls -l $HOME/spikeinterface_datasets
         shell: bash
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/cache@v4
         id: cache-datasets
         with:
-          path: ~/spikeinterface_datasets
+          path: $HOME/spikeinterface_datasets
           key: ${{ runner.os }}-datasets-${{ steps.repo_hash.outputs.dataset_hash }}
           lookup-only: 'true'   # Avoids downloading the data, saving behavior is not affected.
       - name: Cache found?

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -25,9 +25,9 @@ jobs:
           python-version: '3.11'
       - name: Create the directory to store the data
         run: |
-          mkdir -p  $HOME/spikeinterface_datasets/behavior_testing_data/
-          chmod -R 777 $HOME/spikeinterface_datasets
-          ls -l $HOME/spikeinterface_datasets
+          mkdir -p  ~/spikeinterface_datasets/behavior_testing_data/
+          chmod -R 777 ~/spikeinterface_datasets
+          ls -l ~/spikeinterface_datasets
         shell: bash
       - name: Get current hash (SHA) of the ephy_testing_data repo
         id: repo_hash
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/cache@v4
         id: cache-datasets
         with:
-          path: $HOME/spikeinterface_datasets
+          path: ~/spikeinterface_datasets
           key: ${{ runner.os }}-datasets-${{ steps.repo_hash.outputs.dataset_hash }}
           lookup-only: 'true'   # Avoids downloading the data, saving behavior is not affected.
       - name: Cache found?
@@ -69,11 +69,11 @@ jobs:
       - name: Move the downloaded data to the right directory
         if: steps.cache-datasets.outputs.cache-hit != 'true'
         run: |
-          mv ./behavior_testing_data $HOME/spikeinterface_datasets/
+          mv ./behavior_testing_data ~/spikeinterface_datasets/
         shell: bash
       - name: Show size of the cache to assert data is downloaded
         run: |
-          cd $HOME
+          cd ~
           pwd
           du -hs spikeinterface_datasets  # Should show the size of ephy_testing_data
           cd spikeinterface_datasets

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Create the directory to store the data
         run: |
           mkdir -p  ~/spikeinterface_datasets/behavior_testing_data/
-          chmod -R 777 ~/spikeinterface_datasets
           ls -l ~/spikeinterface_datasets
         shell: bash
       - name: Get current hash (SHA) of the ephy_testing_data repo

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: '3.11'
       - name: Create the directory to store the data
         run: |
-          mkdir -p  ~/spikeinterface_datasets/behavior_testing_data/
+          mkdir -p  ~/spikeinterface_datasets/ephy_testing_data/
           ls -l ~/spikeinterface_datasets
         shell: bash
       - name: Get current hash (SHA) of the ephy_testing_data repo
@@ -63,12 +63,12 @@ jobs:
       - name: Download dataset
         if: steps.cache-datasets.outputs.cache-hit != 'true'
         run: |
-          datalad install --recursive --get-data https://gin.g-node.org/CatalystNeuro/behavior_testing_data
+          datalad install --recursive --get-data https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
         shell: bash
       - name: Move the downloaded data to the right directory
         if: steps.cache-datasets.outputs.cache-hit != 'true'
         run: |
-          mv ./behavior_testing_data ~/spikeinterface_datasets/
+          mv ./ephy_testing_data ~/spikeinterface_datasets/
         shell: bash
       - name: Show size of the cache to assert data is downloaded
         run: |
@@ -78,6 +78,6 @@ jobs:
           cd spikeinterface_datasets
           pwd
           ls -lh  # Should show ephy_testing_data
-          cd behavior_testing_data
+          cd ephy_testing_data
           ls -lh
         shell: bash

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: '3.11'
       - name: Create the directory to store the data
         run: |
-          mkdir -p $HOME/spikeinterface_datasets/ephy_testing_data/
+          mkdir -p $HOME/spikeinterface_datasets/behavior_testing_data/
           ls -l $HOME/spikeinterface_datasets
         shell: bash
       - name: Get current hash (SHA) of the ephy_testing_data repo
@@ -63,12 +63,12 @@ jobs:
       - name: Download dataset
         if: steps.cache-datasets.outputs.cache-hit != 'true'
         run: |
-          datalad install --recursive --get-data https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
+          datalad install --recursive --get-data https://gin.g-node.org/CatalystNeuro/behavior_testing_data
         shell: bash
       - name: Move the downloaded data to the right directory
         if: steps.cache-datasets.outputs.cache-hit != 'true'
         run: |
-          mv ./ephy_testing_data $HOME/spikeinterface_datasets/
+          mv ./behavior_testing_data $HOME/spikeinterface_datasets/
         shell: bash
       - name: Show size of the cache to assert data is downloaded
         run: |
@@ -78,6 +78,6 @@ jobs:
           cd spikeinterface_datasets
           pwd
           ls -lh  # Should show ephy_testing_data
-          cd ephy_testing_data
+          cd behavior_testing_data
           ls -lh
         shell: bash

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/cache@v4
         id: cache-datasets
         with:
-          path: ~/spikeinterface_datasets/
+          path: ~/spikeinterface_datasets
           key: ${{ runner.os }}-datasets-${{ steps.repo_hash.outputs.dataset_hash }}
           lookup-only: 'true'   # Avoids downloading the data, saving behavior is not affected.
       - name: Cache found?

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -7,7 +7,10 @@ on:
       - main
   schedule:
     - cron: "0 12 * * *"  # Daily at noon UTC
-
+  pull_request:  # Temporary, will remove this line before merging
+    types: [synchronize, opened, reopened]
+    branches:
+      - main
 jobs:
   create-gin-data-cache-if-missing:
     name: Caching data env
@@ -34,7 +37,7 @@ jobs:
       - uses: actions/cache@v4
         id: cache-datasets
         with:
-          path: ~/spikeinterface_datasets
+          path: $HOME/spikeinterface_datasets
           key: ${{ runner.os }}-datasets-${{ steps.repo_hash.outputs.dataset_hash }}
           lookup-only: 'true'   # Avoids downloading the data, saving behavior is not affected.
       - name: Cache found?

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -2,64 +2,35 @@ name: Create caches for gin ecephys data and virtual env
 
 on:
   workflow_dispatch:
-  push:  # When someting is pushed into main this checks if caches need to re-created
+  push:  # When something is pushed into main this checks if caches need to be re-created
     branches:
       - main
   schedule:
     - cron: "0 12 * * *"  # Daily at noon UTC
 
 jobs:
-
-
-
-  create-virtual-env-cache-if-missing:
-    name: Caching virtual env
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-      - name: Get current year-month
-        id: date
-        run: |
-          echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
-      - name: Get current dependencies hash
-        id: dependencies
-        run: |
-          echo "hash=${{hashFiles('**/pyproject.toml')}}" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
-        id: cache-venv
-        with:
-          path: ${{ github.workspace }}/test_env
-          key: ${{ runner.os }}-venv-${{ steps.dependencies.outputs.hash }}-${{ steps.date.outputs.date }}
-          lookup-only: 'true'   # Avoids downloading the data, saving behavior is not affected.
-      - name: Cache found?
-        run: echo "Cache-hit == ${{steps.cache-venv.outputs.cache-hit == 'true'}}"
-      - name: Create the virtual environment to be cached
-        if: steps.cache-venv.outputs.cache-hit != 'true'
-        uses: ./.github/actions/build-test-environment
-
-
-
-
   create-gin-data-cache-if-missing:
     name: Caching data env
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Create the directory to store the data
         run: |
-          mkdir --parents --verbose $HOME/spikeinterface_datasets/ephy_testing_data/
-          chmod -R 777 $HOME/spikeinterface_datasets
+          mkdir -p $HOME/spikeinterface_datasets/ephy_testing_data/
           ls -l $HOME/spikeinterface_datasets
+        shell: bash
       - name: Get current hash (SHA) of the ephy_testing_data repo
         id: repo_hash
         run: |
           echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
           echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
+        shell: bash
       - uses: actions/cache@v4
         id: cache-datasets
         with:
@@ -68,6 +39,7 @@ jobs:
           lookup-only: 'true'   # Avoids downloading the data, saving behavior is not affected.
       - name: Cache found?
         run: echo "Cache-hit == ${{steps.cache-datasets.outputs.cache-hit == 'true'}}"
+        shell: bash
       - name: Installing datalad and git-annex
         if: steps.cache-datasets.outputs.cache-hit != 'true'
         run: |
@@ -75,17 +47,26 @@ jobs:
           git config --global user.name "CI Almighty"
           python -m pip install -U pip  # Official recommended way
           pip install datalad-installer
-          datalad-installer --sudo ok git-annex --method datalad/packages
+          if [ ${{ runner.os }} == 'Linux' ]; then
+            datalad-installer --sudo ok git-annex --method datalad/packages
+          elif [ ${{ runner.os }} == 'macOS' ]; then
+            datalad-installer --sudo ok git-annex --method brew
+          elif [ ${{ runner.os }} == 'Windows' ]; then
+            datalad-installer --sudo ok git-annex --method datalad/git-annex:release
+          fi
           pip install datalad
           git config --global filter.annex.process "git-annex filter-process"  # recommended for efficiency
+        shell: bash
       - name: Download dataset
         if: steps.cache-datasets.outputs.cache-hit != 'true'
         run: |
           datalad install --recursive --get-data https://gin.g-node.org/NeuralEnsemble/ephy_testing_data
+        shell: bash
       - name: Move the downloaded data to the right directory
         if: steps.cache-datasets.outputs.cache-hit != 'true'
         run: |
           mv --force ./ephy_testing_data $HOME/spikeinterface_datasets/
+        shell: bash
       - name: Show size of the cache to assert data is downloaded
         run: |
           cd $HOME
@@ -96,3 +77,4 @@ jobs:
           ls -lh  # Should show ephy_testing_data
           cd ephy_testing_data
           ls -lh
+        shell: bash

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/cache@v4
         id: cache-datasets
         with:
-          path: $HOME/spikeinterface_datasets
+          path: $HOME/spikeinterface_datasets/*
           key: ${{ runner.os }}-datasets-${{ steps.repo_hash.outputs.dataset_hash }}
           lookup-only: 'true'   # Avoids downloading the data, saving behavior is not affected.
       - name: Cache found?
@@ -68,7 +68,8 @@ jobs:
       - name: Move the downloaded data to the right directory
         if: steps.cache-datasets.outputs.cache-hit != 'true'
         run: |
-          mv --force ./ephy_testing_data $HOME/spikeinterface_datasets/
+          rm -rf $HOME/spikeinterface_datasets/ephy_testing_data/ # Remove existing directory if present
+          mv ./ephy_testing_data $HOME/spikeinterface_datasets/
         shell: bash
       - name: Show size of the cache to assert data is downloaded
         run: |


### PR DESCRIPTION
Two things into this PR. As discussed with everyone the impact of caching the virtual environment is minimal and the impact of caching on the datasets is too large. The first one is 3 vs 5 minutes whereas the latter one is 3 vs 50 minutes.

Plus, there is already [caching functionality](https://github.com/actions/setup-python?tab=readme-ov-file#caching-packages-dependencies) in the setup-python action. I can test that after we get this caching running.

This PR enables caching for windows and macos.

Hopefully this works OK for windows when datasets are not downloaded file by file otherwise I will need a hack for windows : )