### PR TITLE
Add `BaseRecording.reset_times()` function

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -496,7 +496,11 @@ class BaseRecording(BaseRecordingSnippets):
             )
 
     def reset_times(self):
-        """Reset times in-memory for all segments that have a time vector."""
+        """
+        Reset times in-memory for all segments that have a time vector.
+        If the timestamps come from a file, the files won't be modified. but only the in-memory
+        attributes of the recording objects are deleted.
+        """
         for segment_index in range(self.get_num_segments()):
             if self.has_time_vector(segment_index):
                 rs = self._recording_segments[segment_index]

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -495,6 +495,14 @@ class BaseRecording(BaseRecordingSnippets):
                 "Use this carefully!"
             )
 
+    def reset_times(self):
+        """Reset times in-memory for all segments that have a time vector."""
+        for segment_index in range(self.get_num_segments()):
+            if self.has_time_vector(segment_index):
+                rs = self._recording_segments[segment_index]
+                rs.t_start = None
+                rs.time_vector = None
+
     def sample_index_to_time(self, sample_ind, segment_index=None):
         """
         Transform sample index into time in seconds

--- a/src/spikeinterface/core/tests/test_baserecording.py
+++ b/src/spikeinterface/core/tests/test_baserecording.py
@@ -289,6 +289,11 @@ def test_BaseRecording(create_cache_folder):
     rec3 = load_extractor(folder)
     assert np.allclose(times1, rec3.get_times(1))
 
+    # reset times
+    rec.reset_times()
+    for segm in range(num_seg):
+        assert not rec.has_time_vector(segment_index=segm)
+
     # test 3d probe
     rec_3d = generate_recording(ndim=3, num_channels=30)
     locations_3d = rec_3d.get_property("location")


### PR DESCRIPTION
This is a convenience function to discard time_vector information. It only acts in memory