### PR TITLE
Only load `template_metrics` extension on compute if keeping some metrics

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -2033,19 +2033,18 @@ class AnalyzerExtension:
         return None
 
     def load_run_info(self):
+        run_info = None
         if self.format == "binary_folder":
             extension_folder = self._get_binary_extension_folder()
             run_info_file = extension_folder / "run_info.json"
             if run_info_file.is_file():
                 with open(str(run_info_file), "r") as f:
                     run_info = json.load(f)
-            else:
-                warnings.warn(f"Found no run_info file for {self.extension_name}, extension should be re-computed.")
-                run_info = None
 
         elif self.format == "zarr":
             extension_group = self._get_zarr_extension_group(mode="r")
             run_info = extension_group.attrs.get("run_info", None)
+
         if run_info is None:
             warnings.warn(f"Found no run_info file for {self.extension_name}, extension should be re-computed.")
         self.run_info = run_info

--- a/src/spikeinterface/postprocessing/template_metrics.py
+++ b/src/spikeinterface/postprocessing/template_metrics.py
@@ -335,13 +335,18 @@ class ComputeTemplateMetrics(AnalyzerExtension):
         )
 
         existing_metrics = []
-        tm_extension = self.sorting_analyzer.get_extension("template_metrics")
-        if (
-            delete_existing_metrics is False
-            and tm_extension is not None
-            and tm_extension.data.get("metrics") is not None
-        ):
-            existing_metrics = tm_extension.params["metric_names"]
+
+        # Check if we need to propogate any old metrics. If so, we'll do that.
+        # Otherwise, we'll avoid attempting to load an empty template_metrics.
+        if set(self.params["metrics_to_compute"]) != set(self.params["metric_names"]):
+
+            tm_extension = self.sorting_analyzer.get_extension("template_metrics")
+            if (
+                delete_existing_metrics is False
+                and tm_extension is not None
+                and tm_extension.data.get("metrics") is not None
+            ):
+                existing_metrics = tm_extension.params["metric_names"]
 
         # append the metrics which were previously computed
         for metric_name in set(existing_metrics).difference(metrics_to_compute):


### PR DESCRIPTION
Might fix #3471
(Could you try this out please @jonpedros)

When `template_metrics` is computed and `delete_existing_metrics = False`, any old metrics which aren't being recomputed are kept. To do this, the `_run` method loads the old template metric extension (if it exists). However, if this is the first time it has run, it has already created the extension folder. In this case `_run` sees the newly-created folder and tries to load it. Bu there's not much in it, so a no `run_info` warning appears.

To avoid this, this PR only loads the extension folder if there are metrics to be kept.

I think the previous implementation of `load_run_info` was sending two warnings if a `run_info` file didn't exist. I think I've made the logic a bit simpler. Could one of the `run_info` experts take a look please (@jonahpearl @alejoe91 ) - thanks!