### PR TITLE
Remove Non-Serializable writing of json

### DIFF
--- a/src/spikeinterface/sorters/basesorter.py
+++ b/src/spikeinterface/sorters/basesorter.py
@@ -145,9 +145,8 @@ class BaseSorter:
         elif recording.check_serializability("pickle"):
             recording.dump(output_folder / "spikeinterface_recording.pickle", relative_to=output_folder)
         else:
-            # TODO: deprecate and finally remove this after 0.100
-            d = {"warning": "The recording is not serializable to json"}
-            rec_file.write_text(json.dumps(d, indent=4), encoding="utf8")
+            raise RuntimeError("This recording is not serializable and so can not be sorted. Consider `recording.save()` to save a "
+                               "compatible binary file.")
 
         return output_folder
 

--- a/src/spikeinterface/sorters/basesorter.py
+++ b/src/spikeinterface/sorters/basesorter.py
@@ -145,8 +145,10 @@ class BaseSorter:
         elif recording.check_serializability("pickle"):
             recording.dump(output_folder / "spikeinterface_recording.pickle", relative_to=output_folder)
         else:
-            raise RuntimeError("This recording is not serializable and so can not be sorted. Consider `recording.save()` to save a "
-                               "compatible binary file.")
+            raise RuntimeError(
+                "This recording is not serializable and so can not be sorted. Consider `recording.save()` to save a "
+                "compatible binary file."
+            )
 
         return output_folder
 


### PR DESCRIPTION
The note says remove after 0.100 and this caused an issue recently #3448 with the error not being super clear (because recording was None) the  error the user saw was that None didn't have get_num_channels). Since this isn't supported we shouldn't write this here, right? I have run local tests because I need to run, so will update after the CI if needed.