### PR TITLE
Fix integer overflow in parallel computing

### DIFF
--- a/src/spikeinterface/core/job_tools.py
+++ b/src/spikeinterface/core/job_tools.py
@@ -136,11 +136,8 @@ def divide_segment_into_chunks(num_frames, chunk_size):
     else:
         n = num_frames // chunk_size
 
-        frame_starts = np.arange(n) * chunk_size
-        frame_stops = frame_starts + chunk_size
-
-        frame_starts = frame_starts.tolist()
-        frame_stops = frame_stops.tolist()
+        frame_starts = [i * chunk_size for i in range(n)]
+        frame_stops = [(i+1) * chunk_size for i in range(n)]
 
         if (num_frames % chunk_size) > 0:
             frame_starts.append(n * chunk_size)

--- a/src/spikeinterface/core/job_tools.py
+++ b/src/spikeinterface/core/job_tools.py
@@ -137,7 +137,7 @@ def divide_segment_into_chunks(num_frames, chunk_size):
         n = num_frames // chunk_size
 
         frame_starts = [i * chunk_size for i in range(n)]
-        frame_stops = [(i + 1) * chunk_size for i in range(n)]
+        frame_stops = [frame_start + chunk_size for frame_start in frame_starts]
 
         if (num_frames % chunk_size) > 0:
             frame_starts.append(n * chunk_size)

--- a/src/spikeinterface/core/job_tools.py
+++ b/src/spikeinterface/core/job_tools.py
@@ -137,7 +137,7 @@ def divide_segment_into_chunks(num_frames, chunk_size):
         n = num_frames // chunk_size
 
         frame_starts = [i * chunk_size for i in range(n)]
-        frame_stops = [(i+1) * chunk_size for i in range(n)]
+        frame_stops = [(i + 1) * chunk_size for i in range(n)]
 
         if (num_frames % chunk_size) > 0:
             frame_starts.append(n * chunk_size)


### PR DESCRIPTION
`frame_starts = np.arange(n) * chunk_size` will overflow when the recording is ~24 hours long and `chunk_size = "1s"`

Another integer overflow issue on long recordings following #3388 