### PR TITLE
Adding gather_func to find_spikes

### DIFF
--- a/src/spikeinterface/sortingcomponents/matching/main.py
+++ b/src/spikeinterface/sortingcomponents/matching/main.py
@@ -56,7 +56,7 @@ def find_spikes_from_templates(
     elif gather_mode == "npy":
         gather_func = GatherToNpy(folder, names, **gather_kwargs)
     else:
-        raise ValueError(f"wrong gather_mode : {gather_mode}")
+        raise ValueError(f"wrong gather_mode : {gather_mode}. Please choose either 'memory' or 'npy'")
 
     method_class = matching_methods[method]
 

--- a/src/spikeinterface/sortingcomponents/matching/main.py
+++ b/src/spikeinterface/sortingcomponents/matching/main.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 from threadpoolctl import threadpool_limits
 import numpy as np
+from spikeinterface.core.node_pipeline import GatherToMemory, GatherToNpy
 
 from spikeinterface.core.job_tools import ChunkRecordingExecutor, fix_job_kwargs
 from spikeinterface.core import get_chunk_with_margin
 
 
 def find_spikes_from_templates(
-    recording, method="naive", method_kwargs={}, extra_outputs=False, verbose=False, **job_kwargs
+    recording, method="naive", method_kwargs={}, extra_outputs=False, verbose=False,
+    gather_mode="memory",
+    gather_kwargs={},
+    folder=None,
+    names=None,
+    **job_kwargs
 ) -> np.ndarray | tuple[np.ndarray, dict]:
     """Find spike from a recording from given templates.
 
@@ -41,6 +47,13 @@ def find_spikes_from_templates(
 
     job_kwargs = fix_job_kwargs(job_kwargs)
 
+    if gather_mode == "memory":
+        gather_func = GatherToMemory()
+    elif gather_mode == "npy":
+        gather_func = GatherToNpy(folder, names, **gather_kwargs)
+    else:
+        raise ValueError(f"wrong gather_mode : {gather_mode}")
+
     method_class = matching_methods[method]
 
     # initialize
@@ -62,6 +75,7 @@ def find_spikes_from_templates(
         init_func,
         init_args,
         handle_returns=True,
+        gather_func=gather_func,
         job_name=f"find spikes ({method})",
         verbose=verbose,
         **job_kwargs,

--- a/src/spikeinterface/sortingcomponents/matching/main.py
+++ b/src/spikeinterface/sortingcomponents/matching/main.py
@@ -9,12 +9,16 @@ from spikeinterface.core import get_chunk_with_margin
 
 
 def find_spikes_from_templates(
-    recording, method="naive", method_kwargs={}, extra_outputs=False, verbose=False,
+    recording,
+    method="naive",
+    method_kwargs={},
+    extra_outputs=False,
+    verbose=False,
     gather_mode="memory",
     gather_kwargs={},
     folder=None,
     names=None,
-    **job_kwargs
+    **job_kwargs,
 ) -> np.ndarray | tuple[np.ndarray, dict]:
     """Find spike from a recording from given templates.
 


### PR DESCRIPTION
Add the possibility, as requested by @alejoe91 to have a gather_mode function for the find_spike function. However, while copying it from run_node_pipelines, I realized that maybe, the variables folder and names should be better in gather_kwargs, don't you think @samuelgarcia ? They are specific to npy, am I right?