### PR TITLE
Add `*sg_execution_times.rst` to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ examples/tutorials/*.svg
 doc/_build/*
 doc/tutorials/*
 doc/sources/*
+*sg_execution_times.rst
 
 examples/getting_started/tmp_*
 examples/getting_started/phy


### PR DESCRIPTION
Further to the comment [here](https://github.com/SpikeInterface/spikeinterface/pull/2879#discussion_r1656732438), this PR adds `*sg_execution_times.rst` to the gitignore so it is ignored wherever it may be found. This file is generated automatically when building docs.