### PR TITLE
Add parents in HTML representation and always print class name

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -79,6 +79,31 @@ class BaseExtractor:
         # preferred context for multiprocessing
         self._preferred_mp_context = None
 
+    def _repr_html_(self, display_name=True):
+        pass
+
+    def _get_common_repr_html(self, common_style):
+        html_annotations = f"<details style='{common_style}'>  <summary><strong>Annotations</strong></summary><ul>"
+        for key, value in self._annotations.items():
+            html_annotations += f"<li> <strong> {key} </strong>: {value}</li>"
+        html_annotations += f"</details>"
+
+        html_properties = f"<details style='{common_style}'><summary><strong>Properties</strong></summary><ul>"
+        for key, value in self._properties.items():
+            # Add a further indent for each property
+            value_formatted = np.asarray(value)
+            html_properties += f"<details><summary><strong>{key}</strong></summary>{value_formatted}</details>"
+        html_properties += "</ul></details>"
+
+        if self.get_parent():
+            html_parent = f"<details style='{common_style}'>  <summary><strong>Parent</strong></summary><ul>"
+            display_name = self.name != self.get_parent().name
+            html_parent += self.get_parent()._repr_html_(display_name=display_name)
+            html_parent += "</ul></details>"
+        else:
+            html_parent = ""
+        return html_annotations + html_properties + html_parent
+
     @property
     def name(self):
         name = self._annotations.get("name", None)

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -89,7 +89,7 @@ class BaseRecording(BaseRecordingSnippets):
 
         return txt
 
-    def _repr_header(self, parent_name=None):
+    def _repr_header(self, display_name=True):
         num_segments = self.get_num_segments()
         num_channels = self.get_num_channels()
         dtype = self.get_dtype()
@@ -105,7 +105,7 @@ class BaseRecording(BaseRecordingSnippets):
             # Khz for high sampling rate and Hz for LFP
             sampling_frequency_repr = f"{(sf_hz/1000.0):0.1f}kHz" if sf_hz > 10_000.0 else f"{sf_hz:0.1f}Hz"
 
-        if parent_name is None or parent_name != self.name:
+        if display_name and self.name != self.__class__.__name__:
             name = f"{self.name} ({self.__class__.__name__})"
         else:
             name = self.__class__.__name__
@@ -123,11 +123,11 @@ class BaseRecording(BaseRecordingSnippets):
 
         return txt
 
-    def _repr_html_(self, parent_name=None):
+    def _repr_html_(self, display_name=True):
         common_style = "margin-left: 10px;"
         border_style = "border:1px solid #ddd; padding:10px;"
 
-        html_header = f"<div style='{border_style}'><strong>{self._repr_header(parent_name)}</strong></div>"
+        html_header = f"<div style='{border_style}'><strong>{self._repr_header(display_name)}</strong></div>"
 
         html_segments = ""
         if self.get_num_segments() > 1:
@@ -148,26 +148,8 @@ class BaseRecording(BaseRecordingSnippets):
         html_channel_ids = f"<details style='{common_style}'>  <summary><strong>Channel IDs</strong></summary><ul>"
         html_channel_ids += f"{self.channel_ids} </details>"
 
-        html_annotations = f"<details style='{common_style}'>  <summary><strong>Annotations</strong></summary><ul>"
-        for key, value in self._annotations.items():
-            html_annotations += f"<li> <strong> {key} </strong>: {value}</li>"
-        html_annotations += "</ul> </details>"
-
-        html_properties = f"<details style='{common_style}'><summary><strong>Channel Properties</strong></summary><ul>"
-        for key, value in self._properties.items():
-            # Add a further indent for each property
-            value_formatted = np.asarray(value)
-            html_properties += f"<details><summary> <strong> {key} </strong> </summary>{value_formatted}</details>"
-        html_properties += "</ul></details>"
-
-        if self.get_parent():
-            html_parent = f"<details style='{common_style}'>  <summary><strong>Parent</strong></summary><ul>"
-            html_parent += self.get_parent()._repr_html_(parent_name=self.name)
-            html_parent += "</ul></details>"
-        else:
-            html_parent = ""
-
-        html_repr = html_header + html_segments + html_channel_ids + html_annotations + html_properties + html_parent
+        html_extra = self._get_common_repr_html(common_style)
+        html_repr = html_header + html_segments + html_channel_ids + html_extra
         return html_repr
 
     def get_num_segments(self) -> int:

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -89,7 +89,7 @@ class BaseRecording(BaseRecordingSnippets):
 
         return txt
 
-    def _repr_header(self, display_name=True):
+    def _repr_header(self, parent_name=None):
         num_segments = self.get_num_segments()
         num_channels = self.get_num_channels()
         dtype = self.get_dtype()
@@ -105,7 +105,7 @@ class BaseRecording(BaseRecordingSnippets):
             # Khz for high sampling rate and Hz for LFP
             sampling_frequency_repr = f"{(sf_hz/1000.0):0.1f}kHz" if sf_hz > 10_000.0 else f"{sf_hz:0.1f}Hz"
 
-        if display_name:
+        if parent_name is None or parent_name != self.name:
             name = f"{self.name} ({self.__class__.__name__})"
         else:
             name = self.__class__.__name__
@@ -123,11 +123,11 @@ class BaseRecording(BaseRecordingSnippets):
 
         return txt
 
-    def _repr_html_(self, display_name=True):
+    def _repr_html_(self, parent_name=None):
         common_style = "margin-left: 10px;"
         border_style = "border:1px solid #ddd; padding:10px;"
 
-        html_header = f"<div style='{border_style}'><strong>{self._repr_header(display_name)}</strong></div>"
+        html_header = f"<div style='{border_style}'><strong>{self._repr_header(parent_name)}</strong></div>"
 
         html_segments = ""
         if self.get_num_segments() > 1:
@@ -161,7 +161,7 @@ class BaseRecording(BaseRecordingSnippets):
         html_properties += "</ul></details>"
         if self.get_parent():
             html_parent = f"<details style='{common_style}'>  <summary><strong>Parent</strong></summary>"
-            html_parent += self.get_parent()._repr_html_(display_name=False)
+            html_parent += self.get_parent()._repr_html_(parent_name=self.name)
         else:
             html_parent = ""
 

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -89,7 +89,7 @@ class BaseRecording(BaseRecordingSnippets):
 
         return txt
 
-    def _repr_header(self):
+    def _repr_header(self, display_name=True):
         num_segments = self.get_num_segments()
         num_channels = self.get_num_channels()
         dtype = self.get_dtype()
@@ -105,8 +105,13 @@ class BaseRecording(BaseRecordingSnippets):
             # Khz for high sampling rate and Hz for LFP
             sampling_frequency_repr = f"{(sf_hz/1000.0):0.1f}kHz" if sf_hz > 10_000.0 else f"{sf_hz:0.1f}Hz"
 
+        if display_name:
+            name = f"{self.name} ({self.__class__.__name__})"
+        else:
+            name = self.__class__.__name__
+
         txt = (
-            f"{self.name}: "
+            f"{name}: "
             f"{num_channels} channels - "
             f"{sampling_frequency_repr} - "
             f"{num_segments} segments - "
@@ -118,11 +123,11 @@ class BaseRecording(BaseRecordingSnippets):
 
         return txt
 
-    def _repr_html_(self):
+    def _repr_html_(self, display_name=True):
         common_style = "margin-left: 10px;"
         border_style = "border:1px solid #ddd; padding:10px;"
 
-        html_header = f"<div style='{border_style}'><strong>{self._repr_header()}</strong></div>"
+        html_header = f"<div style='{border_style}'><strong>{self._repr_header(display_name)}</strong></div>"
 
         html_segments = ""
         if self.get_num_segments() > 1:
@@ -154,8 +159,13 @@ class BaseRecording(BaseRecordingSnippets):
             value_formatted = np.asarray(value)
             html_properties += f"<details><summary> <strong> {key} </strong> </summary>{value_formatted}</details>"
         html_properties += "</ul></details>"
+        if self.get_parent():
+            html_parent = f"<details style='{common_style}'>  <summary><strong>Parent</strong></summary>"
+            html_parent += self.get_parent()._repr_html_(display_name=False)
+        else:
+            html_parent = ""
 
-        html_repr = html_header + html_segments + html_channel_ids + html_annotations + html_properties
+        html_repr = html_header + html_segments + html_channel_ids + html_annotations + html_properties + html_parent
         return html_repr
 
     def get_num_segments(self) -> int:

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -159,9 +159,11 @@ class BaseRecording(BaseRecordingSnippets):
             value_formatted = np.asarray(value)
             html_properties += f"<details><summary> <strong> {key} </strong> </summary>{value_formatted}</details>"
         html_properties += "</ul></details>"
+
         if self.get_parent():
-            html_parent = f"<details style='{common_style}'>  <summary><strong>Parent</strong></summary>"
+            html_parent = f"<details style='{common_style}'>  <summary><strong>Parent</strong></summary><ul>"
             html_parent += self.get_parent()._repr_html_(parent_name=self.name)
+            html_parent += "</ul></details>"
         else:
             html_parent = ""
 

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -30,19 +30,26 @@ class BaseSorting(BaseExtractor):
         self._cached_spike_trains = {}
 
     def __repr__(self):
+        return self._repr_header()
+
+    def _repr_header(self, parent_name=None):
         nseg = self.get_num_segments()
         nunits = self.get_num_units()
         sf_khz = self.get_sampling_frequency() / 1000.0
-        txt = f"{self.name}: {nunits} units - {nseg} segments - {sf_khz:0.1f}kHz"
+        if parent_name is None or parent_name != self.name:
+            name = f"{self.name} ({self.__class__.__name__})"
+        else:
+            name = self.__class__.__name__
+        txt = f"{name}: {nunits} units - {nseg} segments - {sf_khz:0.1f}kHz"
         if "file_path" in self._kwargs:
             txt += "\n  file_path: {}".format(self._kwargs["file_path"])
         return txt
 
-    def _repr_html_(self):
+    def _repr_html_(self, parent_name=None):
         common_style = "margin-left: 10px;"
         border_style = "border:1px solid #ddd; padding:10px;"
 
-        html_header = f"<div style='{border_style}'><strong>{self.__repr__()}</strong></div>"
+        html_header = f"<div style='{border_style}'><strong>{self._repr_header(parent_name)}</strong></div>"
 
         html_unit_ids = f"<details style='{common_style}'>  <summary><strong>Unit IDs</strong></summary><ul>"
         html_unit_ids += f"{self.unit_ids} </details>"
@@ -61,7 +68,13 @@ class BaseSorting(BaseExtractor):
             html_unit_properties += f"<details><summary><strong>{key}</strong></summary>{value_formatted}</details>"
         html_unit_properties += "</ul></details>"
 
-        html_repr = html_header + html_unit_ids + html_annotations + html_unit_properties
+        if self.get_parent():
+            html_parent = f"<details style='{common_style}'>  <summary><strong>Parent</strong></summary>"
+            html_parent += self.get_parent()._repr_html_(parent_name=self.name)
+        else:
+            html_parent = ""
+
+        html_repr = html_header + html_unit_ids + html_annotations + html_unit_properties + html_parent
         return html_repr
 
     @property

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -32,11 +32,11 @@ class BaseSorting(BaseExtractor):
     def __repr__(self):
         return self._repr_header()
 
-    def _repr_header(self, parent_name=None):
+    def _repr_header(self, display_name=True):
         nseg = self.get_num_segments()
         nunits = self.get_num_units()
         sf_khz = self.get_sampling_frequency() / 1000.0
-        if parent_name is None or parent_name != self.name:
+        if display_name and self.name != self.__class__.__name__:
             name = f"{self.name} ({self.__class__.__name__})"
         else:
             name = self.__class__.__name__
@@ -45,37 +45,18 @@ class BaseSorting(BaseExtractor):
             txt += "\n  file_path: {}".format(self._kwargs["file_path"])
         return txt
 
-    def _repr_html_(self, parent_name=None):
+    def _repr_html_(self, display_name=True):
         common_style = "margin-left: 10px;"
         border_style = "border:1px solid #ddd; padding:10px;"
 
-        html_header = f"<div style='{border_style}'><strong>{self._repr_header(parent_name)}</strong></div>"
+        html_header = f"<div style='{border_style}'><strong>{self._repr_header(display_name)}</strong></div>"
 
         html_unit_ids = f"<details style='{common_style}'>  <summary><strong>Unit IDs</strong></summary><ul>"
         html_unit_ids += f"{self.unit_ids} </details>"
 
-        html_annotations = f"<details style='{common_style}'>  <summary><strong>Annotations</strong></summary><ul>"
-        for key, value in self._annotations.items():
-            html_annotations += f"<li> <strong> {key} </strong>: {value}</li>"
-        html_annotations += f"</details>"
+        html_extra = self._get_common_repr_html(common_style)
 
-        html_unit_properties = (
-            f"<details style='{common_style}'><summary><strong>Unit Properties</strong></summary><ul>"
-        )
-        for key, value in self._properties.items():
-            # Add a further indent for each property
-            value_formatted = np.asarray(value)
-            html_unit_properties += f"<details><summary><strong>{key}</strong></summary>{value_formatted}</details>"
-        html_unit_properties += "</ul></details>"
-
-        if self.get_parent():
-            html_parent = f"<details style='{common_style}'>  <summary><strong>Parent</strong></summary><ul>"
-            html_parent += self.get_parent()._repr_html_(parent_name=self.name)
-            html_parent += "</ul></details>"
-        else:
-            html_parent = ""
-
-        html_repr = html_header + html_unit_ids + html_annotations + html_unit_properties + html_parent
+        html_repr = html_header + html_unit_ids + html_extra
         return html_repr
 
     @property

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -69,8 +69,9 @@ class BaseSorting(BaseExtractor):
         html_unit_properties += "</ul></details>"
 
         if self.get_parent():
-            html_parent = f"<details style='{common_style}'>  <summary><strong>Parent</strong></summary>"
+            html_parent = f"<details style='{common_style}'>  <summary><strong>Parent</strong></summary><ul>"
             html_parent += self.get_parent()._repr_html_(parent_name=self.name)
+            html_parent += "</ul></details>"
         else:
             html_parent = ""
 


### PR DESCRIPTION
I'm always finding myself searching through the kwargs to check the preprocessing chain...
@chrishalcrow you're gonna like this :) 

Added the `Parent` section in the HTML repr (and also appended the class name to the `self.name`). Here's how it looks:

![image](https://github.com/user-attachments/assets/d6a1cdad-48ec-467a-b642-c441d15f2d05)
