### PR TITLE
Remove unit_params_range from generate.py

### DIFF
--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -1440,7 +1440,6 @@ def generate_templates(
     dtype="float32",
     upsample_factor=None,
     unit_params=None,
-    unit_params_range=None,
     mode="ellipsoid",
 ):
     """
@@ -1497,9 +1496,7 @@ def generate_templates(
             * (num_units, num_samples, num_channels, upsample_factor) if upsample_factor is not None
 
     """
-
     unit_params = unit_params or dict()
-    unit_params_range = unit_params_range or dict()
     rng = np.random.default_rng(seed=seed)
 
     # neuron location must be 3D


### PR DESCRIPTION
closes #3077 by removing the unused `unit_params_range` in `generate.py`. This previously allowed the user to set the parameters for templates injected into synthetic recordings. However I think it was superceeded by `unit_params`. @samuelgarcia you were correct on #3077 `unit_params` can take a tuple in which case it will use these as bounds to generate template parameters randomly. So `unit_params` performs the job of `unit_params_range`.