### PR TITLE
Cap python 3.13 until we can remove the cap on numpy <2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 description = "Python toolkit for analysis, visualization, and comparison of spike sorting output"
 readme = "README.md"
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.9,<3.14"  # Only numpy 2.0 supported on python 3.12 for windows. We need to wait for fix on neo
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
From the meeting.  @zm711 please correct if I got anything wrong
python 3.13 only supports numpy 2.0 on windows.
We can't support numpy 2.0 because of neo issues.

We are adding this temporary cap to avoid users getting a complicated error until we fix neo numpy 2.0 support.