### PR TITLE
Playing with `pytest-xdist`

### DIFF
--- a/.github/run_tests.sh
+++ b/.github/run_tests.sh
@@ -8,7 +8,7 @@ if [ -z "$NOVIRTUALENV" ] || [ "$NOVIRTUALENV" != "--no-virtual-env" ]; then
   source $GITHUB_WORKSPACE/test_env/bin/activate
 fi
 
-pytest -m "$MARKER" -vv -ra --durations=0 --durations-min=0.001 | tee report.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
+pytest -m "$MARKER" -n auto  --dist loadfile -vv -ra --durations=0 --durations-min=0.001 | tee report.txt; test ${PIPESTATUS[0]} -eq 0 || exit 1
 echo "# Timing profile of ${MARKER}" >> $GITHUB_STEP_SUMMARY
 python $GITHUB_WORKSPACE/.github/scripts/build_job_summary.py report.txt >> $GITHUB_STEP_SUMMARY
 rm report.txt

--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -78,7 +78,7 @@ jobs:
         run: pip list
 
       - name: Test core
-        run: pytest -m "core"
+        run: pytest -m "core" -n auto  --dist loadfile
         shell: bash
 
       - name: Install Dependencies for Timing Display

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ test = [
     "pytest",
     "pytest-dependency",
     "pytest-cov",
+    "pytest-xdist",
     "psutil",
 
     "huggingface_hub",


### PR DESCRIPTION
This may have been tried before, there is a package `pytest-xdist` which can run tests in parallel. In the past I've tried this and had concurrency issues parallelising tests within the same module, but realized they also have a parallelise-by-module option. Just testing it out to see here to see whether it speeds up tests on the CI.