### PR TITLE
Lazy loading of zarr timestamps

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -811,10 +811,9 @@ class BaseRecordingSegment(BaseSegment):
 
     def get_times(self):
         if self.time_vector is not None:
-            if isinstance(self.time_vector, np.ndarray):
-                return self.time_vector
-            else:
-                return np.array(self.time_vector)
+            if not isinstance(self.time_vector, np.ndarray):
+                self.time_vector = np.array(self.time_vector)
+            return self.time_vector
         else:
             time_vector = np.arange(self.get_num_samples(), dtype="float64")
             time_vector /= self.sampling_frequency

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -422,7 +422,7 @@ class BaseRecording(BaseRecordingSnippets):
 
         return time_kwargs
 
-    def get_times(self, segment_index=None):
+    def get_times(self, segment_index=None) -> np.ndarray:
         """Get time vector for a recording segment.
 
         If the segment has a time_vector, then it is returned. Otherwise
@@ -809,10 +809,9 @@ class BaseRecordingSegment(BaseSegment):
 
         BaseSegment.__init__(self)
 
-    def get_times(self):
+    def get_times(self) -> np.ndarray:
         if self.time_vector is not None:
-            if not isinstance(self.time_vector, np.ndarray):
-                self.time_vector = np.array(self.time_vector)
+            self.time_vector = np.asarray(self.time_vector)
             return self.time_vector
         else:
             time_vector = np.arange(self.get_num_samples(), dtype="float64")

--- a/src/spikeinterface/core/zarrextractors.py
+++ b/src/spikeinterface/core/zarrextractors.py
@@ -66,7 +66,7 @@ class ZarrRecordingExtractor(BaseRecording):
             time_kwargs = {}
             time_vector = self._root.get(f"times_seg{segment_index}", None)
             if time_vector is not None:
-                time_kwargs["time_vector"] = time_vector[:]
+                time_kwargs["time_vector"] = time_vector
             else:
                 if t_starts is None:
                     t_start = None


### PR DESCRIPTION
This was previously discussed here: https://github.com/SpikeInterface/spikeinterface/pull/2828

To sum up, loading and decompressing zarr timestamps for very long recordings can be quite time consuming, so we want to avoid doing that at init. When fetching the timestamps though, if they ar not a numpy array they are cast and cached as np.arryas, to avoid re-reading and re-decompressing at every call