### PR TITLE
allow UnitWaveformsWidget to use probeinterface plot_probe

### DIFF
--- a/src/spikeinterface/widgets/unit_waveforms.py
+++ b/src/spikeinterface/widgets/unit_waveforms.py
@@ -383,11 +383,11 @@ class UnitWaveformsWidget(BaseWidget):
 
             # plot channels
             if dp.plot_channels:
-                from probeinterface.plotting import plot_probe
+                from probeinterface.plotting import create_probe_polygons
 
                 probe = dp.sorting_analyzer_or_templates.get_probe()
-                poly, poly_contour = plot_probe(probe, contacts_colors="w", add_to_axis=False)
-                ax.add_collection(poly)
+                contacts, probe_outline = create_probe_polygons(probe, contacts_colors="w")
+                ax.add_collection(contacts)
 
             # Apply axis_equal setting
             if dp.axis_equal:

--- a/src/spikeinterface/widgets/unit_waveforms.py
+++ b/src/spikeinterface/widgets/unit_waveforms.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import numpy as np
+from packaging.version import parse
 from warnings import warn
+import numpy as np
 
 from .base import BaseWidget, to_attr
 from .utils import get_unit_colors
@@ -383,11 +384,16 @@ class UnitWaveformsWidget(BaseWidget):
 
             # plot channels
             if dp.plot_channels:
-                from probeinterface.plotting import create_probe_polygons
+                from probeinterface import __version__ as pi_version
 
-                probe = dp.sorting_analyzer_or_templates.get_probe()
-                contacts, probe_outline = create_probe_polygons(probe, contacts_colors="w")
-                ax.add_collection(contacts)
+                if parse(pi_version) >= parse("0.2.27"):
+                    from probeinterface.plotting import create_probe_polygons
+
+                    probe = dp.sorting_analyzer_or_templates.get_probe()
+                    contacts, _ = create_probe_polygons(probe, contacts_colors="w")
+                    ax.add_collection(contacts)
+                else:
+                    ax.scatter(dp.channel_locations[:, 0], dp.channel_locations[:, 1], color="k")
 
             # Apply axis_equal setting
             if dp.axis_equal:

--- a/src/spikeinterface/widgets/unit_waveforms.py
+++ b/src/spikeinterface/widgets/unit_waveforms.py
@@ -384,13 +384,14 @@ class UnitWaveformsWidget(BaseWidget):
             # plot channels
             if dp.plot_channels:
                 from probeinterface.plotting import plot_probe
+
                 probe = dp.sorting_analyzer_or_templates.get_probe()
-                poly, poly_contour = plot_probe(probe, contacts_colors='w', add_to_axis=False)
+                poly, poly_contour = plot_probe(probe, contacts_colors="w", add_to_axis=False)
                 ax.add_collection(poly)
 
             # Apply axis_equal setting
             if dp.axis_equal:
-                ax.set_aspect('equal')
+                ax.set_aspect("equal")
 
             if dp.same_axis and dp.plot_legend:
                 if hasattr(self, "legend") and self.legend is not None:

--- a/src/spikeinterface/widgets/unit_waveforms.py
+++ b/src/spikeinterface/widgets/unit_waveforms.py
@@ -386,7 +386,7 @@ class UnitWaveformsWidget(BaseWidget):
             if dp.plot_channels:
                 from probeinterface import __version__ as pi_version
 
-                if parse(pi_version) >= parse("0.2.27"):
+                if parse(pi_version) >= parse("0.2.28"):
                     from probeinterface.plotting import create_probe_polygons
 
                     probe = dp.sorting_analyzer_or_templates.get_probe()

--- a/src/spikeinterface/widgets/unit_waveforms.py
+++ b/src/spikeinterface/widgets/unit_waveforms.py
@@ -383,8 +383,14 @@ class UnitWaveformsWidget(BaseWidget):
 
             # plot channels
             if dp.plot_channels:
-                # TODO enhance this
-                ax.scatter(dp.channel_locations[:, 0], dp.channel_locations[:, 1], color="k")
+                from probeinterface.plotting import plot_probe
+                probe = dp.sorting_analyzer_or_templates.get_probe()
+                poly, poly_contour = plot_probe(probe, contacts_colors='w', add_to_axis=False)
+                ax.add_collection(poly)
+
+            # Apply axis_equal setting
+            if dp.axis_equal:
+                ax.set_aspect('equal')
 
             if dp.same_axis and dp.plot_legend:
                 if hasattr(self, "legend") and self.legend is not None:


### PR DESCRIPTION
Allows the UnitWaveformsWidget to use probeinterface `plot_probe` for channel locations, and implements axes_equal arg which was not previously implemented. This would depend on ProbeInterface [PR 334](https://github.com/SpikeInterface/probeinterface/pull/334) to allow the plot_probe function not to plot directly to an set of axes.

Would this be safe enough (do we expect the sorting_analyzer_or_templates object to always have a probe attached, or should I include a fallback to the original implementation too?