### PR TITLE
Add `peak_channel` to `compute_spike_locations` docstring and docs

### DIFF
--- a/doc/modules/postprocessing.rst
+++ b/doc/modules/postprocessing.rst
@@ -256,8 +256,9 @@ spike_locations
 
 This extension estimates the location of each spike in the sorting output. Spike location estimates can be done
 with center of mass (:code:`method="center_of_mass"` - fast, but less accurate), a monopolar triangulation
-(:code:`method="monopolar_triangulation"` - slow, but more accurate), or with the method of grid convolution
-(:code:`method="grid_convolution"`)
+(:code:`method="monopolar_triangulation"` - slow, but more accurate), the method of grid convolution
+(:code:`method="grid_convolution"`), or by finding the location of the channel containing the extremum amplitude
+(:code:`method="peak_channel"`).
 
 **NOTE:** computing spike locations is required to compute :ref:`drift_metrics`.
 
@@ -285,7 +286,7 @@ unit_locations
 
 This extension is similar to the :code:`spike_locations`, but instead of estimating a location for each spike
 based on individual waveforms, it calculates at the unit level using templates. The same localization methods
-(:code:`method="center_of_mass" | "monopolar_triangulation" | "grid_convolution"`) are available.
+(:code:`method="center_of_mass" | "monopolar_triangulation" | "grid_convolution" | "max_channel"`) are available.
 
 
 .. code-block:: python

--- a/doc/modules/postprocessing.rst
+++ b/doc/modules/postprocessing.rst
@@ -286,7 +286,7 @@ unit_locations
 
 This extension is similar to the :code:`spike_locations`, but instead of estimating a location for each spike
 based on individual waveforms, it calculates at the unit level using templates. The same localization methods
-(:code:`method="center_of_mass" | "monopolar_triangulation" | "grid_convolution" | "max_channel"`) are available.
+(:code:`method="center_of_mass" | "monopolar_triangulation" | "grid_convolution" | "peak_channel"`) are available.
 
 
 .. code-block:: python

--- a/src/spikeinterface/postprocessing/localization_tools.py
+++ b/src/spikeinterface/postprocessing/localization_tools.py
@@ -705,5 +705,5 @@ _unit_location_methods = {
     "center_of_mass": compute_center_of_mass,
     "grid_convolution": compute_grid_convolution,
     "monopolar_triangulation": compute_monopolar_triangulation,
-    "max_channel": compute_location_max_channel,
+    "peak_channel": compute_location_max_channel,
 }

--- a/src/spikeinterface/postprocessing/spike_locations.py
+++ b/src/spikeinterface/postprocessing/spike_locations.py
@@ -35,7 +35,7 @@ class ComputeSpikeLocations(AnalyzerExtension):
               In case channel_from_template=False, this is the radius to get the true peak
           * peak_sign, default: "neg"
               In case channel_from_template=False, this is the peak sign.
-    method : "center_of_mass" | "monopolar_triangulation" | "grid_convolution", default: "center_of_mass"
+    method : "center_of_mass" | "monopolar_triangulation" | "grid_convolution" | "peak_channel", default: "center_of_mass"
         The localization method to use
     method_kwargs : dict, default: dict()
         Other kwargs depending on the method.


### PR DESCRIPTION
Hello, we have a nice undocumented feature: compute spike locations by peak channel! This PR adds the documentation. Thanks to #3783!

**Question** @samuelgarcia @yger : for spike locations the peak_channel method is called `peak_channel`. For unit locations, the peak_channel method is called `max_channel`. I think the `peak_channel` is only just in the SortingComponents module. Maybe we can unify these names now and just use `max_channel` (this one has been documented for a while, so some users might be using it already, so I'd vote to keep this one).