### PR TITLE
Fix integer overflow of the total sample number when concatenating long recordings

### DIFF
--- a/src/spikeinterface/core/segmentutils.py
+++ b/src/spikeinterface/core/segmentutils.py
@@ -157,7 +157,7 @@ class ProxyConcatenateRecordingSegment(BaseRecordingSegment):
         self.parent_segments = parent_segments
         self.all_length = [rec_seg.get_num_samples() for rec_seg in self.parent_segments]
         self.cumsum_length = [0] + [sum(self.all_length[: i + 1]) for i in range(len(self.all_length))]
-        self.total_length = int(np.sum(self.all_length, dtype=np.int64))
+        self.total_length = int(sum(self.all_length))
 
     def get_num_samples(self):
         return self.total_length
@@ -450,7 +450,7 @@ class ProxyConcatenateSortingSegment(BaseSortingSegment):
         self.parent_segments = parent_segments
         self.parent_num_samples = parent_num_samples
         self.cumsum_length = np.cumsum([0] + self.parent_num_samples)
-        self.total_num_samples = np.sum(self.parent_num_samples, dtype=np.int64)
+        self.total_num_samples = int(sum(self.parent_num_samples))
 
     def get_num_samples(self):
         return self.total_num_samples

--- a/src/spikeinterface/core/segmentutils.py
+++ b/src/spikeinterface/core/segmentutils.py
@@ -157,7 +157,7 @@ class ProxyConcatenateRecordingSegment(BaseRecordingSegment):
         self.parent_segments = parent_segments
         self.all_length = [rec_seg.get_num_samples() for rec_seg in self.parent_segments]
         self.cumsum_length = [0] + [sum(self.all_length[: i + 1]) for i in range(len(self.all_length))]
-        self.total_length = int(np.sum(self.all_length))
+        self.total_length = int(np.sum(self.all_length, dtype=np.int64))
 
     def get_num_samples(self):
         return self.total_length
@@ -450,7 +450,7 @@ class ProxyConcatenateSortingSegment(BaseSortingSegment):
         self.parent_segments = parent_segments
         self.parent_num_samples = parent_num_samples
         self.cumsum_length = np.cumsum([0] + self.parent_num_samples)
-        self.total_num_samples = np.sum(self.parent_num_samples)
+        self.total_num_samples = np.sum(self.parent_num_samples, dtype=np.int64)
 
     def get_num_samples(self):
         return self.total_num_samples


### PR DESCRIPTION
Fix integer overflow of the total sample number when concatenating long recordings.

![image](https://github.com/user-attachments/assets/3f66d759-603e-4d37-8283-4bb01f1290fc)
The bug occurs when concatenating recordings exceeding 24 hours in total length at a 30000 Hz sampling rate, leading to integer overflow in `np.sum` function.

Simply adding `dtype=np.int64` in `np.sum` resolves this bug.
![image](https://github.com/user-attachments/assets/655d14d9-b41a-4c1d-a113-6ece25d2ae60)
