### PR TITLE
Fix sphinx doc build

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,9 @@
 version: 2
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py
+
 build:
   os: ubuntu-22.04
   tools:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 
 sphinx:
   # Path to your Sphinx configuration file.
-  configuration: docs/conf.py
+  configuration: doc/conf.py
 
 build:
   os: ubuntu-22.04


### PR DESCRIPTION
Due to this: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/