### PR TITLE
Fix error message and pass through function for generating `NumpySorting`

### DIFF
--- a/src/spikeinterface/core/numpyextractors.py
+++ b/src/spikeinterface/core/numpyextractors.py
@@ -367,12 +367,20 @@ class NumpySorting(BaseSorting):
 
     @staticmethod
     def from_times_labels(times_list, labels_list, sampling_frequency, unit_ids=None) -> "NumpySorting":
+        warning_msg = (
+            "`from_times_labels` is deprecated and will be removed in 0.104.0. Note this function requires"
+            "samples rather than times so should not be used for clarity purposes. For those working in samples please"
+            "use `from_samples_and_labels` instead. For those working in time units (seconds) please use "
+            "`from_times_and_labels` instead."
+        )
+
         warnings.warn(
-            "from_times_labels is deprecated and will be removed in 0.104.0, use from_sample_and_labels instead",
+            warning_msg,
             DeprecationWarning,
             stacklevel=2,
         )
-        return NumpySorting.from_times_and_labels(times_list, labels_list, sampling_frequency, unit_ids)
+        # despite the naming of the original function this required samples
+        return NumpySorting.from_samples_and_labels(times_list, labels_list, sampling_frequency, unit_ids)
 
     @staticmethod
     def from_unit_dict(units_dict_list, sampling_frequency) -> "NumpySorting":


### PR DESCRIPTION
Fixes #3814. 

We can see that a package that relies on si was using our wrongly named function based on the what we told them to do (function requested times but need samples). We fixed the name by making new functions but connected the old function to the wrong new function which means the time <-> sample conversion was backwards. We should keep it connected to the wrong function for at least a version so that the warning can be read by people expecting the behavior and then fixed before we change the behavior in what could be a silent fashion.

https://github.com/flatironinstitute/mountainsort5/blob/a2f4195927b041210bed8c7113eda5f7ffd367e7/mountainsort5/schemes/sorting_scheme2.py#L328

@magland this affects mountainsort. (I'm happy to push a PR for you over there to deal with this. But I would need to know if you want to put a new floor of spikeinterface to 0.102.2 or whether you want me to account for old behavior and new behavior )