### PR TITLE
"quality" property to be read as string instead of object in `BasePhyKilosortSortingExtractor`

### DIFF
--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -159,7 +159,8 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
                 self.set_property(key="original_cluster_id", values=cluster_info[prop_name])
             elif prop_name == "group":
                 # rename group property to 'quality'
-                self.set_property(key="quality", values=cluster_info[prop_name])
+                values = cluster_info[prop_name].values.astype("str")
+                self.set_property(key="quality", values=values)
             else:
                 if load_all_cluster_properties:
                     # pandas loads strings with empty values as objects with NaNs


### PR DESCRIPTION
At the moment, this specific column which we know is a string is unnecessarily read as an object.

This is a simple patch so this property is converted as a string.

Another possible more general solution is to use this function from pandas after reading the cluster info data frames and merging

https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.convert_dtypes.html 

I think this could simplify the logic here where we do the casting:

https://github.com/h-mayorquin/spikeinterface/blob/5953d6cdaac993928988a715725b824edf11d00a/src/spikeinterface/extractors/phykilosortextractors.py#L167-L183

@pauladkisson 