### PR TITLE
Improve error message for `set_probegroup`/`set_probe`

### DIFF
--- a/src/spikeinterface/core/baserecordingsnippets.py
+++ b/src/spikeinterface/core/baserecordingsnippets.py
@@ -172,8 +172,10 @@ class BaseRecordingSnippets(BaseExtractor):
         number_of_device_channel_indices = np.max(list(device_channel_indices) + [0])
         if number_of_device_channel_indices >= self.get_num_channels():
             error_msg = (
-                f"The given Probe have 'device_channel_indices' that do not match channel count \n"
-                f"{number_of_device_channel_indices} vs {self.get_num_channels()} \n"
+                f"The given Probe either has 'device_channel_indices' that does not match channel count \n"
+                f"{len(device_channel_indices)} vs {self.get_num_channels()} \n"
+                f"or it's max index {number_of_device_channel_indices} is the same as the number of channels {self.get_num_channels()} \n"
+                f"If using all channels remember that python is 0-indexed so max device_channel_index should be {self.get_num_channels() - 1} \n"
                 f"device_channel_indices are the following: {device_channel_indices} \n"
                 f"recording channels are the following: {self.get_channel_ids()} \n"
             )


### PR DESCRIPTION
Hey @alejoe91 the confusion in #3477 has come up multiple times. How about this as a change:

1) we check if the list is the wrong length (this is a rare mistake)
2) we see if they forgot to 0-index the list (this is the common mistake)

Happy to workshop this a bit if needed :) 

Just for clarity the current error saying you made a mistake because you have 32 values and you should have 32 values is super confusing, but the problem is that is actually the max value.