### PR TITLE
Fix argument spelling in check for binary compatibility

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -768,7 +768,13 @@ class BaseRecording(BaseRecordingSnippets):
             raise NotImplementedError
 
     def binary_compatible_with(
-        self, dtype=None, time_axis=None, file_paths_lenght=None, file_offset=None, file_suffix=None
+        self,
+        dtype=None,
+        time_axis=None,
+        file_paths_length=None,
+        file_offset=None,
+        file_suffix=None,
+        file_paths_lenght=None,
     ):
         """
         Check is the recording is binary compatible with some constrain on
@@ -779,6 +785,15 @@ class BaseRecording(BaseRecordingSnippets):
           * file_offset
           * file_suffix
         """
+
+        # spelling typo need to fix
+        if file_paths_lenght is not None:
+            warnings.warn(
+                "`file_paths_lenght` is deprecated and will be removed in 0.103.0 please use `file_paths_length`"
+            )
+            if file_paths_length is None:
+                file_paths_length = file_paths_lenght
+
         if not self.is_binary_compatible():
             return False
 
@@ -790,7 +805,7 @@ class BaseRecording(BaseRecordingSnippets):
         if time_axis is not None and time_axis != d["time_axis"]:
             return False
 
-        if file_paths_lenght is not None and file_paths_lenght != len(d["file_paths"]):
+        if file_paths_length is not None and file_paths_length != len(d["file_paths"]):
             return False
 
         if file_offset is not None and file_offset != d["file_offset"]:

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -179,7 +179,7 @@ class Kilosort4Sorter(BaseSorter):
         write_prb(probe_filename, pg)
 
         if params["use_binary_file"]:
-            if not recording.binary_compatible_with(time_axis=0, file_paths_lenght=1):
+            if not recording.binary_compatible_with(time_axis=0, file_paths_length=1):
                 # local copy needed
                 binary_file_path = sorter_output_folder / "recording.dat"
                 write_binary_recording(
@@ -235,7 +235,7 @@ class Kilosort4Sorter(BaseSorter):
         probe_name = ""
 
         if params["use_binary_file"] is None:
-            if recording.binary_compatible_with(time_axis=0, file_paths_lenght=1):
+            if recording.binary_compatible_with(time_axis=0, file_paths_length=1):
                 # no copy
                 binary_description = recording.get_binary_description()
                 filename = str(binary_description["file_paths"][0])
@@ -247,7 +247,7 @@ class Kilosort4Sorter(BaseSorter):
                 file_object = RecordingExtractorAsArray(recording_extractor=recording)
         elif params["use_binary_file"]:
             # here we force the use of a binary file
-            if recording.binary_compatible_with(time_axis=0, file_paths_lenght=1):
+            if recording.binary_compatible_with(time_axis=0, file_paths_length=1):
                 # no copy
                 binary_description = recording.get_binary_description()
                 filename = str(binary_description["file_paths"][0])

--- a/src/spikeinterface/sorters/external/kilosortbase.py
+++ b/src/spikeinterface/sorters/external/kilosortbase.py
@@ -127,7 +127,7 @@ class KilosortBase:
         skip_kilosort_preprocessing = params.get("skip_kilosort_preprocessing", False)
 
         if (
-            recording.binary_compatible_with(dtype="int16", time_axis=0, file_paths_lenght=1)
+            recording.binary_compatible_with(dtype="int16", time_axis=0, file_paths_length=1)
             and not skip_kilosort_preprocessing
         ):
             # no copy


### PR DESCRIPTION
@alejoe91, I'm not sure what the problem is here; I wanted to check if we check for 'int16' in KS which we do. I noticed a typo so I fixed it, but does this check not actually fix the problem for users (related to #3404)? 