### PR TITLE
Re-enable n_jobs in multi-comparison

### DIFF
--- a/src/spikeinterface/comparison/basecomparison.py
+++ b/src/spikeinterface/comparison/basecomparison.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from copy import deepcopy
 from typing import OrderedDict
+from concurrent.futures import ProcessPoolExecutor
 import numpy as np
 
+from spikeinterface.core.job_tools import fix_job_kwargs
 from .comparisontools import make_possible_match, make_best_match, make_hungarian_match
 
 
@@ -27,7 +29,7 @@ class BaseMultiComparison(BaseComparison):
     It handles graph operations, comparisons, and agreements.
     """
 
-    def __init__(self, object_list, name_list, match_score=0.5, chance_score=0.1, verbose=False):
+    def __init__(self, object_list, name_list, match_score=0.5, chance_score=0.1, verbose=False, n_jobs=1):
         import networkx as nx
 
         BaseComparison.__init__(
@@ -41,6 +43,7 @@ class BaseMultiComparison(BaseComparison):
         self.graph = None
         self.subgraphs = None
         self.clean_graph = None
+        self.n_jobs = n_jobs
 
     def _compute_all(self):
         self._do_comparison()
@@ -96,18 +99,38 @@ class BaseMultiComparison(BaseComparison):
             print("Multicomparison step 1: pairwise comparison")
 
         self.comparisons = {}
-        for i in range(len(self.object_list)):
-            for j in range(i + 1, len(self.object_list)):
-                if self.name_list is not None:
-                    name_i = self.name_list[i]
-                    name_j = self.name_list[j]
-                else:
-                    name_i = "object i"
-                    name_j = "object j"
-                if self._verbose:
-                    print(f"  Comparing: {name_i} and {name_j}")
-                comp = self._compare_ij(i, j)
-                self.comparisons[(name_i, name_j)] = comp
+
+        if self.n_jobs == 1:
+            for i in range(len(self.object_list)):
+                for j in range(i + 1, len(self.object_list)):
+                    if self.name_list is not None:
+                        name_i = self.name_list[i]
+                        name_j = self.name_list[j]
+                    else:
+                        name_i = "object i"
+                        name_j = "object j"
+                    if self._verbose:
+                        print(f"  Comparing: {name_i} and {name_j}")
+                    comp = self._compare_ij(i, j)
+                    self.comparisons[(name_i, name_j)] = comp
+        else:
+            n_jobs = fix_job_kwargs({"n_jobs": self.n_jobs})["n_jobs"]
+            job_list = []
+            job_names = []
+            for i in range(len(self.object_list)):
+                for j in range(i + 1, len(self.object_list)):
+                    if self.name_list is not None:
+                        name_i = self.name_list[i]
+                        name_j = self.name_list[j]
+                    else:
+                        name_i = "object i"
+                        name_j = "object j"
+                    job_list.append((i, j))
+                    job_names.append((name_i, name_j))
+            with ProcessPoolExecutor(max_workers=n_jobs) as executor:
+                results = list(executor.map(self._compare_ij, *zip(*job_list)))
+            for job_name, result in zip(job_names, results):
+                self.comparisons[job_name] = result
 
     def _do_graph(self):
         if self._verbose:
@@ -280,12 +303,11 @@ class MixinSpikeTrainComparison:
     Mixin for spike train comparisons to define:
        * delta_time / delta_frames
        * sampling frequency
-       * n_jobs
+       * agreement method
     """
 
-    def __init__(self, delta_time=0.4, agreement_method="count", n_jobs=-1):
+    def __init__(self, delta_time=0.4, agreement_method="count"):
         self.delta_time = delta_time
-        self.n_jobs = n_jobs
         self.agreement_method = agreement_method
         self.sampling_frequency = None
         self.delta_frames = None

--- a/src/spikeinterface/comparison/multicomparisons.py
+++ b/src/spikeinterface/comparison/multicomparisons.py
@@ -77,11 +77,10 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
             name_list=name_list,
             match_score=match_score,
             chance_score=chance_score,
+            n_jobs=n_jobs,
             verbose=verbose,
         )
-        MixinSpikeTrainComparison.__init__(
-            self, delta_time=delta_time, agreement_method=agreement_method, n_jobs=n_jobs
-        )
+        MixinSpikeTrainComparison.__init__(self, delta_time=delta_time, agreement_method=agreement_method)
         self.set_frames_and_frequency(self.object_list)
         self._spiketrain_mode = spiketrain_mode
         self._spiketrains = None
@@ -101,7 +100,6 @@ class MultiSortingComparison(BaseMultiComparison, MixinSpikeTrainComparison):
             match_score=self.match_score,
             chance_score=self.chance_score,
             agreement_method=self.agreement_method,
-            n_jobs=self.n_jobs,
             verbose=False,
         )
         return comp

--- a/src/spikeinterface/comparison/paircomparisons.py
+++ b/src/spikeinterface/comparison/paircomparisons.py
@@ -34,7 +34,6 @@ class BasePairSorterComparison(BasePairComparison, MixinSpikeTrainComparison):
         chance_score: float = 0.1,
         ensure_symmetry: bool = False,
         agreement_method: str = "count",
-        n_jobs: int = 1,
         verbose: bool = False,
     ):
         if sorting1_name is None:
@@ -55,7 +54,7 @@ class BasePairSorterComparison(BasePairComparison, MixinSpikeTrainComparison):
             chance_score=chance_score,
             verbose=verbose,
         )
-        MixinSpikeTrainComparison.__init__(self, delta_time=delta_time, n_jobs=n_jobs)
+        MixinSpikeTrainComparison.__init__(self, delta_time=delta_time)
         self.set_frames_and_frequency(self.object_list)
 
         self.unit1_ids = self.sorting1.get_unit_ids()
@@ -144,8 +143,6 @@ class SymmetricSortingComparison(BasePairSorterComparison):
     agreement_method : "count" | "distance", default: "count"
         The method to compute agreement scores. The "count" method computes agreement scores from spike counts.
         The "distance" method computes agreement scores from spike time distance functions.
-    n_jobs : int, default: -1
-        Number of cores to use in parallel. Uses all available if -1
     verbose : bool, default: False
         If True, output is verbose
 
@@ -165,7 +162,6 @@ class SymmetricSortingComparison(BasePairSorterComparison):
         match_score: float = 0.5,
         chance_score: float = 0.1,
         agreement_method: str = "count",
-        n_jobs: int = -1,
         verbose: bool = False,
     ):
         BasePairSorterComparison.__init__(
@@ -179,7 +175,6 @@ class SymmetricSortingComparison(BasePairSorterComparison):
             chance_score=chance_score,
             ensure_symmetry=True,
             agreement_method=agreement_method,
-            n_jobs=n_jobs,
             verbose=verbose,
         )
 
@@ -269,8 +264,6 @@ class GroundTruthComparison(BasePairSorterComparison):
     agreement_method : "count" | "distance", default: "count"
         The method to compute agreement scores. The "count" method computes agreement scores from spike counts.
         The "distance" method computes agreement scores from spike time distance functions.
-    n_jobs : int, default: -1
-        Number of cores to use in parallel. Uses all available if -1
     compute_labels : bool, default: False
         If True, labels are computed at instantiation
     compute_misclassifications : bool, default: False
@@ -298,7 +291,6 @@ class GroundTruthComparison(BasePairSorterComparison):
         chance_score: float = 0.1,
         exhaustive_gt: bool = False,
         agreement_method: str = "count",
-        n_jobs: int = -1,
         match_mode: str = "hungarian",
         compute_labels: bool = False,
         compute_misclassifications: bool = False,
@@ -321,7 +313,6 @@ class GroundTruthComparison(BasePairSorterComparison):
             chance_score=chance_score,
             ensure_symmetry=False,
             agreement_method=agreement_method,
-            n_jobs=n_jobs,
             verbose=verbose,
         )
         self.exhaustive_gt = exhaustive_gt

--- a/src/spikeinterface/comparison/tests/test_multisortingcomparison.py
+++ b/src/spikeinterface/comparison/tests/test_multisortingcomparison.py
@@ -112,7 +112,8 @@ def test_parallel():
     elapsed_N_jobs = t_stop - t_start
     print(f"Elapsed N jobs: {elapsed_N_jobs}")
 
-    assert elapsed_N_jobs < elapsed_1_job
+    # there is no guarantee there are more than 1 CPU on GH actions. Let's comment it out
+    # assert elapsed_N_jobs < elapsed_1_job
     # check if the results are the same
     for k, cmp in msc_1_job.comparisons.items():
         cmp_N_jobs = msc_N_jobs.comparisons[k]

--- a/src/spikeinterface/comparison/tests/test_multisortingcomparison.py
+++ b/src/spikeinterface/comparison/tests/test_multisortingcomparison.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 
 import pytest
@@ -7,6 +8,9 @@ import time
 from spikeinterface.core import generate_sorting
 from spikeinterface.extractors import NumpySorting
 from spikeinterface.comparison import compare_multiple_sorters, MultiSortingComparison
+
+
+ON_GITHUB = bool(os.getenv("GITHUB_ACTIONS"))
 
 
 @pytest.fixture(scope="module")
@@ -98,22 +102,23 @@ def test_compare_multi_segment():
 
 
 def test_parallel():
-    sorting = generate_sorting(durations=[300])
+    sorting = generate_sorting(durations=[3000])
 
     t_start = time.perf_counter()
-    msc_1_job = compare_multiple_sorters([sorting] * 10, n_jobs=1)
+    msc_1_job = compare_multiple_sorters([sorting] * 20, n_jobs=1)
     t_stop = time.perf_counter()
     elapsed_1_job = t_stop - t_start
     print(f"Elapsed 1 job: {elapsed_1_job}")
 
     t_start = time.perf_counter()
-    msc_N_jobs = compare_multiple_sorters([sorting] * 10, n_jobs=-1)
+    msc_N_jobs = compare_multiple_sorters([sorting] * 20, n_jobs=-1)
     t_stop = time.perf_counter()
     elapsed_N_jobs = t_stop - t_start
     print(f"Elapsed N jobs: {elapsed_N_jobs}")
 
     # there is no guarantee there are more than 1 CPU on GH actions. Let's comment it out
-    # assert elapsed_N_jobs < elapsed_1_job
+    if not ON_GITHUB and os.cpu_count() > 1:
+        assert elapsed_N_jobs < elapsed_1_job
     # check if the results are the same
     for k, cmp in msc_1_job.comparisons.items():
         cmp_N_jobs = msc_N_jobs.comparisons[k]

--- a/src/spikeinterface/comparison/tests/test_multisortingcomparison.py
+++ b/src/spikeinterface/comparison/tests/test_multisortingcomparison.py
@@ -2,6 +2,7 @@ import shutil
 
 import pytest
 import numpy as np
+import time
 
 from spikeinterface.core import generate_sorting
 from spikeinterface.extractors import NumpySorting
@@ -94,6 +95,28 @@ def test_compare_multi_segment():
         for seg_index in range(num_segments):
             st = sort_agr.get_unit_spike_train(unit, seg_index)
             print(f"Segment {seg_index} unit {unit}: {st}")
+
+
+def test_parallel():
+    sorting = generate_sorting(durations=[300])
+
+    t_start = time.perf_counter()
+    msc_1_job = compare_multiple_sorters([sorting] * 10, n_jobs=1)
+    t_stop = time.perf_counter()
+    elapsed_1_job = t_stop - t_start
+    print(f"Elapsed 1 job: {elapsed_1_job}")
+
+    t_start = time.perf_counter()
+    msc_N_jobs = compare_multiple_sorters([sorting] * 10, n_jobs=-1)
+    t_stop = time.perf_counter()
+    elapsed_N_jobs = t_stop - t_start
+    print(f"Elapsed N jobs: {elapsed_N_jobs}")
+
+    assert elapsed_N_jobs < elapsed_1_job
+    # check if the results are the same
+    for k, cmp in msc_1_job.comparisons.items():
+        cmp_N_jobs = msc_N_jobs.comparisons[k]
+        np.testing.assert_array_equal(cmp.agreement_scores, cmp_N_jobs.agreement_scores)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@paul-aparicio I realized that the `n_jobs` parameter was actually not used.

This PR adds it back and updates the parallelization using the `ProcessPoolExecutor`. This will run each comparison in parallel.
A simple test shows that the results are >10x faster (on my machine - 8 CPUs).

Can you test this PR? you just need to add the `n_jobs=-1` to the `compare_multiple_sorters`