### PR TITLE
Analyzer extension exit status

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -2186,7 +2186,9 @@ class AnalyzerExtension:
         return self._get_pipeline_nodes()
 
     def get_data(self, *args, **kwargs):
-        assert self.run_info["run_completed"], f"You must run the extension {self.extension_name} before retrieving data"
+        assert self.run_info[
+            "run_completed"
+        ], f"You must run the extension {self.extension_name} before retrieving data"
         assert len(self.data) > 0, "Extension has been run but no data found."
         return self._get_data(*args, **kwargs)
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1947,10 +1947,10 @@ class AnalyzerExtension:
                     # this load in memmory
                     ext_data = np.array(ext_data_)
 
-        if ext_data is None:
+        if ext_data is not None:
+            self.data[ext_data_name] = ext_data    
+        else:
             warnings.warn(f"Found no data for {self.extension_name}, extension should be re-computed.")
-
-        self.data[ext_data_name] = ext_data
 
     def copy(self, new_sorting_analyzer, unit_ids=None):
         # alessio : please note that this also replace the old select_units!!!
@@ -2183,7 +2183,8 @@ class AnalyzerExtension:
         return self._get_pipeline_nodes()
 
     def get_data(self, *args, **kwargs):
-        assert len(self.data) > 0, f"You must run the extension {self.extension_name} before retrieving data"
+        assert self.run_info["run_completed"], f"You must run the extension {self.extension_name} before retrieving data"
+        assert len(self.data) > 0, "Extension has been run but no data found — data file might be missing. Re-compute the extension."
         return self._get_data(*args, **kwargs)
 
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -2002,6 +2002,8 @@ class AnalyzerExtension:
         self._save_importing_provenance()
         self._save_data(**kwargs)
         self.run_info["data_loadable"] = self._check_data_loadable()
+        if self.run_info["data_loadable"]:
+            self.run_info["run_completed"] = True  # extensions that go through compute_several_extensions() and then run_node_pipeline() never have ext_instance.run() called, so need to check here (or at least somewhere) instead
         self._save_run_info()
 
     def _save_data(self, **kwargs):
@@ -2122,6 +2124,7 @@ class AnalyzerExtension:
         if save:
             self._save_params()
             self._save_importing_provenance()
+            self._save_run_info()
 
     def _save_params(self):
         params_to_save = self.params.copy()

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1934,7 +1934,6 @@ class AnalyzerExtension:
                     # and have a link to the old buffer on windows then it fails
                     # ext_data = np.load(ext_data_file, mmap_mode="r")
                     # so we go back to full loading
-                    print(f"{ext_data_file} is numpy!")
                     ext_data = np.load(ext_data_file)
                 elif ext_data_file.suffix == ".csv":
                     import pandas as pd

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1853,7 +1853,7 @@ class AnalyzerExtension:
             return ext
         else:
             return None
-    
+
     def load_run_info(self):
         if self.format == "binary_folder":
             extension_folder = self._get_binary_extension_folder()
@@ -1861,7 +1861,7 @@ class AnalyzerExtension:
             assert run_info_file.is_file(), f"No run_info file in extension {self.extension_name} folder"
             with open(str(run_info_file), "r") as f:
                 run_info = json.load(f)
-        
+
         elif self.format == "zarr":
             extension_group = self._get_zarr_extension_group(mode="r")
             assert "run_info" in extension_group.attrs, f"No run_info file in extension {self.extension_name} folder"
@@ -1892,7 +1892,11 @@ class AnalyzerExtension:
             for ext_data_file in extension_folder.iterdir():
                 # patch for https://github.com/SpikeInterface/spikeinterface/issues/3041
                 # maybe add a check for version number from the info.json during loading only
-                if ext_data_file.name == "params.json" or ext_data_file.name == "info.json" or ext_data_file.name == "run_info.json":
+                if (
+                    ext_data_file.name == "params.json"
+                    or ext_data_file.name == "info.json"
+                    or ext_data_file.name == "run_info.json"
+                ):
                     continue
                 ext_data_name = ext_data_file.stem
                 if ext_data_file.suffix == ".json":
@@ -1930,10 +1934,10 @@ class AnalyzerExtension:
                 else:
                     # this load in memmory
                     ext_data = np.array(ext_data_)
-        
+
         if ext_data is None:
             warnings.warn(f"Found no data for {self.extension_name}, extension should be re-computed.")
-        
+
         if keep:
             self.data[ext_data_name] = ext_data
 
@@ -1942,10 +1946,16 @@ class AnalyzerExtension:
             self.load_data(keep=False)
             return True
         except (
-            ValueError, IOError, EOFError, KeyError, UnicodeDecodeError,
-            json.JSONDecodeError, pickle.UnpicklingError, pd.errors.ParserError,
-            ArrayNotFoundError
-            ):
+            ValueError,
+            IOError,
+            EOFError,
+            KeyError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            pickle.UnpicklingError,
+            pd.errors.ParserError,
+            ArrayNotFoundError,
+        ):
             return False
 
     def copy(self, new_sorting_analyzer, unit_ids=None):
@@ -1981,7 +1991,7 @@ class AnalyzerExtension:
     def run(self, save=True, **kwargs):
         if save and not self.sorting_analyzer.is_read_only():
             # NB: this call to _save_params() also resets the folder or zarr group
-            self._save_params()  
+            self._save_params()
             self._save_importing_provenance()
             self._save_run_info()
 
@@ -2003,7 +2013,9 @@ class AnalyzerExtension:
         self._save_data(**kwargs)
         self.run_info["data_loadable"] = self._check_data_loadable()
         if self.run_info["data_loadable"]:
-            self.run_info["run_completed"] = True  # extensions that go through compute_several_extensions() and then run_node_pipeline() never have ext_instance.run() called, so need to check here (or at least somewhere) instead
+            self.run_info["run_completed"] = (
+                True  # extensions that go through compute_several_extensions() and then run_node_pipeline() never have ext_instance.run() called, so need to check here (or at least somewhere) instead
+            )
         self._save_run_info()
 
     def _save_data(self, **kwargs):

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -2021,9 +2021,7 @@ class AnalyzerExtension:
         self._save_params()
         self._save_importing_provenance()
         self._save_data(**kwargs)
-        self.run_info["run_completed"] = (
-            True  # extensions that go through compute_several_extensions() and then run_node_pipeline() never have ext_instance.run() called, so need to change run_completed here (or somewhere, at least)
-        )
+        self.run_info["run_completed"] = True
         self._save_run_info()
 
     def _save_data(self, **kwargs):

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -11,6 +11,7 @@ import weakref
 import shutil
 import warnings
 import importlib
+from time import time
 
 import numpy as np
 
@@ -1984,12 +1985,15 @@ class AnalyzerExtension:
             self._save_importing_provenance()
             self._save_run_info()
 
+        start = time()
         self._run(**kwargs)
-        
+        end = time()
+
         if save and not self.sorting_analyzer.is_read_only():
             self._save_data(**kwargs)
             self.run_info["data_loadable"] = self._check_data_loadable()  # maybe overkill?
-            
+
+        self.run_info["runtime_s"] = np.round(end - start, 1)
         self.run_info["run_completed"] = True
         self._save_run_info()
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1948,7 +1948,7 @@ class AnalyzerExtension:
                     ext_data = np.array(ext_data_)
 
         if ext_data is not None:
-            self.data[ext_data_name] = ext_data    
+            self.data[ext_data_name] = ext_data
         else:
             warnings.warn(f"Found no data for {self.extension_name}, extension should be re-computed.")
 
@@ -2183,8 +2183,12 @@ class AnalyzerExtension:
         return self._get_pipeline_nodes()
 
     def get_data(self, *args, **kwargs):
-        assert self.run_info["run_completed"], f"You must run the extension {self.extension_name} before retrieving data"
-        assert len(self.data) > 0, "Extension has been run but no data found — data file might be missing. Re-compute the extension."
+        assert self.run_info[
+            "run_completed"
+        ], f"You must run the extension {self.extension_name} before retrieving data"
+        assert (
+            len(self.data) > 0
+        ), "Extension has been run but no data found — data file might be missing. Re-compute the extension."
         return self._get_data(*args, **kwargs)
 
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -11,7 +11,7 @@ import weakref
 import shutil
 import warnings
 import importlib
-from time import time
+from time import perf_counter
 
 import numpy as np
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1349,12 +1349,13 @@ extension_params={"waveforms":{"ms_before":1.5, "ms_after": "2.5"}}\
             )
             t_end = perf_counter()
             # for pipeline node extensions we can only track the runtime of the run_node_pipeline
-            runtime_s = np.round(t_end - t_start, 1)
+            runtime_s = t_end - t_start
 
             for r, result in enumerate(results):
                 extension_name, variable_name = result_routage[r]
                 extension_instances[extension_name].data[variable_name] = result
                 extension_instances[extension_name].run_info["runtime_s"] = runtime_s
+                extension_instances[extension_name].run_info["run_completed"] = True
 
             for extension_name, extension_instance in extension_instances.items():
                 self.extensions[extension_name] = extension_instance
@@ -2008,7 +2009,7 @@ class AnalyzerExtension:
         t_start = perf_counter()
         self._run(**kwargs)
         t_end = perf_counter()
-        self.run_info["runtime_s"] = np.round(t_end - t_start, 1)
+        self.run_info["runtime_s"] = t_end - t_start
 
         if save and not self.sorting_analyzer.is_read_only():
             self._save_data(**kwargs)
@@ -2020,7 +2021,6 @@ class AnalyzerExtension:
         self._save_params()
         self._save_importing_provenance()
         self._save_data(**kwargs)
-        self.run_info["run_completed"] = True
         self._save_run_info()
 
     def _save_data(self, **kwargs):

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1862,9 +1862,12 @@ class AnalyzerExtension:
             ext.load_data()
             if cls.need_backward_compatibility_on_load:
                 ext._handle_backward_compatibility_on_load()
-            return ext
-        else:
-            return None
+            if len(ext.data) > 0:
+                return ext
+
+        # If extension run not completed, or data has gone missing,
+        # return None to indicate that the extension should be (re)computed.
+        return None
 
     def load_run_info(self):
         if self.format == "binary_folder":
@@ -2183,12 +2186,8 @@ class AnalyzerExtension:
         return self._get_pipeline_nodes()
 
     def get_data(self, *args, **kwargs):
-        assert self.run_info[
-            "run_completed"
-        ], f"You must run the extension {self.extension_name} before retrieving data"
-        assert (
-            len(self.data) > 0
-        ), "Extension has been run but no data found — data file might be missing. Re-compute the extension."
+        assert self.run_info["run_completed"], f"You must run the extension {self.extension_name} before retrieving data"
+        assert len(self.data) > 0, "Extension has been run but no data found."
         return self._get_data(*args, **kwargs)
 
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -2013,9 +2013,9 @@ class AnalyzerExtension:
             self._save_importing_provenance()
             self._save_run_info()
 
-        start = time()
+        start = perf_counter()
         self._run(**kwargs)
-        end = time()
+        end = perf_counter()
 
         if save and not self.sorting_analyzer.is_read_only():
             self._save_data(**kwargs)

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -125,6 +125,39 @@ def test_SortingAnalyzer_zarr(tmp_path, dataset):
     )
 
 
+def test_load_without_runtime_info(tmp_path, dataset):
+    recording, sorting = dataset
+
+    folder = tmp_path / "test_SortingAnalyzer_run_info"
+
+    extensions = ["random_spikes", "templates"]
+    # binary_folder
+    sorting_analyzer = create_sorting_analyzer(
+        sorting, recording, format="binary_folder", folder=folder, sparse=False, sparsity=None
+    )
+    sorting_analyzer.compute(extensions)
+    # remove run_info.json to mimic a previous version of spikeinterface
+    for ext in extensions:
+        (folder / "extensions" / ext / "run_info.json").unlink()
+    # should raise a warning for missing run_info
+    with pytest.warns(UserWarning):
+        sorting_analyzer = load_sorting_analyzer(folder, format="auto")
+
+    # zarr
+    folder = tmp_path / "test_SortingAnalyzer_run_info.zarr"
+    sorting_analyzer = create_sorting_analyzer(
+        sorting, recording, format="zarr", folder=folder, sparse=False, sparsity=None
+    )
+    sorting_analyzer.compute(extensions)
+    # remove run_info from attrs to mimic a previous version of spikeinterface
+    root = sorting_analyzer._get_zarr_root(mode="r+")
+    for ext in extensions:
+        del root["extensions"][ext].attrs["run_info"]
+    # should raise a warning for missing run_info
+    with pytest.warns(UserWarning):
+        sorting_analyzer = load_sorting_analyzer(folder, format="auto")
+
+
 def test_SortingAnalyzer_tmp_recording(dataset):
     recording, sorting = dataset
     recording_cached = recording.save(mode="memory")


### PR DESCRIPTION
Fixes #3329

Here's a first pass at adding information about an extension's completion (or not) to its metadata.

This PR adds a `run_info.json` file to each extension's folder. This contains keys:
* `run_completed` (whether or not the call to `AnalyzerExtension._run()` finished),
* `data_loadable` (whether or not `AnalyzerExtension.load_data()` can be called without an error) 
* `runtime_s` (the runtime of `AnalyzerExtension._run()` in seconds). 

The core logic is implemented in `AnalyzerExtension.run()` and wraps the call to the extension-specific `_run()`. Then when `AnalyzerExtension.get_extension()` is called (and redirects to `AnalyzerExtension.load()` internally), if the run wasn't completed, it simply returns None as if the extension doesn't exist, and the user would be able to catch that and re-run the extension.
 
There is a mild complication with extensions that use the `run_node_pipeline` if called through `compute_several_extensions`, because then `AnalyzerExtension.run()` is never actually called. Instead, it looks like `AnalyzerExtension.save()` is used, so I added the relevant lines there to catch that, and assume that if the code makes it there, the run is completed.

TODO:
* I'm not sure if the implementations in `merge()` and `copy()` are correct, I don't totally understand when those methods are expected to be called / what's wrapping them.
* Write some tests?
 
Notes:
* It is a bit of a slow-down to check if the data are loadable after each run. I'm ambivalent as to whether that check is actually useful, especially since data corruption is more likely to happen sometimes significantly after the run, not immediately after.
* It seemed more reasonable to add a separate `run_info.json` file than trying to cram this into `info.json`, since that is more about the code itself.
