### PR TITLE
Propagate option for using neo channel names as ids in all neo extractors without changing the deafult behavior

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/alphaomega.py
+++ b/src/spikeinterface/extractors/neoextractors/alphaomega.py
@@ -25,14 +25,30 @@ class AlphaOmegaRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     """
 
     NeoRawIOClass = "AlphaOmegaRawIO"
 
-    def __init__(self, folder_path, lsx_files=None, stream_id="RAW", stream_name=None, all_annotations=False):
+    def __init__(
+        self,
+        folder_path,
+        lsx_files=None,
+        stream_id="RAW",
+        stream_name=None,
+        all_annotations: bool = False,
+        use_names_as_ids: bool = False,
+    ):
         neo_kwargs = self.map_to_neo_kwargs(folder_path, lsx_files)
         NeoBaseRecordingExtractor.__init__(
-            self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
+            self,
+            stream_id=stream_id,
+            stream_name=stream_name,
+            all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
+            **neo_kwargs,
         )
         self._kwargs.update(dict(folder_path=str(Path(folder_path).absolute()), lsx_files=lsx_files))
 

--- a/src/spikeinterface/extractors/neoextractors/axona.py
+++ b/src/spikeinterface/extractors/neoextractors/axona.py
@@ -19,13 +19,21 @@ class AxonaRecordingExtractor(NeoBaseRecordingExtractor):
         The file path to load the recordings from.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     """
 
     NeoRawIOClass = "AxonaRawIO"
 
-    def __init__(self, file_path, all_annotations=False):
+    def __init__(self, file_path: str | Path, all_annotations: bool = False, use_names_as_ids: bool = False):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
-        NeoBaseRecordingExtractor.__init__(self, all_annotations=all_annotations, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(
+            self,
+            all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
+            **neo_kwargs,
+        )
         self._kwargs.update({"file_path": str(Path(file_path).absolute())})
 
     @classmethod

--- a/src/spikeinterface/extractors/neoextractors/biocam.py
+++ b/src/spikeinterface/extractors/neoextractors/biocam.py
@@ -29,6 +29,9 @@ class BiocamRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     """
 
     NeoRawIOClass = "BiocamRawIO"
@@ -40,11 +43,17 @@ class BiocamRecordingExtractor(NeoBaseRecordingExtractor):
         electrode_width=None,
         stream_id=None,
         stream_name=None,
-        all_annotations=False,
+        all_annotations: bool = False,
+        use_names_as_ids: bool = False,
     ):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(
-            self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
+            self,
+            stream_id=stream_id,
+            stream_name=stream_name,
+            all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
+            **neo_kwargs,
         )
 
         # load probe from probeinterface

--- a/src/spikeinterface/extractors/neoextractors/blackrock.py
+++ b/src/spikeinterface/extractors/neoextractors/blackrock.py
@@ -27,7 +27,8 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
     use_names_as_ids : bool, default: False
-        If False, use default IDs inherited from Neo. If True, use channel names as IDs.
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
 
     """
 
@@ -38,8 +39,8 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
         file_path,
         stream_id=None,
         stream_name=None,
-        all_annotations=False,
-        use_names_as_ids=False,
+        all_annotations: bool = False,
+        use_names_as_ids: bool = False,
     ):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
         neo_kwargs["load_nev"] = False  # Avoid loading spikes release in neo 0.12.0

--- a/src/spikeinterface/extractors/neoextractors/ced.py
+++ b/src/spikeinterface/extractors/neoextractors/ced.py
@@ -25,14 +25,24 @@ class CedRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     """
 
     NeoRawIOClass = "CedRawIO"
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
+    def __init__(
+        self, file_path, stream_id=None, stream_name=None, all_annotations: bool = False, use_names_as_ids: bool = False
+    ):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(
-            self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
+            self,
+            stream_id=stream_id,
+            stream_name=stream_name,
+            all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
+            **neo_kwargs,
         )
         self._kwargs.update(dict(file_path=str(Path(file_path).absolute())))
         self.extra_requirements.append("neo[ced]")

--- a/src/spikeinterface/extractors/neoextractors/edf.py
+++ b/src/spikeinterface/extractors/neoextractors/edf.py
@@ -24,14 +24,29 @@ class EDFRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations: bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     """
 
     NeoRawIOClass = "EDFRawIO"
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
+    def __init__(
+        self,
+        file_path,
+        stream_id=None,
+        stream_name=None,
+        all_annotations: bool = False,
+        use_names_as_ids: bool = False,
+    ):
         neo_kwargs = {"filename": str(file_path)}
         NeoBaseRecordingExtractor.__init__(
-            self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
+            self,
+            stream_id=stream_id,
+            stream_name=stream_name,
+            all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
+            **neo_kwargs,
         )
         self._kwargs.update({"file_path": str(Path(file_path).absolute())})
         self.extra_requirements.append("neo[edf]")

--- a/src/spikeinterface/extractors/neoextractors/intan.py
+++ b/src/spikeinterface/extractors/neoextractors/intan.py
@@ -28,7 +28,11 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         check we perform is that timestamps are continuous. Setting this to True will ignore this check and set
         the attribute `discontinuous_timestamps` to True in the underlying neo object.
     use_names_as_ids : bool, default: False
-        If False, use default IDs inherited from Neo. If True, use channel names as IDs.
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
+
+        In Intan the ids provided by NeoRawIO are the hardware channel ids while the names are custom names given by
+        the user
 
 
     """

--- a/src/spikeinterface/extractors/neoextractors/maxwell.py
+++ b/src/spikeinterface/extractors/neoextractors/maxwell.py
@@ -30,6 +30,9 @@ class MaxwellRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+    names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     rec_name : str, default: None
         When the file contains several recordings you need to specify the one
         you want to extract. (rec_name='rec0000').
@@ -50,6 +53,7 @@ class MaxwellRecordingExtractor(NeoBaseRecordingExtractor):
         all_annotations=False,
         rec_name=None,
         install_maxwell_plugin=False,
+        use_names_as_ids: bool = False,
     ):
         if install_maxwell_plugin:
             self.install_maxwell_plugin()
@@ -61,6 +65,7 @@ class MaxwellRecordingExtractor(NeoBaseRecordingExtractor):
             stream_name=stream_name,
             block_index=block_index,
             all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
             **neo_kwargs,
         )
 

--- a/src/spikeinterface/extractors/neoextractors/mcsraw.py
+++ b/src/spikeinterface/extractors/neoextractors/mcsraw.py
@@ -28,11 +28,22 @@ class MCSRawRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several blocks, specify the block index you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     """
 
     NeoRawIOClass = "RawMCSRawIO"
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+    def __init__(
+        self,
+        file_path,
+        stream_id=None,
+        stream_name=None,
+        block_index=None,
+        all_annotations=False,
+        use_names_as_ids: bool = False,
+    ):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(
             self,
@@ -40,6 +51,7 @@ class MCSRawRecordingExtractor(NeoBaseRecordingExtractor):
             stream_name=stream_name,
             block_index=block_index,
             all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
             **neo_kwargs,
         )
         self._kwargs.update(dict(file_path=str(Path(file_path).absolute())))

--- a/src/spikeinterface/extractors/neoextractors/mearec.py
+++ b/src/spikeinterface/extractors/neoextractors/mearec.py
@@ -38,13 +38,21 @@ class MEArecRecordingExtractor(NeoBaseRecordingExtractor):
         The file path to load the recordings from.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     """
 
     NeoRawIOClass = "MEArecRawIO"
 
-    def __init__(self, file_path: Union[str, Path], all_annotations: bool = False):
+    def __init__(self, file_path: Union[str, Path], all_annotations: bool = False, use_names_as_ids: bool = False):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
-        NeoBaseRecordingExtractor.__init__(self, all_annotations=all_annotations, **neo_kwargs)
+        NeoBaseRecordingExtractor.__init__(
+            self,
+            all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
+            **neo_kwargs,
+        )
 
         self.extra_requirements.append("mearec")
 

--- a/src/spikeinterface/extractors/neoextractors/neuralynx.py
+++ b/src/spikeinterface/extractors/neoextractors/neuralynx.py
@@ -29,6 +29,9 @@ class NeuralynxRecordingExtractor(NeoBaseRecordingExtractor):
     exclude_filename : list[str], default: None
         List of filename to exclude from the loading.
         For example, use `exclude_filename=["events.nev"]` to skip loading the event file.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     strict_gap_mode : bool, default: False
         See neo documentation.
         Detect gaps using strict mode or not.
@@ -44,16 +47,22 @@ class NeuralynxRecordingExtractor(NeoBaseRecordingExtractor):
 
     def __init__(
         self,
-        folder_path,
+        folder_path: str | Path,
         stream_id=None,
         stream_name=None,
         all_annotations=False,
         exclude_filename=None,
         strict_gap_mode=False,
+        use_names_as_ids: bool = False,
     ):
         neo_kwargs = self.map_to_neo_kwargs(folder_path, exclude_filename, strict_gap_mode)
         NeoBaseRecordingExtractor.__init__(
-            self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
+            self,
+            stream_id=stream_id,
+            stream_name=stream_name,
+            all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
+            **neo_kwargs,
         )
         self._kwargs.update(
             dict(folder_path=str(Path(folder_path).absolute()), exclude_filename=exclude_filename),

--- a/src/spikeinterface/extractors/neoextractors/neuroexplorer.py
+++ b/src/spikeinterface/extractors/neoextractors/neuroexplorer.py
@@ -45,14 +45,24 @@ class NeuroExplorerRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     """
 
     NeoRawIOClass = "NeuroExplorerRawIO"
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
+    def __init__(
+        self, file_path, stream_id=None, stream_name=None, all_annotations: bool = False, use_names_as_ids: bool = False
+    ):
         neo_kwargs = {"filename": str(file_path)}
         NeoBaseRecordingExtractor.__init__(
-            self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
+            self,
+            stream_id=stream_id,
+            stream_name=stream_name,
+            all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
+            **neo_kwargs,
         )
         self._kwargs.update({"file_path": str(Path(file_path).absolute())})
         self.extra_requirements.append("neo[edf]")

--- a/src/spikeinterface/extractors/neoextractors/neuroscope.py
+++ b/src/spikeinterface/extractors/neoextractors/neuroscope.py
@@ -35,15 +35,31 @@ class NeuroScopeRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     """
 
     NeoRawIOClass = "NeuroScopeRawIO"
 
-    def __init__(self, file_path, xml_file_path=None, stream_id=None, stream_name=None, all_annotations=False):
+    def __init__(
+        self,
+        file_path,
+        xml_file_path=None,
+        stream_id=None,
+        stream_name: bool = None,
+        all_annotations: bool = False,
+        use_names_as_ids: bool = False,
+    ):
         neo_kwargs = self.map_to_neo_kwargs(file_path, xml_file_path)
 
         NeoBaseRecordingExtractor.__init__(
-            self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
+            self,
+            stream_id=stream_id,
+            stream_name=stream_name,
+            all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
+            **neo_kwargs,
         )
         if xml_file_path is not None:
             xml_file_path = str(Path(xml_file_path).absolute())

--- a/src/spikeinterface/extractors/neoextractors/nix.py
+++ b/src/spikeinterface/extractors/neoextractors/nix.py
@@ -25,11 +25,22 @@ class NixRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several blocks, specify the block index you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     """
 
     NeoRawIOClass = "NIXRawIO"
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+    def __init__(
+        self,
+        file_path,
+        stream_id=None,
+        stream_name=None,
+        block_index=None,
+        all_annotations: bool = False,
+        use_names_as_ids: bool = False,
+    ):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(
             self,
@@ -37,6 +48,7 @@ class NixRecordingExtractor(NeoBaseRecordingExtractor):
             stream_name=stream_name,
             block_index=block_index,
             all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
             **neo_kwargs,
         )
         self._kwargs.update(dict(file_path=str(Path(file_path).absolute()), stream_id=stream_id))

--- a/src/spikeinterface/extractors/neoextractors/openephys.py
+++ b/src/spikeinterface/extractors/neoextractors/openephys.py
@@ -59,6 +59,9 @@ class OpenEphysLegacyRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several blocks (experiments), specify the block index you want to load
     all_annotations : bool, default: False
         Load exhaustively all annotation from neo
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     ignore_timestamps_errors : None
         Deprecated keyword argument. This is now ignored.
         neo.OpenEphysRawIO is now handling gaps directly but makes the read slower.
@@ -72,8 +75,9 @@ class OpenEphysLegacyRecordingExtractor(NeoBaseRecordingExtractor):
         stream_id=None,
         stream_name=None,
         block_index=None,
-        all_annotations=False,
-        ignore_timestamps_errors=None,
+        all_annotations: bool = False,
+        use_names_as_ids: bool = False,
+        ignore_timestamps_errors: bool = None,
     ):
         if ignore_timestamps_errors is not None:
             warnings.warn(
@@ -88,6 +92,7 @@ class OpenEphysLegacyRecordingExtractor(NeoBaseRecordingExtractor):
             stream_name=stream_name,
             block_index=block_index,
             all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
             **neo_kwargs,
         )
         self._kwargs.update(dict(folder_path=str(Path(folder_path).absolute())))

--- a/src/spikeinterface/extractors/neoextractors/spike2.py
+++ b/src/spikeinterface/extractors/neoextractors/spike2.py
@@ -24,14 +24,24 @@ class Spike2RecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     """
 
     NeoRawIOClass = "Spike2RawIO"
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
+    def __init__(
+        self, file_path, stream_id=None, stream_name=None, all_annotations=False, use_names_as_ids: bool = False
+    ):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(
-            self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
+            self,
+            stream_id=stream_id,
+            stream_name=stream_name,
+            all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
+            **neo_kwargs,
         )
         self._kwargs.update({"file_path": str(Path(file_path).absolute())})
         self.extra_requirements.append("sonpy")

--- a/src/spikeinterface/extractors/neoextractors/spikegadgets.py
+++ b/src/spikeinterface/extractors/neoextractors/spikegadgets.py
@@ -26,14 +26,29 @@ class SpikeGadgetsRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     """
 
     NeoRawIOClass = "SpikeGadgetsRawIO"
 
-    def __init__(self, file_path, stream_id=None, stream_name=None, all_annotations=False):
+    def __init__(
+        self,
+        file_path,
+        stream_id=None,
+        stream_name=None,
+        all_annotations: bool = False,
+        use_names_as_ids: bool = False,
+    ):
         neo_kwargs = self.map_to_neo_kwargs(file_path)
         NeoBaseRecordingExtractor.__init__(
-            self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
+            self,
+            stream_id=stream_id,
+            stream_name=stream_name,
+            all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
+            **neo_kwargs,
         )
         self._kwargs.update(dict(file_path=str(Path(file_path).absolute()), stream_id=stream_id))
 

--- a/src/spikeinterface/extractors/neoextractors/spikeglx.py
+++ b/src/spikeinterface/extractors/neoextractors/spikeglx.py
@@ -38,14 +38,30 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     """
 
     NeoRawIOClass = "SpikeGLXRawIO"
 
-    def __init__(self, folder_path, load_sync_channel=False, stream_id=None, stream_name=None, all_annotations=False):
+    def __init__(
+        self,
+        folder_path,
+        load_sync_channel=False,
+        stream_id=None,
+        stream_name=None,
+        all_annotations: bool = False,
+        use_names_as_ids: bool = False,
+    ):
         neo_kwargs = self.map_to_neo_kwargs(folder_path, load_sync_channel=load_sync_channel)
         NeoBaseRecordingExtractor.__init__(
-            self, stream_id=stream_id, stream_name=stream_name, all_annotations=all_annotations, **neo_kwargs
+            self,
+            stream_id=stream_id,
+            stream_name=stream_name,
+            all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
+            **neo_kwargs,
         )
 
         # open the corresponding stream probe for LF and AP

--- a/src/spikeinterface/extractors/neoextractors/tdt.py
+++ b/src/spikeinterface/extractors/neoextractors/tdt.py
@@ -23,13 +23,24 @@ class TdtRecordingExtractor(NeoBaseRecordingExtractor):
         If there are several streams, specify the stream name you want to load.
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+    use_names_as_ids : bool, default: False
+        Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
+        names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
     block_index : int, default: None
         If there are several blocks (experiments), specify the block index you want to load
     """
 
     NeoRawIOClass = "TdtRawIO"
 
-    def __init__(self, folder_path, stream_id=None, stream_name=None, block_index=None, all_annotations=False):
+    def __init__(
+        self,
+        folder_path,
+        stream_id=None,
+        stream_name=None,
+        block_index=None,
+        all_annotations: bool = False,
+        use_names_as_ids: bool = False,
+    ):
         neo_kwargs = self.map_to_neo_kwargs(folder_path)
         NeoBaseRecordingExtractor.__init__(
             self,
@@ -37,6 +48,7 @@ class TdtRecordingExtractor(NeoBaseRecordingExtractor):
             stream_name=stream_name,
             block_index=block_index,
             all_annotations=all_annotations,
+            use_names_as_ids=use_names_as_ids,
             **neo_kwargs,
         )
         self._kwargs.update(dict(folder_path=str(Path(folder_path).absolute())))


### PR DESCRIPTION
Should fix https://github.com/SpikeInterface/spikeinterface/issues/3194

This just make the option available but does not switch default behavior.