### PR TITLE
Add `RemoveBadChannelsRecording` class and `remove_bad_channels`

### DIFF
--- a/src/spikeinterface/preprocessing/detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/detect_bad_channels.py
@@ -112,7 +112,7 @@ seed : int or None, default: None
             channel_ids=new_channel_ids,
         )
 
-        self._kwargs.update({"channel_labels": channel_labels})
+        self._kwargs.update({"bad_channel_ids": bad_channel_ids, "channel_labels": channel_labels})
         self._kwargs.update(updated_detect_bad_channels_kwargs)
 
 

--- a/src/spikeinterface/preprocessing/preprocessinglist.py
+++ b/src/spikeinterface/preprocessing/preprocessinglist.py
@@ -38,6 +38,7 @@ from .zero_channel_pad import ZeroChannelPaddedRecording, zero_channel_pad
 from .deepinterpolation import DeepInterpolatedRecording, deepinterpolate, train_deepinterpolation
 from .highpass_spatial_filter import HighpassSpatialFilterRecording, highpass_spatial_filter
 from .interpolate_bad_channels import InterpolateBadChannelsRecording, interpolate_bad_channels
+from .detect_bad_channels import RemoveBadChannelsRecording, remove_bad_channels
 from .average_across_direction import AverageAcrossDirectionRecording, average_across_direction
 from .directional_derivative import DirectionalDerivativeRecording, directional_derivative
 from .depth_order import DepthOrderRecording, depth_order
@@ -79,6 +80,7 @@ preprocessers_full_list = [
     DirectionalDerivativeRecording,
     AstypeRecording,
     UnsignedToSignedRecording,
+    RemoveBadChannelsRecording,
 ]
 
 preprocesser_dict = {pp_class.name: pp_class for pp_class in preprocessers_full_list}


### PR DESCRIPTION
Part of plan to `class`-ifty all preprocessing steps. Here's an implementation of a `RemoveBadChannelsRecording` class, inheriting from `ChannelSliceRecording`.

Users can now use
``` python
recording_with_bad_channels_removed = remove_bad_channels(recording)
```
and this will detect and remove the bad channels.

Most difficult thing was the kwargs. `RemoveBadChannelsRecording` shares much of the same signature as `detect_bad_channels`, and I didn't want to duplicate the default parameters, but did want to save them in the `RemoveBadChannelsRecording._kwargs`. Ended up using `inspect` from `signature`, as is also done in the motion module. Happy to discuss different implementations.