### PR TITLE
Allow for concatenated mode in `get_some_projections` and `compute_pc_metrics`

### DIFF
--- a/src/spikeinterface/postprocessing/principal_component.py
+++ b/src/spikeinterface/postprocessing/principal_component.py
@@ -260,7 +260,11 @@ class ComputePrincipalComponents(AnalyzerExtension):
         spike_unit_indices = some_spikes["unit_index"][selected_inds]
 
         if sparsity is None:
-            some_projections = all_projections[selected_inds, :, :][:, :, channel_indices]
+            if self.params["mode"] == "concatenated":
+                some_projections = all_projections[selected_inds, :]
+            else:
+                some_projections = all_projections[selected_inds, :, :][:, :, channel_indices]
+
         else:
             # need re-alignement
             some_projections = np.zeros((selected_inds.size, num_components, channel_indices.size), dtype=dtype)

--- a/src/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/src/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -50,6 +50,13 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
         assert pca.ndim == 2
         assert pca.shape[1] == n_components
 
+        ext_rand = sorting_analyzer.get_extension("random_spikes")
+        num_rand_spikes = len(ext_rand.get_data())
+
+        some_projections = ext.get_some_projections()
+        assert some_projections[0].shape[0] == num_rand_spikes
+        assert some_projections[0].shape[1] == n_components
+
     @pytest.mark.parametrize("sparse", [True, False])
     def test_get_projections(self, sparse):
         """

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -157,7 +157,10 @@ def compute_pc_metrics(
         neighbor_channel_indices = sorting_analyzer.channel_ids_to_indices(neighbor_channel_ids)
 
         labels = all_labels[np.isin(all_labels, neighbor_unit_ids)]
-        pcs = dense_projections[np.isin(all_labels, neighbor_unit_ids)][:, :, neighbor_channel_indices]
+        if pca_ext.params["mode"] == "concatenated":
+            pcs = dense_projections[np.isin(all_labels, neighbor_unit_ids)]
+        else:
+            pcs = dense_projections[np.isin(all_labels, neighbor_unit_ids)][:, :, neighbor_channel_indices]
         pcs_flat = pcs.reshape(pcs.shape[0], -1)
 
         func_args = (pcs_flat, labels, non_nn_metrics, unit_id, unit_ids, metric_params, max_threads_per_worker)


### PR DESCRIPTION
Should fix #3653

Fixes bug where `get_some_projections` and `compute_pc_metrics` couldn't extract pcas when they were computed in concatenated mode. Fixing this allows pca quality metrics to be computed too.

Added a test which used to fail, and now passes.

Harder to test if this definitely works. Here's some evidence: it's code which computes the quality metrics in `concatenated` mode (with 20 components) and in non-concatenated mode (with `5x4=20` components), then computes the metrics. We wouldn't expect the results to be equal, but would expect them to be highly correlated, which they seem to be!

``` python
import numpy as np
import spikeinterface.full as si

rec, sort = si.generate_ground_truth_recording()

sa_1 = si.create_sorting_analyzer(recording=rec, sorting=sort, folder="my_sa", format="binary_folder", overwrite=True, sparse=False, seed=1205)

sa_1.compute({
    "noise_levels": {},
    "random_spikes": {'seed': 1205},
    "waveforms": {},
    "templates": {},
    "principal_components": {"mode": 'concatenated', "n_components": 20},
    "quality_metrics": {"metric_names": ["d_prime","silhouette", "nearest_neighbor"]}
})

sa_2 = si.create_sorting_analyzer(recording=rec, sorting=sort, folder="my_sa", format="binary_folder", overwrite=True, sparse=False)

sa_2.compute({
    "noise_levels": {},
    "random_spikes": {'seed': 1205},
    "waveforms": {},
    "templates": {},
    "principal_components": {},
    "quality_metrics": {"metric_names": ["d_prime","silhouette", "nearest_neighbor"]}
})

qm_1 = sa_1.get_extension("quality_metrics").get_data()
qm_2 = sa_2.get_extension("quality_metrics").get_data()

dprime_corr = np.corrcoef(x = [ qm_1['d_prime'].values, qm_2['d_prime'].values ])
sil_corr = np.corrcoef(x = [ qm_1['silhouette'].values, qm_2['silhouette'].values ])
nnhit_corr = np.corrcoef(x = [ qm_1['nn_hit_rate'].values, qm_2['nn_hit_rate'].values ])
nnmiss_corr = np.corrcoef(x = [ qm_1['nn_miss_rate'].values, qm_2['nn_miss_rate'].values ])

print(dprime_corr)
print(sil_corr)
print(nnhit_corr)
print(nnmiss_corr)
```

with output:

``` python
dprime_corr:  [[1.         0.99704657]
 [0.99704657 1.        ]]
sil_corr:  [[1.         0.95037167]
 [0.95037167 1.        ]]
nnhit_corr:  [[1.         0.98622277]
 [0.98622277 1.        ]]
nnmiss_corr:  [[1.         0.96420438]
 [0.96420438 1.        ]]
```