### PR TITLE
Add `BaseRasterWidget`

### DIFF
--- a/src/spikeinterface/widgets/amplitudes.py
+++ b/src/spikeinterface/widgets/amplitudes.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import numpy as np
 from warnings import warn
 
+from .rasters import BaseRasterWidget
 from .base import BaseWidget, to_attr
 from .utils import get_some_colors
 
 from ..core.sortinganalyzer import SortingAnalyzer
 
+from spikeinterface.core import SortingAnalyzer
 
-class AmplitudesWidget(BaseWidget):
+
+class AmplitudesWidget(BaseRasterWidget):
     """
     Plots spike amplitudes
 
@@ -19,6 +22,9 @@ class AmplitudesWidget(BaseWidget):
         The input waveform extractor
     unit_ids : list or None, default: None
         List of unit ids
+    unit_colors : dict | None, default: None
+        Dict of colors with key : unit, value : color. If None, uses `get_some_colors` to
+        generate colors.
     segment_index : int or None, default: None
         The segment index (or None if mono-segment)
     max_spikes_per_unit : int or None, default: None
@@ -61,9 +67,6 @@ class AmplitudesWidget(BaseWidget):
         if unit_ids is None:
             unit_ids = sorting.unit_ids
 
-        if unit_colors is None:
-            unit_colors = get_some_colors(sorting.unit_ids)
-
         if sorting.get_num_segments() > 1:
             if segment_index is None:
                 warn("More than one segment available! Using segment_index 0")
@@ -73,13 +76,11 @@ class AmplitudesWidget(BaseWidget):
         amplitudes_segment = amplitudes[segment_index]
         total_duration = sorting_analyzer.get_num_samples(segment_index) / sorting_analyzer.sampling_frequency
 
-        spiketrains_segment = {}
-        for i, unit_id in enumerate(sorting.unit_ids):
-            times = sorting.get_unit_spike_train(unit_id, segment_index=segment_index)
-            times = times / sorting.get_sampling_frequency()
-            spiketrains_segment[unit_id] = times
+        all_spiketrains = {
+            unit_id: sorting.get_unit_spike_train(unit_id, segment_index=0, return_times=True)
+            for unit_id in sorting.unit_ids
+        }
 
-        all_spiketrains = spiketrains_segment
         all_amplitudes = amplitudes_segment
         if max_spikes_per_unit is not None:
             spiketrains_to_plot = dict()
@@ -97,167 +98,19 @@ class AmplitudesWidget(BaseWidget):
             spiketrains_to_plot = all_spiketrains
             amplitudes_to_plot = all_amplitudes
 
-        if plot_histograms and bins is None:
-            bins = 100
-
         plot_data = dict(
-            sorting_analyzer=sorting_analyzer,
-            amplitudes=amplitudes_to_plot,
-            unit_ids=unit_ids,
+            spike_train_data=spiketrains_to_plot,
+            y_axis_data=amplitudes_to_plot,
             unit_colors=unit_colors,
-            spiketrains=spiketrains_to_plot,
-            total_duration=total_duration,
             plot_histograms=plot_histograms,
             bins=bins,
+            unit_ids=unit_ids,
             hide_unit_selector=hide_unit_selector,
             plot_legend=plot_legend,
+            y_label="Amplitude",
         )
 
-        BaseWidget.__init__(self, plot_data, backend=backend, **backend_kwargs)
-
-    def plot_matplotlib(self, data_plot, **backend_kwargs):
-        import matplotlib.pyplot as plt
-        from .utils_matplotlib import make_mpl_figure
-
-        dp = to_attr(data_plot)
-
-        if backend_kwargs["axes"] is not None:
-            axes = backend_kwargs["axes"]
-            if dp.plot_histograms:
-                assert np.asarray(axes).size == 2
-            else:
-                assert np.asarray(axes).size == 1
-        elif backend_kwargs["ax"] is not None:
-            assert not dp.plot_histograms
-        else:
-            if dp.plot_histograms:
-                backend_kwargs["num_axes"] = 2
-                backend_kwargs["ncols"] = 2
-            else:
-                backend_kwargs["num_axes"] = None
-
-        self.figure, self.axes, self.ax = make_mpl_figure(**backend_kwargs)
-
-        scatter_ax = self.axes.flatten()[0]
-
-        for unit_id in dp.unit_ids:
-            spiketrains = dp.spiketrains[unit_id]
-            amps = dp.amplitudes[unit_id]
-            scatter_ax.scatter(spiketrains, amps, color=dp.unit_colors[unit_id], s=3, alpha=1, label=unit_id)
-
-            if dp.plot_histograms:
-                if dp.bins is None:
-                    bins = int(len(spiketrains) / 30)
-                else:
-                    bins = dp.bins
-                ax_hist = self.axes.flatten()[1]
-                # this is super slow, using plot and np.histogram is really much faster (and nicer!)
-                # ax_hist.hist(amps, bins=bins, orientation="horizontal", color=dp.unit_colors[unit_id], alpha=0.8)
-                count, bins = np.histogram(amps, bins=bins)
-                ax_hist.plot(count, bins[:-1], color=dp.unit_colors[unit_id], alpha=0.8)
-
-        if dp.plot_histograms:
-            ax_hist = self.axes.flatten()[1]
-            ax_hist.set_ylim(scatter_ax.get_ylim())
-            ax_hist.axis("off")
-            # self.figure.tight_layout()
-
-        if dp.plot_legend:
-            if hasattr(self, "legend") and self.legend is not None:
-                self.legend.remove()
-            self.legend = self.figure.legend(
-                loc="upper center", bbox_to_anchor=(0.5, 1.0), ncol=5, fancybox=True, shadow=True
-            )
-
-        scatter_ax.set_xlim(0, dp.total_duration)
-        scatter_ax.set_xlabel("Times [s]")
-        scatter_ax.set_ylabel(f"Amplitude")
-        scatter_ax.spines["top"].set_visible(False)
-        scatter_ax.spines["right"].set_visible(False)
-        self.figure.subplots_adjust(bottom=0.1, top=0.9, left=0.1)
-
-    def plot_ipywidgets(self, data_plot, **backend_kwargs):
-        import matplotlib.pyplot as plt
-
-        # import ipywidgets.widgets as widgets
-        import ipywidgets.widgets as W
-        from IPython.display import display
-        from .utils_ipywidgets import check_ipywidget_backend, UnitSelector
-
-        check_ipywidget_backend()
-
-        self.next_data_plot = data_plot.copy()
-
-        cm = 1 / 2.54
-        analyzer = data_plot["sorting_analyzer"]
-
-        width_cm = backend_kwargs["width_cm"]
-        height_cm = backend_kwargs["height_cm"]
-
-        ratios = [0.15, 0.85]
-
-        with plt.ioff():
-            output = W.Output()
-            with output:
-                self.figure = plt.figure(figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
-                plt.show()
-
-        self.unit_selector = UnitSelector(analyzer.unit_ids)
-        self.unit_selector.value = list(analyzer.unit_ids)[:1]
-
-        self.checkbox_histograms = W.Checkbox(
-            value=data_plot["plot_histograms"],
-            description="hist",
-        )
-
-        left_sidebar = W.VBox(
-            children=[
-                self.unit_selector,
-                self.checkbox_histograms,
-            ],
-            layout=W.Layout(align_items="center", width="100%", height="100%"),
-        )
-
-        self.widget = W.AppLayout(
-            center=self.figure.canvas,
-            left_sidebar=left_sidebar,
-            pane_widths=ratios + [0],
-        )
-
-        # a first update
-        self._full_update_plot()
-
-        self.unit_selector.observe(self._update_plot, names="value", type="change")
-        self.checkbox_histograms.observe(self._full_update_plot, names="value", type="change")
-
-        if backend_kwargs["display"]:
-            display(self.widget)
-
-    def _full_update_plot(self, change=None):
-        self.figure.clear()
-        data_plot = self.next_data_plot
-        data_plot["unit_ids"] = self.unit_selector.value
-        data_plot["plot_histograms"] = self.checkbox_histograms.value
-        data_plot["plot_legend"] = False
-
-        backend_kwargs = dict(figure=self.figure, axes=None, ax=None)
-        self.plot_matplotlib(data_plot, **backend_kwargs)
-        self._update_plot()
-
-    def _update_plot(self, change=None):
-        for ax in self.axes.flatten():
-            ax.clear()
-
-        data_plot = self.next_data_plot
-        data_plot["unit_ids"] = self.unit_selector.value
-        data_plot["plot_histograms"] = self.checkbox_histograms.value
-        data_plot["plot_legend"] = False
-
-        backend_kwargs = dict(figure=None, axes=self.axes, ax=None)
-        self.plot_matplotlib(data_plot, **backend_kwargs)
-
-        self.figure.canvas.draw()
-        self.figure.canvas.flush_events()
+        BaseRasterWidget.__init__(self, **plot_data, backend=backend, **backend_kwargs)
 
     def plot_sortingview(self, data_plot, **backend_kwargs):
         import sortingview.views as vv
@@ -270,8 +123,8 @@ class AmplitudesWidget(BaseWidget):
         sa_items = [
             vv.SpikeAmplitudesItem(
                 unit_id=u,
-                spike_times_sec=dp.spiketrains[u].astype("float32"),
-                spike_amplitudes=dp.amplitudes[u].astype("float32"),
+                spike_times_sec=dp.spike_train_data[u].astype("float32"),
+                spike_amplitudes=dp.y_axis_data[u].astype("float32"),
             )
             for u in unit_ids
         ]

--- a/src/spikeinterface/widgets/amplitudes.py
+++ b/src/spikeinterface/widgets/amplitudes.py
@@ -41,7 +41,7 @@ class AmplitudesWidget(BaseRasterWidget):
         (matplotlib backend)
     bins : int or None, default: None
         If plot_histogram is True, the number of bins for the amplitude histogram.
-        If None this is automatically adjusted
+        If None, use 100 bins.
     plot_legend : bool, default: True
         True includes legend in plot
     """
@@ -103,6 +103,9 @@ class AmplitudesWidget(BaseRasterWidget):
         else:
             spiketrains_to_plot = all_spiketrains
             amplitudes_to_plot = all_amplitudes
+
+        if plot_histograms and bins is None:
+            bins = 100
 
         plot_data = dict(
             spike_train_data=spiketrains_to_plot,

--- a/src/spikeinterface/widgets/amplitudes.py
+++ b/src/spikeinterface/widgets/amplitudes.py
@@ -110,6 +110,7 @@ class AmplitudesWidget(BaseRasterWidget):
             unit_colors=unit_colors,
             plot_histograms=plot_histograms,
             bins=bins,
+            total_duration=total_duration,
             unit_ids=unit_ids,
             hide_unit_selector=hide_unit_selector,
             plot_legend=plot_legend,

--- a/src/spikeinterface/widgets/amplitudes.py
+++ b/src/spikeinterface/widgets/amplitudes.py
@@ -29,6 +29,10 @@ class AmplitudesWidget(BaseRasterWidget):
         The segment index (or None if mono-segment)
     max_spikes_per_unit : int or None, default: None
         Number of max spikes per unit to display. Use None for all spikes
+    y_lim : tuple or None, default: None
+        The min and max depth to display, if None (min and max of the amplitudes).
+    scatter_decimate : int, default: 1
+        If > 1, the scatter points are decimated.
     hide_unit_selector : bool, default: False
         If True the unit selector is not displayed
         (sortingview backend)
@@ -49,6 +53,8 @@ class AmplitudesWidget(BaseRasterWidget):
         unit_colors=None,
         segment_index=None,
         max_spikes_per_unit=None,
+        y_lim=None,
+        scatter_decimate=1,
         hide_unit_selector=False,
         plot_histograms=False,
         bins=None,
@@ -108,6 +114,8 @@ class AmplitudesWidget(BaseRasterWidget):
             hide_unit_selector=hide_unit_selector,
             plot_legend=plot_legend,
             y_label="Amplitude",
+            y_lim=y_lim,
+            scatter_decimate=scatter_decimate,
         )
 
         BaseRasterWidget.__init__(self, **plot_data, backend=backend, **backend_kwargs)

--- a/src/spikeinterface/widgets/motion.py
+++ b/src/spikeinterface/widgets/motion.py
@@ -6,6 +6,7 @@ from .base import BaseWidget, to_attr
 
 from spikeinterface.core import BaseRecording, SortingAnalyzer
 from spikeinterface.sortingcomponents.motion import Motion
+from .rasters import BaseRasterWidget
 
 
 class MotionWidget(BaseWidget):
@@ -97,7 +98,7 @@ class MotionWidget(BaseWidget):
             ax.set_ylabel("Depth [um]")
 
 
-class DriftRasterMapWidget(BaseWidget):
+class DriftRasterMapWidget(BaseRasterWidget):
     """
     Plot the drift raster map from peaks or a SortingAnalyzer.
     The drift raster map is a scatter plot of the estimated peak depth vs time and it is
@@ -200,56 +201,14 @@ class DriftRasterMapWidget(BaseWidget):
             if peak_amplitudes is not None:
                 peak_amplitudes = peak_amplitudes[peak_mask]
 
-        plot_data = dict(
-            peaks=peaks,
-            peak_locations=peak_locations,
-            peak_amplitudes=peak_amplitudes,
-            direction=direction,
-            sampling_frequency=sampling_frequency,
-            segment_index=segment_index,
-            depth_lim=depth_lim,
-            color_amplitude=color_amplitude,
-            color=color,
-            scatter_decimate=scatter_decimate,
-            cmap=cmap,
-            clim=clim,
-            alpha=alpha,
-            recording=recording,
-        )
-        BaseWidget.__init__(self, plot_data, backend=backend, **backend_kwargs)
+        from matplotlib.pyplot import colormaps
 
-    def plot_matplotlib(self, data_plot, **backend_kwargs):
-        import matplotlib.pyplot as plt
-        from matplotlib.colors import Normalize
-        from .utils_matplotlib import make_mpl_figure
-
-        from spikeinterface.sortingcomponents.motion import correct_motion_on_peaks
-
-        dp = to_attr(data_plot)
-
-        assert backend_kwargs["axes"] is None, "axes argument is not allowed in DriftRasterMapWidget. Use ax instead."
-
-        self.figure, self.axes, self.ax = make_mpl_figure(**backend_kwargs)
-
-        if dp.recording is None:
-            peak_times = dp.peaks["sample_index"] / dp.sampling_frequency
-        else:
-            peak_times = dp.recording.sample_index_to_time(dp.peaks["sample_index"], segment_index=dp.segment_index)
-
-        peak_locs = dp.peak_locations[dp.direction]
-        if dp.scatter_decimate is not None:
-            peak_times = peak_times[:: dp.scatter_decimate]
-            peak_locs = peak_locs[:: dp.scatter_decimate]
-
-        if dp.color_amplitude:
-            amps = dp.peak_amplitudes
+        if color_amplitude:
+            amps = peak_amplitudes
             amps_abs = np.abs(amps)
             q_95 = np.quantile(amps_abs, 0.95)
-            if dp.scatter_decimate is not None:
-                amps = amps[:: dp.scatter_decimate]
-                amps_abs = amps_abs[:: dp.scatter_decimate]
-            cmap = plt.colormaps[dp.cmap]
-            if dp.clim is None:
+            cmap = colormaps[cmap]
+            if clim is None:
                 amps = amps_abs
                 amps /= q_95
                 c = cmap(amps)
@@ -259,17 +218,26 @@ class DriftRasterMapWidget(BaseWidget):
             color_kwargs = dict(
                 color=None,
                 c=c,
-                alpha=dp.alpha,
+                alpha=alpha,
             )
         else:
-            color_kwargs = dict(color=dp.color, c=None, alpha=dp.alpha)
+            color_kwargs = dict(color=color, c=None, alpha=alpha)
 
-        self.ax.scatter(peak_times, peak_locs, s=1, **color_kwargs)
-        if dp.depth_lim is not None:
-            self.ax.set_ylim(*dp.depth_lim)
-        self.ax.set_title("Peak depth")
-        self.ax.set_xlabel("Times [s]")
-        self.ax.set_ylabel("Depth [$\\mu$m]")
+        # convert data into format that `BaseRasterWidget` can take it in
+        spike_train_data = {0: peaks["sample_index"] / sampling_frequency}
+        y_axis_data = {0: peak_locations[direction]}
+
+        plot_data = dict(
+            spike_train_data=spike_train_data,
+            y_axis_data=y_axis_data,
+            y_lim=depth_lim,
+            color_kwargs=color_kwargs,
+            scatter_decimate=scatter_decimate,
+            title="Peak depth",
+            y_label="Depth [um]",
+        )
+
+        BaseRasterWidget.__init__(self, **plot_data, backend=backend, **backend_kwargs)
 
 
 class MotionInfoWidget(BaseWidget):

--- a/src/spikeinterface/widgets/rasters.py
+++ b/src/spikeinterface/widgets/rasters.py
@@ -4,6 +4,269 @@ import numpy as np
 from warnings import warn
 
 from .base import BaseWidget, to_attr, default_backend_kwargs
+from . import get_some_colors
+
+
+class BaseRasterWidget(BaseWidget):
+    """
+    Make a raster plot with spike times on the x axis and arbritary data on the y axis.
+    Can customise plot with histograms, title, labels, ticks etc.
+
+
+    Parameters
+    ----------
+    spike_train_data : dict
+        A dict of spike trains, indexed by the unit_id
+    y_axis_data : dict
+        A dict of the y-axis data, indexed by the unit_id
+    unit_ids : array-like | None, default: None
+        List of unit_ids to plot
+    total_duration : int | None, default: None
+        Duration of spike_train_data in seconds.
+    plot_histograms : bool, default: False
+        Plot histogram of y-axis data in another subplot
+    bins : int | None, default: None
+        Number of bins to use in histogram. If None, use 1/30 of spike train sample length.
+    scatter_decimate : int | None, default: None
+        If > 1, the scatter points are decimated.
+    unit_colors : dict | None, default: None
+        Dict of colors with key : unit, value : color. If None, uses `get_some_colors` to
+        generate colors.
+    color_kwargs : dict | None, default: None
+        More color control for e.g. colouring spikes by property. Passed to `maplotlib.scatter`.
+    plot_legend : bool, default: False
+        If True, the legend is plotted
+    x_lim : tuple or None, default: None
+        The min and max width to display, if None use (0, total_duration)
+    y_lim : tuple or None, default: None
+        The min and max depth to display, if None use the min and max of y_axis_data.
+    title : str | None, default: None
+        Title of plot. If None, no title is displayed.
+    y_label : str | None, default: None
+        Label of y-axis. If None, no label is displayed.
+    y_ticks : dict | None, default: None
+        Ticks on y-axis, passed to `set_yticks`. If None, default ticks are used.
+    hide_unit_selector : bool, default: False
+        For sortingview backend, if True the unit selector is not displayed
+    backend : str | None, default None
+        Which plotting backend to use e.g. 'matplotlib', 'ipywidgets'. If None, uses
+        default from `get_default_plotter_backend`.
+    """
+
+    def __init__(
+        self,
+        spike_train_data: dict,
+        y_axis_data: dict,
+        unit_ids: list | None = None,
+        total_duration: int | None = None,
+        plot_histograms: bool = False,
+        bins: int | None = None,
+        scatter_decimate: int = 1,
+        unit_colors: dict | None = None,
+        color_kwargs: dict | None = None,
+        plot_legend: bool | None = False,
+        y_lim: tuple[float, float] | None = None,
+        x_lim: tuple[float, float] | None = None,
+        title: str | None = None,
+        y_label: str | None = None,
+        y_ticks: bool = False,
+        hide_unit_selector: bool = True,
+        backend: str | None = None,
+        **backend_kwargs,
+    ):
+
+        plot_data = dict(
+            spike_train_data=spike_train_data,
+            y_axis_data=y_axis_data,
+            unit_ids=unit_ids,
+            plot_histograms=plot_histograms,
+            y_lim=y_lim,
+            x_lim=x_lim,
+            scatter_decimate=scatter_decimate,
+            color_kwargs=color_kwargs,
+            unit_colors=unit_colors,
+            y_label=y_label,
+            title=title,
+            total_duration=total_duration,
+            plot_legend=plot_legend,
+            bins=bins,
+            y_ticks=y_ticks,
+            hide_unit_selector=hide_unit_selector,
+        )
+
+        BaseWidget.__init__(self, plot_data, backend=backend, **backend_kwargs)
+
+    def plot_matplotlib(self, data_plot, **backend_kwargs):
+        import matplotlib.pyplot as plt
+        from matplotlib.colors import Normalize
+        from .utils_matplotlib import make_mpl_figure
+
+        dp = to_attr(data_plot)
+
+        if dp.unit_colors is None and dp.color_kwargs is None:
+            unit_colors = get_some_colors(dp.spike_train_data.keys())
+        else:
+            unit_colors = dp.unit_colors
+
+        if backend_kwargs["axes"] is not None:
+            axes = backend_kwargs["axes"]
+            if dp.plot_histograms:
+                assert np.asarray(axes).size == 2
+            else:
+                assert np.asarray(axes).size == 1
+        elif backend_kwargs["ax"] is not None:
+            assert not dp.plot_histograms
+        else:
+            if dp.plot_histograms:
+                backend_kwargs["num_axes"] = 2
+                backend_kwargs["ncols"] = 2
+            else:
+                backend_kwargs["num_axes"] = None
+
+        unit_ids = dp.unit_ids
+        if dp.unit_ids is None:
+            unit_ids = dp.spike_train_data.keys()
+
+        self.figure, self.axes, self.ax = make_mpl_figure(**backend_kwargs)
+        scatter_ax = self.axes.flatten()[0]
+
+        spike_train_data = dp.spike_train_data
+        y_axis_data = dp.y_axis_data
+
+        for unit_id in unit_ids:
+
+            unit_spike_train = spike_train_data[unit_id][:: dp.scatter_decimate]
+            unit_y_data = y_axis_data[unit_id][:: dp.scatter_decimate]
+
+            if dp.color_kwargs is None:
+                scatter_ax.scatter(unit_spike_train, unit_y_data, s=1, label=unit_id, color=unit_colors[unit_id])
+            else:
+                if dp.scatter_decimate != 1:
+                    color_kwargs = dp.color_kwargs
+                    color_kwargs["c"] = dp.color_kwargs["c"][:: dp.scatter_decimate]
+                scatter_ax.scatter(unit_spike_train, unit_y_data, s=1, label=unit_id, **color_kwargs)
+
+            if dp.plot_histograms:
+                if dp.bins is None:
+                    bins = int(len(unit_spike_train) / 30)
+                else:
+                    bins = dp.bins
+                ax_hist = self.axes.flatten()[1]
+                count, bins = np.histogram(unit_y_data, bins=bins)
+                ax_hist.plot(count, bins[:-1], color=unit_colors[unit_id], alpha=0.8)
+
+        if dp.plot_histograms:
+            ax_hist = self.axes.flatten()[1]
+            ax_hist.set_ylim(scatter_ax.get_ylim())
+            ax_hist.axis("off")
+
+        if dp.plot_legend:
+            if hasattr(self, "legend") and self.legend is not None:
+                self.legend.remove()
+            self.legend = self.figure.legend(
+                loc="upper center", bbox_to_anchor=(0.5, 1.0), ncol=5, fancybox=True, shadow=True
+            )
+
+        if dp.y_lim is not None:
+            scatter_ax.set_ylim(*dp.y_lim)
+        x_lim = dp.x_lim
+        if x_lim is None:
+            x_lim = [0, dp.total_duration]
+        scatter_ax.set_xlim(x_lim)
+
+        if dp.y_ticks:
+            scatter_ax.set_yticks(**dp.y_ticks)
+
+        scatter_ax.set_title(dp.title)
+        scatter_ax.set_xlabel("Times [s]")
+        scatter_ax.set_ylabel(dp.y_label)
+        scatter_ax.spines["top"].set_visible(False)
+        scatter_ax.spines["right"].set_visible(False)
+
+    def plot_ipywidgets(self, data_plot, **backend_kwargs):
+        import matplotlib.pyplot as plt
+
+        import ipywidgets.widgets as W
+        from IPython.display import display
+        from spikeinterface.widgets.utils_ipywidgets import check_ipywidget_backend, UnitSelector
+
+        check_ipywidget_backend()
+
+        self.next_data_plot = data_plot.copy()
+
+        cm = 1 / 2.54
+
+        width_cm = backend_kwargs["width_cm"]
+        height_cm = backend_kwargs["height_cm"]
+
+        ratios = [0.15, 0.85]
+
+        with plt.ioff():
+            output = W.Output()
+            with output:
+                self.figure = plt.figure(figsize=((ratios[1] * width_cm) * cm, height_cm * cm))
+                plt.show()
+
+        self.unit_selector = UnitSelector(list(data_plot["spike_train_data"].keys()))
+        self.unit_selector.value = list(data_plot["spike_train_data"].keys())[:1]
+
+        children = [self.unit_selector]
+
+        if data_plot["plot_histograms"] is not None:
+            self.checkbox_histograms = W.Checkbox(
+                value=data_plot["plot_histograms"],
+                description="hist",
+            )
+            children.append(self.checkbox_histograms)
+
+        left_sidebar = W.VBox(
+            children=children,
+            layout=W.Layout(align_items="center", width="100%", height="100%"),
+        )
+
+        self.widget = W.AppLayout(
+            center=self.figure.canvas,
+            left_sidebar=left_sidebar,
+            pane_widths=ratios + [0],
+        )
+
+        # a first update
+        self._full_update_plot()
+
+        self.unit_selector.observe(self._update_plot, names="value", type="change")
+        if data_plot["plot_histograms"] is not None:
+            self.checkbox_histograms.observe(self._full_update_plot, names="value", type="change")
+
+        if backend_kwargs["display"]:
+            display(self.widget)
+
+    def _full_update_plot(self, change=None):
+        self.figure.clear()
+        data_plot = self.next_data_plot
+        data_plot["unit_ids"] = self.unit_selector.value
+        if data_plot["plot_histograms"] is not None:
+            data_plot["plot_histograms"] = self.checkbox_histograms.value
+        data_plot["plot_legend"] = False
+
+        backend_kwargs = dict(figure=self.figure, axes=None, ax=None)
+        self.plot_matplotlib(data_plot, **backend_kwargs)
+        self._update_plot()
+
+    def _update_plot(self, change=None):
+        for ax in self.axes.flatten():
+            ax.clear()
+
+        data_plot = self.next_data_plot
+        data_plot["unit_ids"] = self.unit_selector.value
+        if data_plot["plot_histograms"] is not None:
+            data_plot["plot_histograms"] = self.checkbox_histograms.value
+        data_plot["plot_legend"] = False
+
+        backend_kwargs = dict(figure=None, axes=self.axes, ax=None)
+        self.plot_matplotlib(data_plot, **backend_kwargs)
+
+        self.figure.canvas.draw()
+        self.figure.canvas.flush_events()
 
 
 class RasterWidget(BaseWidget):

--- a/src/spikeinterface/widgets/rasters.py
+++ b/src/spikeinterface/widgets/rasters.py
@@ -4,7 +4,7 @@ import numpy as np
 from warnings import warn
 
 from .base import BaseWidget, to_attr, default_backend_kwargs
-from . import get_some_colors
+from .utils import get_some_colors
 
 
 class BaseRasterWidget(BaseWidget):
@@ -188,7 +188,7 @@ class BaseRasterWidget(BaseWidget):
 
         import ipywidgets.widgets as W
         from IPython.display import display
-        from spikeinterface.widgets.utils_ipywidgets import check_ipywidget_backend, UnitSelector
+        from .utils_ipywidgets import check_ipywidget_backend, UnitSelector
 
         check_ipywidget_backend()
 

--- a/src/spikeinterface/widgets/rasters.py
+++ b/src/spikeinterface/widgets/rasters.py
@@ -141,8 +141,8 @@ class BaseRasterWidget(BaseWidget):
             if dp.color_kwargs is None:
                 scatter_ax.scatter(unit_spike_train, unit_y_data, s=1, label=unit_id, color=unit_colors[unit_id])
             else:
-                if dp.scatter_decimate != 1:
-                    color_kwargs = dp.color_kwargs
+                color_kwargs = dp.color_kwargs
+                if dp.scatter_decimate != 1 and color_kwargs.get("c") is not None:
                     color_kwargs["c"] = dp.color_kwargs["c"][:: dp.scatter_decimate]
                 scatter_ax.scatter(unit_spike_train, unit_y_data, s=1, label=unit_id, **color_kwargs)
 


### PR DESCRIPTION
Added `BaseRasterWidget` widget, and re-factored `AmplitudeWidget`, `RasterWidget` and `DriftRasterMapWidget` to use it.

Following on from @JoeZiminski's comment in #3649, I’ve made a `BaseRasterWidget`, which can be used to make spike times vs anything plots. Some advantages:

- Unifies the plotting logic for `AmplitudeWidget`, `RasterWidget` and `DriftRasterMapWidget` (and later LocationsWidget)
- Plotting kwargs from some widgets can now be used by others. E.g. `y_lim` and `scatter_decimate` from `DriftRasterMapWidget` is now available for `AmplitudeWidget`.

Now users (and devs!) can easily make custom raster plots, e.g. if you have a sorting analyzer called `sa` with spike_amplitudes computed, you can do:

``` python
all_spiketrains = {
    unit_id: sa.sorting.get_unit_spike_train(unit_id, segment_index=0, return_times=True) 
for unit_id in sa.sorting.unit_ids}

locations = sa.get_extension("spike_amplitudes").get_data(outputs="by_unit")[0]
x_locs_squares = {
    unit_id: pow(locations[unit_id],2)
for unit_id in sa.sorting.unit_ids}

BaseRasterWidget(spike_train_data=all_spiketrains, y_axis_data=x_locs_squares, unit_ids=[2,6], backend="matplotlib", y_lim=[0,50_000], title="Amplitudes Squared!!!", y_label="I love axis labels")

```
which makes this:
![amp_squared](https://github.com/user-attachments/assets/148057ce-557e-446a-b775-0fd6d8dc1ce0)

The goal was for this to be totally backend and not change any plots, but when doing it, I think it was a chance to unify some widget style choices. E.g. drawing just the left and bottom axes, and making the data fill the plot. It's a little difficult to test all this stuff. Here's a bunch of plots using `main` and this PR. I've also checking that SortingView can still do an amplitudes plot and played with `ipywidgets` a lot.

OLD vs NEW

![lotsa_plots](https://github.com/user-attachments/assets/393479ae-4ef3-4276-9a9c-202dffad9c61)

