### PR TITLE
Added vspacing_factor as a param for TracesWidget

### DIFF
--- a/src/spikeinterface/widgets/traces.py
+++ b/src/spikeinterface/widgets/traces.py
@@ -52,6 +52,8 @@ class TracesWidget(BaseWidget):
         If dict, keys should be the same as recording keys
     scale : float, default: 1
         Scale factor for the traces
+    vspacing_factor : float, default: 1.5
+        Vertical spacing between channels as a multiple of maximum channel amplitude
     with_colorbar : bool, default: True
         When mode is "map", a colorbar is added
     tile_size : int, default: 1500
@@ -82,6 +84,7 @@ class TracesWidget(BaseWidget):
         tile_size=1500,
         seconds_per_row=0.2,
         scale=1,
+        vspacing_factor=1.5,
         with_colorbar=True,
         add_legend=True,
         backend=None,
@@ -168,7 +171,7 @@ class TracesWidget(BaseWidget):
         traces0 = list_traces[0]
         mean_channel_std = np.mean(np.std(traces0, axis=0))
         max_channel_amp = np.max(np.max(np.abs(traces0), axis=0))
-        vspacing = max_channel_amp * 1.5
+        vspacing = max_channel_amp * vspacing_factor
 
         if rec0.get_channel_groups() is None:
             color_groups = False


### PR DESCRIPTION
It would be useful for me (and maybe others?) to be able to adjust the vertical spacing of traces in the TracesWidget, so I've added an adjustable parameter which defaults (as before) to 1.5x max trace amplitude