### PR TITLE
Patch to allow ipywidget plot_unit_templates to work with sparse templates (instead of analyzer)

### DIFF
--- a/src/spikeinterface/widgets/unit_waveforms.py
+++ b/src/spikeinterface/widgets/unit_waveforms.py
@@ -565,7 +565,7 @@ class UnitWaveformsWidget(BaseWidget):
             channel_locations = self.sorting_analyzer.get_channel_locations()
         else:
             unit_indices = [list(self.templates.unit_ids).index(unit_id) for unit_id in unit_ids]
-            templates = self.templates.templates_array[unit_indices]
+            templates = self.templates.get_dense_templates()[unit_indices]
             templates_shadings = None
             channel_locations = self.templates.get_channel_locations()
 


### PR DESCRIPTION
Currently, the ipywidget plot_unit_templates is not working when launched with sparse Templates and not SortingAnalyzer. This fixes the problem