### PR TITLE
Unify template and quality metrics

### DIFF
--- a/src/spikeinterface/postprocessing/template_metrics.py
+++ b/src/spikeinterface/postprocessing/template_metrics.py
@@ -136,7 +136,7 @@ class ComputeTemplateMetrics(AnalyzerExtension):
             metric_names += get_multi_channel_template_metric_names()
 
         if metrics_kwargs is not None and metric_params is None:
-            deprecation_msg = "`metrics_kwargs` is deprecated and will be removed in version 0.104.0. Please use metric_params instead"
+            deprecation_msg = "`metrics_kwargs` is deprecated and will be removed in version 0.104.0. Please use `metric_params` instead"
             deprecation_msg = "`metrics_kwargs` is deprecated and will be removed in version 0.104.0. Please use `metric_params` instead"
 
             metric_params = {}

--- a/src/spikeinterface/postprocessing/template_metrics.py
+++ b/src/spikeinterface/postprocessing/template_metrics.py
@@ -64,8 +64,7 @@ class ComputeTemplateMetrics(AnalyzerExtension):
         Whether to compute multi-channel metrics
     delete_existing_metrics : bool, default: False
         If True, any template metrics attached to the `sorting_analyzer` are deleted. If False, any metrics which were previously calculated but are not included in `metric_names` are kept, provided the `metric_params` are unchanged.
-    metric_params : dict of dicts
-        metric_params : dict of dicts or None
+    metric_params : dict of dicts or None, default: None
         Dictionary with parameters for template metrics calculation.
         Default parameters can be obtained with: `si.postprocessing.template_metrics.get_default_tm_params()`
 
@@ -138,7 +137,7 @@ class ComputeTemplateMetrics(AnalyzerExtension):
 
         if metrics_kwargs is not None and metric_params is None:
             deprecation_msg = "`metrics_kwargs` is deprecated and will be removed in version 0.104.0. Please use metric_params instead"
-            warnings.warn(deprecation_msg, category=DeprecationWarning)
+            deprecation_msg = "`metrics_kwargs` is deprecated and will be removed in version 0.104.0. Please use `metric_params` instead"
 
             metric_params = {}
             for metric_name in metric_names:

--- a/src/spikeinterface/postprocessing/template_metrics.py
+++ b/src/spikeinterface/postprocessing/template_metrics.py
@@ -344,6 +344,18 @@ class ComputeTemplateMetrics(AnalyzerExtension):
     def _get_data(self):
         return self.data["metrics"]
 
+    def load_params(self):
+        AnalyzerExtension.load_params(self)
+        # For backwards compatibility - this reformats metrics_kwargs as metric_params
+        if (metrics_kwargs := self.params.get("metrics_kwargs")) is not None:
+
+            metric_params = {}
+            for metric_name in self.params["metric_names"]:
+                metric_params[metric_name] = deepcopy(metrics_kwargs)
+            self.params["metric_params"] = metric_params
+
+            del self.params["metrics_kwargs"]
+
 
 register_result_extension(ComputeTemplateMetrics)
 compute_template_metrics = ComputeTemplateMetrics.function_factory()

--- a/src/spikeinterface/postprocessing/template_metrics.py
+++ b/src/spikeinterface/postprocessing/template_metrics.py
@@ -118,7 +118,7 @@ class ComputeTemplateMetrics(AnalyzerExtension):
 
         if metrics_kwargs is not None and metric_params is None:
             deprecation_msg = (
-                "`qm_params` is deprecated and will be removed in version 0.104.0 Please use metric_params instead"
+                "`metrics_kwargs` is deprecated and will be removed in version 0.104.0 Please use metric_params instead"
             )
             metric_params = metrics_kwargs
             warnings.warn(deprecation_msg, category=DeprecationWarning, stacklevel=2)

--- a/src/spikeinterface/postprocessing/template_metrics.py
+++ b/src/spikeinterface/postprocessing/template_metrics.py
@@ -88,8 +88,21 @@ class ComputeTemplateMetrics(AnalyzerExtension):
     need_recording = False
     use_nodepipeline = False
     need_job_kwargs = False
+    need_backward_compatibility_on_load = True
 
     min_channels_for_multi_channel_warning = 10
+
+    def _handle_backward_compatibility_on_load(self):
+
+        # For backwards compatibility - this reformats metrics_kwargs as metric_params
+        if (metrics_kwargs := self.params.get("metrics_kwargs")) is not None:
+
+            metric_params = {}
+            for metric_name in self.params["metric_names"]:
+                metric_params[metric_name] = deepcopy(metrics_kwargs)
+            self.params["metric_params"] = metric_params
+
+            del self.params["metrics_kwargs"]
 
     def _set_params(
         self,
@@ -343,18 +356,6 @@ class ComputeTemplateMetrics(AnalyzerExtension):
 
     def _get_data(self):
         return self.data["metrics"]
-
-    def load_params(self):
-        AnalyzerExtension.load_params(self)
-        # For backwards compatibility - this reformats metrics_kwargs as metric_params
-        if (metrics_kwargs := self.params.get("metrics_kwargs")) is not None:
-
-            metric_params = {}
-            for metric_name in self.params["metric_names"]:
-                metric_params[metric_name] = deepcopy(metrics_kwargs)
-            self.params["metric_params"] = metric_params
-
-            del self.params["metrics_kwargs"]
 
 
 register_result_extension(ComputeTemplateMetrics)

--- a/src/spikeinterface/postprocessing/tests/test_template_metrics.py
+++ b/src/spikeinterface/postprocessing/tests/test_template_metrics.py
@@ -1,11 +1,54 @@
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
-from spikeinterface.postprocessing import ComputeTemplateMetrics
+from spikeinterface.postprocessing import ComputeTemplateMetrics, compute_template_metrics
 import pytest
 import csv
 
 from spikeinterface.postprocessing.template_metrics import _single_channel_metric_name_to_func
 
 template_metrics = list(_single_channel_metric_name_to_func.keys())
+
+
+def test_different_params_template_metrics(small_sorting_analyzer):
+    """
+    Computes template metrics using different params, and check that they are
+    actually calculated using the different params.
+    """
+    compute_template_metrics(
+        sorting_analyzer=small_sorting_analyzer,
+        metric_names=["exp_decay", "spread", "half_width"],
+        metric_params={"exp_decay": {"recovery_window_ms": 0.8}, "spread": {"spread_smooth_um": 15}},
+    )
+
+    tm_extension = small_sorting_analyzer.get_extension("template_metrics")
+    tm_params = tm_extension.params["metric_params"]
+
+    assert tm_params["exp_decay"]["recovery_window_ms"] == 0.8
+    assert tm_params["spread"]["recovery_window_ms"] == 0.7
+    assert tm_params["half_width"]["recovery_window_ms"] == 0.7
+
+    assert tm_params["spread"]["spread_smooth_um"] == 15
+    assert tm_params["exp_decay"]["spread_smooth_um"] == 20
+    assert tm_params["half_width"]["spread_smooth_um"] == 20
+
+
+def test_backwards_compat_params_template_metrics(small_sorting_analyzer):
+    """
+    Computes template metrics using the metrics_kwargs keyword
+    """
+    compute_template_metrics(
+        sorting_analyzer=small_sorting_analyzer,
+        metric_names=["exp_decay", "spread"],
+        metrics_kwargs={"recovery_window_ms": 0.8},
+    )
+
+    tm_extension = small_sorting_analyzer.get_extension("template_metrics")
+    tm_params = tm_extension.params["metric_params"]
+
+    assert tm_params["exp_decay"]["recovery_window_ms"] == 0.8
+    assert tm_params["spread"]["recovery_window_ms"] == 0.8
+
+    assert tm_params["spread"]["spread_smooth_um"] == 20
+    assert tm_params["exp_decay"]["spread_smooth_um"] == 20
 
 
 def test_compute_new_template_metrics(small_sorting_analyzer):
@@ -16,6 +59,8 @@ def test_compute_new_template_metrics(small_sorting_analyzer):
     Then computes template metrics with new parameters and checks that old metrics
     are deleted.
     """
+
+    small_sorting_analyzer.delete_extension("template_metrics")
 
     # calculate just exp_decay
     small_sorting_analyzer.compute({"template_metrics": {"metric_names": ["exp_decay"]}})

--- a/src/spikeinterface/postprocessing/tests/test_template_metrics.py
+++ b/src/spikeinterface/postprocessing/tests/test_template_metrics.py
@@ -47,7 +47,7 @@ def test_compute_new_template_metrics(small_sorting_analyzer):
 
     # check that, when parameters are changed, the old metrics are deleted
     small_sorting_analyzer.compute(
-        {"template_metrics": {"metric_names": ["exp_decay"], "metrics_kwargs": {"recovery_window_ms": 0.6}}}
+        {"template_metrics": {"metric_names": ["exp_decay"], "metric_params": {"recovery_window_ms": 0.6}}}
     )
 
 

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -91,10 +91,10 @@ def compute_pc_metrics(
 
     if qm_params is not None and metric_params is None:
         deprecation_msg = (
-            "`qm_params` is deprecated and will be removed in version 0.104.0 Please use metric_params instead"
+            "`qm_params` is deprecated and will be removed in version 0.104.0. Please use metric_params instead"
         )
-        metric_params = qm_params
         warn(deprecation_msg, category=DeprecationWarning, stacklevel=2)
+        metric_params = qm_params
 
     pca_ext = sorting_analyzer.get_extension("principal_components")
     assert pca_ext is not None, "calculate_pc_metrics() need extension 'principal_components'"

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -6,6 +6,7 @@ import warnings
 from copy import deepcopy
 import platform
 from tqdm.auto import tqdm
+from warnings import warn
 
 import numpy as np
 
@@ -52,6 +53,7 @@ def get_quality_pca_metric_list():
 def compute_pc_metrics(
     sorting_analyzer,
     metric_names=None,
+    metric_params=None,
     qm_params=None,
     unit_ids=None,
     seed=None,
@@ -70,7 +72,7 @@ def compute_pc_metrics(
     metric_names : list of str, default: None
         The list of PC metrics to compute.
         If not provided, defaults to all PC metrics.
-    qm_params : dict or None
+    metric_params : dict or None
         Dictionary with parameters for each PC metric function.
     unit_ids : list of int or None
         List of unit ids to compute metrics for.
@@ -86,6 +88,14 @@ def compute_pc_metrics(
     pc_metrics : dict
         The computed PC metrics.
     """
+
+    if qm_params is not None and metric_params is None:
+        deprecation_msg = (
+            "`qm_params` is deprecated and will be removed in version 0.104.0 Please use metric_params instead"
+        )
+        metric_params = qm_params
+        warn(deprecation_msg, category=DeprecationWarning, stacklevel=2)
+
     pca_ext = sorting_analyzer.get_extension("principal_components")
     assert pca_ext is not None, "calculate_pc_metrics() need extension 'principal_components'"
 
@@ -93,8 +103,8 @@ def compute_pc_metrics(
 
     if metric_names is None:
         metric_names = _possible_pc_metric_names.copy()
-    if qm_params is None:
-        qm_params = _default_params
+    if metric_params is None:
+        metric_params = _default_params
 
     extremum_channels = get_template_extremum_channel(sorting_analyzer)
 
@@ -147,7 +157,7 @@ def compute_pc_metrics(
         pcs = dense_projections[np.isin(all_labels, neighbor_unit_ids)][:, :, neighbor_channel_indices]
         pcs_flat = pcs.reshape(pcs.shape[0], -1)
 
-        func_args = (pcs_flat, labels, non_nn_metrics, unit_id, unit_ids, qm_params, max_threads_per_process)
+        func_args = (pcs_flat, labels, non_nn_metrics, unit_id, unit_ids, metric_params, max_threads_per_process)
         items.append(func_args)
 
     if not run_in_parallel and non_nn_metrics:
@@ -184,7 +194,7 @@ def compute_pc_metrics(
             units_loop = tqdm(units_loop, desc=f"calculate {metric_name} metric", total=len(unit_ids))
 
         func = _nn_metric_name_to_func[metric_name]
-        metric_params = qm_params[metric_name] if metric_name in qm_params else {}
+        metric_params = metric_params[metric_name] if metric_name in metric_params else {}
 
         for _, unit_id in units_loop:
             try:
@@ -213,7 +223,7 @@ def compute_pc_metrics(
 
 
 def calculate_pc_metrics(
-    sorting_analyzer, metric_names=None, qm_params=None, unit_ids=None, seed=None, n_jobs=1, progress_bar=False
+    sorting_analyzer, metric_names=None, metric_params=None, unit_ids=None, seed=None, n_jobs=1, progress_bar=False
 ):
     warnings.warn(
         "The `calculate_pc_metrics` function is deprecated and will be removed in 0.103.0. Please use compute_pc_metrics instead",
@@ -224,7 +234,7 @@ def calculate_pc_metrics(
     pc_metrics = compute_pc_metrics(
         sorting_analyzer,
         metric_names=metric_names,
-        qm_params=qm_params,
+        metric_params=metric_params,
         unit_ids=unit_ids,
         seed=seed,
         n_jobs=n_jobs,
@@ -977,16 +987,16 @@ def _compute_isolation(pcs_target_unit, pcs_other_unit, n_neighbors: int):
 
 
 def pca_metrics_one_unit(args):
-    (pcs_flat, labels, metric_names, unit_id, unit_ids, qm_params, max_threads_per_process) = args
+    (pcs_flat, labels, metric_names, unit_id, unit_ids, metric_params, max_threads_per_process) = args
 
     if max_threads_per_process is None:
-        return _pca_metrics_one_unit(pcs_flat, labels, metric_names, unit_id, unit_ids, qm_params)
+        return _pca_metrics_one_unit(pcs_flat, labels, metric_names, unit_id, unit_ids, metric_params)
     else:
         with threadpool_limits(limits=int(max_threads_per_process)):
-            return _pca_metrics_one_unit(pcs_flat, labels, metric_names, unit_id, unit_ids, qm_params)
+            return _pca_metrics_one_unit(pcs_flat, labels, metric_names, unit_id, unit_ids, metric_params)
 
 
-def _pca_metrics_one_unit(pcs_flat, labels, metric_names, unit_id, unit_ids, qm_params):
+def _pca_metrics_one_unit(pcs_flat, labels, metric_names, unit_id, unit_ids, metric_params):
     pc_metrics = {}
     # metrics
     if "isolation_distance" in metric_names or "l_ratio" in metric_names:
@@ -1015,7 +1025,7 @@ def _pca_metrics_one_unit(pcs_flat, labels, metric_names, unit_id, unit_ids, qm_
     if "nearest_neighbor" in metric_names:
         try:
             nn_hit_rate, nn_miss_rate = nearest_neighbors_metrics(
-                pcs_flat, labels, unit_id, **qm_params["nearest_neighbor"]
+                pcs_flat, labels, unit_id, **metric_params["nearest_neighbor"]
             )
         except:
             nn_hit_rate = np.nan
@@ -1024,7 +1034,7 @@ def _pca_metrics_one_unit(pcs_flat, labels, metric_names, unit_id, unit_ids, qm_
         pc_metrics["nn_miss_rate"] = nn_miss_rate
 
     if "silhouette" in metric_names:
-        silhouette_method = qm_params["silhouette"]["method"]
+        silhouette_method = metric_params["silhouette"]["method"]
         if "simplified" in silhouette_method:
             try:
                 unit_silhouette_score = simplified_silhouette_score(pcs_flat, labels, unit_id)

--- a/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -55,6 +55,13 @@ class ComputeQualityMetrics(AnalyzerExtension):
     need_recording = False
     use_nodepipeline = False
     need_job_kwargs = True
+    need_backward_compatibility_on_load = True
+
+    def _handle_backward_compatibility_on_load(self):
+        # For backwards compatibility - this renames qm_params as metric_params
+        if (qm_params := self.params.get("qm_params")) is not None:
+            self.params["metric_params"] = qm_params
+            del self.params["qm_params"]
 
     def _set_params(
         self,
@@ -261,13 +268,6 @@ class ComputeQualityMetrics(AnalyzerExtension):
 
     def _get_data(self):
         return self.data["metrics"]
-
-    def load_params(self):
-        AnalyzerExtension.load_params(self)
-        # For backwards compatibility - this renames qm_params as metric_params
-        if (qm_params := self.params.get("qm_params")) is not None:
-            self.params["metric_params"] = qm_params
-            del self.params["qm_params"]
 
 
 register_result_extension(ComputeQualityMetrics)

--- a/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -262,6 +262,13 @@ class ComputeQualityMetrics(AnalyzerExtension):
     def _get_data(self):
         return self.data["metrics"]
 
+    def load_params(self):
+        AnalyzerExtension.load_params(self)
+        # For backwards compatibility - this renames qm_params as metric_params
+        if (qm_params := self.params.get("qm_params")) is not None:
+            self.params["metric_params"] = qm_params
+            del self.params["qm_params"]
+
 
 register_result_extension(ComputeQualityMetrics)
 compute_quality_metrics = ComputeQualityMetrics.function_factory()

--- a/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_calculator.py
@@ -16,7 +16,7 @@ from .quality_metric_list import (
     compute_pc_metrics,
     _misc_metric_name_to_func,
     _possible_pc_metric_names,
-    compute_name_to_column_names,
+    qm_compute_name_to_column_names,
 )
 from .misc_metrics import _default_params as misc_metrics_params
 from .pca_metrics import _default_params as pca_metrics_params
@@ -32,7 +32,7 @@ class ComputeQualityMetrics(AnalyzerExtension):
         A SortingAnalyzer object.
     metric_names : list or None
         List of quality metrics to compute.
-    metric_params : dict or None
+    metric_params : dict of dicts or None
         Dictionary with parameters for quality metrics calculation.
         Default parameters can be obtained with: `si.qualitymetrics.get_default_qm_params()`
     skip_pc_metrics : bool, default: False
@@ -254,7 +254,7 @@ class ComputeQualityMetrics(AnalyzerExtension):
         # append the metrics which were previously computed
         for metric_name in set(existing_metrics).difference(metrics_to_compute):
             # some metrics names produce data columns with other names. This deals with that.
-            for column_name in compute_name_to_column_names[metric_name]:
+            for column_name in qm_compute_name_to_column_names[metric_name]:
                 computed_metrics[column_name] = qm_extension.data["metrics"][column_name]
 
         self.data["metrics"] = computed_metrics

--- a/src/spikeinterface/qualitymetrics/quality_metric_list.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_list.py
@@ -55,7 +55,7 @@ _misc_metric_name_to_func = {
 }
 
 # a dict converting the name of the metric for computation to the output of that computation
-compute_name_to_column_names = {
+qm_compute_name_to_column_names = {
     "num_spikes": ["num_spikes"],
     "firing_rate": ["firing_rate"],
     "presence_ratio": ["presence_ratio"],

--- a/src/spikeinterface/qualitymetrics/tests/test_metrics_functions.py
+++ b/src/spikeinterface/qualitymetrics/tests/test_metrics_functions.py
@@ -69,7 +69,7 @@ def test_compute_new_quality_metrics(small_sorting_analyzer):
     assert calculated_metrics == ["snr"]
 
     small_sorting_analyzer.compute(
-        {"quality_metrics": {"metric_names": list(qm_params.keys()), "qm_params": qm_params}}
+        {"quality_metrics": {"metric_names": list(qm_params.keys()), "metric_params": qm_params}}
     )
     small_sorting_analyzer.compute({"quality_metrics": {"metric_names": ["snr"]}})
 
@@ -96,13 +96,13 @@ def test_compute_new_quality_metrics(small_sorting_analyzer):
     # check that, when parameters are changed, the data and metadata are updated
     old_snr_data = deepcopy(quality_metric_extension.get_data()["snr"].values)
     small_sorting_analyzer.compute(
-        {"quality_metrics": {"metric_names": ["snr"], "qm_params": {"snr": {"peak_mode": "peak_to_peak"}}}}
+        {"quality_metrics": {"metric_names": ["snr"], "metric_params": {"snr": {"peak_mode": "peak_to_peak"}}}}
     )
     new_quality_metric_extension = small_sorting_analyzer.get_extension("quality_metrics")
     new_snr_data = new_quality_metric_extension.get_data()["snr"].values
 
     assert np.all(old_snr_data != new_snr_data)
-    assert new_quality_metric_extension.params["qm_params"]["snr"]["peak_mode"] == "peak_to_peak"
+    assert new_quality_metric_extension.params["metric_params"]["snr"]["peak_mode"] == "peak_to_peak"
 
     # check that all quality metrics are deleted when parents are recomputed, even after
     # recomputation
@@ -280,10 +280,10 @@ def test_unit_id_order_independence(small_sorting_analyzer):
     }
 
     quality_metrics_1 = compute_quality_metrics(
-        small_sorting_analyzer, metric_names=get_quality_metric_list(), qm_params=qm_params
+        small_sorting_analyzer, metric_names=get_quality_metric_list(), metric_params=qm_params
     )
     quality_metrics_2 = compute_quality_metrics(
-        small_sorting_analyzer_2, metric_names=get_quality_metric_list(), qm_params=qm_params
+        small_sorting_analyzer_2, metric_names=get_quality_metric_list(), metric_params=qm_params
     )
 
     for metric, metric_2_data in quality_metrics_2.items():

--- a/src/spikeinterface/qualitymetrics/tests/test_quality_metric_calculator.py
+++ b/src/spikeinterface/qualitymetrics/tests/test_quality_metric_calculator.py
@@ -24,14 +24,14 @@ def test_compute_quality_metrics(sorting_analyzer_simple):
     metrics = compute_quality_metrics(
         sorting_analyzer,
         metric_names=["snr"],
-        qm_params=dict(isi_violation=dict(isi_threshold_ms=2)),
+        metric_params=dict(isi_violation=dict(isi_threshold_ms=2)),
         skip_pc_metrics=True,
         seed=2205,
     )
     # print(metrics)
 
     qm = sorting_analyzer.get_extension("quality_metrics")
-    assert qm.params["qm_params"]["isi_violation"]["isi_threshold_ms"] == 2
+    assert qm.params["metric_params"]["isi_violation"]["isi_threshold_ms"] == 2
     assert "snr" in metrics.columns
     assert "isolation_distance" not in metrics.columns
 
@@ -40,7 +40,7 @@ def test_compute_quality_metrics(sorting_analyzer_simple):
     metrics = compute_quality_metrics(
         sorting_analyzer,
         metric_names=None,
-        qm_params=dict(isi_violation=dict(isi_threshold_ms=2)),
+        metric_params=dict(isi_violation=dict(isi_threshold_ms=2)),
         skip_pc_metrics=False,
         seed=2205,
     )
@@ -54,7 +54,7 @@ def test_compute_quality_metrics_recordingless(sorting_analyzer_simple):
     metrics = compute_quality_metrics(
         sorting_analyzer,
         metric_names=None,
-        qm_params=dict(isi_violation=dict(isi_threshold_ms=2)),
+        metric_params=dict(isi_violation=dict(isi_threshold_ms=2)),
         skip_pc_metrics=False,
         seed=2205,
     )
@@ -68,7 +68,7 @@ def test_compute_quality_metrics_recordingless(sorting_analyzer_simple):
     metrics_norec = compute_quality_metrics(
         sorting_analyzer_norec,
         metric_names=None,
-        qm_params=dict(isi_violation=dict(isi_threshold_ms=2)),
+        metric_params=dict(isi_violation=dict(isi_threshold_ms=2)),
         skip_pc_metrics=False,
         seed=2205,
     )
@@ -101,7 +101,7 @@ def test_empty_units(sorting_analyzer_simple):
     metrics_empty = compute_quality_metrics(
         sorting_analyzer_empty,
         metric_names=None,
-        qm_params=dict(isi_violation=dict(isi_threshold_ms=2)),
+        metric_params=dict(isi_violation=dict(isi_threshold_ms=2)),
         skip_pc_metrics=True,
         seed=2205,
     )


### PR DESCRIPTION
Begin unifying template and quality metrics.

We recently discussed unifying the template and quality metric extensions. Here’s a proposal for starting that process. They’re already quite similar: the big difference is how they deal with parameters. Quality metrics have a parameter set for each metric, through the `qm_params` kwarg:

``` python
qm_params = {
    'sd_ratio’: {
         ‘censored_period_ms’: 4.0
    },
    ‘synchrony’: {
        ‘synchrony_sizes’: (2,4)
    }
}
```

while the template metrics have one set of parameters shared between all metrics, through the `metrics_kwargs` kwarg:

``` python
metrics_kwargs = {
    'recovery_window_ms’: 0.4,
    ‘spread_smooth_um’ : 20
}
```

This PR is a proposal to unify the parameter handling of the two metrics extensions, following the more flexible `qm_params` pattern, calling it `metric_params` in both cases. In the transition period, if we get the template metrics `metrics_kwargs`, we propogate these to all metrics. Hence, now the template metrics kwargs would look like:

``` python
metric_params = {
    'spread’: {
         ‘censored_period_ms’: 4.0
    },
    ‘exp_decay’: {
        ‘censored_period_ms’: 100,
        ‘peak_width_ms’: 0.11
    }
}
```

We also extend the `load_params` function for `ComputeQualityMetric` and `ComputeTemplateMetric` for backwards compatibility and add a `get_default_tm_params` function to match the existing `get_default_qm_params`.

This simplifies (and makes some neat refactoring (TODO) possible) for e.g. checking if metrics have already been computed. Would make the code in the curation metrics PR simpler.

Bigger picture, this standardisation is a necessary step if we want to make a more generic MetricExtension class/concept. @alejoe91  discussed a SpikeMetrics class, and it could be a good place for plugins and integration with other projects (e.g. could imagine UnitMatchMetrics class which computes the metrics used in UnitMatch).

Breaking change, so worth discussion. One less disruptive option: keep the `metrics_kwargs` and `qm_params` names, but just change the structure.