### PR TITLE
Round instead of int for `time_to_sample_index`.

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -848,8 +848,10 @@ class BaseRecordingSegment(BaseSegment):
                 sample_index = time_s * self.sampling_frequency
             else:
                 sample_index = (time_s - self.t_start) * self.sampling_frequency
+            sample_index = round(sample_index)
         else:
             sample_index = np.searchsorted(self.time_vector, time_s, side="right") - 1
+
         return int(sample_index)
 
     def get_num_samples(self) -> int:


### PR DESCRIPTION
In `BaseRecordingSegment.time_to_sample_index()` the calculation from time was cast from `float` to `int`. By default this will use floor method of rounding, which can lead to wrong results e.g. doing:

```
sample = 500
time_ = recording.sample_index_to_time(sample)
sample_again = recording.time_to_sample_index(time_)
```
Could lead to `sample` not equalling `sampling_again`.

This PR is tested in #3118.