### PR TITLE
Alternative implementation of causal filter in filter.py

### DIFF
--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -372,7 +372,7 @@ class CausalFilter(FilterRecording):
         margin_ms=5.0,
         dtype=None,
         causal_mode=True,
-        direction="Forward",
+        direction="forward",
         **filter_kwargs,
     ):
         FilterRecording.__init__(

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -327,63 +327,6 @@ class NotchFilterRecording(BasePreprocessor):
         self._kwargs = dict(recording=recording, freq=freq, q=q, margin_ms=margin_ms, dtype=dtype.str)
 
 
-class CausalFilter(FilterRecording):
-    """
-    Performs causal filtering using:
-        * scipy.signal.lfilt or scipy.signal.sosfilt
-
-    Parameters
-    ----------
-    recording : Recording
-        The recording extractor to be re-referenced
-    band : float or list, default: [300.0, 6000.0]
-        If float, cutoff frequency in Hz for "highpass" filter type
-        If list. band (low, high) in Hz for "bandpass" filter type
-    margin_ms : float
-        Margin in ms on border to avoid border effect
-    dtype : dtype or None
-        The dtype of the returned traces. If None, the dtype of the parent recording is used
-    direction : "forward" | "backward", default: "forward"
-        when causal_mode = True, defines the direction of the filtering
-
-    Returns
-    -------
-    filter_recording : CausalFilterRecording
-        The causal-filtered recording extractor object
-
-    {}
-
-    """
-
-    name = "causal_filter"
-
-    def __init__(
-        self,
-        recording,
-        band=[300.0, 6000.0],
-        margin_ms=5.0,
-        dtype=None,
-        direction="forward",
-        **filter_kwargs,
-    ):
-        FilterRecording.__init__(
-            self,
-            recording,
-            band=band,
-            margin_ms=margin_ms,
-            dtype=dtype,
-            direction=direction,
-            **filter_kwargs,
-        )
-        dtype = fix_dtype(recording, dtype)
-        self._kwargs = dict(
-            recording=recording,
-            band=band,
-            margin_ms=margin_ms,
-            dtype=dtype.str,
-            direction=direction,
-        )
-        self._kwargs.update(filter_kwargs)
 
 
 # functions for API

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -28,7 +28,7 @@ class FilterRecording(BasePreprocessor):
 
       * scipy.signal.iirfilter
       * scipy.signal.filtfilt or scipy.signal.sosfiltfilt when direction = "forward-backward"
-      * scipy.signal.lfilt or scipy.signal.sosfilt 
+      * scipy.signal.lfilt or scipy.signal.sosfilt
 
     BandpassFilterRecording is built on top of it.
 
@@ -60,7 +60,7 @@ class FilterRecording(BasePreprocessor):
     direction : "forward" | "backward" | "forward-backward", default: "forward-backward"
         Direction of filtering:
         - forward and backward filter in just one direction, creating phase shifts in the signal.
-        - forward-backward filters in both directions, a zero-phase filtering. 
+        - forward-backward filters in both directions, a zero-phase filtering.
 
     Returns
     -------
@@ -192,7 +192,7 @@ class FilterRecordingSegment(BasePreprocessorSegment):
                 filtered_traces = scipy.signal.lfilt(b, a, traces_chunk, axis=0)
 
             if self.direction == "backward":
-                filtered_traces = np.flip(filtered_traces, axis=0)            
+                filtered_traces = np.flip(filtered_traces, axis=0)
 
         if right_margin > 0:
             filtered_traces = filtered_traces[left_margin:-right_margin, :]

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -57,7 +57,7 @@ class FilterRecording(BasePreprocessor):
         - numerator/denominator : ("ba")
     ftype : str, default: "butter"
         Filter type for `scipy.signal.iirfilter` e.g. "butter", "cheby1".
-    causal_mode : Bool, default: False
+    causal_mode : bool, default: False
         If true, filtering is applied in just one direction.
     direction : "forward" | "backward", default: "forward"
         when causal_mode = True, defines the direction of the filtering

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -354,7 +354,7 @@ def causal_filter(
     recording : Recording
         The recording extractor to be re-referenced
     direction : "forward" | "backward", default: "forward"
-        Direction of causal filter. The "backward" option flips the traces in time before applying the filter 
+        Direction of causal filter. The "backward" option flips the traces in time before applying the filter
         and then flips them back.
     band : float or list, default: [300.0, 6000.0]
         If float, cutoff frequency in Hz for "highpass" filter type
@@ -377,7 +377,7 @@ def causal_filter(
         - numerator/denominator : ("ba")
     ftype : str, default: "butter"
         Filter type for `scipy.signal.iirfilter` e.g. "butter", "cheby1".
-    
+
     Returns
     -------
     filter_recording : FilterRecording
@@ -396,7 +396,7 @@ def causal_filter(
         add_reflect_padding=add_reflect_padding,
         coeff=coeff,
         dtype=dtype,
-    )   
+    )
 
 bandpass_filter.__doc__ = bandpass_filter.__doc__.format(_common_filter_docs)
 highpass_filter.__doc__ = highpass_filter.__doc__.format(_common_filter_docs)

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -402,7 +402,7 @@ filter = define_function_from_class(source_class=FilterRecording, name="filter")
 bandpass_filter = define_function_from_class(source_class=BandpassFilterRecording, name="bandpass_filter")
 notch_filter = define_function_from_class(source_class=NotchFilterRecording, name="notch_filter")
 highpass_filter = define_function_from_class(source_class=HighpassFilterRecording, name="highpass_filter")
-causal_filter = define_function_from_class(source_class=Causal_filter, name="causal_filter")
+causal_filter = define_function_from_class(source_class=CausalFilter, name="causal_filter")
 
 bandpass_filter.__doc__ = bandpass_filter.__doc__.format(_common_filter_docs)
 highpass_filter.__doc__ = highpass_filter.__doc__.format(_common_filter_docs)

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -332,7 +332,71 @@ filter = define_function_from_class(source_class=FilterRecording, name="filter")
 bandpass_filter = define_function_from_class(source_class=BandpassFilterRecording, name="bandpass_filter")
 notch_filter = define_function_from_class(source_class=NotchFilterRecording, name="notch_filter")
 highpass_filter = define_function_from_class(source_class=HighpassFilterRecording, name="highpass_filter")
-causal_filter = define_function_from_class(source_class=CausalFilter, name="causal_filter")
+
+def causal_filter(
+    recording,
+    direction="forward-backward",
+    band=[300.0, 6000.0],
+    btype="bandpass",
+    filter_order=5,
+    ftype="butter",
+    filter_mode="sos",
+    margin_ms=5.0,
+    add_reflect_padding=False,
+    coeff=None,
+    dtype=None,
+):
+    """
+    Generic causal filter built on top of the filter function.
+
+    Parameters
+    ----------
+    recording : Recording
+        The recording extractor to be re-referenced
+    direction : "forward" | "backward", default: "forward"
+        Direction of causal filter. The "backward" option flips the traces in time before applying the filter 
+        and then flips them back.
+    band : float or list, default: [300.0, 6000.0]
+        If float, cutoff frequency in Hz for "highpass" filter type
+        If list. band (low, high) in Hz for "bandpass" filter type
+    btype : "bandpass" | "highpass", default: "bandpass"
+        Type of the filter
+    margin_ms : float, default: 5.0
+        Margin in ms on border to avoid border effect
+    coeff : array | None, default: None
+        Filter coefficients in the filter_mode form.
+    dtype : dtype or None, default: None
+        The dtype of the returned traces. If None, the dtype of the parent recording is used
+    add_reflect_padding : Bool, default False
+        If True, uses a left and right margin during calculation.
+    filter_order : order
+        The order of the filter for `scipy.signal.iirfilter`
+    filter_mode :  "sos" | "ba", default: "sos"
+        Filter form of the filter coefficients for `scipy.signal.iirfilter`:
+        - second-order sections ("sos")
+        - numerator/denominator : ("ba")
+    ftype : str, default: "butter"
+        Filter type for `scipy.signal.iirfilter` e.g. "butter", "cheby1".
+    
+    Returns
+    -------
+    filter_recording : FilterRecording
+        The causal-filtered recording extractor object
+    """
+    assert direction in ["forward", "backward"], "Direction can be either 'forward' or 'backward'"
+    return filter(
+        recording=recording,
+        direction=direction,
+        band=band
+        btype=btype,
+        filter_order=filter_order,
+        ftype=ftype,
+        filter_mode=filter_mode,
+        margin_ms=margin_ms,
+        add_reflect_padding=add_reflect_padding,
+        coeff=coeff,
+        dtype=dtype,
+    )   
 
 bandpass_filter.__doc__ = bandpass_filter.__doc__.format(_common_filter_docs)
 highpass_filter.__doc__ = highpass_filter.__doc__.format(_common_filter_docs)

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -349,8 +349,6 @@ class CausalFilter(FilterRecording):
         Margin in ms on border to avoid border effect
     dtype : dtype or None
         The dtype of the returned traces. If None, the dtype of the parent recording is used
-    causal_mode : Bool, default: True
-        If true, filtering is applied in just one direction.
     direction : "forward" | "backward", default: "forward"
         when causal_mode = True, defines the direction of the filtering
 
@@ -371,7 +369,6 @@ class CausalFilter(FilterRecording):
         band=[300.0, 6000.0],
         margin_ms=5.0,
         dtype=None,
-        causal_mode=True,
         direction="forward",
         **filter_kwargs,
     ):
@@ -381,7 +378,7 @@ class CausalFilter(FilterRecording):
             band=band,
             margin_ms=margin_ms,
             dtype=dtype,
-            causal_mode=causal_mode,
+            causal_mode=True,
             direction=direction,
             **filter_kwargs,
         )

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -327,8 +327,6 @@ class NotchFilterRecording(BasePreprocessor):
         self._kwargs = dict(recording=recording, freq=freq, q=q, margin_ms=margin_ms, dtype=dtype.str)
 
 
-
-
 # functions for API
 filter = define_function_from_class(source_class=FilterRecording, name="filter")
 bandpass_filter = define_function_from_class(source_class=BandpassFilterRecording, name="bandpass_filter")

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -27,7 +27,8 @@ class FilterRecording(BasePreprocessor):
     Generic filter class based on:
 
       * scipy.signal.iirfilter
-      * scipy.signal.filtfilt or scipy.signal.sosfilt
+      * scipy.signal.filtfilt or scipy.signal.sosfiltfilt
+      * scipy.signal.lfilt or scipy.signal.sosfilt when causal_mode = True
 
     BandpassFilterRecording is built on top of it.
 
@@ -56,6 +57,10 @@ class FilterRecording(BasePreprocessor):
         - numerator/denominator : ("ba")
     ftype : str, default: "butter"
         Filter type for `scipy.signal.iirfilter` e.g. "butter", "cheby1".
+    causal_mode : Bool, default: False
+        If true, filtering is applied in just one direction.
+    direction : "forward" | "backward", default: "forward"
+        when causal_mode = True, defines the direction of the filtering
 
     Returns
     -------
@@ -77,6 +82,8 @@ class FilterRecording(BasePreprocessor):
         add_reflect_padding=False,
         coeff=None,
         dtype=None,
+        causal_mode=False,
+        direction="forward"
     ):
         import scipy.signal
 
@@ -108,7 +115,7 @@ class FilterRecording(BasePreprocessor):
         for parent_segment in recording._recording_segments:
             self.add_recording_segment(
                 FilterRecordingSegment(
-                    parent_segment, filter_coeff, filter_mode, margin, dtype, add_reflect_padding=add_reflect_padding
+                    parent_segment, filter_coeff, filter_mode, causal_mode, direction, margin, dtype, add_reflect_padding=add_reflect_padding
                 )
             )
 
@@ -123,14 +130,18 @@ class FilterRecording(BasePreprocessor):
             margin_ms=margin_ms,
             add_reflect_padding=add_reflect_padding,
             dtype=dtype.str,
+            causal_mode=causal_mode,
+            direction=direction,
         )
 
 
 class FilterRecordingSegment(BasePreprocessorSegment):
-    def __init__(self, parent_recording_segment, coeff, filter_mode, margin, dtype, add_reflect_padding=False):
+    def __init__(self, parent_recording_segment, coeff, filter_mode, causal_mode, direction, margin, dtype, add_reflect_padding=False):
         BasePreprocessorSegment.__init__(self, parent_recording_segment)
         self.coeff = coeff
         self.filter_mode = filter_mode
+        self.causal_mode = causal_mode
+        self.direction = direction
         self.margin = margin
         self.add_reflect_padding = add_reflect_padding
         self.dtype = dtype
@@ -151,12 +162,26 @@ class FilterRecordingSegment(BasePreprocessorSegment):
             traces_chunk = traces_chunk.astype("float32")
 
         import scipy.signal
-
-        if self.filter_mode == "sos":
-            filtered_traces = scipy.signal.sosfiltfilt(self.coeff, traces_chunk, axis=0)
-        elif self.filter_mode == "ba":
-            b, a = self.coeff
-            filtered_traces = scipy.signal.filtfilt(b, a, traces_chunk, axis=0)
+            
+        if self.causal_mode:
+            if self.direction == "backward":
+                traces_chunk = np.flip(traces_chunk, axis = 0)
+                
+            if self.filter_mode == "sos":
+                filtered_traces = scipy.signal.sosfilt(self.coeff, traces_chunk, axis=0)
+            elif self.filter_mode == "ba":
+                b, a = self.coeff
+                filtered_traces = scipy.signal.lfilt(b, a, traces_chunk, axis=0)                
+                
+            if self.direction == "backward":
+                filtered_traces = np.flip(filtered_traces, axis = 0)
+            
+        else:
+                if self.filter_mode == "sos":
+                    filtered_traces = scipy.signal.sosfiltfilt(self.coeff, traces_chunk, axis=0)
+                elif self.filter_mode == "ba":
+                    b, a = self.coeff
+                    filtered_traces = scipy.signal.filtfilt(b, a, traces_chunk, axis=0)
 
         if right_margin > 0:
             filtered_traces = filtered_traces[left_margin:-right_margin, :]
@@ -290,12 +315,52 @@ class NotchFilterRecording(BasePreprocessor):
 
         self._kwargs = dict(recording=recording, freq=freq, q=q, margin_ms=margin_ms, dtype=dtype.str)
 
+class Causal_filter(FilterRecording):
+    """
+    Performs causal filtering using:
+        * scipy.signal.lfilt or scipy.signal.sosfilt
+        
+    Parameters
+    ----------
+    recording : Recording
+        The recording extractor to be re-referenced
+    band : float or list, default: [300.0, 6000.0]
+        If float, cutoff frequency in Hz for "highpass" filter type
+        If list. band (low, high) in Hz for "bandpass" filter type
+    margin_ms : float
+        Margin in ms on border to avoid border effect
+    dtype : dtype or None
+        The dtype of the returned traces. If None, the dtype of the parent recording is used
+    causal_mode : Bool, default: True
+        If true, filtering is applied in just one direction.
+    direction : "forward" | "backward", default: "forward"
+        when causal_mode = True, defines the direction of the filtering   
+    Returns
+    -------
+    filter_recording : CausalFilterRecording
+        The causal-filtered recording extractor object
+    
+    {}
+        
+    """
+    name = "causal_filter"
 
+    def __init__(self, recording, band=[300.0, 6000.0], margin_ms=5.0, dtype=None,causal_mode = True, direction = "Forward", **filter_kwargs):
+        FilterRecording.__init__(
+            self, recording, band=band, margin_ms=margin_ms, dtype=dtype, causal_mode = causal_mode, direction = direction ,**filter_kwargs
+        )
+        dtype = fix_dtype(recording, dtype)
+        self._kwargs = dict(
+            recording=recording, band=band, margin_ms=margin_ms, dtype=dtype.str, causal_mode = causal_mode, direction = direction
+        )
+        self._kwargs.update(filter_kwargs)
+            
 # functions for API
 filter = define_function_from_class(source_class=FilterRecording, name="filter")
 bandpass_filter = define_function_from_class(source_class=BandpassFilterRecording, name="bandpass_filter")
 notch_filter = define_function_from_class(source_class=NotchFilterRecording, name="notch_filter")
 highpass_filter = define_function_from_class(source_class=HighpassFilterRecording, name="highpass_filter")
+causal_filter = define_function_from_class(source_class=Causal_filter, name="causal_filter")
 
 bandpass_filter.__doc__ = bandpass_filter.__doc__.format(_common_filter_docs)
 highpass_filter.__doc__ = highpass_filter.__doc__.format(_common_filter_docs)

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -388,7 +388,7 @@ class CausalFilter(FilterRecording):
             band=band,
             margin_ms=margin_ms,
             dtype=dtype.str,
-            causal_mode=causal_mode,
+            causal_mode=True,
             direction=direction,
         )
         self._kwargs.update(filter_kwargs)

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -83,7 +83,7 @@ class FilterRecording(BasePreprocessor):
         coeff=None,
         dtype=None,
         causal_mode=False,
-        direction="forward"
+        direction="forward",
     ):
         import scipy.signal
 
@@ -115,7 +115,14 @@ class FilterRecording(BasePreprocessor):
         for parent_segment in recording._recording_segments:
             self.add_recording_segment(
                 FilterRecordingSegment(
-                    parent_segment, filter_coeff, filter_mode, causal_mode, direction, margin, dtype, add_reflect_padding=add_reflect_padding
+                    parent_segment,
+                    filter_coeff,
+                    filter_mode,
+                    causal_mode,
+                    direction,
+                    margin,
+                    dtype,
+                    add_reflect_padding=add_reflect_padding,
                 )
             )
 
@@ -136,7 +143,17 @@ class FilterRecording(BasePreprocessor):
 
 
 class FilterRecordingSegment(BasePreprocessorSegment):
-    def __init__(self, parent_recording_segment, coeff, filter_mode, causal_mode, direction, margin, dtype, add_reflect_padding=False):
+    def __init__(
+        self,
+        parent_recording_segment,
+        coeff,
+        filter_mode,
+        causal_mode,
+        direction,
+        margin,
+        dtype,
+        add_reflect_padding=False,
+    ):
         BasePreprocessorSegment.__init__(self, parent_recording_segment)
         self.coeff = coeff
         self.filter_mode = filter_mode
@@ -162,26 +179,26 @@ class FilterRecordingSegment(BasePreprocessorSegment):
             traces_chunk = traces_chunk.astype("float32")
 
         import scipy.signal
-            
+
         if self.causal_mode:
             if self.direction == "backward":
-                traces_chunk = np.flip(traces_chunk, axis = 0)
-                
+                traces_chunk = np.flip(traces_chunk, axis=0)
+
             if self.filter_mode == "sos":
                 filtered_traces = scipy.signal.sosfilt(self.coeff, traces_chunk, axis=0)
             elif self.filter_mode == "ba":
                 b, a = self.coeff
-                filtered_traces = scipy.signal.lfilt(b, a, traces_chunk, axis=0)                
-                
+                filtered_traces = scipy.signal.lfilt(b, a, traces_chunk, axis=0)
+
             if self.direction == "backward":
-                filtered_traces = np.flip(filtered_traces, axis = 0)
-            
+                filtered_traces = np.flip(filtered_traces, axis=0)
+
         else:
-                if self.filter_mode == "sos":
-                    filtered_traces = scipy.signal.sosfiltfilt(self.coeff, traces_chunk, axis=0)
-                elif self.filter_mode == "ba":
-                    b, a = self.coeff
-                    filtered_traces = scipy.signal.filtfilt(b, a, traces_chunk, axis=0)
+            if self.filter_mode == "sos":
+                filtered_traces = scipy.signal.sosfiltfilt(self.coeff, traces_chunk, axis=0)
+            elif self.filter_mode == "ba":
+                b, a = self.coeff
+                filtered_traces = scipy.signal.filtfilt(b, a, traces_chunk, axis=0)
 
         if right_margin > 0:
             filtered_traces = filtered_traces[left_margin:-right_margin, :]
@@ -315,11 +332,12 @@ class NotchFilterRecording(BasePreprocessor):
 
         self._kwargs = dict(recording=recording, freq=freq, q=q, margin_ms=margin_ms, dtype=dtype.str)
 
+
 class Causal_filter(FilterRecording):
     """
     Performs causal filtering using:
         * scipy.signal.lfilt or scipy.signal.sosfilt
-        
+
     Parameters
     ----------
     recording : Recording
@@ -334,27 +352,50 @@ class Causal_filter(FilterRecording):
     causal_mode : Bool, default: True
         If true, filtering is applied in just one direction.
     direction : "forward" | "backward", default: "forward"
-        when causal_mode = True, defines the direction of the filtering   
+        when causal_mode = True, defines the direction of the filtering
     Returns
     -------
     filter_recording : CausalFilterRecording
         The causal-filtered recording extractor object
-    
+
     {}
-        
+
     """
+
     name = "causal_filter"
 
-    def __init__(self, recording, band=[300.0, 6000.0], margin_ms=5.0, dtype=None,causal_mode = True, direction = "Forward", **filter_kwargs):
+    def __init__(
+        self,
+        recording,
+        band=[300.0, 6000.0],
+        margin_ms=5.0,
+        dtype=None,
+        causal_mode=True,
+        direction="Forward",
+        **filter_kwargs,
+    ):
         FilterRecording.__init__(
-            self, recording, band=band, margin_ms=margin_ms, dtype=dtype, causal_mode = causal_mode, direction = direction ,**filter_kwargs
+            self,
+            recording,
+            band=band,
+            margin_ms=margin_ms,
+            dtype=dtype,
+            causal_mode=causal_mode,
+            direction=direction,
+            **filter_kwargs,
         )
         dtype = fix_dtype(recording, dtype)
         self._kwargs = dict(
-            recording=recording, band=band, margin_ms=margin_ms, dtype=dtype.str, causal_mode = causal_mode, direction = direction
+            recording=recording,
+            band=band,
+            margin_ms=margin_ms,
+            dtype=dtype.str,
+            causal_mode=causal_mode,
+            direction=direction,
         )
         self._kwargs.update(filter_kwargs)
-            
+
+
 # functions for API
 filter = define_function_from_class(source_class=FilterRecording, name="filter")
 bandpass_filter = define_function_from_class(source_class=BandpassFilterRecording, name="bandpass_filter")

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -333,7 +333,7 @@ class NotchFilterRecording(BasePreprocessor):
         self._kwargs = dict(recording=recording, freq=freq, q=q, margin_ms=margin_ms, dtype=dtype.str)
 
 
-class Causal_filter(FilterRecording):
+class CausalFilter(FilterRecording):
     """
     Performs causal filtering using:
         * scipy.signal.lfilt or scipy.signal.sosfilt

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -353,6 +353,7 @@ class CausalFilter(FilterRecording):
         If true, filtering is applied in just one direction.
     direction : "forward" | "backward", default: "forward"
         when causal_mode = True, defines the direction of the filtering
+
     Returns
     -------
     filter_recording : CausalFilterRecording

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -152,7 +152,7 @@ class FilterRecordingSegment(BasePreprocessorSegment):
         dtype,
         add_reflect_padding=False,
         causal_mode=False,
-        direction="forward"
+        direction="forward",
     ):
         BasePreprocessorSegment.__init__(self, parent_recording_segment)
         self.coeff = coeff

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -118,11 +118,11 @@ class FilterRecording(BasePreprocessor):
                     parent_segment,
                     filter_coeff,
                     filter_mode,
-                    causal_mode,
-                    direction,
                     margin,
                     dtype,
                     add_reflect_padding=add_reflect_padding,
+                    causal_mode=causal_mode,
+                    direction=direction,
                 )
             )
 
@@ -148,11 +148,11 @@ class FilterRecordingSegment(BasePreprocessorSegment):
         parent_recording_segment,
         coeff,
         filter_mode,
-        causal_mode,
-        direction,
         margin,
         dtype,
         add_reflect_padding=False,
+        causal_mode=False,
+        direction="forward"
     ):
         BasePreprocessorSegment.__init__(self, parent_recording_segment)
         self.coeff = coeff
@@ -403,6 +403,7 @@ causal_filter = define_function_from_class(source_class=CausalFilter, name="caus
 
 bandpass_filter.__doc__ = bandpass_filter.__doc__.format(_common_filter_docs)
 highpass_filter.__doc__ = highpass_filter.__doc__.format(_common_filter_docs)
+causal_filter.__doc__ = causal_filter.__doc__.format(_common_filter_docs)
 
 
 def fix_dtype(recording, dtype):


### PR DESCRIPTION
Sorry for the delay, guys. As requested by @samuelgarcia, this is another way to implement causal filtering in filter.py.

Let me know what you think.

PR related to: https://github.com/SpikeInterface/spikeinterface/pull/2942