### PR TITLE
Add `_precomputable_kwarg_names` to `BaseExtractor`

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -54,6 +54,9 @@ class BaseExtractor:
         # store init kwargs for nested serialisation
         self._kwargs = {}
 
+        # kwargs which can be precomputed before being used by the extractor
+        self._precomputable_kwargs = []
+
         # "main_ids" will either be channel_ids or units_ids
         # They are used for properties
         self._main_ids = np.array(main_ids)

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -48,7 +48,7 @@ class BaseExtractor:
     _skip_properties = []
 
     # kwargs which can be precomputed before being used by the extractor
-    _precomputable_kwargs = []
+    _precomputable_kwarg_names = []
 
     installation_mesg = ""
     installed = True

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -47,15 +47,15 @@ class BaseExtractor:
     # these properties are skipped by default in copy_metadata
     _skip_properties = []
 
+    # kwargs which can be precomputed before being used by the extractor
+    _precomputable_kwargs = []
+
     installation_mesg = ""
     installed = True
 
     def __init__(self, main_ids: Sequence) -> None:
         # store init kwargs for nested serialisation
         self._kwargs = {}
-
-        # kwargs which can be precomputed before being used by the extractor
-        self._precomputable_kwargs = []
 
         # "main_ids" will either be channel_ids or units_ids
         # They are used for properties

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -57,6 +57,8 @@ class WhitenRecording(BasePreprocessor):
         The whitened recording extractor
     """
 
+    _precomputable_kwargs = ["W", "M"]
+
     def __init__(
         self,
         recording,
@@ -100,7 +102,6 @@ class WhitenRecording(BasePreprocessor):
             )
 
         BasePreprocessor.__init__(self, recording, dtype=dtype_)
-        self._precomputable_kwargs = ["W", "M"]
 
         for parent_segment in recording._recording_segments:
             rec_segment = WhitenRecordingSegment(parent_segment, W, M, dtype_, int_scale)

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -57,7 +57,7 @@ class WhitenRecording(BasePreprocessor):
         The whitened recording extractor
     """
 
-    _precomputable_kwargs = ["W", "M"]
+    _precomputable_kwarg_names = ["W", "M"]
 
     def __init__(
         self,

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -100,6 +100,7 @@ class WhitenRecording(BasePreprocessor):
             )
 
         BasePreprocessor.__init__(self, recording, dtype=dtype_)
+        self._precomputable_kwargs = ["W", "M"]
 
         for parent_segment in recording._recording_segments:
             rec_segment = WhitenRecordingSegment(parent_segment, W, M, dtype_, int_scale)


### PR DESCRIPTION
As discussed in https://github.com/SpikeInterface/spikeinterface/pull/3685#discussion_r1954036875 and in maintainer meetings, it would be handy to have a `_precomputable_kwargs` in the `BaseExtractor`, especially for Preprocessors.

These are kwargs which can be precomputed for use in a preprocessor. For instance, if you know the whitening matrices, you can pass these directly instead of computing them. If you know the bad channel ids, you can pass these to `RemoveBadChannels` (once it exists #3685) and if you know your motion object, you could pass this to a `CorrectMotion` class (once this exists too!).

This can also be used when saving preprocessed recordings. If we save the provenance and the precomputed data, we can load a preprocessed recording much faster. This will be implemented in a later PR.

This PR has no functionality so there are no new tests.

**Questions**:
- Naming. @alejoe91  had suggested on `_precomputed_kwargs` but I think this is confusing since these kwargs aren't always precomputed, it's just that they _can_ be precomputed. So I've gone for `_precomputable_kwargs`. Opinions?
- Should this be in `BaseExtractor`? Could be in `BasePreprocessor`? Any use cases for it in scenarios other than preprocessing?