### PR TITLE
Update the method of creating an empty file with right size when saving binary files

### DIFF
--- a/src/spikeinterface/core/recording_tools.py
+++ b/src/spikeinterface/core/recording_tools.py
@@ -131,8 +131,10 @@ def write_binary_recording(
         data_size_bytes = dtype_size_bytes * num_frames * num_channels
         file_size_bytes = data_size_bytes + byte_offset
 
+        # create a file with file_size_bytes
         file = open(file_path, "wb+")
-        file.truncate(file_size_bytes)
+        file.seek(file_size_bytes - 1)
+        file.write(b'\0')
         file.close()
         assert Path(file_path).is_file()
 


### PR DESCRIPTION
The current method of creating an empty file with `file_size_bytes` is significantly slow, especially for large files. This PR addresses the issue by introducing a more efficient approach.

Current Implementation in `write_binary_recording` (located in `src/spikeinterface/core/recording_tools.py`):
```python
file = open(file_path, "wb+")
file.truncate(file_size_bytes)
file.close()
```  

Proposed Improvement:
```python
file = open(file_path, "wb+")
file.seek(file_size_bytes - 1)
file.write(b'\0')
file.close()
```

Creating a 100 GB empty file on SSD:
```
Time using seek: 0.05744457244873047 seconds
Time using truncate: 88.06437873840332 seconds
```