### PR TITLE
Handling segments while interpolating Motion

### DIFF
--- a/src/spikeinterface/sortingcomponents/motion/motion_interpolation.py
+++ b/src/spikeinterface/sortingcomponents/motion/motion_interpolation.py
@@ -84,10 +84,10 @@ def interpolate_motion_on_traces(
         The segment index.
     channel_inds : None or list
         If not None, interpolate only a subset of channels.
-    interpolation_time_bin_centers_s : None or np.array
+    interpolation_time_bin_centers_s : None or list of np.array
         Manually specify the time bins which the interpolation happens
         in for this segment. If None, these are the motion estimate's time bins.
-    interpolation_time_bin_edges_s : None or np.array
+    interpolation_time_bin_edges_s : None or list of np.array
         If present, interpolation chunks will be the time bins defined by these edges
         rather than interpolation_time_bin_centers_s or the motion's bins.
     spatial_interpolation_method : "idw" | "kriging", default: "kriging"
@@ -136,6 +136,8 @@ def interpolate_motion_on_traces(
         interpolation_time_bin_centers_s, interpolation_time_bin_edges_s = ensure_time_bins(
             interpolation_time_bin_centers_s, interpolation_time_bin_edges_s
         )
+        interpolation_time_bin_centers_s = interpolation_time_bin_centers_s[0]
+        interpolation_time_bin_edges_s = interpolation_time_bin_edges_s[0]
 
     # bin the frame times according to the interpolation time bins.
     # searchsorted(b, t, side="right") == i means that b[i-1] <= t < b[i]

--- a/src/spikeinterface/sortingcomponents/motion/motion_utils.py
+++ b/src/spikeinterface/sortingcomponents/motion/motion_utils.py
@@ -596,12 +596,12 @@ def ensure_time_bins(time_bin_centers_s=None, time_bin_edges_s=None):
     -------
     time_bin_centers_s, time_bin_edges_s
     """
-    
+
     if isinstance(time_bin_centers_s, np.ndarray):
-            time_bin_centers_s = [time_bin_centers_s]
-    
+        time_bin_centers_s = [time_bin_centers_s]
+
     if isinstance(time_bin_edges_s, np.ndarray):
-            time_bin_edges_s = [time_bin_edges_s]
+        time_bin_edges_s = [time_bin_edges_s]
 
     if time_bin_centers_s is None and time_bin_edges_s is None:
         raise ValueError("Need at least one of time_bin_centers_s or time_bin_edges_s.")
@@ -613,13 +613,17 @@ def ensure_time_bins(time_bin_centers_s=None, time_bin_edges_s=None):
             time_bin_centers_s += [0.5 * (time_bin_edges_s[segment_index][1:] + time_bin_edges_s[segment_index][:-1])]
 
     if time_bin_edges_s is None:
-        
+
         time_bin_edges_s = []
         for segment_index in range(len(time_bin_centers_s)):
-            time_bin_edges_s += [np.empty(time_bin_centers_s[segment_index].shape[0] + 1, dtype=time_bin_centers_s[segment_index].dtype)]
+            time_bin_edges_s += [
+                np.empty(time_bin_centers_s[segment_index].shape[0] + 1, dtype=time_bin_centers_s[segment_index].dtype)
+            ]
             time_bin_edges_s[-1][[0, -1]] = time_bin_centers_s[segment_index][[0, -1]]
             if time_bin_centers_s[segment_index].size > 2:
-                time_bin_edges_s[-1][1:-1] = 0.5 * (time_bin_centers_s[segment_index][1:] + time_bin_centers_s[segment_index][:-1])
+                time_bin_edges_s[-1][1:-1] = 0.5 * (
+                    time_bin_centers_s[segment_index][1:] + time_bin_centers_s[segment_index][:-1]
+                )
 
     return time_bin_centers_s, time_bin_edges_s
 


### PR DESCRIPTION
Actually, I've found that multi-segment is introducing a bug when saving/reloading corrected recordings. This should patch the issue

The bug can be reproduce in main by simply doing
>> static, drifting, sorting = si.generate_drifting_recording(probe_name='Neuropixel-128')
>> corrected = si.correct_motion(drifting)
>> corrected.dump("rec.pickle")
>> corrected2 = si.load('rec.pickle')

The patch should fix the issue