### PR TITLE
add test

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -735,7 +735,7 @@ class BaseRecording(BaseRecordingSnippets):
         non_present_channel_ids = list(set(remove_channel_ids).difference(recording_channel_ids))
         assert (
             len(non_present_channel_ids) == 0
-        ), f"channel ids {non_present_channel_ids} are not in recording ids {recording_channel_ids}."
+        ), f"`remove_channel_ids` {non_present_channel_ids} are not in recording ids {recording_channel_ids}."
 
         new_channel_ids = self.channel_ids[~np.isin(self.channel_ids, remove_channel_ids)]
         sub_recording = ChannelSliceRecording(self, new_channel_ids)

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -731,6 +731,12 @@ class BaseRecording(BaseRecordingSnippets):
     def _remove_channels(self, remove_channel_ids):
         from .channelslice import ChannelSliceRecording
 
+        recording_channel_ids = self.get_channel_ids()
+        non_present_channel_ids = list(set(remove_channel_ids).difference(recording_channel_ids))
+        assert (
+            len(non_present_channel_ids) == 0
+        ), f"channel ids {non_present_channel_ids} are not in recording ids {recording_channel_ids}."
+
         new_channel_ids = self.channel_ids[~np.isin(self.channel_ids, remove_channel_ids)]
         sub_recording = ChannelSliceRecording(self, new_channel_ids)
         return sub_recording

--- a/src/spikeinterface/core/tests/test_channelslicerecording.py
+++ b/src/spikeinterface/core/tests/test_channelslicerecording.py
@@ -77,7 +77,26 @@ def test_failure_with_non_unique_channel_ids():
     seed = 10
     rec = generate_recording(num_channels=4, durations=durations, set_probe=False, seed=seed)
     with pytest.raises(AssertionError):
-        rec_sliced = ChannelSliceRecording(rec, channel_ids=[0, 1], renamed_channel_ids=[0, 0])
+        rec_sliced = ChannelSliceRecording(rec, channel_ids=["0", "1"], renamed_channel_ids=[0, 0])
+
+
+def test_remove_channels():
+    """
+    Check that `remove_channels` returns a recording with the correct channels removed, and that
+    it raises an error if non-existent channels are given.
+    """
+    durations = [1.0]
+    seed = 1205
+
+    # Note: generated recordings have channel ids: '0', '1', '2', '3', ...
+    rec = generate_recording(num_channels=4, durations=durations, set_probe=False, seed=seed)
+
+    rec_sliced = rec.remove_channels(remove_channel_ids=["0", "2"])
+    rec_sliced_channel_ids = rec_sliced.get_channel_ids()
+    assert np.all(rec_sliced_channel_ids == np.array(["1", "3"]))
+
+    with pytest.raises(AssertionError):
+        rec_sliced = rec.remove_channels(remove_channel_ids=[0, "1"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3816. In `remove_channels` this PR adds an `Assertion` that all given channels-to-remove are in the recording ids. And adds a test.

Example message:

``` python
rec = generate_recording(num_channels=4, durations=durations, set_probe=False, seed=seed)
rec_sliced = rec.remove_channels(remove_channel_ids=[0, "1"])
```
```
>>> AssertionError: `remove_channel_ids` [0] are not in recording ids ['0' '1' '2' '3'].
```