### PR TITLE
Remove artefacts based of an enveloppe

### DIFF
--- a/src/spikeinterface/preprocessing/preprocessinglist.py
+++ b/src/spikeinterface/preprocessing/preprocessinglist.py
@@ -43,6 +43,7 @@ from .directional_derivative import DirectionalDerivativeRecording, directional_
 from .depth_order import DepthOrderRecording, depth_order
 from .astype import AstypeRecording, astype
 from .unsigned_to_signed import UnsignedToSignedRecording, unsigned_to_signed
+from .silence_artefacts import SilenceArtefactsRecording, silence_artefacts
 
 
 preprocessers_full_list = [
@@ -79,6 +80,7 @@ preprocessers_full_list = [
     DirectionalDerivativeRecording,
     AstypeRecording,
     UnsignedToSignedRecording,
+    SilenceArtefactsRecording,
 ]
 
 preprocesser_dict = {pp_class.name: pp_class for pp_class in preprocessers_full_list}

--- a/src/spikeinterface/preprocessing/preprocessinglist.py
+++ b/src/spikeinterface/preprocessing/preprocessinglist.py
@@ -43,7 +43,7 @@ from .directional_derivative import DirectionalDerivativeRecording, directional_
 from .depth_order import DepthOrderRecording, depth_order
 from .astype import AstypeRecording, astype
 from .unsigned_to_signed import UnsignedToSignedRecording, unsigned_to_signed
-from .silence_artefacts import SilenceArtefactsRecording, silence_artefacts
+from .silence_artefacts import SilencedArtefactsRecording, silence_artefacts
 
 
 preprocessers_full_list = [
@@ -80,7 +80,7 @@ preprocessers_full_list = [
     DirectionalDerivativeRecording,
     AstypeRecording,
     UnsignedToSignedRecording,
-    SilenceArtefactsRecording,
+    SilencedArtefactsRecording,
 ]
 
 preprocesser_dict = {pp_class.name: pp_class for pp_class in preprocessers_full_list}

--- a/src/spikeinterface/preprocessing/silence_artefacts.py
+++ b/src/spikeinterface/preprocessing/silence_artefacts.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import numpy as np
+
+from spikeinterface.core.core_tools import define_function_from_class
+from silence_periods import SilencedPeriodsRecording
+from rectify import RectifyRecording
+from filter_gaussian import FilterGaussianRecording
+from ..core.job_tools import split_job_kwargs, fix_job_kwargs
+
+from ..core import  get_noise_levels
+from ..core.generate import NoiseGeneratorRecording
+from .basepreprocessor import BasePreprocessor
+
+
+from ..core.node_pipeline import PeakDetector, base_peak_dtype
+import numpy as np
+
+class DetectThresholdCrossing(PeakDetector):
+    
+    name = "threshold_crossings"
+    preferred_mp_context = None
+    
+    def __init__(
+        self,
+        recording,
+        detect_threshold=5,
+        noise_levels=None,
+        random_chunk_kwargs={},
+    ):
+        PeakDetector.__init__(self, recording, return_output=True)
+        if noise_levels is None:
+            noise_levels = get_noise_levels(recording, return_scaled=False, **random_chunk_kwargs)
+        self.abs_thresholds = noise_levels * detect_threshold
+        self._dtype = np.dtype(base_peak_dtype + [("onset", "bool")])
+
+    def get_trace_margin(self):
+        return 0
+
+    def get_dtype(self):
+        return self._dtype
+    
+    def compute(self, traces, start_frame, end_frame, segment_index, max_margin):
+        z =  (traces - self.abs_thresholds)
+        threshold_mask = np.diff((z > 0) != 0, axis=0)
+        indices = np.where(threshold_mask)
+        local_peaks = np.zeros(indices[0].size, dtype=self._dtype)
+        local_peaks["sample_index"] = indices[0]
+        local_peaks["channel_index"] = indices[1]
+        for channel_ind in np.unique(indices[1]):
+            mask = np.flatnonzero(indices[1] == channel_ind)
+            local_peaks["onset"][mask[::2]] = True
+            local_peaks["onset"][mask[1::2]] = False
+        idx = np.argsort(local_peaks["sample_index"])
+        local_peaks = local_peaks[idx]
+        return (local_peaks, )
+
+
+def detect_onsets(enveloppe, detect_threshold=5, **job_kwargs):
+
+    from spikeinterface.core.node_pipeline import (
+        run_node_pipeline,
+    )
+
+    node0 = DetectThresholdCrossing(enveloppe)
+    
+    peaks = run_node_pipeline(
+        enveloppe,
+        [node0],
+        job_kwargs,
+        job_name="detecting threshold crossings",
+        )
+
+    results = {}
+    for channel_ind, channel_id in enumerate(enveloppe.channel_ids):
+
+        mask = peaks["channel_index"] == channel_ind
+        sub_peaks = peaks[mask]
+        onset_mask = sub_peaks["onset"] == 1
+        onsets = sub_peaks[onset_mask]
+        offsets = sub_peaks[~onset_mask]
+        periods = []
+
+        if len(onsets) > 0:
+            if onsets['sample_index'][0] > offsets['sample_index'][0]:
+                periods += [(0, offsets['sample_index'][0])]
+                offsets = offsets[1:]
+                
+            for i in range(len(onsets)):
+                periods += [(onsets['sample_index'][i], offsets['sample_index'][i])]
+            
+            if len(onsets) > len(offsets):
+               periods += [(onsets['sample_index'][0], enveloppe.get_num_samples())]
+                
+        results[channel_id] = periods
+        
+    return results
+
+
+class SilencedArtefactsRecording(SilencedPeriodsRecording):
+    """
+    Silence user-defined periods from recording extractor traces. The code will construct
+    an enveloppe of the recording (as a low pass filtered version of the traces) and detect
+    threshold crossings to identify the periods to silence. The periods are then silenced either
+    on a per channel basis or across all channels by replacing the values by zeros or by 
+    adding gaussian noise with the same variance as the one in the recordings
+
+    Parameters
+    ----------
+    recording : RecordingExtractor
+        The recording extractor to silence putative artefacts
+    per_channel : bool, default: True
+        If True, the periods are silenced on a per channel basis. If False, the periods are silenced
+        across all channels
+    detect_threshold : float, default: 5
+        The threshold to detect artefacts. The threshold is computed as `detect_threshold * noise_level`
+    freq_max : float, default: 20
+        The maximum frequency for the low pass filter used
+    noise_levels : array
+        Noise levels if already computed
+    seed : int | None, default: None
+        Random seed for `get_noise_levels` and `NoiseGeneratorRecording`.
+        If none, `get_noise_levels` uses `seed=0` and `NoiseGeneratorRecording` generates a random seed using `numpy.random.default_rng`.
+    mode : "zeros" | "noise, default: "zeros"
+        Determines what periods are replaced by. Can be one of the following:
+
+        - "zeros": Artifacts are replaced by zeros.
+
+        - "noise": The periods are filled with a gaussion noise that has the
+                   same variance that the one in the recordings, on a per channel
+                   basis
+    **random_chunk_kwargs : Keyword arguments for `spikeinterface.core.get_random_data_chunk()` function
+
+    Returns
+    -------
+    silenced_recording : SilencedArtefactsRecording
+        The recording extractor after silencing detected artefacts
+    """
+
+    def __init__(self, 
+                 recording,
+                 per_channel=True,
+                 detect_threshold=5,
+                 freq_max=20., 
+                 mode="zeros", 
+                 noise_levels=None,
+                 seed=None, 
+                 **random_chunk_kwargs):
+        
+
+        _, job_kwargs  = split_job_kwargs(random_chunk_kwargs)
+        job_kwargs = fix_job_kwargs(job_kwargs)
+
+        available_modes = ("zeros", "noise")
+        recording = RectifyRecording(recording)
+        recording = FilterGaussianRecording(recording, freq_min=0, freq_max=20)
+
+        periods = detect_onsets(recording, 
+                                detect_threshold=detect_threshold, 
+                                **random_chunk_kwargs)
+
+        # some checks
+        assert mode in available_modes, f"mode {mode} is not an available mode: {available_modes}"
+
+        if mode in ["noise"]:
+            if noise_levels is None:
+                random_slices_kwargs = random_chunk_kwargs.copy()
+                random_slices_kwargs["seed"] = seed
+                noise_levels = get_noise_levels(
+                    recording, return_scaled=False, random_slices_kwargs=random_slices_kwargs
+                )
+            noise_generator = NoiseGeneratorRecording(
+                num_channels=recording.get_num_channels(),
+                sampling_frequency=recording.sampling_frequency,
+                durations=[recording.select_segments(i).get_duration() for i in range(recording.get_num_segments())],
+                dtype=recording.dtype,
+                seed=seed,
+                noise_levels=noise_levels,
+                strategy="on_the_fly",
+                noise_block_size=int(recording.sampling_frequency),
+            )
+        else:
+            noise_generator = None
+
+
+
+        BasePreprocessor.__init__(self, recording)
+        for seg_index, parent_segment in enumerate(recording._recording_segments):
+            periods = list_periods[seg_index]
+            periods = np.asarray(periods, dtype="int64")
+            periods = np.sort(periods, axis=0)
+            rec_segment = SilencedArtefactsRecording(parent_segment, periods, mode, noise_generator, seg_index)
+            self.add_recording_segment(rec_segment)
+
+        self._kwargs = dict(recording=recording, list_periods=list_periods, mode=mode, seed=seed)
+        self._kwargs.update(random_chunk_kwargs)
+
+
+# function for API
+silence_artefacts = define_function_from_class(source_class=SilencedArtefactsRecording, name="silence_artefacts")

--- a/src/spikeinterface/preprocessing/silence_artefacts.py
+++ b/src/spikeinterface/preprocessing/silence_artefacts.py
@@ -7,10 +7,7 @@ from .silence_periods import SilencedPeriodsRecording
 from .rectify import RectifyRecording
 from .filter_gaussian import GaussianFilterRecording
 from ..core.job_tools import split_job_kwargs, fix_job_kwargs
-
 from ..core import  get_noise_levels
-from ..core.generate import NoiseGeneratorRecording
-from .basepreprocessor import BasePreprocessor
 
 
 from ..core.node_pipeline import PeakDetector, base_peak_dtype
@@ -43,61 +40,54 @@ class DetectThresholdCrossing(PeakDetector):
     def compute(self, traces, start_frame, end_frame, segment_index, max_margin):
         z =  (traces - self.abs_thresholds).mean(1)
         threshold_mask = np.diff((z > 0) != 0, axis=0)
-        indices,  = np.where(threshold_mask)
+        indices  = np.flatnonzero(threshold_mask)
         local_peaks = np.zeros(indices.size, dtype=self._dtype)
         local_peaks["sample_index"] = indices
-        #local_peaks["channel_index"] = indices[-1]
-        #for channel_ind in np.unique(indices[1]):
-        #    mask = np.flatnonzero(indices[1] == channel_ind)
-        #    local_peaks["onset"][mask[::2]] = True
-        #    local_peaks["onset"][mask[1::2]] = False
-        #idx = np.argsort(local_peaks["sample_index"])
-        #local_peaks = local_peaks[idx]
         local_peaks["onset"][::2] = True
         local_peaks["onset"][1::2] = False
         return (local_peaks, )
 
 
-def detect_onsets(recording, detect_threshold=5, **job_kwargs):
+def detect_onsets(recording, detect_threshold=5, **extra_kwargs):
 
     from spikeinterface.core.node_pipeline import (
         run_node_pipeline,
     )
 
-    node0 = DetectThresholdCrossing(recording, detect_threshold, **job_kwargs)
+    random_chunk_kwargs, job_kwargs  = split_job_kwargs(extra_kwargs)
+    job_kwargs = fix_job_kwargs(job_kwargs)
+
+    node0 = DetectThresholdCrossing(recording, detect_threshold, **random_chunk_kwargs)
     
     peaks = run_node_pipeline(
         recording,
         [node0],
         job_kwargs,
-        job_name="detecting threshold crossings",
+        job_name="detect threshold crossings",
         )
 
-    results = []
-    print(peaks)
-    # for channel_ind, channel_id in enumerate(recording.channel_ids):
-
-    #     mask = peaks["channel_index"] == channel_ind
-    #     sub_peaks = peaks[mask]
-    #     onset_mask = sub_peaks["onset"] == 1
-    #     onsets = sub_peaks[onset_mask]
-    #     offsets = sub_peaks[~onset_mask]
-    #     periods = []
-
-    #     # if len(onsets) > 0:
-    #     #     if onsets['sample_index'][0] > offsets['sample_index'][0]:
-    #     #         periods += [(0, offsets['sample_index'][0])]
-    #     #         offsets = offsets[1:]
-                
-    #     #     for i in range(len(onsets)):
-    #     #         periods += [(onsets['sample_index'][i], offsets['sample_index'][i])]
-            
-    #     #     if len(onsets) > len(offsets):
-    #     #        periods += [(onsets['sample_index'][0], recording.get_num_samples())]
-                
-    #     results[channel_id] = periods
+    periods = []
+    num_seg = recording.get_num_segments()
+    for seg_index in range(num_seg):
+        sub_periods = []
+        mask = peaks["segment_index"] == 0
+        sub_peaks = peaks[mask]
+        onsets = sub_peaks[sub_peaks['onset']]
+        offsets = sub_peaks[~sub_peaks['onset']]
         
-    return results
+        if onsets['sample_index'][0] > offsets['sample_index'][0]:
+            sub_periods += [(0, offsets['sample_index'][0])]
+            offsets = offsets[1:]
+        
+        for i in range(min(len(onsets), len(offsets))):
+            sub_periods += [(onsets['sample_index'][i], offsets['sample_index'][i])]
+
+        if len(onsets) > len(offsets):
+            sub_periods += [(onsets['sample_index'][0], recording.get_num_samples(seg_index))]
+
+        periods.append(sub_periods)
+        
+    return periods
 
 
 class SilencedArtefactsRecording(SilencedPeriodsRecording):
@@ -139,17 +129,12 @@ class SilencedArtefactsRecording(SilencedPeriodsRecording):
 
     def __init__(self, 
                  recording,
-                 per_channel=True,
                  detect_threshold=5,
                  freq_max=20., 
                  mode="zeros", 
                  noise_levels=None,
                  seed=None, 
                  **random_chunk_kwargs):
-        
-
-        _, job_kwargs  = split_job_kwargs(random_chunk_kwargs)
-        job_kwargs = fix_job_kwargs(job_kwargs)
 
         recording = RectifyRecording(recording)
         recording = GaussianFilterRecording(recording, freq_min=None, freq_max=freq_max)
@@ -165,6 +150,9 @@ class SilencedArtefactsRecording(SilencedPeriodsRecording):
                                           noise_levels=noise_levels, 
                                           seed=seed, 
                                           **random_chunk_kwargs)
+
+        #self._kwargs = dict(recording=recording, list_periods=list_periods, mode=mode, seed=seed)
+        #self._kwargs.update(random_chunk_kwargs)
 
 
 # function for API

--- a/src/spikeinterface/preprocessing/silence_artefacts.py
+++ b/src/spikeinterface/preprocessing/silence_artefacts.py
@@ -111,7 +111,7 @@ class SilencedArtefactsRecording(SilencedPeriodsRecording):
     seed : int | None, default: None
         Random seed for `get_noise_levels` and `NoiseGeneratorRecording`.
         If none, `get_noise_levels` uses `seed=0` and `NoiseGeneratorRecording` generates a random seed using `numpy.random.default_rng`.
-    mode : "zeros" | "noise, default: "zeros"
+    mode : "zeros" | "noise", default: "zeros"
         Determines what periods are replaced by. Can be one of the following:
 
         - "zeros": Artifacts are replaced by zeros.
@@ -131,28 +131,29 @@ class SilencedArtefactsRecording(SilencedPeriodsRecording):
                  recording,
                  detect_threshold=5,
                  freq_max=20., 
-                 mode="zeros", 
+                 mode="noise", 
                  noise_levels=None,
-                 seed=None, 
+                 seed=None,
+                 list_periods=None,
                  **random_chunk_kwargs):
 
-        recording = RectifyRecording(recording)
-        recording = GaussianFilterRecording(recording, freq_min=None, freq_max=freq_max)
+        enveloppe = RectifyRecording(recording)
+        enveloppe = GaussianFilterRecording(enveloppe, freq_min=None, freq_max=freq_max)
 
-        periods = detect_onsets(recording, 
+        if list_periods is None:
+            list_periods = detect_onsets(enveloppe, 
                                 detect_threshold=detect_threshold, 
                                 **random_chunk_kwargs)
 
         SilencedPeriodsRecording.__init__(self, 
                                           recording, 
-                                          periods, 
+                                          list_periods, 
                                           mode=mode, 
                                           noise_levels=noise_levels, 
                                           seed=seed, 
                                           **random_chunk_kwargs)
 
-        #self._kwargs = dict(recording=recording, list_periods=list_periods, mode=mode, seed=seed)
-        #self._kwargs.update(random_chunk_kwargs)
+        self._kwargs.update({'detect_threshold' : detect_threshold, 'freq_max' : freq_max})
 
 
 # function for API

--- a/src/spikeinterface/preprocessing/silence_periods.py
+++ b/src/spikeinterface/preprocessing/silence_periods.py
@@ -5,7 +5,7 @@ import numpy as np
 from spikeinterface.core.core_tools import define_function_from_class
 from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 
-from ..core import get_random_data_chunks, get_noise_levels
+from ..core import get_noise_levels
 from ..core.generate import NoiseGeneratorRecording
 
 


### PR DESCRIPTION
Because this code has been asked by several people, I have the feeling that there might be the need for such a preprocessing Node, to remove artefacts. The idea is the following: the node creates an low-pass filtered version of the rectified signal, compute the noise levels of this new signal, and detect thresholds crossings (onsets/offsets). We are then using these detected time periods to feed a silence_periods nodes, such that periods spotted by the enveloppe will be blanked.

Do you think such a node can be useful? For people using tetrode/few channels it seems to matter quite a lot. For denser probes, this could be debatted, and especially one could think about extending the silence_periods node to work on a per_channel basis instead of across all channels. But this could be debated