### PR TITLE
Add warning message for stream with mixed units

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -344,13 +344,6 @@ class BaseRecording(BaseRecordingSnippets):
                 traces = traces.astype(f"int{dtype.itemsize * 8}")
 
         if return_scaled:
-            if hasattr(self, "NeoRawIOClass"):
-                if self.has_non_standard_units:
-                    message = (
-                        f"This extractor based on neo.{self.NeoRawIOClass} has channels with units not in (V, mV, uV)"
-                    )
-                    warnings.warn(message)
-
             if not self.has_scaleable_traces():
                 if self._dtype.kind == "f":
                     # here we do not truely have scale but we assume this is scaled


### PR DESCRIPTION
After reviewing [PR #3728](https://github.com/SpikeInterface/spikeinterface/pull/3728), I don't think we should be raising an error when non-voltage units are found. Loading data with NIDQ should be fine, and in that case, the warning isn’t particularly useful—it just adds noise.

What we should warn the user about is when the extractor contains mixed units (voltage and non-voltage), as this likely indicates that the stream should be subsetted. This PR improves this and gives the user the tools to figure out which channels might have to be removed.

As a side benefit, this also addresses a request that @samuelgarcia made a while ago to move this warning logic from the base extractor to Neo, which is an added benefit.