### PR TITLE
Reset-times: segment must have either time vector or sampling frequency

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -506,6 +506,7 @@ class BaseRecording(BaseRecordingSnippets):
                 rs = self._recording_segments[segment_index]
                 rs.t_start = None
                 rs.time_vector = None
+                rs.sampling_frequency = self.sampling_frequency
 
     def sample_index_to_time(self, sample_ind, segment_index=None):
         """

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -497,16 +497,17 @@ class BaseRecording(BaseRecordingSnippets):
 
     def reset_times(self):
         """
-        Reset times in-memory for all segments that have a time vector.
+        Reset time information in-memory for all segments that have a time vector.
         If the timestamps come from a file, the files won't be modified. but only the in-memory
-        attributes of the recording objects are deleted.
+        attributes of the recording objects are deleted. Also `t_start` is set to None and the
+        segment's sampling frequency is set to the recording's sampling frequency.
         """
         for segment_index in range(self.get_num_segments()):
             if self.has_time_vector(segment_index):
                 rs = self._recording_segments[segment_index]
-                rs.t_start = None
                 rs.time_vector = None
-                rs.sampling_frequency = self.sampling_frequency
+            rs.t_start = None
+            rs.sampling_frequency = self.sampling_frequency
 
     def sample_index_to_time(self, sample_ind, segment_index=None):
         """

--- a/src/spikeinterface/core/tests/test_baserecording.py
+++ b/src/spikeinterface/core/tests/test_baserecording.py
@@ -292,7 +292,11 @@ def test_BaseRecording(create_cache_folder):
     # reset times
     rec.reset_times()
     for segm in range(num_seg):
+        time_info = rec.get_time_info(segment_index=segm)
         assert not rec.has_time_vector(segment_index=segm)
+        assert time_info["t_start"] is None
+        assert time_info["time_vector"] is None
+        assert time_info["sampling_frequency"] == rec.sampling_frequency
 
     # test 3d probe
     rec_3d = generate_recording(ndim=3, num_channels=30)


### PR DESCRIPTION
Fixes a bug in reset times that causes issues downstream, since rec segments must have either a `sampling_frequency` or a `time_vector`