### PR TITLE
Added sphinxcontrib-jquery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ test = [
 
 docs = [
     "Sphinx",
-    "sphinx_rtd_theme",
+    "sphinx_rtd_theme>=1.2",
     "sphinx-gallery",
     "sphinx-design",
     "numpydoc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ docs = [
     "sphinx-design",
     "numpydoc",
     "ipython",
+    "sphinxcontrib-jquery",
 
     # for notebooks in the gallery
     "MEArec", # Use as an example


### PR DESCRIPTION
…query

Fixes #3306  issue of missing the `sphinxcontrib.jquery` to the pyproject.toml.

Still needs to address other components of that issue.