### PR TITLE
update to run_sorter_jobs() and slurm

### DIFF
--- a/src/spikeinterface/sorters/launcher.py
+++ b/src/spikeinterface/sorters/launcher.py
@@ -26,14 +26,14 @@ _default_engine_kwargs = dict(
     joblib=dict(n_jobs=-1, backend="loky"),
     processpoolexecutor=dict(max_workers=2, mp_context=None),
     dask=dict(client=None),
-    slurm=dict(tmp_script_folder=None, cpus_per_task=1, mem="1G"),
+    slurm=dict(tmp_script_folder=None, sbatch_args=dict(cpus_per_task=1, mem="1G")),
 )
 
 
 _implemented_engine = list(_default_engine_kwargs.keys())
 
 
-def run_sorter_jobs(job_list, engine="loop", engine_kwargs={}, return_output=False):
+def run_sorter_jobs(job_list, engine="loop", engine_kwargs=None, return_output=False):
     """
     Run several :py:func:`run_sorter()` sequentially or in parallel given a list of jobs.
 
@@ -55,10 +55,9 @@ def run_sorter_jobs(job_list, engine="loop", engine_kwargs={}, return_output=Fal
 
     Where *blocking* means that this function is blocking until the results are returned.
     This is in opposition to *asynchronous*, where the function returns `None` almost immediately (aka non-blocking),
-    but the results must be retrieved by hand when jobs are finished. No mechanisim is provided here to be know
-    when jobs are finish.
+    but the results must be retrieved by hand when jobs are finished. No mechanism is provided here to know
+    when jobs are finished.
     In this *asynchronous* case, the :py:func:`~spikeinterface.sorters.read_sorter_folder()` helps to retrieve individual results.
-
 
     Parameters
     ----------
@@ -68,10 +67,12 @@ def run_sorter_jobs(job_list, engine="loop", engine_kwargs={}, return_output=Fal
         The engine to run the list.
         * "loop" : a simple loop. This engine is
     engine_kwargs : dict
+        In the case of engine="slum", arguments to sbatch can be passed via sbatch_args, which is a dictionary whose
+        keys correspond to the --args to be passed to sbatch.
 
     return_output : bool, dfault False
         Return a sortings or None.
-        This also overwrite kwargs in  in run_sorter(with_sorting=True/False)
+        This also overwrite kwargs in run_sorter(with_sorting=True/False)
 
     Returns
     -------
@@ -81,6 +82,7 @@ def run_sorter_jobs(job_list, engine="loop", engine_kwargs={}, return_output=Fal
 
     assert engine in _implemented_engine, f"engine must be in {_implemented_engine}"
 
+    engine_kwargs = {} if None else engine_kwargs
     engine_kwargs_ = dict()
     engine_kwargs_.update(_default_engine_kwargs[engine])
     engine_kwargs_.update(engine_kwargs)
@@ -150,8 +152,6 @@ def run_sorter_jobs(job_list, engine="loop", engine_kwargs={}, return_output=Fal
         if tmp_script_folder is None:
             tmp_script_folder = tempfile.mkdtemp(prefix="spikeinterface_slurm_")
         tmp_script_folder = Path(tmp_script_folder)
-        cpus_per_task = engine_kwargs["cpus_per_task"]
-        mem = engine_kwargs["mem"]
 
         tmp_script_folder.mkdir(exist_ok=True, parents=True)
 
@@ -180,8 +180,8 @@ def run_sorter_jobs(job_list, engine="loop", engine_kwargs={}, return_output=Fal
                 )
                 f.write(slurm_script)
                 os.fchmod(f.fileno(), mode=stat.S_IRWXU)
-
-            subprocess.Popen(["sbatch", str(script_name.absolute()), f"-cpus-per-task={cpus_per_task}", f"-mem={mem}"])
+            sbatch_args = ' '.join(['--{k}={v}' for k, v in engine_kwargs['sbatch_args'].items()])
+            subprocess.Popen("sbatch", str(script_name.absolute()), sbatch_args)
 
     return out
 


### PR DESCRIPTION
I am trying to run spikeinterface sorters on a HPC cluster and needed to pass specific parameters to `slurm`/`sbatch`.

I added the option to pass arbitrary arguments to `sbatch` in the `engine_kwargs`.

Let me know if that's causing any issues