### PR TITLE
Add `get_start_time`/`get_end_time` functions and use them in `get_duration`

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -233,7 +233,7 @@ class BaseRecording(BaseRecordingSnippets):
             The duration in seconds
         """
         segment_duration = (
-            self.get_stop_time(segment_index) - self.get_start_time(segment_index) + (1 / self.get_sampling_frequency())
+            self.get_end_time(segment_index) - self.get_start_time(segment_index) + (1 / self.get_sampling_frequency())
         )
         return segment_duration
 
@@ -456,7 +456,7 @@ class BaseRecording(BaseRecordingSnippets):
         rs = self._recording_segments[segment_index]
         return rs.get_start_time()
 
-    def get_stop_time(self, segment_index=None) -> float:
+    def get_end_time(self, segment_index=None) -> float:
         """Get the stop time of the recording segment.
 
         Parameters
@@ -471,7 +471,7 @@ class BaseRecording(BaseRecordingSnippets):
         """
         segment_index = self._check_segment_index(segment_index)
         rs = self._recording_segments[segment_index]
-        return rs.get_stop_time()
+        return rs.get_end_time()
 
     def has_time_vector(self, segment_index=None):
         """Check if the segment of the recording has a time vector.
@@ -937,11 +937,11 @@ class BaseRecordingSegment(BaseSegment):
         else:
             return self.t_start if self.t_start is not None else 0.0
 
-    def get_stop_time(self) -> float:
+    def get_end_time(self) -> float:
         if self.time_vector is not None:
             return self.time_vector[-1]
         else:
-            t_stop = self.get_num_samples() / self.sampling_frequency
+            t_stop = (self.get_num_samples() - 1) / self.sampling_frequency
             if self.t_start is not None:
                 t_stop += self.t_start
             return t_stop

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -59,7 +59,7 @@ class BaseRecording(BaseRecordingSnippets):
         if num_segments > 1:
             samples_per_segment = [self.get_num_samples(segment_index) for segment_index in range(num_segments)]
             memory_per_segment_bytes = (self.get_memory_size(segment_index) for segment_index in range(num_segments))
-            durations = [self.get_duration(segment_index) for segment_index in range(num_segments)]
+            durations = [self.get_duration(segment_index, use_times=False) for segment_index in range(num_segments)]
 
             samples_per_segment_formated = [f"{samples:,}" for samples in samples_per_segment]
             durations_per_segment_formated = [convert_seconds_to_str(d) for d in durations]
@@ -95,7 +95,7 @@ class BaseRecording(BaseRecordingSnippets):
         dtype = self.get_dtype()
 
         total_samples = self.get_total_samples()
-        total_duration = self.get_total_duration()
+        total_duration = self.get_total_duration(use_times=False)
         total_memory_size = self.get_total_memory_size()
 
         sf_hz = self.get_sampling_frequency()
@@ -216,7 +216,7 @@ class BaseRecording(BaseRecordingSnippets):
 
         return sum(samples_per_segment)
 
-    def get_duration(self, segment_index=None) -> float:
+    def get_duration(self, segment_index=None, use_times=True) -> float:
         """
         Returns the duration in seconds.
 
@@ -226,6 +226,9 @@ class BaseRecording(BaseRecordingSnippets):
             The sample index to retrieve the duration for.
             For multi-segment objects, it is required, default: None
             With single segment recording returns the duration of the single segment
+        use_times : bool, default: True
+            If True, the duration is calculated using the time vector if available.
+            If False, the duration is calculated using the number of samples and the sampling frequency.
 
         Returns
         -------
@@ -234,7 +237,7 @@ class BaseRecording(BaseRecordingSnippets):
         """
         segment_index = self._check_segment_index(segment_index)
 
-        if self.has_time_vector(segment_index):
+        if self.has_time_vector(segment_index) and use_times:
             times = self.get_times(segment_index)
             segment_duration = times[-1] - times[0] + (1 / self.get_sampling_frequency())
         else:
@@ -243,16 +246,24 @@ class BaseRecording(BaseRecordingSnippets):
 
         return segment_duration
 
-    def get_total_duration(self) -> float:
+    def get_total_duration(self, use_times=True) -> float:
         """
         Returns the total duration in seconds
+
+        Parameters
+        ----------
+        use_times : bool, default: True
+            If True, the duration is calculated using the time vector if available.
+            If False, the duration is calculated using the number of samples and the sampling frequency.
 
         Returns
         -------
         float
             The duration in seconds
         """
-        duration = sum([self.get_duration(idx) for idx in range(self.get_num_segments())])
+        duration = sum(
+            [self.get_duration(segment_index, use_times) for segment_index in range(self.get_num_segments())]
+        )
         return duration
 
     def get_memory_size(self, segment_index=None) -> int:

--- a/src/spikeinterface/core/loading.py
+++ b/src/spikeinterface/core/loading.py
@@ -104,7 +104,7 @@ def load(file_or_folder_or_dict, base_folder=None) -> BaseExtractor:
                 raise ValueError(error_msg)
         else:
             # remote case - zarr
-            if str(file_path).endswith(".zarr"):
+            if str(file_path).endswith(".zarr") or str(file_path).endswith(".zarr/"):
                 from .zarrextractors import read_zarr
 
                 extractor = read_zarr(file_path)


### PR DESCRIPTION
Since the `__repr__` uses the `get_duration`s function, I added an option to avoid using timestamps to estimate duration. 
In fact, this can be quite slow for long zarr datasets with timestamps, since the whole array is loaded in mem when calling `get_times()`.