### PR TITLE
Mark failing sorter test on Windows*Python3.12 as xfail

### DIFF
--- a/src/spikeinterface/sorters/tests/test_runsorter.py
+++ b/src/spikeinterface/sorters/tests/test_runsorter.py
@@ -1,7 +1,9 @@
 import os
+import platform
 import pytest
 from pathlib import Path
 import shutil
+from packaging.version import parse
 
 from spikeinterface import generate_ground_truth_recording
 from spikeinterface.sorters import run_sorter
@@ -19,6 +21,10 @@ def generate_recording():
     return _generate_recording()
 
 
+@pytest.mark.xfail(
+    platform.system() == "Windows" and parse(platform.python_version()) > parse("3.12"),
+    reason="3rd parth threadpoolctl issue: OSError('GetModuleFileNameEx failed')",
+)
 def test_run_sorter_local(generate_recording, create_cache_folder):
     recording = generate_recording
     cache_folder = create_cache_folder


### PR DESCRIPTION
See https://github.com/SpikeInterface/spikeinterface/actions/runs/9693230325/job/26748253219?pr=3090

Let's not waste too much time here for the time being since it seems a 3rd party problem