### PR TITLE
Expose `backend_options` at the analyzer level to set `storage_options` and `saving_options`

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -828,7 +828,7 @@ class SortingAnalyzer:
             )
             new_sorting_analyzer = SortingAnalyzer.load_from_zarr(folder, recording=recording)
             new_sorting_analyzer.folder = folder
-            new_sorting_analyzer._zarr_kwargs = zarr_kwargs
+            new_sorting_analyzer.set_zarr_kwargs(zarr_kwargs)
         else:
             raise ValueError(f"SortingAnalyzer.save: unsupported format: {format}")
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -260,7 +260,9 @@ class SortingAnalyzer:
             txt += " - has recording"
         if self.has_temporary_recording():
             txt += " - has temporary recording"
-        ext_txt = f"Loaded {len(self.extensions)} extensions: " + ", ".join(self.extensions.keys())
+        ext_txt = f"Loaded {len(self.extensions)} extensions"
+        if len(self.extensions) > 0:
+            ext_txt += f": {', '.join(self.extensions.keys())}"
         txt += "\n" + ext_txt
         return txt
 
@@ -2297,7 +2299,8 @@ class AnalyzerExtension:
         """
         # this ensure data is also deleted and corresponds to params
         # this also ensure the group is created
-        self._reset_extension_folder()
+        if save:
+            self._reset_extension_folder()
 
         params = self._set_params(**params)
         self.params = params

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -828,7 +828,7 @@ class SortingAnalyzer:
             )
             new_sorting_analyzer = SortingAnalyzer.load_from_zarr(folder, recording=recording)
             new_sorting_analyzer.folder = folder
-            new_sorting_analyzer.set_zarr_kwargs(zarr_kwargs)
+            new_sorting_analyzer.set_zarr_kwargs(**zarr_kwargs)
         else:
             raise ValueError(f"SortingAnalyzer.save: unsupported format: {format}")
 

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -137,8 +137,9 @@ def test_SortingAnalyzer_zarr(tmp_path, dataset):
         sparsity=None,
         return_scaled=False,
         overwrite=True,
+        backend_options={"saving_options": {"compressor": None}},
     )
-    sorting_analyzer_no_compression.backend_kwargs = {"zarr": dict(compressor=None)}
+    print(sorting_analyzer_no_compression._backend_options)
     sorting_analyzer_no_compression.compute(["random_spikes", "templates"])
     assert (
         sorting_analyzer_no_compression._get_zarr_root()["extensions"]["random_spikes"][
@@ -154,7 +155,7 @@ def test_SortingAnalyzer_zarr(tmp_path, dataset):
     lzma_compressor = LZMA()
     folder = tmp_path / "test_SortingAnalyzer_zarr_lzma.zarr"
     sorting_analyzer_lzma = sorting_analyzer_no_compression.save_as(
-        format="zarr", folder=folder, backend_kwargs=dict(compressor=lzma_compressor)
+        format="zarr", folder=folder, backend_options={"saving_options": {"compressor": lzma_compressor}}
     )
     assert (
         sorting_analyzer_lzma._get_zarr_root()["extensions"]["random_spikes"][

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -10,6 +10,7 @@ from spikeinterface.core import (
     load_sorting_analyzer,
     get_available_analyzer_extensions,
     get_default_analyzer_extension_params,
+    get_default_zarr_compressor,
 )
 from spikeinterface.core.sortinganalyzer import (
     register_result_extension,
@@ -99,15 +100,24 @@ def test_SortingAnalyzer_zarr(tmp_path, dataset):
     recording, sorting = dataset
 
     folder = tmp_path / "test_SortingAnalyzer_zarr.zarr"
-    if folder.exists():
-        shutil.rmtree(folder)
 
+    default_compressor = get_default_zarr_compressor()
     sorting_analyzer = create_sorting_analyzer(
-        sorting, recording, format="zarr", folder=folder, sparse=False, sparsity=None
+        sorting, recording, format="zarr", folder=folder, sparse=False, sparsity=None, overwrite=True
     )
     sorting_analyzer.compute(["random_spikes", "templates"])
     sorting_analyzer = load_sorting_analyzer(folder, format="auto")
     _check_sorting_analyzers(sorting_analyzer, sorting, cache_folder=tmp_path)
+
+    # check that compression is applied
+    assert (
+        sorting_analyzer._get_zarr_root()["extensions"]["random_spikes"]["random_spikes_indices"].compressor.codec_id
+        == default_compressor.codec_id
+    )
+    assert (
+        sorting_analyzer._get_zarr_root()["extensions"]["templates"]["average"].compressor.codec_id
+        == default_compressor.codec_id
+    )
 
     # test select_units see https://github.com/SpikeInterface/spikeinterface/issues/3041
     # this bug requires that we have an info.json file so we calculate templates above
@@ -117,11 +127,44 @@ def test_SortingAnalyzer_zarr(tmp_path, dataset):
     assert len(remove_units_sorting_analyer.unit_ids) == len(sorting_analyzer.unit_ids) - 1
     assert 1 not in remove_units_sorting_analyer.unit_ids
 
-    folder = tmp_path / "test_SortingAnalyzer_zarr.zarr"
-    if folder.exists():
-        shutil.rmtree(folder)
-    sorting_analyzer = create_sorting_analyzer(
-        sorting, recording, format="zarr", folder=folder, sparse=False, sparsity=None, return_scaled=False
+    # test no compression
+    sorting_analyzer_no_compression = create_sorting_analyzer(
+        sorting,
+        recording,
+        format="zarr",
+        folder=folder,
+        sparse=False,
+        sparsity=None,
+        return_scaled=False,
+        overwrite=True,
+    )
+    sorting_analyzer_no_compression.set_zarr_kwargs(compressor=None)
+    sorting_analyzer_no_compression.compute(["random_spikes", "templates"])
+    assert (
+        sorting_analyzer_no_compression._get_zarr_root()["extensions"]["random_spikes"][
+            "random_spikes_indices"
+        ].compressor
+        is None
+    )
+    assert sorting_analyzer_no_compression._get_zarr_root()["extensions"]["templates"]["average"].compressor is None
+
+    # test a different compressor
+    from numcodecs import LZMA
+
+    lzma_compressor = LZMA()
+    folder = tmp_path / "test_SortingAnalyzer_zarr_lzma.zarr"
+    sorting_analyzer_lzma = sorting_analyzer_no_compression.save_as(
+        format="zarr", folder=folder, compressor=lzma_compressor
+    )
+    assert (
+        sorting_analyzer_lzma._get_zarr_root()["extensions"]["random_spikes"][
+            "random_spikes_indices"
+        ].compressor.codec_id
+        == LZMA.codec_id
+    )
+    assert (
+        sorting_analyzer_lzma._get_zarr_root()["extensions"]["templates"]["average"].compressor.codec_id
+        == LZMA.codec_id
     )
 
 
@@ -326,7 +369,7 @@ def _check_sorting_analyzers(sorting_analyzer, original_sorting, cache_folder):
         else:
             folder = None
         sorting_analyzer5 = sorting_analyzer.merge_units(
-            merge_unit_groups=[[0, 1]], new_unit_ids=[50], format=format, folder=folder, mode="hard"
+            merge_unit_groups=[[0, 1]], new_unit_ids=[50], format=format, folder=folder, merging_mode="hard"
         )
 
     # test compute with extension-specific params

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -138,7 +138,7 @@ def test_SortingAnalyzer_zarr(tmp_path, dataset):
         return_scaled=False,
         overwrite=True,
     )
-    sorting_analyzer_no_compression.set_zarr_kwargs(compressor=None)
+    sorting_analyzer_no_compression.backend_kwargs = {"zarr": dict(compressor=None)}
     sorting_analyzer_no_compression.compute(["random_spikes", "templates"])
     assert (
         sorting_analyzer_no_compression._get_zarr_root()["extensions"]["random_spikes"][
@@ -154,7 +154,7 @@ def test_SortingAnalyzer_zarr(tmp_path, dataset):
     lzma_compressor = LZMA()
     folder = tmp_path / "test_SortingAnalyzer_zarr_lzma.zarr"
     sorting_analyzer_lzma = sorting_analyzer_no_compression.save_as(
-        format="zarr", folder=folder, compressor=lzma_compressor
+        format="zarr", folder=folder, backend_kwargs=dict(compressor=lzma_compressor)
     )
     assert (
         sorting_analyzer_lzma._get_zarr_root()["extensions"]["random_spikes"][

--- a/src/spikeinterface/core/zarrextractors.py
+++ b/src/spikeinterface/core/zarrextractors.py
@@ -329,8 +329,7 @@ def add_sorting_to_zarr_group(sorting: BaseSorting, zarr_group: zarr.hierarchy.G
     zarr_group.attrs["num_segments"] = int(num_segments)
     zarr_group.create_dataset(name="unit_ids", data=sorting.unit_ids, compressor=None)
 
-    if "compressor" not in kwargs:
-        compressor = get_default_zarr_compressor()
+    compressor = kwargs.get("compressor", get_default_zarr_compressor())
 
     # save sub fields
     spikes_group = zarr_group.create_group(name="spikes")


### PR DESCRIPTION
Generally, default compression works fine, but I've been hitting some errors with chunks being too large when analyzing very long NP recordings (>8h). 

This PR gives the possibility to modify the zarr arguments used to create a dataset. These can be passed at the `create_sorting_analyzer` or `save_as` step. The update test shows it in action