### PR TITLE
Whitening fix - compute covariance matrix in float

### DIFF
--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -20,7 +20,7 @@ class WhitenRecording(BasePreprocessor):
         The recording extractor to be whitened.
     dtype : None or dtype, default: None
         Datatype of the output recording (covariance matrix estimation
-        and whitening are performed in float64.
+        and whitening are performed in float64).
         If None the the parent dtype is kept.
         For integer dtype a int_scale must be also given.
     mode : "global" | "local", default: "global"

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -76,8 +76,9 @@ class WhitenRecording(BasePreprocessor):
         dtype_ = fix_dtype(recording, dtype)
 
         if dtype_.kind == "i":
-            assert int_scale is not None, ("For recording with dtype=int you must set the output dtype to float "
-                                           " OR set a int_scale")
+            assert int_scale is not None, (
+                "For recording with dtype=int you must set the output dtype to float " " OR set a int_scale"
+            )
 
         if W is not None:
             W = np.asarray(W)

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -124,7 +124,7 @@ class WhitenRecordingSegment(BasePreprocessorSegment):
     def get_traces(self, start_frame, end_frame, channel_indices):
         traces = self.parent_recording_segment.get_traces(start_frame, end_frame, slice(None))
         traces_dtype = traces.dtype
-        # if uint --> force int
+        # if uint --> force float
         if traces_dtype.kind == "u":
             traces = traces.astype("float32")
 
@@ -185,6 +185,7 @@ def compute_whitening_matrix(
 
     """
     random_data = get_random_data_chunks(recording, concatenated=True, return_scaled=False, **random_chunk_kwargs)
+    random_data = random_data.astype(np.float64)
 
     regularize_kwargs = regularize_kwargs if regularize_kwargs is not None else {"method": "GraphicalLassoCV"}
 

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -19,6 +19,8 @@ class WhitenRecording(BasePreprocessor):
     recording : RecordingExtractor
         The recording extractor to be whitened.
     dtype : None or dtype, default: None
+        Datatype of the output recording (covariance matrix estimation
+        and whitening are performed in float64.
         If None the the parent dtype is kept.
         For integer dtype a int_scale must be also given.
     mode : "global" | "local", default: "global"
@@ -74,7 +76,8 @@ class WhitenRecording(BasePreprocessor):
         dtype_ = fix_dtype(recording, dtype)
 
         if dtype_.kind == "i":
-            assert int_scale is not None, "For recording with dtype=int you must set dtype=float32 OR set a int_scale"
+            assert int_scale is not None, ("For recording with dtype=int you must set the output dtype to float "
+                                           " OR set a int_scale")
 
         if W is not None:
             W = np.asarray(W)

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -77,7 +77,7 @@ class WhitenRecording(BasePreprocessor):
 
         if dtype_.kind == "i":
             assert int_scale is not None, (
-                "For recording with dtype=int you must set the output dtype to float " " OR set a int_scale"
+                "For recording with dtype=int you must set the output dtype to float OR set a int_scale"
             )
 
         if W is not None:

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -76,9 +76,9 @@ class WhitenRecording(BasePreprocessor):
         dtype_ = fix_dtype(recording, dtype)
 
         if dtype_.kind == "i":
-            assert int_scale is not None, (
-                "For recording with dtype=int you must set the output dtype to float OR set a int_scale"
-            )
+            assert (
+                int_scale is not None
+            ), "For recording with dtype=int you must set the output dtype to float OR set a int_scale"
 
         if W is not None:
             W = np.asarray(W)

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -20,7 +20,7 @@ class WhitenRecording(BasePreprocessor):
         The recording extractor to be whitened.
     dtype : None or dtype, default: None
         Datatype of the output recording (covariance matrix estimation
-        and whitening are performed in float64).
+        and whitening are performed in float32).
         If None the the parent dtype is kept.
         For integer dtype a int_scale must be also given.
     mode : "global" | "local", default: "global"
@@ -189,7 +189,7 @@ def compute_whitening_matrix(
 
     """
     random_data = get_random_data_chunks(recording, concatenated=True, return_scaled=False, **random_chunk_kwargs)
-    random_data = random_data.astype(np.float64)
+    random_data = random_data.astype(np.float32)
 
     regularize_kwargs = regularize_kwargs if regularize_kwargs is not None else {"method": "GraphicalLassoCV"}
 


### PR DESCRIPTION
In `whiten.py` there is a datatype argument to set the datatype of the output recording. The casting is performed after whitening has been performed and does not affect the datatype used for computing the whitening matrix. Up until `0.100.8`, the covariance matrix was always computed in `float32`, but in `0.101.0` the line `random_data = np.astype(random_data, np.float32)` that was [under this line](https://github.com/SpikeInterface/spikeinterface/blob/4a1a45a67db4534150d591bd5324e271ae8af740/src/spikeinterface/preprocessing/whiten.py#L187) was removed. Now if the recording is `int16` the covariance matrix estimation is performed in `int16` and will overflow in nearly all cases.

This PR reinstates that line, for now casting to `float64`. The recording `dtype` will be cast back to the user-specified `dtype` or the input recording `dtype`, so I don't think there is any downside in using maximum precision. The only thing is, maybe we will want to move to GPU support in future, and using float32 will keep it consistent. 

Unless I'm missing something, I think it would be worth rolling this out in an update ASAP and making a note of this on the release note header. My understanding is the majority of recording datatypes are stored `int16` and so this regression may catch out quite a lot of users since `0.101.0` and is quite hard to track down. 

TODOs
- [ ] extend tests

