### PR TITLE
Switch `numba` check to `importlib.util.find_spec`

### DIFF
--- a/src/spikeinterface/core/sorting_tools.py
+++ b/src/spikeinterface/core/sorting_tools.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import importlib.util
+
 import numpy as np
 
 from .basesorting import BaseSorting
 from .numpyextractors import NumpySorting
+
+numba_spec = importlib.util.find_spec("numba")
+if numba_spec is not None:
+    HAVE_NUMBA = True
+else:
+    HAVE_NUMBA = False
 
 
 def spike_vector_to_spike_trains(spike_vector: list[np.array], unit_ids: np.array) -> dict[dict[str, np.array]]:
@@ -25,13 +33,6 @@ def spike_vector_to_spike_trains(spike_vector: list[np.array], unit_ids: np.arra
         A dict containing, for each segment, the spike trains of all units
         (as a dict: unit_id --> spike_train).
     """
-
-    try:
-        import numba
-
-        HAVE_NUMBA = True
-    except:
-        HAVE_NUMBA = False
 
     if HAVE_NUMBA:
         # the trick here is to have a function getter
@@ -75,12 +76,6 @@ def spike_vector_to_indices(spike_vector: list[np.array], unit_ids: np.array, ab
         A dict containing, for each segment, the spike indices of all units
         (as a dict: unit_id --> index).
     """
-    try:
-        import numba
-
-        HAVE_NUMBA = True
-    except:
-        HAVE_NUMBA = False
 
     if HAVE_NUMBA:
         # the trick here is to have a function getter

--- a/src/spikeinterface/postprocessing/alignsorting.py
+++ b/src/spikeinterface/postprocessing/alignsorting.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-import numpy as np
-from typing import Optional
-
 from spikeinterface import BaseSorting, BaseSortingSegment
 from spikeinterface.core.core_tools import define_function_from_class
-from spikeinterface.core.template_tools import get_template_extremum_channel_peak_shift
 
 
 class AlignSortingExtractor(BaseSorting):

--- a/src/spikeinterface/postprocessing/correlograms.py
+++ b/src/spikeinterface/postprocessing/correlograms.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
-import math
-import warnings
+
+from copy import deepcopy
+import importlib.util
+
 import numpy as np
 from spikeinterface.core.sortinganalyzer import register_result_extension, AnalyzerExtension, SortingAnalyzer
-from copy import deepcopy
+
 
 from spikeinterface.core.waveforms_extractor_backwards_compatibility import MockWaveformExtractor
 
-try:
-    import numba
-
+numba_spec = importlib.util.find_spec("numba")
+if numba_spec is not None:
     HAVE_NUMBA = True
-except ModuleNotFoundError as err:
+else:
     HAVE_NUMBA = False
 
 
@@ -524,6 +525,7 @@ def _compute_correlograms_numba(sorting, window_size, bin_size):
 
 
 if HAVE_NUMBA:
+    import numba
 
     @numba.jit(
         nopython=True,

--- a/src/spikeinterface/postprocessing/isi.py
+++ b/src/spikeinterface/postprocessing/isi.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
+import importlib.util
+
 import numpy as np
 
 from spikeinterface.core.sortinganalyzer import register_result_extension, AnalyzerExtension
 
-try:
-    import numba
-
+numba_spec = importlib.util.find_spec("numba")
+if numba_spec is not None:
     HAVE_NUMBA = True
-except ModuleNotFoundError as err:
+else:
     HAVE_NUMBA = False
 
 
@@ -181,6 +182,7 @@ def compute_isi_histograms_numba(sorting, window_ms: float = 50.0, bin_ms: float
 
 
 if HAVE_NUMBA:
+    import numba
 
     @numba.jit(
         nopython=True,

--- a/src/spikeinterface/postprocessing/localization_tools.py
+++ b/src/spikeinterface/postprocessing/localization_tools.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
 import warnings
+import importlib.util
 
 import numpy as np
+
 from spikeinterface.core import SortingAnalyzer, Templates, compute_sparsity
 from spikeinterface.core.template_tools import _get_nbefore, get_dense_templates_array, get_template_extremum_channel
 
-try:
-    import numba
-
+numba_spec = importlib.util.find_spec("numba")
+if numba_spec is not None:
     HAVE_NUMBA = True
-except ImportError:
+else:
     HAVE_NUMBA = False
 
 
@@ -652,7 +653,9 @@ def get_convolution_weights(
 
 
 if HAVE_NUMBA:
-    enforce_decrease_shells = numba.jit(enforce_decrease_shells_data, nopython=True)
+    from numba import jit
+
+    enforce_decrease_shells = jit(enforce_decrease_shells_data, nopython=True)
 
 
 def compute_location_max_channel(

--- a/src/spikeinterface/postprocessing/spike_locations.py
+++ b/src/spikeinterface/postprocessing/spike_locations.py
@@ -5,9 +5,7 @@ import numpy as np
 from spikeinterface.core.job_tools import _shared_job_kwargs_doc, fix_job_kwargs
 from spikeinterface.core.sortinganalyzer import register_result_extension, AnalyzerExtension
 from spikeinterface.core.template_tools import get_template_extremum_channel
-
 from spikeinterface.core.sorting_tools import spike_vector_to_indices
-
 from spikeinterface.core.node_pipeline import SpikeRetriever, run_node_pipeline
 
 

--- a/src/spikeinterface/postprocessing/template_similarity.py
+++ b/src/spikeinterface/postprocessing/template_similarity.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 import numpy as np
 import warnings
+import importlib.util
 
 from spikeinterface.core.sortinganalyzer import register_result_extension, AnalyzerExtension
 from spikeinterface.core.template_tools import get_dense_templates_array
 from spikeinterface.core.sparsity import ChannelSparsity
 
-try:
-    import numba
 
+numba_spec = importlib.util.find_spec("numba")
+if numba_spec is not None:
     HAVE_NUMBA = True
-except ImportError:
+else:
     HAVE_NUMBA = False
 
 
@@ -216,6 +217,7 @@ def _compute_similarity_matrix_numpy(templates_array, other_templates_array, num
 if HAVE_NUMBA:
 
     from math import sqrt
+    import numba
 
     @numba.jit(nopython=True, parallel=True, fastmath=True, nogil=True)
     def _compute_similarity_matrix_numba(templates_array, other_templates_array, num_shifts, mask, method):

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 
 
 from collections import namedtuple
-
 import math
-import numpy as np
 import warnings
+import importlib.util
+
+import numpy as np
 
 from spikeinterface.core.job_tools import fix_job_kwargs, split_job_kwargs
 from spikeinterface.postprocessing import correlogram_for_one_segment
@@ -26,11 +27,10 @@ from spikeinterface.core.template_tools import (
 )
 
 
-try:
-    import numba
-
+numba_spec = importlib.util.find_spec("numba")
+if numba_spec is not None:
     HAVE_NUMBA = True
-except ModuleNotFoundError as err:
+else:
     HAVE_NUMBA = False
 
 
@@ -377,8 +377,8 @@ def compute_refrac_period_violations(
     res = namedtuple("rp_violations", ["rp_contamination", "rp_violations"])
 
     if not HAVE_NUMBA:
-        print("Error: numba is not installed.")
-        print("compute_refrac_period_violations cannot run without numba.")
+        warnings.warn("Error: numba is not installed.")
+        warnings.warn("compute_refrac_period_violations cannot run without numba.")
         return None
 
     sorting = sorting_analyzer.sorting
@@ -1397,6 +1397,7 @@ def _compute_violations(obs_viol, firing_rate, spike_count, ref_period_dur, cont
 
 
 if HAVE_NUMBA:
+    import numba
 
     @numba.jit(nopython=True, nogil=True, cache=False)
     def _compute_nb_violations_numba(spike_train, t_r):
@@ -1468,7 +1469,6 @@ def compute_sd_ratio(
     num_spikes : dict
         The number of spikes, across all segments, for each unit ID.
     """
-    import numba
     from spikeinterface.curation.curation_tools import _find_duplicated_spikes_keep_first_iterative
 
     kwargs, job_kwargs = split_job_kwargs(kwargs)

--- a/src/spikeinterface/sortingcomponents/matching/tdc.py
+++ b/src/spikeinterface/sortingcomponents/matching/tdc.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+
+import importlib.util
+
 import numpy as np
 from spikeinterface.core import (
     get_channel_distances,
@@ -12,12 +15,10 @@ from .base import BaseTemplateMatching, _base_matching_dtype
 from spikeinterface.generation.drift_tools import DriftingTemplates
 
 
-try:
-    import numba
-    from numba import jit, prange
-
+numba_spec = importlib.util.find_spec("numba")
+if numba_spec is not None:
     HAVE_NUMBA = True
-except ImportError:
+else:
     HAVE_NUMBA = False
 
 
@@ -807,6 +808,7 @@ def fit_one_amplitude_with_neighbors(
 
 
 if HAVE_NUMBA:
+    from numba import jit, prange
 
     @jit(nopython=True)
     def construct_prediction_sparse(

--- a/src/spikeinterface/sortingcomponents/peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/peak_detection.py
@@ -35,9 +35,12 @@ else:
     HAVE_NUMBA = False
 
 torch_spec = importlib.util.find_spec("torch")
-torch_nn_functional_spec = importlib.util.find_spec("torch.nn")
-if torch_spec is not None and torch_nn_functional_spec is not None:
-    HAVE_TORCH = True
+if torch_spec is not None:
+    torch_nn_functional_spec = importlib.util.find_spec("torch.nn")
+    if torch_nn_functional_spec is not None:
+        HAVE_TORCH = True
+    else:
+        HAVE_TORCH = False
 else:
     HAVE_TORCH = False
 

--- a/src/spikeinterface/sortingcomponents/peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/peak_detection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import copy
 from typing import Tuple, List, Optional
+import importlib.util
 
 import numpy as np
 
@@ -27,21 +28,18 @@ from spikeinterface.postprocessing.localization_tools import get_convolution_wei
 
 from .tools import make_multi_method_doc
 
-try:
-    import numba
-
+numba_spec = importlib.util.find_spec("numba")
+if numba_spec is not None:
     HAVE_NUMBA = True
-except ImportError:
+else:
     HAVE_NUMBA = False
 
-try:
-    import torch
-    import torch.nn.functional as F
-
+torch_spec = importlib.util.find_spec("torch")
+torch_nn_functional_spec = importlib.util.find_spec("torch.nn.functional")
+if torch_spec is not None and torch_nn_functional_spec is not None:
     HAVE_TORCH = True
-except ImportError:
+else:
     HAVE_TORCH = False
-
 
 """
 TODO:
@@ -499,8 +497,12 @@ class DetectPeakByChannelTorch(PeakDetectorWrapper):
         return_tensor=False,
         random_chunk_kwargs={},
     ):
+
         if not HAVE_TORCH:
             raise ModuleNotFoundError('"by_channel_torch" needs torch which is not installed')
+
+        import torch.cuda
+
         assert peak_sign in ("both", "neg", "pos")
         if device is None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -839,6 +841,7 @@ class DetectPeakLocallyExclusiveTorch(PeakDetectorWrapper):
 
 
 if HAVE_NUMBA:
+    import numba
 
     @numba.jit(nopython=True, parallel=False)
     def _numba_detect_peak_pos(
@@ -932,6 +935,8 @@ if HAVE_NUMBA:
 
 
 if HAVE_TORCH:
+    import torch
+    import torch.nn.functional as F
 
     @torch.no_grad()
     def _torch_detect_peaks(traces, peak_sign, abs_thresholds, exclude_sweep_size=5, neighbours_mask=None, device=None):
@@ -1109,7 +1114,6 @@ class DetectPeakLocallyExclusiveOpenCL(PeakDetectorWrapper):
 
 class OpenCLDetectPeakExecutor:
     def __init__(self, abs_thresholds, exclude_sweep_size, neighbours_mask, peak_sign):
-        import pyopencl
 
         self.chunk_size = None
 

--- a/src/spikeinterface/sortingcomponents/peak_detection.py
+++ b/src/spikeinterface/sortingcomponents/peak_detection.py
@@ -35,7 +35,7 @@ else:
     HAVE_NUMBA = False
 
 torch_spec = importlib.util.find_spec("torch")
-torch_nn_functional_spec = importlib.util.find_spec("torch.nn.functional")
+torch_nn_functional_spec = importlib.util.find_spec("torch.nn")
 if torch_spec is not None and torch_nn_functional_spec is not None:
     HAVE_TORCH = True
 else:


### PR DESCRIPTION
Same idea as #3795, but moving our numba check to find_spec so that we don't waste time importing. The import is moved to run time so that only users using a numba based function pay the cost. 

I was hoping the `torch.nn.functional` check would work so I was just winging that one. I'll fix it soon :) 