### PR TITLE
Add pip install requests to mountainsort4 install instructions

### DIFF
--- a/doc/get_started/install_sorters.rst
+++ b/doc/get_started/install_sorters.rst
@@ -189,7 +189,7 @@ Mountainsort4
 * Authors: 	Jeremy Magland, Alex Barnett, Jason Chung, Loren Frank, Leslie Greengard
 * Installation::
 
-      pip install mountainsort4
+      pip install mountainsort4 requests
 
 Mountainsort5
 ^^^^^^^^^^^^^


### PR DESCRIPTION
I just ran into the same issue as in #3367 and was quite puzzled. I think `pip install requests` should be included in the mountainsort4 installation instructions here in the spikeinterface docs.