### PR TITLE
Fix zarr folder suffix handling

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -17,6 +17,7 @@ import numpy as np
 from .globals import get_global_tmp_folder, is_set_global_tmp_folder
 from .core_tools import (
     check_json,
+    clean_zarr_folder_name,
     is_dict_extractor,
     SIJsonEncoder,
     make_paths_relative,
@@ -1061,9 +1062,7 @@ class BaseExtractor:
                         print(f"Use zarr_path={zarr_path}")
         else:
             if storage_options is None:
-                folder = Path(folder)
-                if folder.suffix != ".zarr":
-                    folder = folder.parent / f"{folder.stem}.zarr"
+                folder = clean_zarr_folder_name(folder)
                 if folder.is_dir() and overwrite:
                     shutil.rmtree(folder)
                 zarr_path = folder

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -153,6 +153,13 @@ def check_json(dictionary: dict) -> dict:
     return json.loads(json_string)
 
 
+def clean_zarr_folder_name(folder):
+        folder = Path(folder)
+        if folder.suffix != ".zarr":
+            folder = folder.parent / f"{folder.stem}.zarr"
+        return folder
+
+
 def add_suffix(file_path, possible_suffix):
     file_path = Path(file_path)
     if isinstance(possible_suffix, str):

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -154,10 +154,10 @@ def check_json(dictionary: dict) -> dict:
 
 
 def clean_zarr_folder_name(folder):
-        folder = Path(folder)
-        if folder.suffix != ".zarr":
-            folder = folder.parent / f"{folder.stem}.zarr"
-        return folder
+    folder = Path(folder)
+    if folder.suffix != ".zarr":
+        folder = folder.parent / f"{folder.stem}.zarr"
+    return folder
 
 
 def add_suffix(file_path, possible_suffix):

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -830,6 +830,8 @@ class SortingAnalyzer:
         format : "memory" | "binary_folder" | "zarr", default: "memory"
             The new backend format to use
         """
+        if format == "zarr":
+            folder = clean_zarr_folder_name(folder)
         return self._save_or_select_or_merge(format=format, folder=folder)
 
     def select_units(self, unit_ids, format="memory", folder=None) -> "SortingAnalyzer":
@@ -855,6 +857,8 @@ class SortingAnalyzer:
             The newly create sorting_analyzer with the selected units
         """
         # TODO check that unit_ids are in same order otherwise many extension do handle it properly!!!!
+        if format == "zarr":
+            folder = clean_zarr_folder_name(folder)
         return self._save_or_select_or_merge(format=format, folder=folder, unit_ids=unit_ids)
 
     def remove_units(self, remove_unit_ids, format="memory", folder=None) -> "SortingAnalyzer":
@@ -881,6 +885,8 @@ class SortingAnalyzer:
         """
         # TODO check that unit_ids are in same order otherwise many extension do handle it properly!!!!
         unit_ids = self.unit_ids[~np.isin(self.unit_ids, remove_unit_ids)]
+        if format == "zarr":
+            folder = clean_zarr_folder_name(folder)
         return self._save_or_select_or_merge(format=format, folder=folder, unit_ids=unit_ids)
 
     def merge_units(
@@ -938,6 +944,9 @@ class SortingAnalyzer:
         analyzer :  SortingAnalyzer
             The newly create `SortingAnalyzer` with the selected units
         """
+
+        if format == "zarr":
+            folder = clean_zarr_folder_name(folder)
 
         assert merging_mode in ["soft", "hard"], "Merging mode should be either soft or hard"
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -164,6 +164,8 @@ def load_sorting_analyzer(folder, load_extensions=True, format="auto"):
         The loaded SortingAnalyzer
 
     """
+    if format == "zarr":
+        folder = clean_zarr_folder_name(folder)
     return SortingAnalyzer.load(folder, load_extensions=load_extensions, format=format)
 
 


### PR DESCRIPTION
While troubleshooting for #3348, I noticed some odd behavior with zarr-based sorting analyzers. Specifically, in some parts of the code, it seemed like the user would be permitted to pass a folder name with the `.zarr` suffix included (ie `folder=/my/favorite/analyzer/` instead of `folder=/my/favorite/analyzer.zarr/`). This led to two error cases when using `create_sorting_analyzer` if the user tried to make a new folder without the suffix: 
1) it would be created by [create_zarr](https://github.com/SpikeInterface/spikeinterface/blob/007b6efd0e675e60658199112d0541fba2b432cd/src/spikeinterface/core/sortinganalyzer.py#L272) [with the suffix](https://github.com/SpikeInterface/spikeinterface/blob/007b6efd0e675e60658199112d0541fba2b432cd/src/spikeinterface/core/sortinganalyzer.py#L492), but then would fail to load directly after because the `load_from_zarr` function didn't add the `.zarr` suffix.
2) when checking for the folder's existence when `overwrite=True` in the [beginning](https://github.com/SpikeInterface/spikeinterface/blob/007b6efd0e675e60658199112d0541fba2b432cd/src/spikeinterface/core/sortinganalyzer.py#L114) of the function, it would not delete the folder (since the real folder has the `.zarr` extension, but the user's `folder` arg doesn't). But then later in `SortingAnalyzer.create_zarr` there is another check for whether the folder exists, and when the suffix'd folder does indeed exist, it raises an error, defeating the point of the `overwrite` kwarg.

This PR fixes that by:
1) creating a single `clean_zarr_folder_name` in `core_tools.py` that will check for a `.zarr` suffix and add one if there isn't already
2) cleaning the user-provided folder to ensure that if `mode="zarr"`, the folder passed to internal funcs always has `.zarr` appended. Cleaning happens in:
* create_sorting_analyzer
* load_sorting_analyzer
* merge_units
* save_as
* select_units
* remove_units
* [not copy, since that goes just into memory]

I also added cleaning in `SortingAnalyzer.create_zarr()` and `SortingAnalyzer._save_or_select_or_merge()` themselves which might be redundant. Hopefully I didn't miss any other entry points but I haven't extensively tested.

Obviously another solution here would be to insist that the user just put the `.zarr` suffix on themselves. But I like this way, as it allows for minimal change to a user's code (mode from binary_folder to zarr) and they will get the desired zarr behavior.