### PR TITLE
Refactor pandas save load and convert dtypes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ preprocessing = [
 full = [
     "h5py",
     "pandas",
-    "xarray",
     "scipy",
     "scikit-learn",
     "networkx",
@@ -148,7 +147,6 @@ test = [
     "pytest-dependency",
     "pytest-cov",
 
-    "xarray",
     "huggingface_hub",
 
     # preprocessing
@@ -193,7 +191,6 @@ docs = [
     "pandas", # in the modules gallery comparison tutorial
     "hdbscan>=0.8.33",   # For sorters spykingcircus2 + tridesclous
     "numba", # For many postprocessing functions
-    "xarray", # For use of SortingAnalyzer zarr format
     "networkx",
     # Download data
     "pooch>=1.8.2",

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -591,7 +591,7 @@ class SortingAnalyzer:
                 warnings.warn(
                     "The zarr store was not properly consolidated prior to v0.101.1. "
                     "This may lead to unexpected behavior in loading extensions. "
-                    "Please consider re-saving the SortingAnalyzer object."
+                    "Please consider re-generating the SortingAnalyzer object."
                 )
 
         # load internal sorting in memory

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -2240,9 +2240,10 @@ class AnalyzerExtension:
         return self._get_pipeline_nodes()
 
     def get_data(self, *args, **kwargs):
-        assert self.run_info[
-            "run_completed"
-        ], f"You must run the extension {self.extension_name} before retrieving data"
+        if self.run_info is not None:
+            assert self.run_info[
+                "run_completed"
+            ], f"You must run the extension {self.extension_name} before retrieving data"
         assert len(self.data) > 0, "Extension has been run but no data found."
         return self._get_data(*args, **kwargs)
 

--- a/src/spikeinterface/postprocessing/template_metrics.py
+++ b/src/spikeinterface/postprocessing/template_metrics.py
@@ -287,7 +287,7 @@ class ComputeTemplateMetrics(AnalyzerExtension):
                     warnings.warn(f"Error computing metric {metric_name} for unit {unit_id}: {e}")
                     value = np.nan
                 template_metrics.at[index, metric_name] = value
-        return template_metrics
+        return template_metrics.convert_dtypes()
 
     def _run(self, verbose=False):
         self.data["metrics"] = self._compute_metrics(

--- a/src/spikeinterface/postprocessing/template_metrics.py
+++ b/src/spikeinterface/postprocessing/template_metrics.py
@@ -287,7 +287,11 @@ class ComputeTemplateMetrics(AnalyzerExtension):
                     warnings.warn(f"Error computing metric {metric_name} for unit {unit_id}: {e}")
                     value = np.nan
                 template_metrics.at[index, metric_name] = value
-        return template_metrics.convert_dtypes()
+
+        # we use the convert_dtypes to convert the columns to the most appropriate dtype and avoid object columns
+        # (in case of NaN values)
+        template_metrics = template_metrics.convert_dtypes()
+        return template_metrics
 
     def _run(self, verbose=False):
         self.data["metrics"] = self._compute_metrics(

--- a/src/spikeinterface/postprocessing/tests/common_extension_tests.py
+++ b/src/spikeinterface/postprocessing/tests/common_extension_tests.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pytest
 import shutil
 import numpy as np
-import pandas as pd
 
 from spikeinterface.core import generate_ground_truth_recording
 from spikeinterface.core import create_sorting_analyzer, load_sorting_analyzer
@@ -117,6 +116,8 @@ class AnalyzerExtensionCommonTestSuite:
         with the passed parameters, and check the output is not empty, the extension
         exists and `select_units()` method works.
         """
+        import pandas as pd
+
         if extension_class.need_job_kwargs:
             job_kwargs = dict(n_jobs=2, chunk_duration="1s", progress_bar=True)
         else:

--- a/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -108,6 +108,8 @@ class ComputeQualityMetrics(AnalyzerExtension):
         """
         Compute quality metrics.
         """
+        import pandas as pd
+
         metric_names = self.params["metric_names"]
         qm_params = self.params["qm_params"]
         # sparsity = self.params["sparsity"]
@@ -131,8 +133,6 @@ class ComputeQualityMetrics(AnalyzerExtension):
         else:
             non_empty_unit_ids = unit_ids
             empty_unit_ids = []
-
-        import pandas as pd
 
         metrics = pd.DataFrame(index=unit_ids)
 
@@ -185,7 +185,10 @@ class ComputeQualityMetrics(AnalyzerExtension):
         if len(empty_unit_ids) > 0:
             metrics.loc[empty_unit_ids] = np.nan
 
-        return metrics.convert_dtypes()
+        # we use the convert_dtypes to convert the columns to the most appropriate dtype and avoid object columns
+        # (in case of NaN values)
+        metrics = metrics.convert_dtypes()
+        return metrics
 
     def _run(self, verbose=False, **job_kwargs):
         self.data["metrics"] = self._compute_metrics(

--- a/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -185,7 +185,7 @@ class ComputeQualityMetrics(AnalyzerExtension):
         if len(empty_unit_ids) > 0:
             metrics.loc[empty_unit_ids] = np.nan
 
-        return metrics
+        return metrics.convert_dtypes()
 
     def _run(self, verbose=False, **job_kwargs):
         self.data["metrics"] = self._compute_metrics(

--- a/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -141,7 +141,6 @@ class ComputeQualityMetrics(AnalyzerExtension):
         """
         import pandas as pd
 
-        metric_names = self.params["metric_names"]
         qm_params = self.params["qm_params"]
         # sparsity = self.params["sparsity"]
         seed = self.params["seed"]


### PR DESCRIPTION
We found out that zarr consolidation doens't seem to play well with our way of saving/loading dataframes to zarr, using xarray.

`xarray` was only used to save/load pandas dataframes to zarr, and this PR modifies that by saving each column and the index directly. This is similar to how xarray saves to zarr, so it should be backcompatible (testing now).

To make sure we don't run in such problems in the future, I added a roundtrip test in the common extension tests that asserts that data reloaded is the same as the original ones.

As sugegsted by @h-mayorquin here #3365, the generated and reloaded dataframes are also converted to numpy dtypes with the `convert_dtypes` function. We just have to make sure to call a `Series.to_numpy` to cast pandas dtypes to numpy ones.
