### PR TITLE
Add torch to test installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,9 @@ test = [
     # for sortingview backend
     "sortingview",
 
+    # for motion and sortingcomponents
+    "torch",
+
     # curation
     "skops",
     "huggingface_hub",


### PR DESCRIPTION
Accidentally removed it when removing tridesclous and pymde and makes codecov tests fail.