### PR TITLE
Docstrings extractors update, fix PR01 and PR02 #3016

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -117,7 +117,7 @@ Non-NEO-based
     .. autofunction:: read_bids
     .. autofunction:: read_cbin_ibl
     .. autofunction:: read_combinato
-    .. autofunction:: read_ibl_streaming_recording
+    .. autofunction:: read_ibl_recording
     .. autofunction:: read_hdsort
     .. autofunction:: read_herdingspikes
     .. autofunction:: read_kilosort

--- a/doc/modules/extractors.rst
+++ b/doc/modules/extractors.rst
@@ -125,7 +125,7 @@ For raw recording formats, we currently support:
 * **Biocam HDF5** :py:func:`~spikeinterface.extractors.read_biocam()`
 * **CED** :py:func:`~spikeinterface.extractors.read_ced()`
 * **EDF** :py:func:`~spikeinterface.extractors.read_edf()`
-* **IBL streaming** :py:func:`~spikeinterface.extractors.read_ibl_streaming_recording()`
+* **IBL streaming** :py:func:`~spikeinterface.extractors.read_ibl_recording()`
 * **Intan** :py:func:`~spikeinterface.extractors.read_intan()`
 * **MaxWell** :py:func:`~spikeinterface.extractors.read_maxwell()`
 * **MCS H5** :py:func:`~spikeinterface.extractors.read_mcsh5()`

--- a/src/spikeinterface/extractors/cbin_ibl.py
+++ b/src/spikeinterface/extractors/cbin_ibl.py
@@ -27,9 +27,11 @@ class CompressedBinaryIblExtractor(BaseRecording):
     load_sync_channel : bool, default: False
         Load or not the last channel (sync).
         If not then the probe is loaded.
-    stream_name : str, default: "ap".
+    stream_name : {"ap", "lp"}, default: "ap".
         Whether to load AP or LFP band, one
         of "ap" or "lp".
+    cbin_file : str or None, default None
+        The cbin file of the recording. If None, searches in `folder_path` for file.
 
     Returns
     -------

--- a/src/spikeinterface/extractors/herdingspikesextractors.py
+++ b/src/spikeinterface/extractors/herdingspikesextractors.py
@@ -20,7 +20,7 @@ class HerdingspikesSortingExtractor(BaseSorting):
 
     Parameters
     ----------
-    folder_path : str or Path
+    file_path : str or Path
         Path to the ALF folder.
     load_unit_info : bool, default: True
         Whether to load the unit info from the file.

--- a/src/spikeinterface/extractors/iblextractors.py
+++ b/src/spikeinterface/extractors/iblextractors.py
@@ -41,7 +41,7 @@ class IblRecordingExtractor(BaseRecording):
     stream_name : str
         The name of the stream to load for the session.
         These can be retrieved from calling `StreamingIblExtractor.get_stream_names(session="<your session ID>")`.
-    load_sync_channels : bool, default: false
+    load_sync_channel : bool, default: false
         Load or not the last channel (sync).
         If not then the probe is loaded.
     cache_folder : str or None, default: None

--- a/src/spikeinterface/extractors/neoextractors/alphaomega.py
+++ b/src/spikeinterface/extractors/neoextractors/alphaomega.py
@@ -50,6 +50,11 @@ class AlphaOmegaRecordingExtractor(NeoBaseRecordingExtractor):
 class AlphaOmegaEventExtractor(NeoBaseEventExtractor):
     """
     Class for reading events from AlphaOmega MPX file format
+
+    Parameters
+    ----------
+    folder_path : str or Path-like
+        The folder path to the AlphaOmega events.
     """
 
     mode = "folder"

--- a/src/spikeinterface/extractors/neoextractors/biocam.py
+++ b/src/spikeinterface/extractors/neoextractors/biocam.py
@@ -42,7 +42,6 @@ class BiocamRecordingExtractor(NeoBaseRecordingExtractor):
         electrode_width=None,
         stream_id=None,
         stream_name=None,
-        block_index=None,
         all_annotations=False,
     ):
         neo_kwargs = self.map_to_neo_kwargs(file_path)

--- a/src/spikeinterface/extractors/neoextractors/blackrock.py
+++ b/src/spikeinterface/extractors/neoextractors/blackrock.py
@@ -26,8 +26,9 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
-    use_names_as_ids : bool or None, default: None
-        If True, use channel names as IDs. If None, use default IDs.
+    use_names_as_ids : bool, default: False
+        If False, use default IDs inherited from Neo. If True, use channel names as IDs.
+
     """
 
     mode = "file"

--- a/src/spikeinterface/extractors/neoextractors/blackrock.py
+++ b/src/spikeinterface/extractors/neoextractors/blackrock.py
@@ -26,6 +26,8 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool or None, default: None
+        If True, use channel names as IDs. If None, use default IDs.
     """
 
     mode = "file"
@@ -37,7 +39,6 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
         file_path,
         stream_id=None,
         stream_name=None,
-        block_index=None,
         all_annotations=False,
         use_names_as_ids=False,
     ):

--- a/src/spikeinterface/extractors/neoextractors/ced.py
+++ b/src/spikeinterface/extractors/neoextractors/ced.py
@@ -23,8 +23,6 @@ class CedRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name : str, default: None
         If there are several streams, specify the stream name you want to load.
-    block_index : int, default: None
-        If there are several blocks, specify the block index you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
     """

--- a/src/spikeinterface/extractors/neoextractors/intan.py
+++ b/src/spikeinterface/extractors/neoextractors/intan.py
@@ -28,7 +28,9 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         check we perform is that timestamps are continuous. Setting this to True will ignore this check and set
         the attribute `discontinuous_timestamps` to True in the underlying neo object.
     use_names_as_ids : bool, default: False
-        If True, use channel names as IDs. If False, use default IDs inherited from neo.
+        If False, use default IDs inherited from Neo. If True, use channel names as IDs.
+
+
     """
 
     mode = "file"

--- a/src/spikeinterface/extractors/neoextractors/intan.py
+++ b/src/spikeinterface/extractors/neoextractors/intan.py
@@ -27,6 +27,8 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         If True, data that violates integrity assumptions will be loaded. At the moment the only integrity
         check we perform is that timestamps are continuous. Setting this to True will ignore this check and set
         the attribute `discontinuous_timestamps` to True in the underlying neo object.
+    use_names_as_ids : bool or None, default: None
+        If True, use channel names as IDs. If None, use default IDs.
     """
 
     mode = "file"

--- a/src/spikeinterface/extractors/neoextractors/intan.py
+++ b/src/spikeinterface/extractors/neoextractors/intan.py
@@ -27,8 +27,8 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         If True, data that violates integrity assumptions will be loaded. At the moment the only integrity
         check we perform is that timestamps are continuous. Setting this to True will ignore this check and set
         the attribute `discontinuous_timestamps` to True in the underlying neo object.
-    use_names_as_ids : bool or None, default: None
-        If True, use channel names as IDs. If None, use default IDs.
+    use_names_as_ids : bool, default: False
+        If True, use channel names as IDs. If False, use default IDs inherited from neo.
     """
 
     mode = "file"

--- a/src/spikeinterface/extractors/neoextractors/maxwell.py
+++ b/src/spikeinterface/extractors/neoextractors/maxwell.py
@@ -35,6 +35,8 @@ class MaxwellRecordingExtractor(NeoBaseRecordingExtractor):
         you want to extract. (rec_name='rec0000').
     install_maxwell_plugin : bool, default: False
         If True, install the maxwell plugin for neo.
+    block_index : int, default: None
+        If there are several blocks (experiments), specify the block index you want to load
     """
 
     mode = "file"

--- a/src/spikeinterface/extractors/neoextractors/neuralynx.py
+++ b/src/spikeinterface/extractors/neoextractors/neuralynx.py
@@ -26,16 +26,17 @@ class NeuralynxRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
-    exlude_filename : list[str], default: None
+    exclude_filename : list[str], default: None
         List of filename to exclude from the loading.
         For example, use `exclude_filename=["events.nev"]` to skip loading the event file.
     strict_gap_mode : bool, default: False
         See neo documentation.
         Detect gaps using strict mode or not.
-          * strict_gap_mode = True then a gap is consider when timstamp difference between two
-            consecutive data packets is more than one sample interval.
-          * strict_gap_mode = False then a gap has an increased tolerance. Some new systems with different clocks need this option
-            otherwise, too many gaps are detected
+        * strict_gap_mode = True then a gap is consider when timstamp difference between
+        two consecutive data packets is more than one sample interval.
+        * strict_gap_mode = False then a gap has an increased tolerance. Some new systems
+        with different clocks need this option otherwise, too many gaps are detected
+
         Note that here the default is False contrary to neo.
     """
 

--- a/src/spikeinterface/extractors/neoextractors/plexon2.py
+++ b/src/spikeinterface/extractors/neoextractors/plexon2.py
@@ -19,7 +19,7 @@ class Plexon2RecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream id you want to load.
     stream_name : str, default: None
         If there are several streams, specify the stream name you want to load.
-    use_names_as_ids:
+    use_names_as_ids : bool, default: True
         If True, the names of the signals are used as channel ids. If False, the channel ids are a combination of the
         source id and the channel index.
 

--- a/src/spikeinterface/extractors/neoextractors/spikegadgets.py
+++ b/src/spikeinterface/extractors/neoextractors/spikegadgets.py
@@ -32,7 +32,7 @@ class SpikeGadgetsRecordingExtractor(NeoBaseRecordingExtractor):
     NeoRawIOClass = "SpikeGadgetsRawIO"
     name = "spikegadgets"
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(
             self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs

--- a/src/spikeinterface/extractors/neoextractors/tdt.py
+++ b/src/spikeinterface/extractors/neoextractors/tdt.py
@@ -23,6 +23,8 @@ class TdtRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    block_index : int, default: None
+        If there are several blocks (experiments), specify the block index you want to load
     """
 
     mode = "folder"

--- a/src/spikeinterface/extractors/toy_example.py
+++ b/src/spikeinterface/extractors/toy_example.py
@@ -62,13 +62,13 @@ def toy_example(
     seed : int or None, default: None
         Seed for random initialization.
     upsample_factor : None or int, default: None
-        A upsampling factor used only when templates are not provided.
+        An upsampling factor, used only when templates are not provided.
     num_columns : int, default:  1
         Number of columns in probe.
     average_peak_amplitude : float, default: -100
-        Average peak amplitude of generated templates
+        Average peak amplitude of generated templates.
     contact_spacing_um : float, default: 40.0
-        Spacing between probe contacts.
+        Spacing between probe contacts in micrometers.
 
     Returns
     -------

--- a/src/spikeinterface/extractors/toy_example.py
+++ b/src/spikeinterface/extractors/toy_example.py
@@ -57,12 +57,18 @@ def toy_example(
         Spike time in the recording
     spike_labels : np.array or list[nparray] or None, default: None
         Cluster label for each spike time (needs to specified both together).
-    # score_detection : int (between 0 and 1)
-    #    Generate the sorting based on a subset of spikes compare with the trace generation
     firing_rate : float, default: 3.0
         The firing rate for the units (in Hz)
     seed : int or None, default: None
         Seed for random initialization.
+    upsample_factor : None or int, default: None
+        A upsampling factor used only when templates are not provided.
+    num_columns : int, default:  1
+        Number of columns in probe.
+    average_peak_amplitude : float, default: -100
+        Average peak amplitude of generated templates
+    contact_spacing_um : float, default: 40.0
+        Spacing between probe contacts.
 
     Returns
     -------

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -10,15 +10,14 @@ from ..core import get_chunk_with_margin
 
 _common_filter_docs = """**filter_kwargs : dict
         Certain keyword arguments for `scipy.signal` filters:
-        filter_order : order
-            The order of the filter
-        filter_mode :  "sos" | "ba", default: "sos"
-            Filter form of the filter coefficients:
-            - second-order sections ("sos")
-            - numerator/denominator : ("ba")
-        ftype : str, default: "butter"
-            Filter type for `scipy.signal.iirfilter` e.g. "butter", "cheby1".
-    """
+            filter_order : order
+                The order of the filter
+            filter_mode :  "sos" | "ba", default: "sos"
+                Filter form of the filter coefficients:
+                - second-order sections ("sos")
+                - numerator/denominator : ("ba")
+            ftype : str, default: "butter"
+                Filter type for `scipy.signal.iirfilter` e.g. "butter", "cheby1"."""
 
 
 class FilterRecording(BasePreprocessor):

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -11,7 +11,9 @@ from ..core import get_chunk_with_margin
 _common_filter_docs = """**filter_kwargs : dict
         Certain keyword arguments for `scipy.signal` filters:
             filter_order : order
-                The order of the filter
+                The order of the filter. Note as filtering is applied with scipy's
+                `filtfilt` functions (i.e. acausal, zero-phase) the effective
+                order will be double the `filter_order`.
             filter_mode :  "sos" | "ba", default: "sos"
                 Filter form of the filter coefficients:
                 - second-order sections ("sos")


### PR DESCRIPTION
Update docstrings in public Extractors module functions to be compliant with PR01 and PR02 from numpydoc.
(also fix a whitespace error in Preprocessing)

Two controversial changes:
- This update BREAKS `BiocamRecordingExtractor`, `SpikeGadgetsRecordingExtractor` and `BlackrockRecordingExtractor`, which all had an unused `block_index` parameter in their `__init__`. I think it's better to delete these than to document something which is unused => can create unexpected behaviour. Is this a problem @alejoe91 @samuelgarcia ?
- `read_openephys` still fails PR01 and PR02 because the Parameters are bundled in a `kwargs` dict. But the Parameters are very helpful and, from the user point of view, can be passed as "normal" parameters. Not sure what to do. Code here: https://github.com/SpikeInterface/spikeinterface/blob/d963aa26e31a9b6bc0bea2a4973f76d4dbafb062/src/spikeinterface/extractors/neoextractors/openephys.py#L304

The rules are...

https://numpydoc.readthedocs.io/en/latest/validation.html#
"PR01": "Parameters {missing_params} not documented",
"PR02": "Unknown parameters {unknown_params}",

...and they ensure that the function argument agrees with the Parameters listed in docstrings.