### PR TITLE
Update `load_motion_info` to load legacy motion folders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ test_extractors = [
 ]
 
 test_preprocessing = [
-    "ibllib>=2.36.0", # for IBL
+    # "ibllib>=2.36.0", # for IBL
     "torch",
 ]
 

--- a/src/spikeinterface/preprocessing/motion.py
+++ b/src/spikeinterface/preprocessing/motion.py
@@ -513,14 +513,14 @@ def load_motion_info(folder):
         else:
             motion_info[name] = None
 
-    try:
+    if (folder / "motion").is_dir():
         motion = Motion.load(folder / "motion")
-    except IOError as e:
-        warnings.warn("The Motion object could not be loaded. Trying to load the legacy format")
+    else:
+        warnings.warn("Trying to load Motion from the legacy format")
         required_files = ["spatial_bins.npy", "temporal_bins.npy", "motion.npy"]
         for required_file in required_files:
             if not (folder / required_file).is_file():
-                raise IOError("The provided folder is not a valid legacy motion folder")
+                raise IOError("The provided folder is not a valid motion folder")
         spatial_bins_um = np.load(folder / "spatial_bins.npy")
         temporal_bins_s = [np.load(folder / "temporal_bins.npy")]
         displacement = [np.load(folder / "motion.npy")]

--- a/src/spikeinterface/preprocessing/motion.py
+++ b/src/spikeinterface/preprocessing/motion.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import copy
-import numpy as np
+import warnings
 import json
 import shutil
-from pathlib import Path
 import time
 import inspect
+from pathlib import Path
+import numpy as np
+
 
 from spikeinterface.core import get_noise_levels, fix_job_kwargs
 from spikeinterface.core.job_tools import _shared_job_kwargs_doc
@@ -511,6 +513,19 @@ def load_motion_info(folder):
         else:
             motion_info[name] = None
 
-    motion_info["motion"] = Motion.load(folder / "motion")
+    try:
+        motion = Motion.load(folder / "motion")
+    except IOError as e:
+        warnings.warn("The Motion object could not be loaded. Trying to load the legacy format")
+        required_files = ["spatial_bins.npy", "temporal_bins.npy", "motion.npy"]
+        for required_file in required_files:
+            if not (folder / required_file).is_file():
+                raise IOError("The provided folder is not a valid legacy motion folder")
+        spatial_bins_um = np.load(folder / "spatial_bins.npy")
+        temporal_bins_s = [np.load(folder / "temporal_bins.npy")]
+        displacement = [np.load(folder / "motion.npy")]
 
+        motion = Motion(displacement=displacement, temporal_bins_s=temporal_bins_s, spatial_bins_um=spatial_bins_um)
+
+    motion_info["motion"] = motion
     return motion_info


### PR DESCRIPTION
When we added the `Motion.load` to the `load_motion_info`, we forgot to handle back-compatibility.

This PR just tries to load a legacy motion in case the `Motion.load` fails.