### PR TITLE
Replace deep relative imports with absolute imports

### DIFF
--- a/examples/how_to/drift_with_lfp.py
+++ b/examples/how_to/drift_with_lfp.py
@@ -47,7 +47,7 @@ from spikeinterface.sortingcomponents.motion import estimate_motion
 
 # the dataset has been downloaded locally
 base_folder = Path("/mnt/data/sam/DataSpikeSorting/")
-np_data_drift = base_folder / 'human_neuropixel" / "Pt02"
+np_data_drift = base_folder / "human_neuropixel" / "Pt02"
 
 # ### Read the spikeglx file
 

--- a/src/spikeinterface/benchmark/benchmark_sorter.py
+++ b/src/spikeinterface/benchmark/benchmark_sorter.py
@@ -3,9 +3,9 @@ This replace the previous `GroundTruthStudy`
 """
 
 import numpy as np
-from ..core import NumpySorting
+from spikeinterface.core import NumpySorting
 from .benchmark_base import Benchmark, BenchmarkStudy
-from ..sorters import run_sorter
+from spikeinterface.sorters import run_sorter
 from spikeinterface.comparison import compare_sorter_to_ground_truth
 
 

--- a/src/spikeinterface/comparison/paircomparisons.py
+++ b/src/spikeinterface/comparison/paircomparisons.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import numpy as np
 
-from ..core import BaseSorting
-from ..core.core_tools import define_function_from_class
+from spikeinterface.core import BaseSorting
+from spikeinterface.core.core_tools import define_function_from_class
 from .basecomparison import BasePairComparison, MixinSpikeTrainComparison, MixinTemplateComparison
 from .comparisontools import (
     do_count_event,
@@ -15,7 +15,7 @@ from .comparisontools import (
     do_count_score,
     compute_performance,
 )
-from ..postprocessing import compute_template_similarity_by_pair
+from spikeinterface.postprocessing import compute_template_similarity_by_pair
 
 
 class BasePairSorterComparison(BasePairComparison, MixinSpikeTrainComparison):

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -882,7 +882,7 @@ class BaseRecording(BaseRecordingSnippets):
         return True
 
     def astype(self, dtype, round: bool | None = None):
-        from ..preprocessing.astype import astype
+        from spikeinterface.preprocessing.astype import astype
 
         return astype(self, dtype=dtype, round=round)
 

--- a/src/spikeinterface/curation/auto_merge.py
+++ b/src/spikeinterface/curation/auto_merge.py
@@ -13,8 +13,8 @@ try:
 except ImportError:
     HAVE_NUMBA = False
 
-from ..core import SortingAnalyzer
-from ..qualitymetrics import compute_refrac_period_violations, compute_firing_rates
+from spikeinterface.core import SortingAnalyzer
+from spikeinterface.qualitymetrics import compute_refrac_period_violations, compute_firing_rates
 
 from .mergeunitssorting import MergeUnitsSorting
 from .curation_tools import resolve_merging_graph

--- a/src/spikeinterface/curation/remove_excess_spikes.py
+++ b/src/spikeinterface/curation/remove_excess_spikes.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 from typing import Optional
 import numpy as np
 
-from ..core import BaseSorting, BaseSortingSegment, BaseRecording
-from ..core.waveform_tools import has_exceeding_spikes
+from spikeinterface.core import BaseSorting, BaseSortingSegment, BaseRecording
+from spikeinterface.core.waveform_tools import has_exceeding_spikes
 
 
 class RemoveExcessSpikesSorting(BaseSorting):

--- a/src/spikeinterface/curation/remove_redundant.py
+++ b/src/spikeinterface/curation/remove_redundant.py
@@ -4,8 +4,8 @@ from spikeinterface import BaseSorting
 
 from spikeinterface import SortingAnalyzer
 
-from ..core.template_tools import get_template_extremum_channel_peak_shift, get_template_amplitudes
-from ..postprocessing import align_sorting
+from spikeinterface.core.template_tools import get_template_extremum_channel_peak_shift, get_template_amplitudes
+from spikeinterface.postprocessing import align_sorting
 
 
 _remove_strategies = ("minimum_shift", "highest_amplitude", "max_spikes")

--- a/src/spikeinterface/extractors/cellexplorersortingextractor.py
+++ b/src/spikeinterface/extractors/cellexplorersortingextractor.py
@@ -4,8 +4,8 @@ import numpy as np
 from pathlib import Path
 
 
-from ..core import BaseSorting, BaseSortingSegment
-from ..core.core_tools import define_function_from_class
+from spikeinterface.core import BaseSorting, BaseSortingSegment
+from spikeinterface.core.core_tools import define_function_from_class
 
 
 class CellExplorerSortingExtractor(BaseSorting):

--- a/src/spikeinterface/extractors/neoextractors/neo_utils.py
+++ b/src/spikeinterface/extractors/neoextractors/neo_utils.py
@@ -56,7 +56,7 @@ def get_neo_num_blocks(extractor_name, *args, **kwargs) -> int:
 
 
 def get_neo_extractor(extractor_name):
-    from ..extractorlist import recording_extractor_full_dict
+    from spikeinterface.extractors.extractorlist import recording_extractor_full_dict
 
     assert extractor_name in recording_extractor_full_dict, (
         f"{extractor_name} not an extractor name:" f"\n{list(recording_extractor_full_dict.keys())}"

--- a/src/spikeinterface/extractors/sinapsrecordingextractors.py
+++ b/src/spikeinterface/extractors/sinapsrecordingextractors.py
@@ -6,8 +6,8 @@ import numpy as np
 
 from probeinterface import get_probe
 
-from ..core import BaseRecording, BaseRecordingSegment, BinaryRecordingExtractor, ChannelSliceRecording
-from ..core.core_tools import define_function_from_class
+from spikeinterface.core import BaseRecording, BaseRecordingSegment, BinaryRecordingExtractor, ChannelSliceRecording
+from spikeinterface.core.core_tools import define_function_from_class
 
 
 class SinapsResearchPlatformRecordingExtractor(ChannelSliceRecording):
@@ -24,7 +24,7 @@ class SinapsResearchPlatformRecordingExtractor(ChannelSliceRecording):
     """
 
     def __init__(self, file_path: str | Path, stream_name: str = "filt"):
-        from ..preprocessing import UnsignedToSignedRecording
+        from spikeinterface.preprocessing import UnsignedToSignedRecording
 
         file_path = Path(file_path)
         meta_file = file_path.parent / f"metadata_{file_path.stem}.txt"

--- a/src/spikeinterface/generation/__init__.py
+++ b/src/spikeinterface/generation/__init__.py
@@ -31,4 +31,20 @@ from .template_database import (
 )
 
 # expose the core generate functions
-from spikeinterface.core.generate import generate_recording, generate_sorting, generate_snippets, generate_templates, generate_recording_by_size, generate_ground_truth_recording, add_synchrony_to_sorting, synthesize_random_firings, inject_some_duplicate_units, inject_some_split_units, synthetize_spike_train_bad_isi, NoiseGeneratorRecording, noise_generator_recording, InjectTemplatesRecording, inject_templates
+from spikeinterface.core.generate import (
+    generate_recording,
+    generate_sorting,
+    generate_snippets,
+    generate_templates,
+    generate_recording_by_size,
+    generate_ground_truth_recording,
+    add_synchrony_to_sorting,
+    synthesize_random_firings,
+    inject_some_duplicate_units,
+    inject_some_split_units,
+    synthetize_spike_train_bad_isi,
+    NoiseGeneratorRecording,
+    noise_generator_recording,
+    InjectTemplatesRecording,
+    inject_templates,
+)

--- a/src/spikeinterface/generation/__init__.py
+++ b/src/spikeinterface/generation/__init__.py
@@ -31,20 +31,4 @@ from .template_database import (
 )
 
 # expose the core generate functions
-from ..core.generate import (
-    generate_recording,
-    generate_sorting,
-    generate_snippets,
-    generate_templates,
-    generate_recording_by_size,
-    generate_ground_truth_recording,
-    add_synchrony_to_sorting,
-    synthesize_random_firings,
-    inject_some_duplicate_units,
-    inject_some_split_units,
-    synthetize_spike_train_bad_isi,
-    NoiseGeneratorRecording,
-    noise_generator_recording,
-    InjectTemplatesRecording,
-    inject_templates,
-)
+from spikeinterface.core.generate import generate_recording, generate_sorting, generate_snippets, generate_templates, generate_recording_by_size, generate_ground_truth_recording, add_synchrony_to_sorting, synthesize_random_firings, inject_some_duplicate_units, inject_some_split_units, synthetize_spike_train_bad_isi, NoiseGeneratorRecording, noise_generator_recording, InjectTemplatesRecording, inject_templates

--- a/src/spikeinterface/postprocessing/amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/amplitude_scalings.py
@@ -11,7 +11,7 @@ from spikeinterface.core.sortinganalyzer import register_result_extension, Analy
 
 from spikeinterface.core.node_pipeline import SpikeRetriever, PipelineNode, run_node_pipeline, find_parent_of_type
 
-from ..core.template_tools import get_dense_templates_array, _get_nbefore
+from spikeinterface.core.template_tools import get_dense_templates_array, _get_nbefore
 
 
 class ComputeAmplitudeScalings(AnalyzerExtension):

--- a/src/spikeinterface/postprocessing/noise_level.py
+++ b/src/spikeinterface/postprocessing/noise_level.py
@@ -1,3 +1,3 @@
 # "noise_levels" extensions is now in core
 # this is kept name space compatibility but should be removed soon
-from ..core.analyzer_extension_core import ComputeNoiseLevels, compute_noise_levels
+from spikeinterface.core.analyzer_extension_core import ComputeNoiseLevels, compute_noise_levels

--- a/src/spikeinterface/postprocessing/template_metrics.py
+++ b/src/spikeinterface/postprocessing/template_metrics.py
@@ -10,9 +10,9 @@ import numpy as np
 import warnings
 from copy import deepcopy
 
-from ..core.sortinganalyzer import register_result_extension, AnalyzerExtension
-from ..core.template_tools import get_template_extremum_channel
-from ..core.template_tools import get_dense_templates_array
+from spikeinterface.core.sortinganalyzer import register_result_extension, AnalyzerExtension
+from spikeinterface.core.template_tools import get_template_extremum_channel
+from spikeinterface.core.template_tools import get_dense_templates_array
 
 # DEBUG = False
 

--- a/src/spikeinterface/postprocessing/template_similarity.py
+++ b/src/spikeinterface/postprocessing/template_similarity.py
@@ -4,8 +4,8 @@ import numpy as np
 import warnings
 
 from spikeinterface.core.sortinganalyzer import register_result_extension, AnalyzerExtension
-from ..core.template_tools import get_dense_templates_array
-from ..core.sparsity import ChannelSparsity
+from spikeinterface.core.template_tools import get_dense_templates_array
+from spikeinterface.core.sparsity import ChannelSparsity
 
 try:
     import numba

--- a/src/spikeinterface/postprocessing/unit_locations.py
+++ b/src/spikeinterface/postprocessing/unit_locations.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import warnings
 
-from ..core.sortinganalyzer import register_result_extension, AnalyzerExtension
+from spikeinterface.core.sortinganalyzer import register_result_extension, AnalyzerExtension
 from .localization_tools import _unit_location_methods
 
 

--- a/src/spikeinterface/preprocessing/astype.py
+++ b/src/spikeinterface/preprocessing/astype.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from ..core.core_tools import define_function_from_class
+from spikeinterface.core.core_tools import define_function_from_class
 from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 from .filter import fix_dtype
 

--- a/src/spikeinterface/preprocessing/clip.py
+++ b/src/spikeinterface/preprocessing/clip.py
@@ -5,7 +5,7 @@ import numpy as np
 from spikeinterface.core.core_tools import define_function_from_class
 from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 
-from ..core import get_random_data_chunks
+from spikeinterface.core import get_random_data_chunks
 
 
 class ClipRecording(BasePreprocessor):

--- a/src/spikeinterface/preprocessing/common_reference.py
+++ b/src/spikeinterface/preprocessing/common_reference.py
@@ -5,7 +5,7 @@ from typing import Optional, Literal
 from spikeinterface.core.core_tools import define_function_from_class
 
 from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
-from ..core import get_closest_channels
+from spikeinterface.core import get_closest_channels
 from spikeinterface.core.baserecording import BaseRecording
 
 from .filter import fix_dtype

--- a/src/spikeinterface/preprocessing/correct_lsb.py
+++ b/src/spikeinterface/preprocessing/correct_lsb.py
@@ -4,7 +4,7 @@ import warnings
 import numpy as np
 
 from .normalize_scale import scale
-from ..core import get_random_data_chunks
+from spikeinterface.core import get_random_data_chunks
 
 
 def correct_lsb(recording, num_chunks_per_segment=20, chunk_size=10000, seed=None, verbose=False):

--- a/src/spikeinterface/preprocessing/decimate.py
+++ b/src/spikeinterface/preprocessing/decimate.py
@@ -7,7 +7,7 @@ from spikeinterface.core.core_tools import (
 
 from .basepreprocessor import BasePreprocessor
 from .filter import fix_dtype
-from ..core import BaseRecordingSegment
+from spikeinterface.core import BaseRecordingSegment
 
 
 class DecimateRecording(BasePreprocessor):

--- a/src/spikeinterface/preprocessing/deepinterpolation/deepinterpolation.py
+++ b/src/spikeinterface/preprocessing/deepinterpolation/deepinterpolation.py
@@ -5,8 +5,8 @@ from typing import Optional
 from packaging.version import parse
 
 from .tf_utils import has_tf, import_tf
-from ...core.core_tools import define_function_from_class
-from ..basepreprocessor import BasePreprocessor, BasePreprocessorSegment
+from spikeinterface.core.core_tools import define_function_from_class
+from spikeinterface.preprocessing.basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 
 
 class DeepInterpolatedRecording(BasePreprocessor):

--- a/src/spikeinterface/preprocessing/deepinterpolation/generators.py
+++ b/src/spikeinterface/preprocessing/deepinterpolation/generators.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Optional
 import numpy as np
 
-from ...core import concatenate_recordings, BaseRecording, BaseRecordingSegment
+from spikeinterface.core import concatenate_recordings, BaseRecording, BaseRecordingSegment
 
 from deepinterpolation.generator_collection import SequentialGenerator
 

--- a/src/spikeinterface/preprocessing/deepinterpolation/train.py
+++ b/src/spikeinterface/preprocessing/deepinterpolation/train.py
@@ -8,7 +8,7 @@ from concurrent.futures import ProcessPoolExecutor
 import multiprocessing as mp
 
 from .tf_utils import import_tf
-from ...core import BaseRecording
+from spikeinterface.core import BaseRecording
 
 
 global train_func

--- a/src/spikeinterface/preprocessing/depth_order.py
+++ b/src/spikeinterface/preprocessing/depth_order.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from ..core import order_channels_by_depth, ChannelSliceRecording
-from ..core.core_tools import define_function_from_class
+from spikeinterface.core import order_channels_by_depth, ChannelSliceRecording
+from spikeinterface.core.core_tools import define_function_from_class
 
 
 class DepthOrderRecording(ChannelSliceRecording):

--- a/src/spikeinterface/preprocessing/detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/detect_bad_channels.py
@@ -5,7 +5,7 @@ import numpy as np
 from typing import Literal
 
 from .filter import highpass_filter
-from ..core import get_random_data_chunks, order_channels_by_depth, BaseRecording
+from spikeinterface.core import get_random_data_chunks, order_channels_by_depth, BaseRecording
 
 
 def detect_bad_channels(

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -5,7 +5,7 @@ import numpy as np
 from spikeinterface.core.core_tools import define_function_from_class
 from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 
-from ..core import get_chunk_with_margin
+from spikeinterface.core import get_chunk_with_margin
 
 
 _common_filter_docs = """**filter_kwargs : dict

--- a/src/spikeinterface/preprocessing/filter_opencl.py
+++ b/src/spikeinterface/preprocessing/filter_opencl.py
@@ -5,7 +5,7 @@ import scipy.signal
 
 from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 
-from ..core import get_chunk_with_margin
+from spikeinterface.core import get_chunk_with_margin
 
 try:
     import pyopencl

--- a/src/spikeinterface/preprocessing/highpass_spatial_filter.py
+++ b/src/spikeinterface/preprocessing/highpass_spatial_filter.py
@@ -4,8 +4,8 @@ import numpy as np
 
 from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 from .filter import fix_dtype
-from ..core import order_channels_by_depth, get_chunk_with_margin
-from ..core.core_tools import define_function_from_class
+from spikeinterface.core import order_channels_by_depth, get_chunk_with_margin
+from spikeinterface.core.core_tools import define_function_from_class
 
 
 class HighpassSpatialFilterRecording(BasePreprocessor):

--- a/src/spikeinterface/preprocessing/normalize_scale.py
+++ b/src/spikeinterface/preprocessing/normalize_scale.py
@@ -8,7 +8,7 @@ from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 
 from .filter import fix_dtype
 
-from ..core import get_random_data_chunks
+from spikeinterface.core import get_random_data_chunks
 
 
 class ScaleRecordingSegment(BasePreprocessorSegment):

--- a/src/spikeinterface/preprocessing/phase_shift.py
+++ b/src/spikeinterface/preprocessing/phase_shift.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from spikeinterface.core.core_tools import define_function_from_class
 
-from ..core import get_chunk_with_margin
+from spikeinterface.core import get_chunk_with_margin
 
 from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 

--- a/src/spikeinterface/preprocessing/resample.py
+++ b/src/spikeinterface/preprocessing/resample.py
@@ -10,7 +10,7 @@ from spikeinterface.core.core_tools import (
 
 from .basepreprocessor import BasePreprocessor
 from .filter import fix_dtype
-from ..core import get_chunk_with_margin, BaseRecordingSegment
+from spikeinterface.core import get_chunk_with_margin, BaseRecordingSegment
 
 
 class ResampleRecording(BasePreprocessor):

--- a/src/spikeinterface/preprocessing/silence_periods.py
+++ b/src/spikeinterface/preprocessing/silence_periods.py
@@ -5,8 +5,8 @@ import numpy as np
 from spikeinterface.core.core_tools import define_function_from_class
 from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 
-from ..core import get_random_data_chunks, get_noise_levels
-from ..core.generate import NoiseGeneratorRecording
+from spikeinterface.core import get_random_data_chunks, get_noise_levels
+from spikeinterface.core.generate import NoiseGeneratorRecording
 
 
 class SilencedPeriodsRecording(BasePreprocessor):

--- a/src/spikeinterface/preprocessing/unsigned_to_signed.py
+++ b/src/spikeinterface/preprocessing/unsigned_to_signed.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from ..core.core_tools import define_function_from_class
+from spikeinterface.core.core_tools import define_function_from_class
 from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 
 

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -5,7 +5,7 @@ import numpy as np
 from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 from spikeinterface.core.core_tools import define_function_from_class
 
-from ..core import get_random_data_chunks, get_channel_distances
+from spikeinterface.core import get_random_data_chunks, get_channel_distances
 from .filter import fix_dtype
 
 

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -19,7 +19,11 @@ import warnings
 from spikeinterface.core.job_tools import fix_job_kwargs, split_job_kwargs
 from spikeinterface.postprocessing import correlogram_for_one_segment
 from spikeinterface.core import SortingAnalyzer, get_noise_levels
-from spikeinterface.core.template_tools import get_template_extremum_channel, get_template_extremum_amplitude, get_dense_templates_array
+from spikeinterface.core.template_tools import (
+    get_template_extremum_channel,
+    get_template_extremum_amplitude,
+    get_dense_templates_array,
+)
 
 
 try:

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -17,13 +17,9 @@ import numpy as np
 import warnings
 
 from spikeinterface.core.job_tools import fix_job_kwargs, split_job_kwargs
-from ..postprocessing import correlogram_for_one_segment
-from ..core import SortingAnalyzer, get_noise_levels
-from ..core.template_tools import (
-    get_template_extremum_channel,
-    get_template_extremum_amplitude,
-    get_dense_templates_array,
-)
+from spikeinterface.postprocessing import correlogram_for_one_segment
+from spikeinterface.core import SortingAnalyzer, get_noise_levels
+from spikeinterface.core.template_tools import get_template_extremum_channel, get_template_extremum_amplitude, get_dense_templates_array
 
 
 try:
@@ -1469,7 +1465,7 @@ def compute_sd_ratio(
         The number of spikes, across all segments, for each unit ID.
     """
     import numba
-    from ..curation.curation_tools import _find_duplicated_spikes_keep_first_iterative
+    from spikeinterface.curation.curation_tools import _find_duplicated_spikes_keep_first_iterative
 
     kwargs, job_kwargs = split_job_kwargs(kwargs)
     job_kwargs = fix_job_kwargs(job_kwargs)

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -16,8 +16,8 @@ from threadpoolctl import threadpool_limits
 
 from .misc_metrics import compute_num_spikes, compute_firing_rates
 
-from ..core import get_random_data_chunks, compute_sparsity
-from ..core.template_tools import get_template_extremum_channel
+from spikeinterface.core import get_random_data_chunks, compute_sparsity
+from spikeinterface.core.template_tools import get_template_extremum_channel
 
 _possible_pc_metric_names = [
     "isolation_distance",

--- a/src/spikeinterface/sorters/external/combinato.py
+++ b/src/spikeinterface/sorters/external/combinato.py
@@ -6,9 +6,9 @@ from typing import Union
 import sys
 import json
 
-from ..utils import ShellScript
+from spikeinterface.sorters.utils import ShellScript
 from spikeinterface.core import write_to_h5_dataset_format
-from ..basesorter import BaseSorter
+from spikeinterface.sorters.basesorter import BaseSorter
 from spikeinterface.extractors import CombinatoSortingExtractor
 from spikeinterface.preprocessing import ScaleRecording
 

--- a/src/spikeinterface/sorters/external/hdsort.py
+++ b/src/spikeinterface/sorters/external/hdsort.py
@@ -9,8 +9,8 @@ import sys
 import numpy as np
 
 from spikeinterface.core import write_to_h5_dataset_format
-from ..basesorter import BaseSorter
-from ..utils import ShellScript
+from spikeinterface.sorters.basesorter import BaseSorter
+from spikeinterface.sorters.utils import ShellScript
 
 # from spikeinterface.extractors import MaxOneRecordingExtractor
 from spikeinterface.extractors import HDSortSortingExtractor

--- a/src/spikeinterface/sorters/external/herdingspikes.py
+++ b/src/spikeinterface/sorters/external/herdingspikes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from packaging import version
 
-from ..basesorter import BaseSorter
+from spikeinterface.sorters.basesorter import BaseSorter
 
 from spikeinterface.extractors import HerdingspikesSortingExtractor
 

--- a/src/spikeinterface/sorters/external/ironclust.py
+++ b/src/spikeinterface/sorters/external/ironclust.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from typing import Union
 import sys
 
-from ..utils import ShellScript
-from ..basesorter import BaseSorter, get_job_kwargs
+from spikeinterface.sorters.utils import ShellScript
+from spikeinterface.sorters.basesorter import BaseSorter, get_job_kwargs
 
 from spikeinterface.extractors import MdaRecordingExtractor, MdaSortingExtractor
 

--- a/src/spikeinterface/sorters/external/kilosort.py
+++ b/src/spikeinterface/sorters/external/kilosort.py
@@ -5,9 +5,9 @@ import os
 from typing import Union
 import numpy as np
 
-from ..basesorter import BaseSorter
+from spikeinterface.sorters.basesorter import BaseSorter
 from .kilosortbase import KilosortBase
-from ..utils import get_git_commit
+from spikeinterface.sorters.utils import get_git_commit
 
 
 def check_if_installed(kilosort_path: Union[str, None]):

--- a/src/spikeinterface/sorters/external/kilosort2.py
+++ b/src/spikeinterface/sorters/external/kilosort2.py
@@ -4,9 +4,9 @@ from pathlib import Path
 import os
 from typing import Union
 
-from ..basesorter import BaseSorter
+from spikeinterface.sorters.basesorter import BaseSorter
 from .kilosortbase import KilosortBase
-from ..utils import get_git_commit
+from spikeinterface.sorters.utils import get_git_commit
 
 PathType = Union[str, Path]
 

--- a/src/spikeinterface/sorters/external/kilosort2_5.py
+++ b/src/spikeinterface/sorters/external/kilosort2_5.py
@@ -4,9 +4,9 @@ from pathlib import Path
 import os
 from typing import Union
 
-from ..basesorter import BaseSorter
+from spikeinterface.sorters.basesorter import BaseSorter
 from .kilosortbase import KilosortBase
-from ..utils import get_git_commit
+from spikeinterface.sorters.utils import get_git_commit
 
 
 PathType = Union[str, Path]

--- a/src/spikeinterface/sorters/external/kilosort3.py
+++ b/src/spikeinterface/sorters/external/kilosort3.py
@@ -4,9 +4,9 @@ from pathlib import Path
 import os
 from typing import Union
 
-from ..basesorter import BaseSorter
+from spikeinterface.sorters.basesorter import BaseSorter
 from .kilosortbase import KilosortBase
-from ..utils import get_git_commit
+from spikeinterface.sorters.utils import get_git_commit
 
 PathType = Union[str, Path]
 

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -6,10 +6,10 @@ import warnings
 from packaging import version
 
 
-from ...core import write_binary_recording
-from ..basesorter import BaseSorter, get_job_kwargs
+from spikeinterface.core import write_binary_recording
+from spikeinterface.sorters.basesorter import BaseSorter, get_job_kwargs
 from .kilosortbase import KilosortBase
-from ..basesorter import get_job_kwargs
+from spikeinterface.sorters.basesorter import get_job_kwargs
 from importlib.metadata import version as importlib_version
 
 PathType = Union[str, Path]

--- a/src/spikeinterface/sorters/external/kilosortbase.py
+++ b/src/spikeinterface/sorters/external/kilosortbase.py
@@ -8,8 +8,8 @@ import sys
 
 import numpy as np
 
-from ..utils import ShellScript, get_matlab_shell_name, get_bash_path
-from ..basesorter import get_job_kwargs
+from spikeinterface.sorters.utils import ShellScript, get_matlab_shell_name, get_bash_path
+from spikeinterface.sorters.basesorter import get_job_kwargs
 from spikeinterface.extractors import KiloSortSortingExtractor
 from spikeinterface.core import write_binary_recording
 from spikeinterface.preprocessing.zero_channel_pad import TracePaddedRecording

--- a/src/spikeinterface/sorters/external/klusta.py
+++ b/src/spikeinterface/sorters/external/klusta.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import sys
 import shutil
 
-from ..basesorter import BaseSorter, get_job_kwargs
-from ..utils import ShellScript
+from spikeinterface.sorters.basesorter import BaseSorter, get_job_kwargs
+from spikeinterface.sorters.utils import ShellScript
 
 from probeinterface import write_prb
 

--- a/src/spikeinterface/sorters/external/mountainsort4.py
+++ b/src/spikeinterface/sorters/external/mountainsort4.py
@@ -6,7 +6,7 @@ from packaging.version import parse
 
 from spikeinterface.preprocessing import bandpass_filter, whiten
 
-from ..basesorter import BaseSorter
+from spikeinterface.sorters.basesorter import BaseSorter
 from spikeinterface.core.old_api_utils import NewToOldRecording
 from spikeinterface.core import load_extractor
 

--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -10,7 +10,7 @@ from warnings import warn
 from spikeinterface.preprocessing import bandpass_filter, whiten
 
 from spikeinterface.core.baserecording import BaseRecording
-from ..basesorter import BaseSorter, get_job_kwargs
+from spikeinterface.sorters.basesorter import BaseSorter, get_job_kwargs
 
 from spikeinterface.extractors import NpzSortingExtractor
 

--- a/src/spikeinterface/sorters/external/pykilosort.py
+++ b/src/spikeinterface/sorters/external/pykilosort.py
@@ -8,7 +8,7 @@ from spikeinterface.core import load_extractor
 from spikeinterface.extractors import KiloSortSortingExtractor
 from spikeinterface.core import write_binary_recording
 import json
-from ..basesorter import BaseSorter, get_job_kwargs
+from spikeinterface.sorters.basesorter import BaseSorter, get_job_kwargs
 
 
 class PyKilosortSorter(BaseSorter):

--- a/src/spikeinterface/sorters/external/spyking_circus.py
+++ b/src/spikeinterface/sorters/external/spyking_circus.py
@@ -8,8 +8,8 @@ from numpy.lib.format import open_memmap
 import sys
 
 from spikeinterface.extractors import SpykingCircusSortingExtractor
-from ..basesorter import BaseSorter
-from ..utils import ShellScript
+from spikeinterface.sorters.basesorter import BaseSorter
+from spikeinterface.sorters.utils import ShellScript
 
 from probeinterface import write_prb
 

--- a/src/spikeinterface/sorters/external/tridesclous.py
+++ b/src/spikeinterface/sorters/external/tridesclous.py
@@ -10,7 +10,7 @@ from pprint import pprint
 
 from spikeinterface.extractors import TridesclousSortingExtractor
 
-from ..basesorter import BaseSorter, get_job_kwargs
+from spikeinterface.sorters.basesorter import BaseSorter, get_job_kwargs
 from spikeinterface.core import write_binary_recording
 
 from probeinterface import write_prb

--- a/src/spikeinterface/sorters/external/waveclus.py
+++ b/src/spikeinterface/sorters/external/waveclus.py
@@ -8,8 +8,8 @@ import sys
 import json
 
 
-from ..basesorter import BaseSorter
-from ..utils import ShellScript
+from spikeinterface.sorters.basesorter import BaseSorter
+from spikeinterface.sorters.utils import ShellScript
 
 from spikeinterface.core import write_to_h5_dataset_format
 from spikeinterface.extractors import WaveClusSortingExtractor

--- a/src/spikeinterface/sorters/external/waveclus_snippets.py
+++ b/src/spikeinterface/sorters/external/waveclus_snippets.py
@@ -8,8 +8,8 @@ import sys
 import json
 
 
-from ..basesorter import BaseSorter
-from ..utils import ShellScript
+from spikeinterface.sorters.basesorter import BaseSorter
+from spikeinterface.sorters.utils import ShellScript
 
 from spikeinterface.extractors import WaveClusSortingExtractor
 from spikeinterface.extractors import WaveClusSnippetsExtractor

--- a/src/spikeinterface/sorters/external/yass.py
+++ b/src/spikeinterface/sorters/external/yass.py
@@ -5,8 +5,8 @@ import os
 import numpy as np
 import sys
 
-from ..basesorter import BaseSorter, get_job_kwargs
-from ..utils import ShellScript
+from spikeinterface.sorters.basesorter import BaseSorter, get_job_kwargs
+from spikeinterface.sorters.utils import ShellScript
 
 from spikeinterface.core import write_binary_recording
 from spikeinterface.extractors import YassSortingExtractor

--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -13,11 +13,11 @@ from spikeinterface import DEV_MODE
 import spikeinterface
 
 
-from .. import __version__ as si_version
+from spikeinterface import __version__ as si_version
 
 
-from ..core import BaseRecording, NumpySorting, load
-from ..core.core_tools import check_json, is_editable_mode
+from spikeinterface.core import BaseRecording, NumpySorting, load
+from spikeinterface.core.core_tools import check_json, is_editable_mode
 from .sorterlist import sorter_dict
 from .utils import (
     SpikeSortingError,

--- a/src/spikeinterface/sortingcomponents/motion/decentralized.py
+++ b/src/spikeinterface/sortingcomponents/motion/decentralized.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from tqdm.auto import tqdm, trange
 
-from ...core.motion import Motion
+from spikeinterface.core.motion import Motion
 from .motion_utils import get_spatial_windows, get_spatial_bin_edges, make_2d_motion_histogram, scipy_conv1d
 
 from .dredge import normxcorr1d

--- a/src/spikeinterface/sortingcomponents/motion/dredge.py
+++ b/src/spikeinterface/sortingcomponents/motion/dredge.py
@@ -28,7 +28,7 @@ import warnings
 import numpy as np
 from tqdm.auto import trange
 
-from ...core.motion import Motion
+from spikeinterface.core.motion import Motion
 from .motion_utils import (
     get_spatial_bin_edges,
     get_spatial_windows,

--- a/src/spikeinterface/sortingcomponents/motion/iterative_template.py
+++ b/src/spikeinterface/sortingcomponents/motion/iterative_template.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ...core.motion import Motion
+from spikeinterface.core.motion import Motion
 from .motion_utils import get_spatial_windows, get_spatial_bin_edges, make_3d_motion_histograms
 
 

--- a/src/spikeinterface/sortingcomponents/motion/motion_estimation.py
+++ b/src/spikeinterface/sortingcomponents/motion/motion_estimation.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from spikeinterface.sortingcomponents.tools import make_multi_method_doc
 
-from ...core.motion import Motion
+from spikeinterface.core.motion import Motion
 from .decentralized import DecentralizedRegistration
 from .iterative_template import IterativeTemplateRegistration
 from .dredge import DredgeLfpRegistration, DredgeApRegistration

--- a/src/spikeinterface/sortingcomponents/peak_localization.py
+++ b/src/spikeinterface/sortingcomponents/peak_localization.py
@@ -23,7 +23,12 @@ from spikeinterface.core import get_channel_distances
 
 from spikeinterface.postprocessing.unit_locations import dtype_localize_by_method, possible_localization_methods
 
-from spikeinterface.postprocessing.localization_tools import make_radial_order_parents, solve_monopolar_triangulation, enforce_decrease_shells_data, get_grid_convolution_templates_and_weights
+from spikeinterface.postprocessing.localization_tools import (
+    make_radial_order_parents,
+    solve_monopolar_triangulation,
+    enforce_decrease_shells_data,
+    get_grid_convolution_templates_and_weights,
+)
 
 from .tools import get_prototype_and_waveforms_from_peaks
 

--- a/src/spikeinterface/sortingcomponents/peak_localization.py
+++ b/src/spikeinterface/sortingcomponents/peak_localization.py
@@ -21,17 +21,9 @@ from .tools import make_multi_method_doc
 
 from spikeinterface.core import get_channel_distances
 
-from ..postprocessing.unit_locations import (
-    dtype_localize_by_method,
-    possible_localization_methods,
-)
+from spikeinterface.postprocessing.unit_locations import dtype_localize_by_method, possible_localization_methods
 
-from ..postprocessing.localization_tools import (
-    make_radial_order_parents,
-    solve_monopolar_triangulation,
-    enforce_decrease_shells_data,
-    get_grid_convolution_templates_and_weights,
-)
+from spikeinterface.postprocessing.localization_tools import make_radial_order_parents, solve_monopolar_triangulation, enforce_decrease_shells_data, get_grid_convolution_templates_and_weights
 
 from .tools import get_prototype_and_waveforms_from_peaks
 

--- a/src/spikeinterface/widgets/all_amplitudes_distributions.py
+++ b/src/spikeinterface/widgets/all_amplitudes_distributions.py
@@ -6,7 +6,7 @@ from warnings import warn
 from .base import BaseWidget, to_attr
 from .utils import get_some_colors
 
-from ..core import SortingAnalyzer
+from spikeinterface.core import SortingAnalyzer
 
 
 class AllAmplitudesDistributionsWidget(BaseWidget):

--- a/src/spikeinterface/widgets/amplitudes.py
+++ b/src/spikeinterface/widgets/amplitudes.py
@@ -7,7 +7,7 @@ from .rasters import BaseRasterWidget
 from .base import BaseWidget, to_attr
 from .utils import get_some_colors
 
-from ..core.sortinganalyzer import SortingAnalyzer
+from spikeinterface.core.sortinganalyzer import SortingAnalyzer
 
 from spikeinterface.core import SortingAnalyzer
 

--- a/src/spikeinterface/widgets/base.py
+++ b/src/spikeinterface/widgets/base.py
@@ -5,8 +5,8 @@ import inspect
 global default_backend_
 default_backend_ = "matplotlib"
 
-from ..core import SortingAnalyzer, BaseSorting
-from ..core.waveforms_extractor_backwards_compatibility import MockWaveformExtractor
+from spikeinterface.core import SortingAnalyzer, BaseSorting
+from spikeinterface.core.waveforms_extractor_backwards_compatibility import MockWaveformExtractor
 
 
 def get_default_plotter_backend():

--- a/src/spikeinterface/widgets/crosscorrelograms.py
+++ b/src/spikeinterface/widgets/crosscorrelograms.py
@@ -4,9 +4,9 @@ import numpy as np
 from typing import Union
 
 from .base import BaseWidget, to_attr
-from ..core.sortinganalyzer import SortingAnalyzer
-from ..core.basesorting import BaseSorting
-from ..postprocessing import compute_correlograms
+from spikeinterface.core.sortinganalyzer import SortingAnalyzer
+from spikeinterface.core.basesorting import BaseSorting
+from spikeinterface.postprocessing import compute_correlograms
 
 
 class CrossCorrelogramsWidget(BaseWidget):

--- a/src/spikeinterface/widgets/metrics.py
+++ b/src/spikeinterface/widgets/metrics.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from .base import BaseWidget, to_attr
 from .utils import get_unit_colors
-from ..core.core_tools import check_json
+from spikeinterface.core.core_tools import check_json
 
 
 class MetricsBaseWidget(BaseWidget):

--- a/src/spikeinterface/widgets/potential_merges.py
+++ b/src/spikeinterface/widgets/potential_merges.py
@@ -11,7 +11,7 @@ from .unit_templates import UnitTemplatesWidget
 
 from .utils import get_some_colors
 
-from ..core.sortinganalyzer import SortingAnalyzer
+from spikeinterface.core.sortinganalyzer import SortingAnalyzer
 
 
 class PotentialMergesWidget(BaseWidget):

--- a/src/spikeinterface/widgets/quality_metrics.py
+++ b/src/spikeinterface/widgets/quality_metrics.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from .metrics import MetricsBaseWidget
-from ..core.sortinganalyzer import SortingAnalyzer
+from spikeinterface.core.sortinganalyzer import SortingAnalyzer
 
 
 class QualityMetricsWidget(MetricsBaseWidget):

--- a/src/spikeinterface/widgets/sorting_summary.py
+++ b/src/spikeinterface/widgets/sorting_summary.py
@@ -13,7 +13,7 @@ from .unit_locations import UnitLocationsWidget
 from .unit_templates import UnitTemplatesWidget
 
 
-from ..core import SortingAnalyzer
+from spikeinterface.core import SortingAnalyzer
 
 
 _default_displayed_unit_properties = ["firing_rate", "num_spikes", "x", "y", "amplitude_median", "snr", "rp_violation"]

--- a/src/spikeinterface/widgets/spike_locations.py
+++ b/src/spikeinterface/widgets/spike_locations.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from .base import BaseWidget, to_attr
 from .utils import get_unit_colors
-from ..core.sortinganalyzer import SortingAnalyzer
+from spikeinterface.core.sortinganalyzer import SortingAnalyzer
 
 
 class SpikeLocationsWidget(BaseWidget):

--- a/src/spikeinterface/widgets/spike_locations_by_time.py
+++ b/src/spikeinterface/widgets/spike_locations_by_time.py
@@ -6,7 +6,7 @@ from warnings import warn
 from .base import BaseWidget, to_attr
 from .utils import get_some_colors
 
-from ..core.sortinganalyzer import SortingAnalyzer
+from spikeinterface.core.sortinganalyzer import SortingAnalyzer
 
 
 class LocationsWidget(BaseWidget):

--- a/src/spikeinterface/widgets/spikes_on_traces.py
+++ b/src/spikeinterface/widgets/spikes_on_traces.py
@@ -5,12 +5,12 @@ import numpy as np
 from .base import BaseWidget, to_attr
 from .utils import get_unit_colors
 from .traces import TracesWidget
-from ..core import ChannelSparsity
-from ..core.template_tools import get_template_extremum_channel
-from ..core.sortinganalyzer import SortingAnalyzer
-from ..core.baserecording import BaseRecording
-from ..core.basesorting import BaseSorting
-from ..postprocessing import compute_unit_locations
+from spikeinterface.core import ChannelSparsity
+from spikeinterface.core.template_tools import get_template_extremum_channel
+from spikeinterface.core.sortinganalyzer import SortingAnalyzer
+from spikeinterface.core.baserecording import BaseRecording
+from spikeinterface.core.basesorting import BaseSorting
+from spikeinterface.postprocessing import compute_unit_locations
 
 
 class SpikesOnTracesWidget(BaseWidget):

--- a/src/spikeinterface/widgets/template_metrics.py
+++ b/src/spikeinterface/widgets/template_metrics.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from .metrics import MetricsBaseWidget
-from ..core.sortinganalyzer import SortingAnalyzer
+from spikeinterface.core.sortinganalyzer import SortingAnalyzer
 
 
 class TemplateMetricsWidget(MetricsBaseWidget):

--- a/src/spikeinterface/widgets/template_similarity.py
+++ b/src/spikeinterface/widgets/template_similarity.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 from .base import BaseWidget, to_attr
-from ..core.sortinganalyzer import SortingAnalyzer
+from spikeinterface.core.sortinganalyzer import SortingAnalyzer
 
 
 class TemplateSimilarityWidget(BaseWidget):

--- a/src/spikeinterface/widgets/traces.py
+++ b/src/spikeinterface/widgets/traces.py
@@ -4,7 +4,7 @@ import warnings
 
 import numpy as np
 
-from ..core import BaseRecording
+from spikeinterface.core import BaseRecording
 from .base import BaseWidget, to_attr
 from .utils import get_some_colors, array_to_image
 
@@ -107,7 +107,7 @@ class TracesWidget(BaseWidget):
             )
 
         if order_channel_by_depth and rec0.has_channel_location():
-            from ..preprocessing import depth_order
+            from spikeinterface.preprocessing import depth_order
 
             rec0 = depth_order(rec0)
             recordings = {k: depth_order(rec) for k, rec in recordings.items()}
@@ -642,7 +642,7 @@ class TracesWidget(BaseWidget):
 
     def plot_ephyviewer(self, data_plot, **backend_kwargs):
         import ephyviewer
-        from ..preprocessing import depth_order
+        from spikeinterface.preprocessing import depth_order
 
         dp = to_attr(data_plot)
 

--- a/src/spikeinterface/widgets/unit_depths.py
+++ b/src/spikeinterface/widgets/unit_depths.py
@@ -7,7 +7,7 @@ from .base import BaseWidget, to_attr
 from .utils import get_unit_colors
 
 
-from ..core.template_tools import get_template_extremum_amplitude
+from spikeinterface.core.template_tools import get_template_extremum_amplitude
 
 
 class UnitDepthsWidget(BaseWidget):

--- a/src/spikeinterface/widgets/unit_locations.py
+++ b/src/spikeinterface/widgets/unit_locations.py
@@ -7,7 +7,7 @@ from probeinterface import ProbeGroup
 
 from .base import BaseWidget, to_attr
 from .utils import get_unit_colors
-from ..core.sortinganalyzer import SortingAnalyzer
+from spikeinterface.core.sortinganalyzer import SortingAnalyzer
 
 
 class UnitLocationsWidget(BaseWidget):

--- a/src/spikeinterface/widgets/unit_probe_map.py
+++ b/src/spikeinterface/widgets/unit_probe_map.py
@@ -8,8 +8,8 @@ from typing import Union
 from .base import BaseWidget, to_attr
 
 # from .utils import get_unit_colors
-from ..core.sortinganalyzer import SortingAnalyzer
-from ..core.template_tools import get_dense_templates_array
+from spikeinterface.core.sortinganalyzer import SortingAnalyzer
+from spikeinterface.core.template_tools import get_dense_templates_array
 
 
 class UnitProbeMapWidget(BaseWidget):

--- a/src/spikeinterface/widgets/unit_templates.py
+++ b/src/spikeinterface/widgets/unit_templates.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ..core import SortingAnalyzer
+from spikeinterface.core import SortingAnalyzer
 from .unit_waveforms import UnitWaveformsWidget
 from .base import to_attr
 

--- a/src/spikeinterface/widgets/unit_waveforms.py
+++ b/src/spikeinterface/widgets/unit_waveforms.py
@@ -6,8 +6,8 @@ from warnings import warn
 from .base import BaseWidget, to_attr
 from .utils import get_unit_colors
 
-from ..core import ChannelSparsity, SortingAnalyzer, Templates
-from ..core.basesorting import BaseSorting
+from spikeinterface.core import ChannelSparsity, SortingAnalyzer, Templates
+from spikeinterface.core.basesorting import BaseSorting
 
 
 class UnitWaveformsWidget(BaseWidget):

--- a/src/spikeinterface/widgets/unit_waveforms_density_map.py
+++ b/src/spikeinterface/widgets/unit_waveforms_density_map.py
@@ -5,7 +5,7 @@ import numpy as np
 from .base import BaseWidget, to_attr
 from .utils import get_unit_colors
 
-from ..core import ChannelSparsity, get_template_extremum_channel
+from spikeinterface.core import ChannelSparsity, get_template_extremum_channel
 
 
 class UnitWaveformDensityMapWidget(BaseWidget):

--- a/src/spikeinterface/widgets/utils_sortingview.py
+++ b/src/spikeinterface/widgets/utils_sortingview.py
@@ -4,8 +4,8 @@ from warnings import warn
 
 import numpy as np
 
-from ..core import SortingAnalyzer, BaseSorting
-from ..core.core_tools import check_json
+from spikeinterface.core import SortingAnalyzer, BaseSorting
+from spikeinterface.core.core_tools import check_json
 from .utils import make_units_table_from_sorting, make_units_table_from_analyzer
 
 


### PR DESCRIPTION
Following on from discussions in #3027 and #3764, this PR makes (most) imports absolute.

PEP8 and the default ruff and flake-8 rules allow for simple (same folder) relative imports. For now, I've been conservative with changes and left these in.

Did this with a single command:
```
uvx ruff check --select TID252 --fix --unsafe-fixes
```

Let's find out how unsafe these fixes were!