### PR TITLE
add `load_extension()` in `MockWaveformExtractor` for backwards compatibility

### DIFF
--- a/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
+++ b/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
@@ -248,6 +248,9 @@ class MockWaveformExtractor:
     def has_extension(self, extension_name: str) -> bool:
         return self.sorting_analyzer.has_extension(extension_name)
 
+    def load_extension(self, extension_name: str):
+        return self.sorting_analyzer.load_extension(extension_name)
+
     def select_units(self, unit_ids):
         return self.sorting_analyzer.select_units(unit_ids)
 

--- a/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
+++ b/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
@@ -249,7 +249,7 @@ class MockWaveformExtractor:
         return self.sorting_analyzer.has_extension(extension_name)
 
     def load_extension(self, extension_name: str):
-        return self.sorting_analyzer.load_extension(extension_name)
+        return self.sorting_analyzer.get_extension(extension_name)
 
     def select_units(self, unit_ids):
         return self.sorting_analyzer.select_units(unit_ids)


### PR DESCRIPTION
Looks like this one function got missed while adding backward compatibility for the old WaveformExtractor extensions.

Without this fix, I get the error:

```
waves = si.load_waveforms(paths['si_waveforms'], with_recording=False, sorting = sorting)
locs = waves.load_extension('unit_locations').get_data()


AttributeError: 'MockWaveformExtractor' object has no attribute 'load_extension'
```