### PR TITLE
Add assert to check when `.zarr` folder doesn't exist

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -642,6 +642,9 @@ class SortingAnalyzer:
 
     @classmethod
     def load_from_zarr(cls, folder, recording=None, backend_options=None):
+
+        assert Path(folder).is_dir(), f"This folder does not exists {folder}"
+
         import zarr
         from .loading import load
 


### PR DESCRIPTION
Hello, shared some zarr'd sorting analyzers with a colleague. If you mistype the filepath, but include `.zarr` the current error is:

``` python
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    sa = si.load_sorting_analyzer("/Users/chris/ks_.zarr")
  File "/Users/chris/Work/Edinburgh/Spike/si_dev/spikeinterface_dev/spikeinterface/src/spikeinterface/core/sortinganalyzer.py", line 199, in load_sorting_analyzer
    return SortingAnalyzer.load(folder, load_extensions=load_extensions, format=format, backend_options=backend_options)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chris/Work/Edinburgh/Spike/si_dev/spikeinterface_dev/spikeinterface/src/spikeinterface/core/sortinganalyzer.py", line 366, in load
    sorting_analyzer = SortingAnalyzer.load_from_zarr(
        folder, recording=recording, backend_options=backend_options
    )
  File "/Users/chris/Work/Edinburgh/Spike/si_dev/spikeinterface_dev/spikeinterface/src/spikeinterface/core/sortinganalyzer.py", line 651, in load_from_zarr                                       zarr_root = super_zarr_open(str(folder), mode="r", storage_options=storage_options)
  File "/Users/chris/Work/Edinburgh/Spike/si_dev/spikeinterface_dev/spikeinterface/src/spikeinterface/core/zarrextractors.py", line 83, in super_zarr_open
    if root is None:
       ^^^^
UnboundLocalError: cannot access local variable 'root' where it is not associated with a value
```

which isn't super helpful and they were (rightfully) confused. This PR would change the trace to:

``` python
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    sa = si.load_sorting_analyzer("/Users/chris/ks_.zarr")
  File "/Users/chris/Work/Edinburgh/Spike/si_dev/spikeinterface_dev/spikeinterface/src/spikeinterface/core/sortinganalyzer.py", line 199, in load_sorting_analyzer
    return SortingAnalyzer.load(folder, load_extensions=load_extensions, format=format, backend_options=backend_options)                                                                                 ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                        File "/Users/chris/Work/Edinburgh/Spike/si_dev/spikeinterface_dev/spikeinterface/src/spikeinterface/core/sortinganalyzer.py", line 366, in load                                                 sorting_analyzer = SortingAnalyzer.load_from_zarr(
        folder, recording=recording, backend_options=backend_options                               )
  File "/Users/chris/Work/Edinburgh/Spike/si_dev/spikeinterface_dev/spikeinterface/src/spikeinterface/core/sortinganalyzer.py", line 646, in load_from_zarr
    assert Path(folder).is_dir(), f"This folder does not exists {folder}"
           ~~~~~~~~~~~~~~~~~~~^^                                                               
AssertionError: This folder does not exists /Users/chris/ks_.zarr
```

I put this in `load_from_zarr`, rather than going up a level. I think it needs to be here - if it was in `load` the remote path would raise an assertion?