### PR TITLE
Add `shift start time` function.

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -509,6 +509,26 @@ class BaseRecording(BaseRecordingSnippets):
             rs.t_start = None
             rs.sampling_frequency = self.sampling_frequency
 
+    def shift_start_time(self, shift, segment_index=None):
+        """
+        Shift the starting time of the times.
+
+        shift : int | float
+            The shift to apply to the first time point. If positive,
+            the current start time will be increased by `shift`. If
+            negative, the start time will be decreased.
+
+        segment_index : int | None
+            The segment on which to shift the times.
+        """
+        segment_index = self._check_segment_index(segment_index)
+        rs = self._recording_segments[segment_index]
+
+        if self.has_time_vector():
+            rs.time_vector += shift
+        else:
+            rs.t_start += shift
+
     def sample_index_to_time(self, sample_ind, segment_index=None):
         """
         Transform sample index into time in seconds

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -509,7 +509,7 @@ class BaseRecording(BaseRecordingSnippets):
             rs.t_start = None
             rs.sampling_frequency = self.sampling_frequency
 
-    def shift_start_time(self, shift, segment_index=None):
+    def shift_start_time(self, shift: int | float, segment_index: int | None = None) -> None:
         """
         Shift the starting time of the times.
 
@@ -536,15 +536,14 @@ class BaseRecording(BaseRecordingSnippets):
             else:
                 rs.t_start += shift
 
-    def sample_index_to_time(self, sample_ind, segment_index=None):
-        """
-        Transform sample index into time in seconds
-        """
+    def sample_index_to_time(self, sample_ind: int, segment_index: int | None = None):
+        """ """
         segment_index = self._check_segment_index(segment_index)
         rs = self._recording_segments[segment_index]
         return rs.sample_index_to_time(sample_ind)
 
-    def time_to_sample_index(self, time_s, segment_index=None):
+    def time_to_sample_index(self, time_s: float, segment_index: int | None = None):
+        """ """
         segment_index = self._check_segment_index(segment_index)
         rs = self._recording_segments[segment_index]
         return rs.time_to_sample_index(time_s)

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -526,8 +526,6 @@ class BaseRecording(BaseRecordingSnippets):
             The segment on which to shift the times. if `None`, all
             segments will be shifted.
         """
-        self._check_segment_index(segment_index)  # Check the segment index is valid only
-
         if segment_index is None:
             segments_to_shift = range(self.get_num_segments())
         else:
@@ -536,7 +534,7 @@ class BaseRecording(BaseRecordingSnippets):
         for idx in segments_to_shift:
             rs = self._recording_segments[idx]
 
-            if self.has_time_vector():
+            if self.has_time_vector(segment_index=idx):
                 rs.time_vector += shift
             else:
                 rs.t_start += shift

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -539,14 +539,15 @@ class BaseRecording(BaseRecordingSnippets):
             else:
                 rs.t_start += shift
 
-    def sample_index_to_time(self, sample_ind: int, segment_index: int | None = None):
-        """ """
+    def sample_index_to_time(self, sample_ind, segment_index=None):
+        """
+        Transform sample index into time in seconds
+        """
         segment_index = self._check_segment_index(segment_index)
         rs = self._recording_segments[segment_index]
         return rs.sample_index_to_time(sample_ind)
 
-    def time_to_sample_index(self, time_s: float, segment_index: int | None = None):
-        """ """
+    def time_to_sample_index(self, time_s, segment_index=None):
         segment_index = self._check_segment_index(segment_index)
         rs = self._recording_segments[segment_index]
         return rs.time_to_sample_index(time_s)

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -511,8 +511,7 @@ class BaseRecording(BaseRecordingSnippets):
 
     def shift_times(self, shift: int | float, segment_index: int | None = None) -> None:
         """
-        Shift all times by a scalar value. The default behaviour is to
-        shift all segments uniformly.
+        Shift all times by a scalar value.
 
         Parameters
         ----------
@@ -523,8 +522,8 @@ class BaseRecording(BaseRecordingSnippets):
             started earlier.
 
         segment_index : int | None
-            The segment on which to shift the times. if `None`, all
-            segments will be shifted.
+            The segment on which to shift the times.
+            If `None`, all segments will be shifted.
         """
         if segment_index is None:
             segments_to_shift = range(self.get_num_segments())

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -509,19 +509,24 @@ class BaseRecording(BaseRecordingSnippets):
             rs.t_start = None
             rs.sampling_frequency = self.sampling_frequency
 
-    def shift_start_time(self, shift: int | float, segment_index: int | None = None) -> None:
+    def shift_times(self, shift: int | float, segment_index: int | None = None) -> None:
         """
-        Shift the starting time of the times.
+        Shift all times by a scalar value. The default behaviour is to
+        shift all segments uniformly.
 
+        Parameters
+        ----------
         shift : int | float
-            The shift to apply to the first time point. If positive,
-            the current start time will be increased by `shift`. If
-            negative, the start time will be decreased.
+            The shift to apply. If positive, times will be increased by `shift`.
+            e.g. shifting by 1 will be like the recording started 1 second later.
+            If negative, the start time will be decreased i.e. as if the recording
+            started earlier.
 
         segment_index : int | None
-            The segment on which to shift the times.
+            The segment on which to shift the times. if `None`, all
+            segments will be shifted.
         """
-        self._check_segment_index(segment_index)
+        self._check_segment_index(segment_index)  # Check the segment index is valid only
 
         if segment_index is None:
             segments_to_shift = range(self.get_num_segments())

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -521,13 +521,20 @@ class BaseRecording(BaseRecordingSnippets):
         segment_index : int | None
             The segment on which to shift the times.
         """
-        segment_index = self._check_segment_index(segment_index)
-        rs = self._recording_segments[segment_index]
+        self._check_segment_index(segment_index)
 
-        if self.has_time_vector():
-            rs.time_vector += shift
+        if segment_index is None:
+            segments_to_shift = range(self.get_num_segments())
         else:
-            rs.t_start += shift
+            segments_to_shift = (segment_index,)
+
+        for idx in segments_to_shift:
+            rs = self._recording_segments[idx]
+
+            if self.has_time_vector():
+                rs.time_vector += shift
+            else:
+                rs.t_start += shift
 
     def sample_index_to_time(self, sample_ind, segment_index=None):
         """

--- a/src/spikeinterface/core/tests/test_time_handling.py
+++ b/src/spikeinterface/core/tests/test_time_handling.py
@@ -15,7 +15,10 @@ class TestTimeHandling:
     is generated on the fly. Both time representations are tested here.
     """
 
-    # Fixtures #####
+    # #########################################################################
+    # Fixtures
+    # #########################################################################
+
     @pytest.fixture(scope="session")
     def time_vector_recording(self):
         """
@@ -95,7 +98,10 @@ class TestTimeHandling:
         raw_recording, times_recording, all_times = time_recording_fixture
         return (raw_recording, times_recording, all_times)
 
-    # Tests #####
+    # #########################################################################
+    # Tests
+    # #########################################################################
+
     def test_has_time_vector(self, time_vector_recording):
         """
         Test the `has_time_vector` function returns `False` before
@@ -305,7 +311,87 @@ class TestTimeHandling:
 
         assert np.array_equal(sorting_analyzer.get_total_duration(), raw_recording.get_total_duration())
 
-    # Helpers ####
+    @pytest.mark.parametrize("fixture_name", ["time_vector_recording", "t_start_recording"])
+    @pytest.mark.parametrize("shift", [-123.456, 123.456])
+    def test_shift_time_all_segments(self, request, fixture_name, shift):
+        """
+        Shift the times in every segment using the `None` default, then
+        check that every segment of the recording is shifted as expected.
+        """
+        _, times_recording, all_times = self._get_fixture_data(request, fixture_name)
+
+        num_segments, orig_seg_data = self._store_all_times(times_recording)
+
+        times_recording.shift_times(shift)  # use default `segment_index=None`
+
+        for idx in range(num_segments):
+            assert np.allclose(
+                orig_seg_data[idx], times_recording.get_times(segment_index=idx) - shift, rtol=0, atol=1e-8
+            )
+
+    @pytest.mark.parametrize("fixture_name", ["time_vector_recording", "t_start_recording"])
+    @pytest.mark.parametrize("shift", [-123.456, 123.456])
+    def test_shift_times_different_segments(self, request, fixture_name, shift):
+        """
+        Shift each segment separately, and check the shifted segment only
+        is shifted as expected.
+        """
+        _, times_recording, all_times = self._get_fixture_data(request, fixture_name)
+
+        num_segments, orig_seg_data = self._store_all_times(times_recording)
+
+        # For each segment, shift the segment only and check the
+        # times are updated as expected.
+        for idx in range(num_segments):
+
+            scaler = idx + 2
+            times_recording.shift_times(shift * scaler, segment_index=idx)
+
+            assert np.allclose(
+                orig_seg_data[idx], times_recording.get_times(segment_index=idx) - shift * scaler, rtol=0, atol=1e-8
+            )
+
+            # Just do a little check that we are not
+            # accidentally changing some other segments,
+            # which should remain unchanged at this point in the loop.
+            if idx != num_segments - 1:
+                assert np.array_equal(orig_seg_data[idx + 1], times_recording.get_times(segment_index=idx + 1))
+
+    @pytest.mark.parametrize("fixture_name", ["time_vector_recording", "t_start_recording"])
+    def test_save_and_load_time_shift(self, request, fixture_name, tmp_path):
+        """
+        Save the shifted data and check the shift is propagated correctly.
+        """
+        _, times_recording, all_times = self._get_fixture_data(request, fixture_name)
+
+        shift = 100
+        times_recording.shift_times(shift=shift)
+
+        times_recording.save(folder=tmp_path / "my_file")
+
+        loaded_recording = si.load_extractor(tmp_path / "my_file")
+
+        for idx in range(times_recording.get_num_segments()):
+            assert np.array_equal(
+                times_recording.get_times(segment_index=idx), loaded_recording.get_times(segment_index=idx)
+            )
+
+    def _store_all_times(self, recording):
+        """
+        Convenience function to store original times of all segments to a dict.
+        """
+        num_segments = recording.get_num_segments()
+        seg_data = {}
+
+        for idx in range(num_segments):
+            seg_data[idx] = copy.deepcopy(recording.get_times(segment_index=idx))
+
+        return num_segments, seg_data
+
+    # #########################################################################
+    # Helpers
+    # #########################################################################
+
     def _check_times_match(self, recording, all_times):
         """
         For every segment in a recording, check the `get_times()`


### PR DESCRIPTION
This PR adds a 'shift start time' function that a user can use to set a new start time for their recording.

This follows from discussions on the time API #3117 and #3157. Briefly, there are two ways to handle time in SI, a `t_start` recording attribute that is used to set the start time. Under this regime, the (regularly) spaced timeseries is regenerated on the fly from `t_start`, num samples and sampling frequency. Alternatively, a (more memory heavy) `time_vector` can be set to explicitly set the time array for a recording. As I understand it this is useful in the case there are gaps in the recording or there is some clock drift. From the user perspective, they always get a time vector back from `get_times()`.

This PR implements a `shift_start_time` as suggested by @h-mayorquin as a convenient way for users to shift the start time of their recording, abstracting away the technical details of the implementation under the hood (`t_start` vs `time_vector`).

I have updated the PR #3072  containing documentation on times, the relevant proposed section can be found [here](https://spikeinterface--3072.org.readthedocs.build/en/3072/tutorials/core/plot_6_handle_times_ver2.html#shifting-the-start-time).