### PR TITLE
Add Intan port groups by default

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/intan.py
+++ b/src/spikeinterface/extractors/neoextractors/intan.py
@@ -64,7 +64,9 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
             **neo_kwargs,
         )
 
-        self._add_channel_groups()
+        amplifier_streams = ["RHS2000 amplifier channel", "RHD2000 amplifier channel"]
+        if self.stream_name in amplifier_streams:
+            self._add_channel_groups()
 
         self._kwargs.update(
             dict(file_path=str(Path(file_path).resolve()), ignore_integrity_checks=ignore_integrity_checks),

--- a/src/spikeinterface/extractors/neoextractors/intan.py
+++ b/src/spikeinterface/extractors/neoextractors/intan.py
@@ -64,22 +64,16 @@ class IntanRecordingExtractor(NeoBaseRecordingExtractor):
             **neo_kwargs,
         )
 
-        self._kwargs.update(dict(file_path=str(Path(file_path).absolute())))
-        if "ignore_integrity_checks" in neo_kwargs:
-            self._kwargs["ignore_integrity_checks"] = neo_kwargs["ignore_integrity_checks"]
+        # self.set_channel_groups()
+
+        self._kwargs.update(
+            dict(file_path=str(Path(file_path).resolve()), ignore_integrity_checks=ignore_integrity_checks),
+        )
 
     @classmethod
     def map_to_neo_kwargs(cls, file_path, ignore_integrity_checks: bool = False):
 
-        # Only propagate the argument if the version is greater than 0.13.1
-        import packaging
-        import neo
-
-        neo_version = packaging.version.parse(neo.__version__)
-        if neo_version > packaging.version.parse("0.13.1"):
-            neo_kwargs = {"filename": str(file_path), "ignore_integrity_checks": ignore_integrity_checks}
-        else:
-            neo_kwargs = {"filename": str(file_path)}
+        neo_kwargs = {"filename": str(file_path), "ignore_integrity_checks": ignore_integrity_checks}
         return neo_kwargs
 
 


### PR DESCRIPTION
@zm711 

We discussed this a while ago. 

This will be useful for stream users so they can sort or split by group which are (in most cases not all) mapped to different probes or devices:

![image](https://github.com/user-attachments/assets/c3358fee-4243-4fcf-b169-8c3d7e310ba6)
