### PR TITLE
Better error message for `BaseExtractor.load()` 

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -766,6 +766,7 @@ class BaseExtractor:
             if "warning" in d:
                 print("The extractor was not serializable to file")
                 return None
+
             extractor = BaseExtractor.from_dict(d, base_folder=base_folder)
             return extractor
 
@@ -798,7 +799,10 @@ class BaseExtractor:
             return extractor
 
         else:
-            raise ValueError("spikeinterface.Base.load() file_path must be an existing folder or file")
+            error_msg = f"Failed to load the file_path {file_path} must be an existing folder or file"
+            if base_folder:
+                error_msg = f"\n base folder provided is {base_folder}"
+            raise ValueError(error_msg)
 
     def __reduce__(self):
         """

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -799,7 +799,7 @@ class BaseExtractor:
             return extractor
 
         else:
-            error_msg = f"Failed to load the file_path {file_path} must be an existing folder or file"
+            error_msg = f"{file_path} is not a file or a folder"
             if base_folder:
                 error_msg = f"\n The provided base_folder is {base_folder}"
             raise ValueError(error_msg)

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -799,9 +799,8 @@ class BaseExtractor:
             return extractor
 
         else:
-            error_msg = f"{file_path} is not a file or a folder"
-            if base_folder:
-                error_msg = f"\n The provided base_folder is {base_folder}"
+            error_msg = f"{file_path} is not a file or a folder. It should point out to either a json, pickle file or a
+            folder that is the result of extractor.save(...)"
             raise ValueError(error_msg)
 
     def __reduce__(self):

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -801,7 +801,7 @@ class BaseExtractor:
         else:
             error_msg = f"Failed to load the file_path {file_path} must be an existing folder or file"
             if base_folder:
-                error_msg = f"\n base folder provided is {base_folder}"
+                error_msg = f"\n The provided base_folder is {base_folder}"
             raise ValueError(error_msg)
 
     def __reduce__(self):

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -799,8 +799,8 @@ class BaseExtractor:
             return extractor
 
         else:
-            error_msg = f"{file_path} is not a file or a folder. It should point out to either a json, pickle file or a
-            folder that is the result of extractor.save(...)"
+            error_msg = f"{file_path} is not a file or a folder. It should point out to either a json, pickle file or a "
+            "folder that is the result of extractor.save(...)"
             raise ValueError(error_msg)
 
     def __reduce__(self):

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -799,7 +799,9 @@ class BaseExtractor:
             return extractor
 
         else:
-            error_msg = f"{file_path} is not a file or a folder. It should point out to either a json, pickle file or a "
+            error_msg = (
+                f"{file_path} is not a file or a folder. It should point out to either a json, pickle file or a "
+            )
             "folder that is the result of extractor.save(...)"
             raise ValueError(error_msg)
 

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -799,7 +799,7 @@ class BaseExtractor:
 
         else:
             error_msg = (
-                f"{file_path} is not a file or a folder. It should point out to either a json, pickle file or a "
+                f"{file_path} is not a file or a folder. It should point to either a json, pickle file or a "
                 "folder that is the result of extractor.save(...)"
             )
             raise ValueError(error_msg)

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -801,8 +801,8 @@ class BaseExtractor:
         else:
             error_msg = (
                 f"{file_path} is not a file or a folder. It should point out to either a json, pickle file or a "
+                "folder that is the result of extractor.save(...)"
             )
-            "folder that is the result of extractor.save(...)"
             raise ValueError(error_msg)
 
     def __reduce__(self):


### PR DESCRIPTION
As in the title, related to issue https://github.com/SpikeInterface/spikeinterface/issues/3148