### PR TITLE
Remove remaining array.ptp()s

### DIFF
--- a/src/spikeinterface/postprocessing/localization_tools.py
+++ b/src/spikeinterface/postprocessing/localization_tools.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import warnings
 
 import numpy as np
+from spikeinterface.core import SortingAnalyzer, Templates, compute_sparsity
+from spikeinterface.core.template_tools import (_get_nbefore,
+                                                get_dense_templates_array,
+                                                get_template_extremum_channel)
 
 try:
     import numba
@@ -12,8 +16,6 @@ except ImportError:
     HAVE_NUMBA = False
 
 
-from spikeinterface.core import compute_sparsity, SortingAnalyzer, Templates
-from spikeinterface.core.template_tools import get_template_extremum_channel, _get_nbefore, get_dense_templates_array
 
 
 def compute_monopolar_triangulation(
@@ -110,7 +112,7 @@ def compute_monopolar_triangulation(
         # wf is (nsample, nchan) - chann is only nieghboor
         wf = templates[i, :, :][:, chan_inds]
         if feature == "ptp":
-            wf_data = wf.ptp(axis=0)
+            wf_data = np.ptp(wf, axis=0)
         elif feature == "energy":
             wf_data = np.linalg.norm(wf, axis=0)
         elif feature == "peak_voltage":
@@ -188,7 +190,7 @@ def compute_center_of_mass(
         wf = templates[i, :, :]
 
         if feature == "ptp":
-            wf_data = (wf[:, chan_inds]).ptp(axis=0)
+            wf_data = np.ptp(wf[:, chan_inds], axis=0)
         elif feature == "mean":
             wf_data = (wf[:, chan_inds]).mean(axis=0)
         elif feature == "energy":

--- a/src/spikeinterface/postprocessing/localization_tools.py
+++ b/src/spikeinterface/postprocessing/localization_tools.py
@@ -4,9 +4,7 @@ import warnings
 
 import numpy as np
 from spikeinterface.core import SortingAnalyzer, Templates, compute_sparsity
-from spikeinterface.core.template_tools import (_get_nbefore,
-                                                get_dense_templates_array,
-                                                get_template_extremum_channel)
+from spikeinterface.core.template_tools import _get_nbefore, get_dense_templates_array, get_template_extremum_channel
 
 try:
     import numba
@@ -14,8 +12,6 @@ try:
     HAVE_NUMBA = True
 except ImportError:
     HAVE_NUMBA = False
-
-
 
 
 def compute_monopolar_triangulation(

--- a/src/spikeinterface/sortingcomponents/motion/dredge.py
+++ b/src/spikeinterface/sortingcomponents/motion/dredge.py
@@ -22,21 +22,15 @@ but the original function dredge_ap() and dredge_online_lfp() can be used direct
 
 """
 
+import gc
 import warnings
 
-from tqdm.auto import trange
 import numpy as np
+from tqdm.auto import trange
 
-import gc
-
-from .motion_utils import (
-    Motion,
-    get_spatial_windows,
-    get_window_domains,
-    scipy_conv1d,
-    make_2d_motion_histogram,
-    get_spatial_bin_edges,
-)
+from .motion_utils import (Motion, get_spatial_bin_edges, get_spatial_windows,
+                           get_window_domains, make_2d_motion_histogram,
+                           scipy_conv1d)
 
 
 # simple class wrapper to be compliant with estimate_motion
@@ -979,7 +973,7 @@ def xcorr_windows(
 
     if max_disp_um is None:
         if rigid:
-            max_disp_um = int(spatial_bin_edges_um.ptp() // 4)
+            max_disp_um = int(np.ptp(spatial_bin_edges_um) // 4)
         else:
             max_disp_um = int(win_scale_um // 4)
 

--- a/src/spikeinterface/sortingcomponents/motion/dredge.py
+++ b/src/spikeinterface/sortingcomponents/motion/dredge.py
@@ -28,9 +28,14 @@ import warnings
 import numpy as np
 from tqdm.auto import trange
 
-from .motion_utils import (Motion, get_spatial_bin_edges, get_spatial_windows,
-                           get_window_domains, make_2d_motion_histogram,
-                           scipy_conv1d)
+from .motion_utils import (
+    Motion,
+    get_spatial_bin_edges,
+    get_spatial_windows,
+    get_window_domains,
+    make_2d_motion_histogram,
+    scipy_conv1d,
+)
 
 
 # simple class wrapper to be compliant with estimate_motion


### PR DESCRIPTION
For numpy 2.0 support -- `ggrep -R -P '(?<!np)\.ptp\(' src/*` says these were the last ones.