### PR TITLE
Proposal for adding Examples to docstrings

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/alphaomega.py
+++ b/src/spikeinterface/extractors/neoextractors/alphaomega.py
@@ -18,7 +18,7 @@ class AlphaOmegaRecordingExtractor(NeoBaseRecordingExtractor):
     folder_path : str or Path-like
         The folder path to the AlphaOmega recordings.
     lsx_files : list of strings or None, default: None
-        A list of listings files that refers to mpx files to load.
+        A list of files that refers to mpx files to load.
     stream_id : {"RAW", "LFP", "SPK", "ACC", "AI", "UD"}, default: "RAW"
         If there are several streams, specify the stream id you want to load.
     stream_name : str, default: None
@@ -28,6 +28,12 @@ class AlphaOmegaRecordingExtractor(NeoBaseRecordingExtractor):
     use_names_as_ids : bool, default: False
         Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
         names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
+
+    Examples
+    --------
+    >>> from spikeinterface.extractors import read_alphaomega
+    >>> recording = read_alphaomega(folder_path="alphaomega_folder")
+
     """
 
     NeoRawIOClass = "AlphaOmegaRawIO"

--- a/src/spikeinterface/extractors/neoextractors/axona.py
+++ b/src/spikeinterface/extractors/neoextractors/axona.py
@@ -22,6 +22,11 @@ class AxonaRecordingExtractor(NeoBaseRecordingExtractor):
     use_names_as_ids : bool, default: False
         Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
         names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
+
+    Examples
+    --------
+    >>> from spikeinterface.extractors import read_axona
+    >>> recording = read_axona(file_path=r'my_data.set')
     """
 
     NeoRawIOClass = "AxonaRawIO"

--- a/src/spikeinterface/extractors/neoextractors/ced.py
+++ b/src/spikeinterface/extractors/neoextractors/ced.py
@@ -28,6 +28,11 @@ class CedRecordingExtractor(NeoBaseRecordingExtractor):
     use_names_as_ids : bool, default: False
         Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
         names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
+
+    Examples
+    --------
+    >>> from spikeinterface.extractors import read_ced
+    >>> recording = read_ced(file_path=r'my_data.smr')
     """
 
     NeoRawIOClass = "CedRawIO"

--- a/src/spikeinterface/extractors/neoextractors/intan.py
+++ b/src/spikeinterface/extractors/neoextractors/intan.py
@@ -34,7 +34,13 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
         In Intan the ids provided by NeoRawIO are the hardware channel ids while the names are custom names given by
         the user
 
-
+    Examples
+    --------
+    >>> from spikeinterface.extractors import read_intan
+    # intan amplifier data is stored in stream_id = '0'
+    >>> recording = read_intan(file_path=r'my_data.rhd', stream_id='0')
+    # intan has multi-file formats as well, but in this case our path should point to the header file 'info.rhd'
+    >>> recording = read_intan(file_path=r'info.rhd', stream_id='0')
     """
 
     NeoRawIOClass = "IntanRawIO"

--- a/src/spikeinterface/extractors/neoextractors/plexon.py
+++ b/src/spikeinterface/extractors/neoextractors/plexon.py
@@ -30,6 +30,11 @@ class PlexonRecordingExtractor(NeoBaseRecordingExtractor):
         Example for wideband signals:
             names: ["WB01", "WB02", "WB03", "WB04"]
             ids: ["0" , "1", "2", "3"]
+
+    Examples
+    --------
+    >>> from spikeinterface.extractors import read_plexon
+    >>> recording = read_plexon(file_path=r'my_data.plx')
     """
 
     NeoRawIOClass = "PlexonRawIO"

--- a/src/spikeinterface/extractors/neoextractors/plexon2.py
+++ b/src/spikeinterface/extractors/neoextractors/plexon2.py
@@ -28,6 +28,11 @@ class Plexon2RecordingExtractor(NeoBaseRecordingExtractor):
             ids: ["source3.1" , "source3.2", "source3.3", "source3.4"]
     all_annotations : bool, default: False
         Load exhaustively all annotations from neo.
+
+    Examples
+    --------
+    >>> from spikeinterface.extractors import read_plexon2
+    >>> recording = read_plexon2(file_path=r'my_data.pl2')
     """
 
     NeoRawIOClass = "Plexon2RawIO"

--- a/src/spikeinterface/extractors/neoextractors/spikegadgets.py
+++ b/src/spikeinterface/extractors/neoextractors/spikegadgets.py
@@ -29,6 +29,11 @@ class SpikeGadgetsRecordingExtractor(NeoBaseRecordingExtractor):
     use_names_as_ids : bool, default: False
         Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
         names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
+
+    Examples
+    --------
+    >>> from spikeinterface.extractors import read_spikegadgets
+    >>> recording = read_spikegadgets(file_path=r'my_data.rec')
     """
 
     NeoRawIOClass = "SpikeGadgetsRawIO"

--- a/src/spikeinterface/extractors/neoextractors/spikeglx.py
+++ b/src/spikeinterface/extractors/neoextractors/spikeglx.py
@@ -41,6 +41,13 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
     use_names_as_ids : bool, default: False
         Determines the format of the channel IDs used by the extractor. If set to True, the channel IDs will be the
         names from NeoRawIO. If set to False, the channel IDs will be the ids provided by NeoRawIO.
+
+    Examples
+    --------
+    >>> from spikeinterface.extractors import read_spikeglx
+    >>> recording = read_spikeglx(folder_path=r'path_to_folder_with_data', load_sync_channel=False)
+    # we can load the sync channel, but then the probe is not loaded
+    >>> recording = read_spikeglx(folder_path=r'pat_to_folder_with_data', load_sync_channel=True)
     """
 
     NeoRawIOClass = "SpikeGLXRawIO"


### PR DESCRIPTION
To increase documentation for users that don't read the docs but instead use `help` or their IDE docstring reader we could begin to add examples to the code base. `read_intan` is the clearest for what I would like examples to be, but I think even beginning to add examples that we flesh out later would be an incremental improvement (for example intan stream_id ='0' is for amplifier data. I could also add an example with how to use name.

What do people think about this in general? 