### PR TITLE
Insist on version > 4.0.16 for kilosort 4

### DIFF
--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -57,6 +57,7 @@ class Kilosort4Sorter(BaseSorter):
         "skip_kilosort_preprocessing": False,
         "scaleproc": None,
         "torch_device": "auto",
+        "bad_channels": None,
     }
 
     _params_description = {
@@ -99,6 +100,7 @@ class Kilosort4Sorter(BaseSorter):
         "skip_kilosort_preprocessing": "Can optionally skip the internal kilosort preprocessing",
         "scaleproc": "int16 scaling of whitened data, if None set to 200.",
         "torch_device": "Select the torch device auto/cuda/cpu",
+        "bad_channels": "A list of channel indices (rows in the binary file) that should not be included in sorting. Listing channels here is equivalent to excluding them from the probe dictionary.",
     }
 
     sorter_description = """Kilosort4 is a Python package for spike sorting on GPUs with template matching.
@@ -132,6 +134,25 @@ class Kilosort4Sorter(BaseSorter):
         import kilosort as ks
 
         return ks.__version__
+
+    @classmethod
+    def initialize_folder(cls, recording, output_folder, verbose, remove_existing_folder):
+        if not cls.is_installed():
+            raise Exception(
+                f"The sorter {cls.sorter_name} is not installed. Please install it with:\n{cls.installation_mesg}"
+            )
+        cls.check_sorter_version()
+        return super(Kilosort4Sorter, cls).initialize_folder(recording, output_folder, verbose, remove_existing_folder)
+
+    @classmethod
+    def check_sorter_version(cls):
+        kilosort_version = version.parse(cls.get_sorter_version())
+        if kilosort_version < version.parse("4.0.16"):
+            raise Exception(
+                f"""SpikeInterface only supports kilosort versions 4.0.16 and above. You are running version {kilosort_version}. To install the latest version, run:
+                        >>> pip install kilosort --upgrade
+                """
+            )
 
     @classmethod
     def _setup_recording(cls, recording, sorter_output_folder, params, verbose):
@@ -205,17 +226,15 @@ class Kilosort4Sorter(BaseSorter):
         # NOTE: Also modifies settings in-place
         data_dir = ""
         results_dir = sorter_output_folder
-        filename, data_dir, results_dir, probe = set_files(settings, filename, probe, probe_name, data_dir, results_dir)
-        if version.parse(cls.get_sorter_version()) >= version.parse("4.0.12"):
-            ops = initialize_ops(settings, probe, recording.get_dtype(), do_CAR, invert_sign, device, False)
-            n_chan_bin, fs, NT, nt, twav_min, chan_map, dtype, do_CAR, invert, _, _, tmin, tmax, artifact, _, _ = (
-                get_run_parameters(ops)
-            )
-        else:
-            ops = initialize_ops(settings, probe, recording.get_dtype(), do_CAR, invert_sign, device)
-            n_chan_bin, fs, NT, nt, twav_min, chan_map, dtype, do_CAR, invert, _, _, tmin, tmax, artifact = (
-                get_run_parameters(ops)
-            )
+        bad_channels = params["bad_channels"]
+        filename, data_dir, results_dir, probe = set_files(
+            settings, filename, probe, probe_name, data_dir, results_dir, bad_channels
+        )
+
+        ops = initialize_ops(settings, probe, recording.get_dtype(), do_CAR, invert_sign, device, False)
+        n_chan_bin, fs, NT, nt, twav_min, chan_map, dtype, do_CAR, invert, _, _, tmin, tmax, artifact, _, _ = (
+            get_run_parameters(ops)
+        )
 
         # Set preprocessing and drift correction parameters
         if not params["skip_kilosort_preprocessing"]:


### PR DESCRIPTION
As discussed in #3316, we decided to only support the latest version of kilosort. This PR checks the version and makes the arguments consistent with the kilosort arguments for version 4.0.16.

I added the version check by extending `initialize_folder`, which is where the installation check is. It's a little awkward because we should do the installation check before the version check, but this doesn't quite fit in the structure of the `BaseSorter` `initialize_folder` method. So we actually check that kilosort is installed twice.

