### PR TITLE
Prevent error of trying to delete non-existent variable in sorting components

### DIFF
--- a/src/spikeinterface/sortingcomponents/clustering/clustering_tools.py
+++ b/src/spikeinterface/sortingcomponents/clustering/clustering_tools.py
@@ -590,10 +590,10 @@ def detect_mixtures(templates, method_kwargs={}, job_kwargs={}, tmp_folder=None,
     local_job_kargs = {"n_jobs": 1, "progress_bar": False}
 
     DEBUG = False
+    sub_recording = None  # we only do a sub recording if we have data to iterate through
     while keep_searching:
 
         keep_searching = False
-        sub_recording = None  # we only do a sub recording if we have data to iterate through
 
         for i in list(set(range(nb_templates)).difference(ignore_inds)):
 

--- a/src/spikeinterface/sortingcomponents/clustering/clustering_tools.py
+++ b/src/spikeinterface/sortingcomponents/clustering/clustering_tools.py
@@ -593,6 +593,7 @@ def detect_mixtures(templates, method_kwargs={}, job_kwargs={}, tmp_folder=None,
     while keep_searching:
 
         keep_searching = False
+        sub_recording = None  # we only do a sub recording if we have data to iterate through
 
         for i in list(set(range(nb_templates)).difference(ignore_inds)):
 


### PR DESCRIPTION
Fixes #3812

Basically in the case that either `nb_templates` is 0 or the number of `ignore_inds` is the same as the `nb_templates` we skip the for loop that generates the `sub_recording` variable. so when we try to `del` it later it causes an error. 

I'm not completely sure what you are hoping for this function @yger and @samuelgarcia so feel free to make a better solution :) 