### PR TITLE
Fix time handling test memory

### DIFF
--- a/src/spikeinterface/core/tests/test_time_handling.py
+++ b/src/spikeinterface/core/tests/test_time_handling.py
@@ -280,7 +280,6 @@ class TestTimeHandling:
         """
         _, times_recording, _ = time_vector_recording
 
-        durations = [times_recording.get_duration(s) for s in range(times_recording.get_num_segments())]
         sorting = si.generate_sorting(
             durations=[times_recording.get_duration(s) for s in range(times_recording.get_num_segments())]
         )

--- a/src/spikeinterface/core/tests/test_time_handling.py
+++ b/src/spikeinterface/core/tests/test_time_handling.py
@@ -49,19 +49,14 @@ class TestTimeHandling:
         spaced timeseries data. Return the original recording,
         recoridng with time vectors added and list including the added time vectors.
         """
-        times_recording = copy.deepcopy(raw_recording)
+        times_recording = raw_recording.clone()
         all_time_vectors = []
         for segment_index in range(raw_recording.get_num_segments()):
 
             t_start = segment_index + 1 * 100
+            t_stop = t_start + raw_recording.get_duration(segment_index) + segment_index + 1
 
-            some_small_increasing_numbers = np.arange(times_recording.get_num_samples(segment_index)) * (
-                1 / times_recording.get_sampling_frequency()
-            )
-
-            offsets = np.cumsum(some_small_increasing_numbers)
-            time_vector = t_start + times_recording.get_times(segment_index) + offsets
-
+            time_vector = np.linspace(t_start, t_stop, raw_recording.get_num_samples(segment_index))
             all_time_vectors.append(time_vector)
             times_recording.set_times(times=time_vector, segment_index=segment_index)
 
@@ -285,6 +280,7 @@ class TestTimeHandling:
         """
         _, times_recording, _ = time_vector_recording
 
+        durations = [times_recording.get_duration(s) for s in range(times_recording.get_num_segments())]
         sorting = si.generate_sorting(
             durations=[times_recording.get_duration(s) for s in range(times_recording.get_num_segments())]
         )


### PR DESCRIPTION
@JoeZiminski I realized that the `test_sorting_analyzer_get_durations` test was using up 10s of GBs of RAM!

This is because the cumulative offsets ended up creating durations of over 30'000 seconds, used to generate sorting objects. I refactored the test to "manually" extend the duration with a simple linspace