### PR TITLE
Fix sortingview curation no merge case 

### DIFF
--- a/src/spikeinterface/curation/curation_format.py
+++ b/src/spikeinterface/curation/curation_format.py
@@ -96,10 +96,13 @@ def convert_from_sortingview_curation_format_v0(sortingview_dict, destination_fo
         sortingview_dict["mergeGroups"] = []
     merge_groups = sortingview_dict["mergeGroups"]
     merged_units = sum(merge_groups, [])
-    if len(merged_units) > 0:
-        unit_id_type = int if isinstance(merged_units[0], int) else str
+
+    first_unit_id = next(iter(sortingview_dict["labelsByUnit"].keys()))
+    if str.isdigit(first_unit_id):
+        unit_id_type = int
     else:
         unit_id_type = str
+
     all_units = []
     all_labels = []
     manual_labels = []

--- a/src/spikeinterface/curation/curation_format.py
+++ b/src/spikeinterface/curation/curation_format.py
@@ -92,7 +92,8 @@ def convert_from_sortingview_curation_format_v0(sortingview_dict, destination_fo
     """
 
     assert destination_format == "1"
-
+    if "mergeGroups" not in sortingview_dict.keys():
+        sortingview_dict["mergeGroups"] = []
     merge_groups = sortingview_dict["mergeGroups"]
     merged_units = sum(merge_groups, [])
     if len(merged_units) > 0:

--- a/src/spikeinterface/curation/tests/sv-sorting-curation-no-merge.json
+++ b/src/spikeinterface/curation/tests/sv-sorting-curation-no-merge.json
@@ -1,0 +1,1 @@
+{"labelsByUnit":{"2":["mua"],"3":["mua"],"4":["mua"],"5":["accept"],"6":["accept"],"7":["accept"],"8":["artifact"],"9":["artifact"]}}

--- a/src/spikeinterface/curation/tests/test_sortingview_curation.py
+++ b/src/spikeinterface/curation/tests/test_sortingview_curation.py
@@ -250,13 +250,13 @@ def test_json_no_merge_curation():
     sorting = generate_sorting(num_units=10)
 
     json_file = parent_folder / "sv-sorting-curation-no-merge.json"
-    sorting_curated_json = apply_sortingview_curation(sorting, uri_or_json=json_file)
-    # ValueError: Curation format: some labeled units are not in the unit list
+    sorting_curated = apply_sortingview_curation(sorting, uri_or_json=json_file)
 
 
 if __name__ == "__main__":
     # generate_sortingview_curation_dataset()
     # test_sha1_curation()
+
     test_gh_curation()
     test_json_curation()
     test_false_positive_curation()

--- a/src/spikeinterface/curation/tests/test_sortingview_curation.py
+++ b/src/spikeinterface/curation/tests/test_sortingview_curation.py
@@ -243,6 +243,18 @@ def test_label_inheritance_str():
     assert np.all(sorting_include_accept.get_property("accept"))
 
 
+def test_json_no_merge_curation():
+    """
+    Test curation with no merges using a JSON file.
+    """
+    sorting = generate_sorting(num_units=10)
+
+    # from curation.json
+    json_file = parent_folder / "sv-sorting-curation-no-merge.json"
+    # print(f"Sorting: {sorting.get_unit_ids()}")
+    sorting_curated_json = apply_sortingview_curation(sorting, uri_or_json=json_file)
+
+
 if __name__ == "__main__":
     # generate_sortingview_curation_dataset()
     # test_sha1_curation()
@@ -251,3 +263,4 @@ if __name__ == "__main__":
     test_false_positive_curation()
     test_label_inheritance_int()
     test_label_inheritance_str()
+    test_json_no_merge_curation()

--- a/src/spikeinterface/curation/tests/test_sortingview_curation.py
+++ b/src/spikeinterface/curation/tests/test_sortingview_curation.py
@@ -249,10 +249,9 @@ def test_json_no_merge_curation():
     """
     sorting = generate_sorting(num_units=10)
 
-    # from curation.json
     json_file = parent_folder / "sv-sorting-curation-no-merge.json"
-    # print(f"Sorting: {sorting.get_unit_ids()}")
     sorting_curated_json = apply_sortingview_curation(sorting, uri_or_json=json_file)
+    # ValueError: Curation format: some labeled units are not in the unit list
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3308 
In the case where no merges are made in sortingview, two errors are thrown. 
First error is due to sortingview not returning a curation_dict with a "mergeGroups" key which hopefully I fixed. 
Second error is due to type mismatch between labeled units and unit list. This one still needs to be fixed. 

Edit: Second error fixed. I believe this PR is ready to be reviewed. 

