### PR TITLE
Analyzer docstring cleanup

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -815,10 +815,10 @@ class SortingAnalyzer:
 
         Parameters
         ----------
-        folder : str or Path
-            The output waveform folder
-        format : "binary_folder" | "zarr", default: "binary_folder"
-            The backend to use for saving the waveforms
+        folder : str | Path | None, default: None
+            The output waveform folder if `format` is "zarr" or "binary_folder"
+        format : "memory" | "binary_folder" | "zarr", default: "memory"
+            The new backend format to use
         """
         return self._save_or_select_or_merge(format=format, folder=folder)
 
@@ -835,8 +835,9 @@ class SortingAnalyzer:
             The unit ids to keep in the new SortingAnalyzer object
         format : "memory" | "binary_folder" | "zarr" , default: "memory"
             The format of the returned SortingAnalyzer.
-        folder : Path or None
-            The new folder where selected waveforms are copied.
+        folder : Path | None, deafult: None
+            The new folder where selected waveforms are copied if `format` is
+            "binary_folder" or "zarr"
 
         Returns
         -------
@@ -859,8 +860,9 @@ class SortingAnalyzer:
             The unit ids to remove in the new SortingAnalyzer object.
         format : "memory" | "binary_folder" | "zarr" , default: "memory"
             The format of the returned SortingAnalyzer.
-        folder : Path or None
-            The new folder where selected waveforms are copied.
+        folder : Path or None, default: None
+            The new folder where selected waveforms are copied if `format`
+            is "binary_folder" or "zarr"
 
         Returns
         -------
@@ -886,9 +888,9 @@ class SortingAnalyzer:
     ) -> "SortingAnalyzer":
         """
         This method is equivalent to `save_as()`but with a list of merges that have to be achieved.
-        Merges units by creating a new sorting analyzer object in a new folder with appropriate merges
+        Merges units by creating a new SortingAnalyzer object with the appropriate merges
 
-        Extensions are also updated to display the merged unit ids.
+        Extensions are also updated to display the merged `unit_ids`.
 
         Parameters
         ----------
@@ -898,30 +900,31 @@ class SortingAnalyzer:
         new_unit_ids : None or list
             A new unit_ids for merged units. If given, it needs to have the same length as `merge_unit_groups`. If None,
             merged units will have the first unit_id of every lists of merges
-        censor_ms : None or float
-            When merging units, any spikes violating this refractory period will be discarded. Default is None
-        merging_mode : "soft" can be in ["soft", "hard"]
-            How merges are performed. In the "soft" mode, merges will be approximated, with no reloading of the
-            waveforms. This will lead to approximations. If "hard", recomputations are accuratly performed,
+        censor_ms : None or float, default: None
+            When merging units, any spikes violating this refractory period will be discarded. If None all units are kept
+        merging_mode : ["soft", "hard"], default: "soft"
+            How merges are performed. If the `merge_mode` is "soft" , merges will be approximated, with no reloading of the
+            waveforms. This will lead to approximations. If `merge_mode` is "hard", recomputations are accurately performed,
             reloading waveforms if needed
         sparsity_overlap : float, default 0.75
             The percentage of overlap that units should share in order to accept merges. If this criteria is not
-            achieved, soft merging will not be possible
+            achieved, soft merging will not be possible and an error will be raised
         new_id_strategy : "append" | "take_first", default: "append"
             The strategy that should be used, if `new_unit_ids` is None, to create new unit_ids.
-                * "append" : new_units_ids will be added at the end of max(sorging.unit_ids)
+                * "append" : new_units_ids will be added at the end of max(sorting.unit_ids)
                 * "take_first" : new_unit_ids will be the first unit_id of every list of merges
-        folder : Path or None
-            The new folder where selected waveforms are copied
-        format : "auto" | "binary_folder" | "zarr"
-            The format of the folder.
-        verbose:
+        folder : Path or None | default: None
+            The new folder where selected waveforms are copied for `format` "binary_folder" or "zarr"
+        format : "memory" | "binary_folder" | "zarr", default: "memory"
+            The format of SortingAnalyzer
+        verbose : bool, default: False
+            Whether to display calculations (such as sparsity estimation)
 
 
         Returns
         -------
         analyzer :  SortingAnalyzer
-            The newly create sorting_analyzer with the selected units
+            The newly create SortingAnalyzer with the selected units
         """
 
         assert merging_mode in ["soft", "hard"], "Merging mode should be either soft or hard"

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -900,7 +900,7 @@ class SortingAnalyzer:
         new_unit_ids : None or list
             A new unit_ids for merged units. If given, it needs to have the same length as `merge_unit_groups`. If None,
             merged units will have the first unit_id of every lists of merges
-        censor_ms : None or float, default: None
+        censor_ms : None | float, default: None
             When merging units, any spikes violating this refractory period will be discarded. If None all units are kept
         merging_mode : ["soft", "hard"], default: "soft"
             How merges are performed. If the `merge_mode` is "soft" , merges will be approximated, with no reloading of the
@@ -913,7 +913,7 @@ class SortingAnalyzer:
             The strategy that should be used, if `new_unit_ids` is None, to create new unit_ids.
                 * "append" : new_units_ids will be added at the end of max(sorting.unit_ids)
                 * "take_first" : new_unit_ids will be the first unit_id of every list of merges
-        folder : Path or None | default: None
+        folder : Path | None, default: None
             The new folder where selected waveforms are copied for `format` "binary_folder" or "zarr"
         format : "memory" | "binary_folder" | "zarr", default: "memory"
             The format of SortingAnalyzer
@@ -924,7 +924,7 @@ class SortingAnalyzer:
         Returns
         -------
         analyzer :  SortingAnalyzer
-            The newly create SortingAnalyzer with the selected units
+            The newly create `SortingAnalyzer` with the selected units
         """
 
         assert merging_mode in ["soft", "hard"], "Merging mode should be either soft or hard"

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -816,7 +816,7 @@ class SortingAnalyzer:
         Parameters
         ----------
         folder : str | Path | None, default: None
-            The output waveform folder if `format` is "zarr" or "binary_folder"
+            The output folder if `format` is "zarr" or "binary_folder"
         format : "memory" | "binary_folder" | "zarr", default: "memory"
             The new backend format to use
         """
@@ -836,7 +836,7 @@ class SortingAnalyzer:
         format : "memory" | "binary_folder" | "zarr" , default: "memory"
             The format of the returned SortingAnalyzer.
         folder : Path | None, deafult: None
-            The new folder where selected waveforms are copied if `format` is
+            The new folder where the analyzer with selected units is copied if `format` is
             "binary_folder" or "zarr"
 
         Returns
@@ -861,7 +861,7 @@ class SortingAnalyzer:
         format : "memory" | "binary_folder" | "zarr" , default: "memory"
             The format of the returned SortingAnalyzer.
         folder : Path or None, default: None
-            The new folder where selected waveforms are copied if `format`
+            The new folder where the analyzer without removed units is copied if `format`
             is "binary_folder" or "zarr"
 
         Returns
@@ -914,7 +914,7 @@ class SortingAnalyzer:
                 * "append" : new_units_ids will be added at the end of max(sorting.unit_ids)
                 * "take_first" : new_unit_ids will be the first unit_id of every list of merges
         folder : Path | None, default: None
-            The new folder where selected waveforms are copied for `format` "binary_folder" or "zarr"
+            The new folder where the analyzer with merged units is copied for `format` "binary_folder" or "zarr"
         format : "memory" | "binary_folder" | "zarr", default: "memory"
             The format of SortingAnalyzer
         verbose : bool, default: False

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -897,7 +897,7 @@ class SortingAnalyzer:
         merge_unit_groups : list/tuple of lists/tuples
             A list of lists for every merge group. Each element needs to have at least two elements (two units to merge),
             but it can also have more (merge multiple units at once).
-        new_unit_ids : None or list
+        new_unit_ids : None | list, default: None
             A new unit_ids for merged units. If given, it needs to have the same length as `merge_unit_groups`. If None,
             merged units will have the first unit_id of every lists of merges
         censor_ms : None | float, default: None


### PR DESCRIPTION
Mostly just cleaning up the `merge_units` docstring for the release. We could probably do more cleanup later, but these are the big ones I saw. 