### PR TITLE
Remove unused rng from `drifting_generator.py`

### DIFF
--- a/src/spikeinterface/generation/drifting_generator.py
+++ b/src/spikeinterface/generation/drifting_generator.py
@@ -348,9 +348,6 @@ def generate_drifting_recording(
 
         This can be helpfull for motion benchmark.
     """
-
-    rng = np.random.default_rng(seed=seed)
-
     # probe
     if generate_probe_kwargs is None:
         generate_probe_kwargs = _toy_probes[probe_name]


### PR DESCRIPTION
This PR removes an unused `rng = np.random.default_rng(seed=seed)` from `generate_drifting_recording()`. I think this is a better pattern vs. setting global seed (detailed in [this](https://blog.scientific-python.org/numpy/numpy-rng/) nice article @h-mayorquin originally posted) but is currently unused so removed. An alternative is to make refactorings to pass this around?
