### PR TITLE
Use tdc2 instead of tdc for testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,15 +164,6 @@ test = [
     # for sortingview backend
     "sortingview",
 
-
-    ## install tridesclous for testing ##
-    "tridesclous>=1.6.8",
-
-    ## sliding_nn
-    "pymde",
-    "torch",
-    "pynndescent",
-
     # curation
     "skops",
     "huggingface_hub",

--- a/src/spikeinterface/sorters/tests/test_runsorter.py
+++ b/src/spikeinterface/sorters/tests/test_runsorter.py
@@ -32,7 +32,7 @@ def test_run_sorter_local(generate_recording, create_cache_folder):
     sorter_params = {"detect_threshold": 4.9}
 
     sorting = run_sorter(
-        "tridesclous",
+        "tridesclous2",
         recording,
         output_folder=cache_folder / "sorting_tdc_local",
         remove_existing_folder=True,

--- a/src/spikeinterface/sorters/tests/test_runsorter.py
+++ b/src/spikeinterface/sorters/tests/test_runsorter.py
@@ -29,7 +29,7 @@ def test_run_sorter_local(generate_recording, create_cache_folder):
     recording = generate_recording
     cache_folder = create_cache_folder
 
-    sorter_params = {"detect_threshold": 4.9}
+    sorter_params = {"detection": {"detect_threshold": 4.9}}
 
     sorting = run_sorter(
         "tridesclous2",


### PR DESCRIPTION
Should fix failing tests here: https://github.com/SpikeInterface/spikeinterface/pull/3597

Also removed unused packages for sliding_nn