### PR TITLE
Cleanup imports and use `importlib.util.find_spec` rather than try-except

### DIFF
--- a/src/spikeinterface/comparison/collision.py
+++ b/src/spikeinterface/comparison/collision.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from .paircomparisons import GroundTruthComparison
-from .groundtruthstudy import GroundTruthStudy
+
+# keep import as we do not want to delete code below.
+# from .groundtruthstudy import GroundTruthStudy
 from .comparisontools import make_collision_events
 
 import numpy as np

--- a/src/spikeinterface/comparison/correlogram.py
+++ b/src/spikeinterface/comparison/correlogram.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from .paircomparisons import GroundTruthComparison
-from .groundtruthstudy import GroundTruthStudy
+
+# this import was previously used. Leave for now.
+# from .groundtruthstudy import GroundTruthStudy
 from spikeinterface.postprocessing import compute_correlograms
 
 

--- a/src/spikeinterface/core/baserecordingsnippets.py
+++ b/src/spikeinterface/core/baserecordingsnippets.py
@@ -6,7 +6,6 @@ import numpy as np
 from probeinterface import Probe, ProbeGroup, write_probeinterface, read_probeinterface, select_axes
 
 from .base import BaseExtractor
-from .core_tools import check_json
 from .recording_tools import check_probe_do_not_overlap
 
 from warnings import warn

--- a/src/spikeinterface/core/frameslicerecording.py
+++ b/src/spikeinterface/core/frameslicerecording.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import numpy as np
 
 from .baserecording import BaseRecording, BaseRecordingSegment
 

--- a/src/spikeinterface/core/frameslicesorting.py
+++ b/src/spikeinterface/core/frameslicesorting.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import numpy as np
-import warnings
 
 from .basesorting import BaseSorting, BaseSortingSegment
 from .waveform_tools import has_exceeding_spikes

--- a/src/spikeinterface/core/npyfoldersnippets.py
+++ b/src/spikeinterface/core/npyfoldersnippets.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 from pathlib import Path
 import json
 
-import numpy as np
-
 from .npysnippetsextractor import NpySnippetsExtractor
 from .core_tools import define_function_from_class, make_paths_absolute
 

--- a/src/spikeinterface/core/snippets_tools.py
+++ b/src/spikeinterface/core/snippets_tools.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import numpy as np
+
 from .job_tools import fix_job_kwargs
 from .waveform_tools import extract_waveforms_to_buffers
 from .numpyextractors import NumpySnippets

--- a/src/spikeinterface/core/template_tools.py
+++ b/src/spikeinterface/core/template_tools.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import numpy as np
-import warnings
 
 from .template import Templates
 from .sortinganalyzer import SortingAnalyzer

--- a/src/spikeinterface/core/testing.py
+++ b/src/spikeinterface/core/testing.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from .base import BaseExtractor
 from .baserecording import BaseRecording
 from .basesorting import BaseSorting
 

--- a/src/spikeinterface/core/unitsaggregationsorting.py
+++ b/src/spikeinterface/core/unitsaggregationsorting.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import warnings
 import numpy as np
 
 from .core_tools import define_function_from_class

--- a/src/spikeinterface/core/unitsaggregationsorting.py
+++ b/src/spikeinterface/core/unitsaggregationsorting.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import warnings
 import numpy as np
 
 from .core_tools import define_function_from_class

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
-import multiprocessing
 
 from spikeinterface.core.baserecording import BaseRecording
 

--- a/src/spikeinterface/sorters/external/combinato.py
+++ b/src/spikeinterface/sorters/external/combinato.py
@@ -10,7 +10,6 @@ from spikeinterface.sorters.utils import ShellScript
 from spikeinterface.core import write_to_h5_dataset_format
 from spikeinterface.sorters.basesorter import BaseSorter
 from spikeinterface.extractors import CombinatoSortingExtractor
-from spikeinterface.preprocessing import ScaleRecording
 
 
 PathType = Union[str, Path]

--- a/src/spikeinterface/sorters/external/herdingspikes.py
+++ b/src/spikeinterface/sorters/external/herdingspikes.py
@@ -95,12 +95,13 @@ class HerdingspikesSorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
-        try:
-            import herdingspikes as hs
+        import importlib.util
 
-            HAVE_HS = True
-        except ImportError:
+        spec = importlib.util.find_spec("herdingspikes")
+        if spec is None:
             HAVE_HS = False
+        else:
+            HAVE_HS = True
         return HAVE_HS
 
     @classmethod

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -72,12 +72,13 @@ class Kilosort4Sorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
-        try:
-            import kilosort as ks
-            import torch
+        import importlib.util
 
+        ks_spec = importlib.util.find_spec("kilosort")
+        torch_spec = importlib.util.find_spec("torch")
+        if ks_spec is not None and torch_spec is not None:
             HAVE_KS = True
-        except ImportError:
+        else:
             HAVE_KS = False
         return HAVE_KS
 

--- a/src/spikeinterface/sorters/external/klusta.py
+++ b/src/spikeinterface/sorters/external/klusta.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 import sys
 import shutil
+import importlib.util
+from importlib.metadata import version
 
 from spikeinterface.sorters.basesorter import BaseSorter, get_job_kwargs
 from spikeinterface.sorters.utils import ShellScript
@@ -60,8 +62,6 @@ class KlustaSorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
-        import importlib.util
-
         klusta_spec = importlib.util.find_spec("klusta")
         klustakwik2_spec = importlib.util.find_spec("klustakwik2")
         if klusta_spec is not None and klustakwik2_spec is not None:
@@ -72,7 +72,7 @@ class KlustaSorter(BaseSorter):
 
     @classmethod
     def get_sorter_version(cls):
-        return klusta.__version__
+        return version("klusta")
 
     @classmethod
     def _setup_recording(cls, recording, sorter_output_folder, params, verbose):

--- a/src/spikeinterface/sorters/external/klusta.py
+++ b/src/spikeinterface/sorters/external/klusta.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 from pathlib import Path
 import sys
 import shutil
@@ -12,14 +11,6 @@ from probeinterface import write_prb
 
 from spikeinterface.core import write_binary_recording
 from spikeinterface.extractors import KlustaSortingExtractor
-
-try:
-    import klusta
-    import klustakwik2
-
-    HAVE_KLUSTA = True
-except ImportError:
-    HAVE_KLUSTA = False
 
 
 class KlustaSorter(BaseSorter):
@@ -69,6 +60,14 @@ class KlustaSorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
+        import importlib.util
+
+        klusta_spec = importlib.util.find_spec("klusta")
+        klustakwik2_spec = importlib.util.find_spec("klustakwik2")
+        if klusta_spec is not None and klustakwik2_spec is not None:
+            HAVE_KLUSTA = True
+        else:
+            HAVE_KLUSTA = False
         return HAVE_KLUSTA
 
     @classmethod

--- a/src/spikeinterface/sorters/external/mountainsort4.py
+++ b/src/spikeinterface/sorters/external/mountainsort4.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from tempfile import tempdir
 from packaging.version import parse
 
 from spikeinterface.preprocessing import bandpass_filter, whiten
-
 from spikeinterface.sorters.basesorter import BaseSorter
 from spikeinterface.core.old_api_utils import NewToOldRecording
-from spikeinterface.core import load_extractor
-
 from spikeinterface.extractors import NpzSortingExtractor, NumpySorting
 
 
@@ -63,11 +59,12 @@ class Mountainsort4Sorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
-        try:
-            import mountainsort4
+        import importlib.util
 
+        ms4_spec = importlib.util.find_spec("mountainsort4")
+        if ms4_spec is not None:
             HAVE_MS4 = True
-        except ImportError:
+        else:
             HAVE_MS4 = False
         return HAVE_MS4
 

--- a/src/spikeinterface/sorters/external/mountainsort4.py
+++ b/src/spikeinterface/sorters/external/mountainsort4.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from packaging.version import parse
+import importlib.util
 
 from spikeinterface.preprocessing import bandpass_filter, whiten
 from spikeinterface.sorters.basesorter import BaseSorter
@@ -59,7 +60,6 @@ class Mountainsort4Sorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
-        import importlib.util
 
         ms4_spec = importlib.util.find_spec("mountainsort4")
         if ms4_spec is not None:

--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -4,14 +4,15 @@ from pathlib import Path
 from packaging.version import parse
 
 import shutil
-import numpy as np
 from warnings import warn
+import importlib.util
+from importlib.metadata import version
+
+import numpy as np
 
 from spikeinterface.preprocessing import bandpass_filter, whiten
-
 from spikeinterface.core.baserecording import BaseRecording
 from spikeinterface.sorters.basesorter import BaseSorter, get_job_kwargs
-
 from spikeinterface.extractors import NpzSortingExtractor
 
 
@@ -82,21 +83,19 @@ class Mountainsort5Sorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
-        try:
-            import mountainsort5
-
+        ms5_spec = importlib.util.find_spec("mountainsort5")
+        if ms5_spec is not None:
             HAVE_MS5 = True
-        except ImportError:
+        else:
             HAVE_MS5 = False
-            mountainsort5 = None
 
         if HAVE_MS5:
-            assert mountainsort5
-            vv = parse(mountainsort5.__version__)
+            ms5_version = version("mountainsort5")
+            vv = parse(ms5_version)
             if vv < parse("0.3"):
-                print(
+                warn(
                     f"WARNING: This version of SpikeInterface expects Mountainsort5 version 0.3.x or newer. "
-                    f"You have version {mountainsort5.__version__}"
+                    f"You have version {ms5_version}"
                 )
                 HAVE_MS5 = False
         return HAVE_MS5

--- a/src/spikeinterface/sorters/external/pykilosort.py
+++ b/src/spikeinterface/sorters/external/pykilosort.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 import warnings
 import json
+import importlib.util
+from importlib.metadata import version
 
 import numpy as np
 
@@ -120,7 +122,6 @@ class PyKilosortSorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
-        import importlib.util
 
         pyks_spec = importlib.util.find_spec("pykilosort")
         if pyks_spec is not None:
@@ -132,9 +133,8 @@ class PyKilosortSorter(BaseSorter):
 
     @classmethod
     def get_sorter_version(cls):
-        import pykilosort
 
-        return pykilosort.__version__
+        return version("pykilosort")
 
     @classmethod
     def _check_params(cls, recording, sorter_output_folder, params):

--- a/src/spikeinterface/sorters/external/pykilosort.py
+++ b/src/spikeinterface/sorters/external/pykilosort.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-import numpy as np
 import warnings
+import json
 
-from spikeinterface.core import load_extractor
+import numpy as np
+
 from spikeinterface.extractors import KiloSortSortingExtractor
 from spikeinterface.core import write_binary_recording
-import json
 from spikeinterface.sorters.basesorter import BaseSorter, get_job_kwargs
 
 
@@ -120,11 +120,12 @@ class PyKilosortSorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
-        try:
-            import pykilosort
+        import importlib.util
 
+        pyks_spec = importlib.util.find_spec("pykilosort")
+        if pyks_spec is not None:
             HAVE_PYKILOSORT = True
-        except ImportError:
+        else:
             HAVE_PYKILOSORT = False
 
         return HAVE_PYKILOSORT

--- a/src/spikeinterface/sorters/external/spyking_circus.py
+++ b/src/spikeinterface/sorters/external/spyking_circus.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 from pathlib import Path
 import os
 import numpy as np
@@ -64,11 +63,12 @@ class SpykingcircusSorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
-        try:
-            import circus
+        import importlib.util
 
+        circus_spec = importlib.util.find_spec("circus")
+        if circus_spec is not None:
             HAVE_SC = True
-        except ImportError:
+        else:
             HAVE_SC = False
         return HAVE_SC
 

--- a/src/spikeinterface/sorters/external/spyking_circus.py
+++ b/src/spikeinterface/sorters/external/spyking_circus.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 from pathlib import Path
 import os
+import importlib.util
+from importlib.metadata import version
+import sys
+
 import numpy as np
 from numpy.lib.format import open_memmap
-import sys
+
 
 from spikeinterface.extractors import SpykingCircusSortingExtractor
 from spikeinterface.sorters.basesorter import BaseSorter
@@ -63,7 +67,6 @@ class SpykingcircusSorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
-        import importlib.util
 
         circus_spec = importlib.util.find_spec("circus")
         if circus_spec is not None:
@@ -74,9 +77,7 @@ class SpykingcircusSorter(BaseSorter):
 
     @staticmethod
     def get_sorter_version():
-        import circus
-
-        return circus.__version__
+        return version("circus")
 
     @classmethod
     def _check_params(cls, recording, sorter_output_folder, params):

--- a/src/spikeinterface/sorters/external/tridesclous.py
+++ b/src/spikeinterface/sorters/external/tridesclous.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-from pathlib import Path
-import os
-import shutil
-import numpy as np
-import copy
+
 import time
 from pprint import pprint
+import importlib.util
+from importlib.metadata import version
 
 from spikeinterface.extractors import TridesclousSortingExtractor
-
 from spikeinterface.sorters.basesorter import BaseSorter, get_job_kwargs
 from spikeinterface.core import write_binary_recording
 
@@ -57,24 +54,17 @@ class TridesclousSorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
-        try:
-            import tridesclous as tdc
-
+        tdc_spec = importlib.util.find_spec("tridesclous")
+        if tdc_spec is not None:
             HAVE_TDC = True
-        except ImportError:
-            HAVE_TDC = False
-        except:
-            print(
-                "tridesclous is installed, but it has some dependency problems, check numba or hdbscan installations!"
-            )
+        else:
             HAVE_TDC = False
         return HAVE_TDC
 
     @classmethod
     def get_sorter_version(cls):
-        import tridesclous as tdc
 
-        return tdc.__version__
+        return version("tridesclous")
 
     @classmethod
     def _check_params(cls, recording, sorter_output_folder, params):

--- a/src/spikeinterface/sorters/external/yass.py
+++ b/src/spikeinterface/sorters/external/yass.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import os
 import numpy as np
 import sys
+import importlib.util
+from importlib.metadata import version
 
 from spikeinterface.sorters.basesorter import BaseSorter, get_job_kwargs
 from spikeinterface.sorters.utils import ShellScript
@@ -110,20 +112,16 @@ class YassSorter(BaseSorter):
 
     @classmethod
     def is_installed(cls):
-        try:
-            import yaml
-            import yass
-
+        yass_spec = importlib.util.find_spec("yass")
+        if yass_spec is not None:
             HAVE_YASS = True
-        except ImportError:
+        else:
             HAVE_YASS = False
         return HAVE_YASS
 
     @classmethod
     def get_sorter_version(cls):
-        import yass
-
-        return yass.__version__
+        return version("yass")
 
     @classmethod
     def _setup_recording(cls, recording, sorter_output_folder, params, verbose):

--- a/src/spikeinterface/widgets/traces.py
+++ b/src/spikeinterface/widgets/traces.py
@@ -604,10 +604,10 @@ class TracesWidget(BaseWidget):
     def plot_sortingview(self, data_plot, **backend_kwargs):
         import sortingview.views as vv
         from .utils_sortingview import handle_display_and_url
+        import importlib.util
 
-        try:
-            import pyvips
-        except ImportError:
+        spec = importlib.util.find_spec("pyvips")
+        if spec is None:
             raise ImportError("To use `plot_traces()` in sortingview you need the pyvips package.")
 
         dp = to_attr(data_plot)

--- a/src/spikeinterface/widgets/unit_depths.py
+++ b/src/spikeinterface/widgets/unit_depths.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import numpy as np
-from warnings import warn
 
 from .base import BaseWidget, to_attr
 from .utils import get_unit_colors

--- a/src/spikeinterface/widgets/unit_locations.py
+++ b/src/spikeinterface/widgets/unit_locations.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import numpy as np
-from typing import Union
-
 from probeinterface import ProbeGroup
 
 from .base import BaseWidget, to_attr

--- a/src/spikeinterface/widgets/unit_probe_map.py
+++ b/src/spikeinterface/widgets/unit_probe_map.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import numpy as np
-from typing import Union
 
 # from probeinterface import ProbeGroup
 


### PR DESCRIPTION
try-except is expensive especially to import something like torch just to check if the user has it. What if we move more toward `importlib.util.find_spec` instead? Also cleaned up a few imports.

in draft for feedback--I could do more. For example we could change the numba check to this instead which I think would be useful. Doing a single test on my Mac showed that trying to import numba took 0.1997 seconds whereas doing the find_spec took 0.00016 seconds. They are marginal gains for sure, but having a really smooth import experience for users keeps them with a good feeling for the package. Thoughts all?