### PR TITLE
Expose save preprocessing in ks4

### DIFF
--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -217,7 +217,7 @@ class Kilosort4Sorter(BaseSorter):
                 do_CAR,
                 invert_sign,
                 device,
-                save_preprocesed_copy=save_preprocessed_copy,
+                save_preprocesed_copy=save_preprocessed_copy,  # this kwarg is correct (typo)
             )
             n_chan_bin, fs, NT, nt, twav_min, chan_map, dtype, do_CAR, invert, _, _, tmin, tmax, artifact, _, _ = (
                 get_run_parameters(ops)

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -99,7 +99,7 @@ class Kilosort4Sorter(BaseSorter):
         "save_extra_kwargs": "If True, additional kwargs are saved to the output",
         "skip_kilosort_preprocessing": "Can optionally skip the internal kilosort preprocessing",
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
-        "save_preprocessed_copy": "save a pre-processed copy of the data (including drift correction) to temp_wh.dat in the results directory",
+        "save_preprocessed_copy": "save a pre-processed copy of the data (including drift correction) to temp_wh.dat in the results directory and format Phy output to use that copy of the data",
         "torch_device": "Select the torch device auto/cuda/cpu",
     }
 

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -56,6 +56,7 @@ class Kilosort4Sorter(BaseSorter):
         "save_extra_kwargs": False,
         "skip_kilosort_preprocessing": False,
         "scaleproc": None,
+        "save_preprocessed_copy": False,
         "torch_device": "auto",
     }
 
@@ -98,6 +99,7 @@ class Kilosort4Sorter(BaseSorter):
         "save_extra_kwargs": "If True, additional kwargs are saved to the output",
         "skip_kilosort_preprocessing": "Can optionally skip the internal kilosort preprocessing",
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
+        "save_preprocessed_copy": "save a pre-processed copy of the data (including drift correction) to temp_wh.dat in the results directory",
         "torch_device": "Select the torch device auto/cuda/cpu",
     }
 
@@ -186,6 +188,7 @@ class Kilosort4Sorter(BaseSorter):
         do_CAR = params["do_CAR"]
         invert_sign = params["invert_sign"]
         save_extra_vars = params["save_extra_kwargs"]
+        save_preprocessed_copy = (params["save_preprocessed_copy"],)
         progress_bar = None
         settings_ks = {k: v for k, v in params.items() if k in DEFAULT_SETTINGS}
         settings_ks["n_chan_bin"] = recording.get_num_channels()
@@ -207,7 +210,15 @@ class Kilosort4Sorter(BaseSorter):
         results_dir = sorter_output_folder
         filename, data_dir, results_dir, probe = set_files(settings, filename, probe, probe_name, data_dir, results_dir)
         if version.parse(cls.get_sorter_version()) >= version.parse("4.0.12"):
-            ops = initialize_ops(settings, probe, recording.get_dtype(), do_CAR, invert_sign, device, False)
+            ops = initialize_ops(
+                settings,
+                probe,
+                recording.get_dtype(),
+                do_CAR,
+                invert_sign,
+                device,
+                save_preprocesed_copy=save_preprocessed_copy,
+            )
             n_chan_bin, fs, NT, nt, twav_min, chan_map, dtype, do_CAR, invert, _, _, tmin, tmax, artifact, _, _ = (
                 get_run_parameters(ops)
             )


### PR DESCRIPTION
This PR edits `kilosort4.py` to expose the `save_preprocessed_copy` parameter. Now, `temp_wh.dat` is saveed to the sorting output and `params.py` is edited to point `phy` to the `temp_wh.dat.` @carlacodes if you have some time maybe you could check off this fork/branch this is behaving as expected? I tested with the below code:

<details><summary> Test code </summary>

```
import numpy as np
import spikeinterface.full as si

recording, _, sorting = si.generate_drifting_recording(
    duration=10.0,
    generate_displacement_vector_kwargs=dict(
        displacement_sampling_frequency=5.0,
        drift_start_um=[0, 20],
        drift_stop_um=[0, -20],
        drift_step_um=1,
        motion_list=[
            dict(
                drift_mode="zigzag",
                non_rigid_gradient=None,
                t_start_drift=None,
                t_end_drift=None,
                period_s=200,
            ),
        ],
    ),
)

si.run_sorter("kilosort4", recording, save_preprocessed_copy=True)
```

</details>

At present this is not tested in #3085 but that can be extended after this PR is merged. 

More generally @alejoe91, at present `kilosort4.py` replicates the body of `run_sorter.py` but as versions progress, this might prove difficult to maintain and requires a lot of testing e.g. #3085 to check nothing was missed. I wonder if long-term (assuming I am correct in thinking this is done to skip: preprocessing and drift correction), we can ask / work with KS4 team to expose options to skip preprocessing if they are interested. Then, we could just wrap the `run_kilosort` function directly and testing would just be checking the kwargs are passed properly (rather than having to check the outputs). Maybe there are other considerations I have overlooked though, WDYT?