### PR TITLE
Fix dict representation in aggregation (numpy 2.0)

### DIFF
--- a/src/spikeinterface/core/baserecordingsnippets.py
+++ b/src/spikeinterface/core/baserecordingsnippets.py
@@ -560,7 +560,7 @@ class BaseRecordingSnippets(BaseExtractor):
             recordings = []
         elif outputs == "dict":
             recordings = {}
-        for value in np.unique(values):
+        for value in np.unique(values).tolist():
             (inds,) = np.nonzero(values == value)
             new_channel_ids = self.get_channel_ids()[inds]
             subrec = self.select_channels(new_channel_ids)


### PR DESCRIPTION
Because numpy 2.0 changes the string representation of string scalars the aggregated dict is displaying strangely. This fixes it:

![image](https://github.com/user-attachments/assets/7eb62b92-f8d2-4c4f-b762-4e3d6dd188dd)
