### PR TITLE
Make `time_range` conversion to array dtype `float64` 

### DIFF
--- a/src/spikeinterface/widgets/traces.py
+++ b/src/spikeinterface/widgets/traces.py
@@ -145,7 +145,7 @@ class TracesWidget(BaseWidget):
         fs = rec0.get_sampling_frequency()
         if time_range is None:
             time_range = (t_start, t_start + 1.0)
-        time_range = np.array(time_range)
+        time_range = np.array(time_range, dtype=np.float64)
         if time_range[1] > t_end:
             warnings.warn(
                 "You have selected a time after the end of the segment. The range will be clipped to " f"{t_end}"


### PR DESCRIPTION
One of the most edge-case, inconsequential bugs ever: If your recording is < 1 second long and if you specify `time_range=(0, 1)` instead of `(0, 1.0)` then the cast from `tuple` to `array` will generate an `int` array. When`t_end` is assigned to it it will round to `0` leading to `time_range=(0, 0)` and failure to retrieve traces.

This is for a super-short example file I am using😅 