### PR TITLE
Update floor of `setuptools` for metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["setuptools>=62.0"]
+requires = ["setuptools>=78.0.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
We (Heberto and I ) ran into this issue on Neo yesterday. There is a long-term switch from `-` to `_` in setuptools. This means that some old packages without wheels are breaking. This led to a lot of angry comments on setuptools so they decided to switch back from error to warning with 78.0.2 so we should probably put the floor to that just in case :) 