### PR TITLE
Allow `aggregate_channels` to accept a dict of recordings

### DIFF
--- a/src/spikeinterface/core/baserecordingsnippets.py
+++ b/src/spikeinterface/core/baserecordingsnippets.py
@@ -564,6 +564,7 @@ class BaseRecordingSnippets(BaseExtractor):
             (inds,) = np.nonzero(values == value)
             new_channel_ids = self.get_channel_ids()[inds]
             subrec = self.select_channels(new_channel_ids)
+            subrec.set_annotation("split_by_property", value=property)
             if outputs == "list":
                 recordings.append(subrec)
             elif outputs == "dict":

--- a/src/spikeinterface/core/channelsaggregationrecording.py
+++ b/src/spikeinterface/core/channelsaggregationrecording.py
@@ -25,7 +25,10 @@ class ChannelsAggregationRecording(BaseRecording):
                 # If default 'group'ing (all equal 0), we label the recordings using the 'group' property
                 recording_groups = []
                 for recording in recording_list:
-                    recording_groups.extend(recording.get_property("group"))
+                    if (group_property := recording.get_property("group")) is not None:
+                        recording_groups.extend(group_property)
+                    else:
+                        recording_groups.extend([0])
                 if np.all(np.unique(recording_groups) == np.array([0])):
                     for group_id, recording in enumerate(recording_list):
                         recording.set_property("group", group_id * np.ones(recording.get_num_channels()))

--- a/src/spikeinterface/core/channelsaggregationrecording.py
+++ b/src/spikeinterface/core/channelsaggregationrecording.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import warnings
 
 import numpy as np
 
@@ -236,13 +237,17 @@ class ChannelsAggregationRecordingSegment(BaseRecordingSegment):
         return np.concatenate(traces, axis=1)
 
 
-def aggregate_channels(recording_list, renamed_channel_ids=None):
+def aggregate_channels(
+    recording_list_or_dict=None,
+    renamed_channel_ids=None,
+    recording_list=None,
+):
     """
     Aggregates channels of multiple recording into a single recording object
 
     Parameters
     ----------
-    recording_list: list | dict
+    recording_list_or_dict: list | dict
         List or dict of BaseRecording objects to aggregate.
     renamed_channel_ids: array-like
         If given, channel ids are renamed as provided.
@@ -252,4 +257,13 @@ def aggregate_channels(recording_list, renamed_channel_ids=None):
     aggregate_recording: ChannelsAggregationRecording
         The aggregated recording object
     """
-    return ChannelsAggregationRecording(recording_list, renamed_channel_ids)
+
+    if recording_list is not None:
+        warnings.warn(
+            "`recording_list` is deprecated and will be removed in 0.105.0. Please use `recording_list_or_dict` instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        recording_list_or_dict = recording_list
+
+    return ChannelsAggregationRecording(recording_list_or_dict, renamed_channel_ids)

--- a/src/spikeinterface/core/channelsaggregationrecording.py
+++ b/src/spikeinterface/core/channelsaggregationrecording.py
@@ -19,9 +19,21 @@ class ChannelsAggregationRecording(BaseRecording):
             recording_list = list(recording_list_or_dict.values())
         elif isinstance(recording_list_or_dict, list):
             recording_list = recording_list_or_dict
+
+            # Check if the recordings were previously split using `split_by`
+            if recording_list[0].get_annotation("split_by_property") is None:
+                # If default 'group'ing (all equal 0), we label the recordings using the 'group' property
+                recording_groups = []
+                for recording in recording_list:
+                    recording_groups.extend(recording.get_property("group"))
+                if np.all(np.unique(recording_groups) == np.array([0])):
+                    for group_id, recording in enumerate(recording_list):
+                        recording.set_property("group", group_id * np.ones(recording.get_num_channels()))
         else:
-            raise TypeError("`aggregate_channels` only accepts a list of recordings or a dict whose values are all recordings.")
-        
+            raise TypeError(
+                "`aggregate_channels` only accepts a list of recordings or a dict whose values are all recordings."
+            )
+
         self._recordings = recording_list
 
         self._perform_consistency_checks()
@@ -215,7 +227,7 @@ def aggregate_channels(recording_list, renamed_channel_ids=None):
     Parameters
     ----------
     recording_list: list | dict
-        List or dict of BaseRecording objects to aggregate
+        List or dict of BaseRecording objects to aggregate.
     renamed_channel_ids: array-like
         If given, channel ids are renamed as provided.
 

--- a/src/spikeinterface/core/channelsaggregationrecording.py
+++ b/src/spikeinterface/core/channelsaggregationrecording.py
@@ -13,8 +13,15 @@ class ChannelsAggregationRecording(BaseRecording):
 
     """
 
-    def __init__(self, recording_list, renamed_channel_ids=None):
+    def __init__(self, recording_list_or_dict, renamed_channel_ids=None):
 
+        if isinstance(recording_list_or_dict, dict):
+            recording_list = list(recording_list_or_dict.values())
+        elif isinstance(recording_list_or_dict, list):
+            recording_list = recording_list_or_dict
+        else:
+            raise TypeError("`aggregate_channels` only accepts a list of recordings or a dict whose values are all recordings.")
+        
         self._recordings = recording_list
 
         self._perform_consistency_checks()
@@ -207,8 +214,8 @@ def aggregate_channels(recording_list, renamed_channel_ids=None):
 
     Parameters
     ----------
-    recording_list: list
-        List of BaseRecording objects to aggregate
+    recording_list: list | dict
+        List or dict of BaseRecording objects to aggregate
     renamed_channel_ids: array-like
         If given, channel ids are renamed as provided.
 

--- a/src/spikeinterface/core/tests/test_channelsaggregationrecording.py
+++ b/src/spikeinterface/core/tests/test_channelsaggregationrecording.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from spikeinterface.core import aggregate_channels
-
 from spikeinterface.core import generate_recording
 
 
@@ -21,65 +20,97 @@ def test_channelsaggregationrecording():
     recording2.set_channel_locations([[20.0, 20.0], [20.0, 40.0], [20.0, 60.0]])
     recording3.set_channel_locations([[40.0, 20.0], [40.0, 40.0], [40.0, 60.0]])
 
-    # test num channels
-    recording_agg = aggregate_channels([recording1, recording2, recording3])
-    assert len(recording_agg.get_channel_ids()) == 3 * num_channels
+    recordings_list_possibilities = [
+        [recording1, recording2, recording3], 
+        {0: recording1, 1: recording2, 2: recording3}
+    ]
 
-    assert np.allclose(recording_agg.get_times(0), recording1.get_times(0))
+    for recordings_list in recordings_list_possibilities:
 
-    # test traces
-    channel_ids = recording1.get_channel_ids()
+        # test num channels
+        recording_agg = aggregate_channels(recordings_list)
+        assert len(recording_agg.get_channel_ids()) == 3 * num_channels
 
-    for seg in range(num_seg):
-        # single channels
-        traces1_1 = recording1.get_traces(channel_ids=[channel_ids[1]], segment_index=seg)
-        traces2_0 = recording2.get_traces(channel_ids=[channel_ids[0]], segment_index=seg)
-        traces3_2 = recording3.get_traces(channel_ids=[channel_ids[2]], segment_index=seg)
+        assert np.allclose(recording_agg.get_times(0), recording1.get_times(0))
 
-        assert np.allclose(traces1_1, recording_agg.get_traces(channel_ids=[str(channel_ids[1])], segment_index=seg))
-        assert np.allclose(
-            traces2_0,
-            recording_agg.get_traces(channel_ids=[str(num_channels + int(channel_ids[0]))], segment_index=seg),
-        )
-        assert np.allclose(
-            traces3_2,
-            recording_agg.get_traces(channel_ids=[str(2 * num_channels + int(channel_ids[2]))], segment_index=seg),
-        )
-        # all traces
-        traces1 = recording1.get_traces(segment_index=seg)
-        traces2 = recording2.get_traces(segment_index=seg)
-        traces3 = recording3.get_traces(segment_index=seg)
+        # test traces
+        channel_ids = recording1.get_channel_ids()
 
-        assert np.allclose(traces1, recording_agg.get_traces(channel_ids=["0", "1", "2"], segment_index=seg))
-        assert np.allclose(traces2, recording_agg.get_traces(channel_ids=["3", "4", "5"], segment_index=seg))
-        assert np.allclose(traces3, recording_agg.get_traces(channel_ids=["6", "7", "8"], segment_index=seg))
+        for seg in range(num_seg):
+            # single channels
+            traces1_1 = recording1.get_traces(channel_ids=[channel_ids[1]], segment_index=seg)
+            traces2_0 = recording2.get_traces(channel_ids=[channel_ids[0]], segment_index=seg)
+            traces3_2 = recording3.get_traces(channel_ids=[channel_ids[2]], segment_index=seg)
 
-    # test rename channels
-    renamed_channel_ids = [f"#Channel {i}" for i in range(3 * num_channels)]
-    recording_agg_renamed = aggregate_channels(
-        [recording1, recording2, recording3], renamed_channel_ids=renamed_channel_ids
-    )
-    assert all(chan in renamed_channel_ids for chan in recording_agg_renamed.get_channel_ids())
+            assert np.allclose(traces1_1, recording_agg.get_traces(channel_ids=[str(channel_ids[1])], segment_index=seg))
+            assert np.allclose(
+                traces2_0,
+                recording_agg.get_traces(channel_ids=[str(num_channels + int(channel_ids[0]))], segment_index=seg),
+            )
+            assert np.allclose(
+                traces3_2,
+                recording_agg.get_traces(channel_ids=[str(2 * num_channels + int(channel_ids[2]))], segment_index=seg),
+            )
+            # all traces
+            traces1 = recording1.get_traces(segment_index=seg)
+            traces2 = recording2.get_traces(segment_index=seg)
+            traces3 = recording3.get_traces(segment_index=seg)
 
-    # test properties
-    # complete property
-    recording1.set_property("brain_area", ["CA1"] * num_channels)
-    recording2.set_property("brain_area", ["CA2"] * num_channels)
-    recording3.set_property("brain_area", ["CA3"] * num_channels)
+            assert np.allclose(traces1, recording_agg.get_traces(channel_ids=["0", "1", "2"], segment_index=seg))
+            assert np.allclose(traces2, recording_agg.get_traces(channel_ids=["3", "4", "5"], segment_index=seg))
+            assert np.allclose(traces3, recording_agg.get_traces(channel_ids=["6", "7", "8"], segment_index=seg))
 
-    # skip for inconsistency
-    recording1.set_property("template", np.zeros((num_channels, 4, 30)))
-    recording2.set_property("template", np.zeros((num_channels, 20, 50)))
-    recording3.set_property("template", np.zeros((num_channels, 2, 10)))
+            # test rename channels
+            renamed_channel_ids = [f"#Channel {i}" for i in range(3 * num_channels)]
+            recording_agg_renamed = aggregate_channels(
+                recordings_list, renamed_channel_ids=renamed_channel_ids
+            )
+            assert all(chan in renamed_channel_ids for chan in recording_agg_renamed.get_channel_ids())
 
-    # incomplete property
-    recording1.set_property("quality", ["good"] * num_channels)
-    recording2.set_property("quality", ["bad"] * num_channels)
+            # test properties
+            # complete property
+            recording1.set_property("brain_area", ["CA1"] * num_channels)
+            recording2.set_property("brain_area", ["CA2"] * num_channels)
+            recording3.set_property("brain_area", ["CA3"] * num_channels)
 
-    recording_agg_prop = aggregate_channels([recording1, recording2, recording3])
-    assert "brain_area" in recording_agg_prop.get_property_keys()
-    assert "quality" not in recording_agg_prop.get_property_keys()
-    print(recording_agg_prop.get_property("brain_area"))
+            # skip for inconsistency
+            recording1.set_property("template", np.zeros((num_channels, 4, 30)))
+            recording2.set_property("template", np.zeros((num_channels, 20, 50)))
+            recording3.set_property("template", np.zeros((num_channels, 2, 10)))
+
+            # incomplete property
+            recording1.set_property("quality", ["good"] * num_channels)
+            recording2.set_property("quality", ["bad"] * num_channels)
+
+            recording_agg_prop = aggregate_channels(recordings_list)
+            assert "brain_area" in recording_agg_prop.get_property_keys()
+            assert "quality" not in recording_agg_prop.get_property_keys()
+            print(recording_agg_prop.get_property("brain_area"))
+
+def test_split_then_aggreate_preserve_user_property():
+    """
+    Checks that splitting then aggregating a recording preserves the unit_id to property mapping.
+    """
+
+    num_channels = 10
+    durations = [10,5]
+    recording = generate_recording(num_channels=num_channels, durations=durations, set_probe=False)
+    
+    recording.set_property(key='group', values=[2,0,1,1,1,0,1,0,1,2])
+
+    old_properties = recording.get_property(key='group')
+    old_channel_ids = recording.channel_ids
+    old_properties_ids_dict = dict(zip(old_channel_ids,old_properties))
+
+    split_recordings = recording.split_by('group')
+
+    aggregated_recording = aggregate_channels(split_recordings)
+
+    new_properties = aggregated_recording.get_property(key='group')
+    new_channel_ids = aggregated_recording.channel_ids
+    new_properties_ids_dict = dict(zip(new_channel_ids,new_properties))
+
+    assert np.all(old_properties_ids_dict == new_properties_ids_dict)
 
 
 def test_channel_aggregation_preserve_ids():


### PR DESCRIPTION
Related to #3711

Allows `aggregate_channels` to accept a dict of recordings. This allows for the workflow (once #3711 is merged) of the kind:

``` python
split_recordings = recording.split_by('group')
preprocessed_recordings = si.common_reference(si.bandpass_filter(split_recordings))
aggregated_preprocessing_recording = si.aggregate_channels(preprocessed_recordings)
```

or the truly horrifying
``` python
preprocessed_recording =  si.aggregate_channels(si.common_reference(si.bandpass_filter(recording.split_by('group'))))
```

edit: PR is mostly new tests
