### PR TITLE
Change installation instructions in readme to be compatible with all OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can also have a look at the [spikeinterface-gui](https://github.com/SpikeInt
 
 ## How to install spikeinterface
 
-You can install the latest version of `spikeinterface` version with pip (using quotes ensures `pip install` works in all terminals):
+You can install the latest version of `spikeinterface` version with pip (using quotes ensures `pip install` works in all terminals/shells):
 
 ```bash
 pip install "spikeinterface[full]"

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can also have a look at the [spikeinterface-gui](https://github.com/SpikeInt
 
 ## How to install spikeinterface
 
-You can install the latest version of `spikeinterface` version with pip:
+You can install the latest version of `spikeinterface` version with pip (using quotes ensures `pip install` works in all terminals):
 
 ```bash
 pip install "spikeinterface[full]"

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You can also have a look at the [spikeinterface-gui](https://github.com/SpikeInt
 You can install the latest version of `spikeinterface` version with pip:
 
 ```bash
-pip install spikeinterface[full]
+pip install "spikeinterface[full]"
 ```
 
 The `[full]` option installs all the extra dependencies for all the different sub-modules.
@@ -99,7 +99,7 @@ The `[full]` option installs all the extra dependencies for all the different su
 To install all interactive widget backends, you can use:
 
 ```bash
- pip install spikeinterface[full,widgets]
+ pip install "spikeinterface[full,widgets]"
 ```
 
 


### PR DESCRIPTION
So double quotes works on all operating systems, see:

https://github.com/catalystneuro/neuroconv/issues/947

https://discuss.python.org/t/pep-621-how-to-specify-dependencies/4599/61

