### PR TITLE
Fix use of keep during run_sorter benchmark

### DIFF
--- a/src/spikeinterface/benchmark/benchmark_base.py
+++ b/src/spikeinterface/benchmark/benchmark_base.py
@@ -209,7 +209,7 @@ class BenchmarkStudy:
 
             result_folder = self.folder / "results" / self.key_to_str(key)
             sorter_folder = self.folder / "sorters" / self.key_to_str(key)
-        
+
             if keep and result_folder.exists():
                 continue
             elif not keep and (result_folder.exists() or sorter_folder.exists()):

--- a/src/spikeinterface/benchmark/benchmark_base.py
+++ b/src/spikeinterface/benchmark/benchmark_base.py
@@ -208,10 +208,11 @@ class BenchmarkStudy:
         for key in case_keys:
 
             result_folder = self.folder / "results" / self.key_to_str(key)
-
+            sorter_folder = self.folder / "sorters" / self.key_to_str(key)
+        
             if keep and result_folder.exists():
                 continue
-            elif not keep and result_folder.exists():
+            elif not keep and (result_folder.exists() or sorter_folder.exists()):
                 self.remove_benchmark(key)
             job_keys.append(key)
 

--- a/src/spikeinterface/benchmark/benchmark_sorter.py
+++ b/src/spikeinterface/benchmark/benchmark_sorter.py
@@ -56,6 +56,15 @@ class SorterStudy(BenchmarkStudy):
         benchmark = SorterBenchmark(recording, gt_sorting, params, sorter_folder)
         return benchmark
 
+    def remove_benchmark(self, key):
+        BenchmarkStudy.remove_benchmark(self, key)
+
+        sorter_folder = self.folder / "sorters" / self.key_to_str(key)
+        import shutil
+        if sorter_folder.exists():
+            shutil.rmtree(sorter_folder)
+        
+
     def get_performance_by_unit(self, case_keys=None):
         import pandas as pd
 

--- a/src/spikeinterface/benchmark/benchmark_sorter.py
+++ b/src/spikeinterface/benchmark/benchmark_sorter.py
@@ -61,9 +61,9 @@ class SorterStudy(BenchmarkStudy):
 
         sorter_folder = self.folder / "sorters" / self.key_to_str(key)
         import shutil
+
         if sorter_folder.exists():
             shutil.rmtree(sorter_folder)
-        
 
     def get_performance_by_unit(self, case_keys=None):
         import pandas as pd

--- a/src/spikeinterface/curation/auto_merge.py
+++ b/src/spikeinterface/curation/auto_merge.py
@@ -231,7 +231,7 @@ def compute_merge_unit_groups(
         params = _default_step_params.get(step).copy()
         if steps_params is not None and step in steps_params:
             params.update(steps_params[step])
-
+    
         # STEP : remove units with too few spikes
         if step == "num_spikes":
 

--- a/src/spikeinterface/curation/auto_merge.py
+++ b/src/spikeinterface/curation/auto_merge.py
@@ -231,7 +231,7 @@ def compute_merge_unit_groups(
         params = _default_step_params.get(step).copy()
         if steps_params is not None and step in steps_params:
             params.update(steps_params[step])
-    
+
         # STEP : remove units with too few spikes
         if step == "num_spikes":
 


### PR DESCRIPTION
During a benchmark_sorter study, it could be that a particular sorter is crashing. If we want to relaunch, the keep=False method will not work and relaunch will not be permitted because the files of the sorter are not deleted. This fixes the issue