### PR TITLE
Convert generated unit_ids in docs to strings

### DIFF
--- a/examples/tutorials/widgets/plot_2_sort_gallery.py
+++ b/examples/tutorials/widgets/plot_2_sort_gallery.py
@@ -31,14 +31,14 @@ w_isi = sw.plot_isi_distribution(sorting, window_ms=150.0, bin_ms=5.0, figsize=(
 # plot_autocorrelograms()
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 
-w_ach = sw.plot_autocorrelograms(sorting, window_ms=150.0, bin_ms=5.0, unit_ids=[1, 2, 5])
+w_ach = sw.plot_autocorrelograms(sorting, window_ms=150.0, bin_ms=5.0, unit_ids=['1', '2', '5'])
 
 ##############################################################################
 # plot_crosscorrelograms()
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-w_cch = sw.plot_crosscorrelograms(sorting, window_ms=150.0, bin_ms=5.0, unit_ids=[1, 2, 5])
+w_cch = sw.plot_crosscorrelograms(sorting, window_ms=150.0, bin_ms=5.0, unit_ids=['1', '2', '5'])
 
 plt.show()
 


### PR DESCRIPTION
#3588 broke one of the tutorials in the docs, since the selected `unit_id`s were integers, but should now by string.

This PR string-ifies the unit_ids to fix the docs.