### PR TITLE
Drop python 3.8 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 description = "Python toolkit for analysis, visualization, and comparison of spike sorting output"
 readme = "README.md"
-requires-python = ">=3.8,<4.0"
+requires-python = ">=3.9,<4.0"
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Python 3.9 is going in October:

https://devguide.python.org/versions/

See #3253 plus we are not testing for python 3.8 in the CI. 

Let's drop it.