### PR TITLE
Fix widgets tests and add test on unit_table_properties

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -202,7 +202,7 @@ jobs:
         shell: bash
         if: env.RUN_WIDGETS_TESTS == 'true'
         run: |
-          pip install -e .[full]
+          pip install -e .[full,widgets]
           ./.github/run_tests.sh widgets --no-virtual-env
 
       - name: Test exporters

--- a/src/spikeinterface/widgets/tests/test_widgets.py
+++ b/src/spikeinterface/widgets/tests/test_widgets.py
@@ -539,6 +539,21 @@ class TestWidgets(unittest.TestCase):
                     backend=backend,
                     **self.backend_kwargs[backend],
                 )
+                # add unit_properties
+                sw.plot_sorting_summary(
+                    self.sorting_analyzer_sparse,
+                    unit_table_properties=["firing_rate", "snr"],
+                    backend=backend,
+                    **self.backend_kwargs[backend],
+                )
+                # adding a missing property should raise a warning
+                with self.assertWarns(UserWarning):
+                    sw.plot_sorting_summary(
+                        self.sorting_analyzer_sparse,
+                        unit_table_properties=["missing_property"],
+                        backend=backend,
+                        **self.backend_kwargs[backend],
+                    )
 
     def test_plot_agreement_matrix(self):
         possible_backends = list(sw.AgreementMatrixWidget.get_possible_backends())


### PR DESCRIPTION
Not sure how but https://github.com/SpikeInterface/spikeinterface/pull/3299 broke a bunch of widgets tests that were uncaught and are showing up in the daily full tests.

The fix here is that the `generate_unit_table_view` needs to support both a `SortingAnalyzer` and a `BaseSorting`, because it's used by other widgets as well