### PR TITLE
Propagate `agreemennt_method` to `compare_multiple_sorters`

### DIFF
--- a/src/spikeinterface/comparison/basecomparison.py
+++ b/src/spikeinterface/comparison/basecomparison.py
@@ -283,9 +283,10 @@ class MixinSpikeTrainComparison:
        * n_jobs
     """
 
-    def __init__(self, delta_time=0.4, n_jobs=-1):
+    def __init__(self, delta_time=0.4, agreement_method="count", n_jobs=-1):
         self.delta_time = delta_time
         self.n_jobs = n_jobs
+        self.agreement_method = agreement_method
         self.sampling_frequency = None
         self.delta_frames = None
 

--- a/src/spikeinterface/comparison/multicomparisons.py
+++ b/src/spikeinterface/comparison/multicomparisons.py
@@ -35,6 +35,9 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
         Minimum agreement score to match units
     chance_score : float, default: 0.1
         Minimum agreement score to for a possible match
+    agreement_method : "count" | "distance", default: "count"
+        The method to compute agreement scores. The "count" method computes agreement scores from spike counts.
+        The "distance" method computes agreement scores from spike time distance functions.
     n_jobs : int, default: -1
        Number of cores to use in parallel. Uses all available if -1
     spiketrain_mode : "union" | "intersection", default: "union"
@@ -60,6 +63,7 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
         delta_time=0.4,  # sampling_frequency=None,
         match_score=0.5,
         chance_score=0.1,
+        agreement_method="count",
         n_jobs=-1,
         spiketrain_mode="union",
         verbose=False,
@@ -75,7 +79,9 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
             chance_score=chance_score,
             verbose=verbose,
         )
-        MixinSpikeTrainComparison.__init__(self, delta_time=delta_time, n_jobs=n_jobs)
+        MixinSpikeTrainComparison.__init__(
+            self, delta_time=delta_time, agreement_method=agreement_method, n_jobs=n_jobs
+        )
         self.set_frames_and_frequency(self.object_list)
         self._spiketrain_mode = spiketrain_mode
         self._spiketrains = None
@@ -93,6 +99,8 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
             sorting2_name=self.name_list[j],
             delta_time=self.delta_time,
             match_score=self.match_score,
+            chance_score=self.chance_score,
+            agreement_method=self.agreement_method,
             n_jobs=self.n_jobs,
             verbose=False,
         )

--- a/src/spikeinterface/comparison/tests/test_multisortingcomparison.py
+++ b/src/spikeinterface/comparison/tests/test_multisortingcomparison.py
@@ -41,12 +41,15 @@ def test_compare_multiple_sorters(setup_module):
     )
     msc = compare_multiple_sorters([sorting1, sorting2, sorting3], verbose=True)
     msc_shuffle = compare_multiple_sorters([sorting3, sorting1, sorting2])
+    msc_dist = compare_multiple_sorters([sorting3, sorting1, sorting2], agreement_method="distance")
 
     agr = msc._do_agreement_matrix()
     agr_shuffle = msc_shuffle._do_agreement_matrix()
+    agr_dist = msc_dist._do_agreement_matrix()
 
     print(agr)
     print(agr_shuffle)
+    print(agr_dist)
 
     assert len(msc.get_agreement_sorting(minimum_agreement_count=3).get_unit_ids()) == 3
     assert len(msc.get_agreement_sorting(minimum_agreement_count=2).get_unit_ids()) == 5
@@ -57,7 +60,14 @@ def test_compare_multiple_sorters(setup_module):
     assert len(msc.get_agreement_sorting(minimum_agreement_count=2).get_unit_ids()) == len(
         msc_shuffle.get_agreement_sorting(minimum_agreement_count=2).get_unit_ids()
     )
+    assert len(msc.get_agreement_sorting(minimum_agreement_count=3).get_unit_ids()) == len(
+        msc_dist.get_agreement_sorting(minimum_agreement_count=3).get_unit_ids()
+    )
+    assert len(msc.get_agreement_sorting(minimum_agreement_count=2).get_unit_ids()) == len(
+        msc_dist.get_agreement_sorting(minimum_agreement_count=2).get_unit_ids()
+    )
     assert len(msc.get_agreement_sorting().get_unit_ids()) == len(msc_shuffle.get_agreement_sorting().get_unit_ids())
+    assert len(msc.get_agreement_sorting().get_unit_ids()) == len(msc_dist.get_agreement_sorting().get_unit_ids())
     agreement_2 = msc.get_agreement_sorting(minimum_agreement_count=2, minimum_agreement_count_only=True)
     assert np.all([agreement_2.get_unit_property(u, "agreement_number")] == 2 for u in agreement_2.get_unit_ids())
 


### PR DESCRIPTION
Fixes #3734

@paul-aparicio 

@h-mayorquin developed a faster method for sorting comparison here https://github.com/SpikeInterface/spikeinterface/pull/2192, but that was not propagated to the `compare_multple_sorters`

With this PR, you can do `compare_multiple_sorters(..., agreement_method="distance")` and the speed should be much higher. Can you give it a try?