### PR TITLE
Method to bypass matching, and assign a labels to all peaks given templates and SVD representation

### DIFF
--- a/src/spikeinterface/sortingcomponents/clustering/circus.py
+++ b/src/spikeinterface/sortingcomponents/clustering/circus.py
@@ -19,17 +19,10 @@ from spikeinterface.core.waveform_tools import estimate_templates
 from .clustering_tools import remove_duplicates_via_matching
 from spikeinterface.core.recording_tools import get_noise_levels, get_channel_distances
 from spikeinterface.sortingcomponents.peak_selection import select_peaks
-from spikeinterface.sortingcomponents.waveforms.temporal_pca import TemporalPCAProjection
-from spikeinterface.sortingcomponents.waveforms.hanning_filter import HanningFilter
 from spikeinterface.core.template import Templates
 from spikeinterface.core.sparsity import compute_sparsity
 from spikeinterface.sortingcomponents.tools import remove_empty_templates
-import pickle, json
-from spikeinterface.core.node_pipeline import (
-    run_node_pipeline,
-    ExtractSparseWaveforms,
-    PeakRetriever,
-)
+from spikeinterface.sortingcomponents.clustering.peak_svd import extract_peaks_svd
 
 
 from spikeinterface.sortingcomponents.tools import extract_waveform_at_max_channel
@@ -55,13 +48,16 @@ class CircusClustering:
             "recursive_depth": 3,
             "returns_split_count": True,
         },
+        "split_kwargs": {"projection_mode": "tsvd", "n_pca_features": 0.9},
         "radius_um": 100,
+        "neighbors_radius_um": 50,
         "n_svd": 5,
         "few_waveforms": None,
         "ms_before": 0.5,
         "ms_after": 0.5,
         "noise_threshold": 4,
         "rank": 5,
+        "templates_from_svd": False,
         "noise_levels": None,
         "tmp_folder": None,
         "verbose": True,
@@ -78,6 +74,8 @@ class CircusClustering:
         fs = recording.get_sampling_frequency()
         ms_before = params["ms_before"]
         ms_after = params["ms_after"]
+        radius_um = params["radius_um"]
+        neighbors_radius_um = params["neighbors_radius_um"]
         nbefore = int(ms_before * fs / 1000.0)
         nafter = int(ms_after * fs / 1000.0)
         if params["tmp_folder"] is None:
@@ -108,186 +106,106 @@ class CircusClustering:
         valid = np.argmax(np.abs(wfs), axis=1) == nbefore
         wfs = wfs[valid]
 
-        # Perform Hanning filtering
-        hanning_before = np.hanning(2 * nbefore)
-        hanning_after = np.hanning(2 * nafter)
-        hanning = np.concatenate((hanning_before[:nbefore], hanning_after[nafter:]))
-        wfs *= hanning
-
         from sklearn.decomposition import TruncatedSVD
 
-        tsvd = TruncatedSVD(params["n_svd"])
-        tsvd.fit(wfs)
+        svd_model = TruncatedSVD(params["n_svd"])
+        svd_model.fit(wfs)
+        features_folder = tmp_folder / "tsvd_features"
+        features_folder.mkdir(exist_ok=True)
 
-        model_folder = tmp_folder / "tsvd_model"
-
-        model_folder.mkdir(exist_ok=True)
-        with open(model_folder / "pca_model.pkl", "wb") as f:
-            pickle.dump(tsvd, f)
-
-        model_params = {
-            "ms_before": ms_before,
-            "ms_after": ms_after,
-            "sampling_frequency": float(fs),
-        }
-
-        with open(model_folder / "params.json", "w") as f:
-            json.dump(model_params, f)
-
-        # features
-        node0 = PeakRetriever(recording, peaks)
-
-        radius_um = params["radius_um"]
-        node1 = ExtractSparseWaveforms(
+        peaks_svd, sparse_mask, svd_model = extract_peaks_svd(
             recording,
-            parents=[node0],
-            return_output=False,
+            peaks,
             ms_before=ms_before,
             ms_after=ms_after,
+            svd_model=svd_model,
             radius_um=radius_um,
+            folder=features_folder,
+            **job_kwargs,
         )
 
-        node2 = HanningFilter(recording, parents=[node0, node1], return_output=False)
+        neighbours_mask = get_channel_distances(recording) <= neighbors_radius_um
 
-        node3 = TemporalPCAProjection(
-            recording, parents=[node0, node2], return_output=True, model_folder_path=model_folder
-        )
-
-        pipeline_nodes = [node0, node1, node2, node3]
-
-        if len(params["recursive_kwargs"]) == 0:
-            from sklearn.decomposition import PCA
-
-            all_pc_data = run_node_pipeline(
-                recording,
-                pipeline_nodes,
-                job_kwargs,
-                job_name="extracting features",
-            )
-
-            peak_labels = -1 * np.ones(len(peaks), dtype=int)
-            nb_clusters = 0
-            for c in np.unique(peaks["channel_index"]):
-                mask = peaks["channel_index"] == c
-                sub_data = all_pc_data[mask]
-                sub_data = sub_data.reshape(len(sub_data), -1)
-
-                if all_pc_data.shape[1] > params["n_svd"]:
-                    tsvd = PCA(params["n_svd"], whiten=True)
-                else:
-                    tsvd = PCA(all_pc_data.shape[1], whiten=True)
-
-                hdbscan_data = tsvd.fit_transform(sub_data)
-                try:
-                    clustering = hdbscan.hdbscan(hdbscan_data, **d["hdbscan_kwargs"])
-                    local_labels = clustering[0]
-                except Exception:
-                    local_labels = np.zeros(len(hdbscan_data))
-                valid_clusters = local_labels > -1
-                if np.sum(valid_clusters) > 0:
-                    local_labels[valid_clusters] += nb_clusters
-                    peak_labels[mask] = local_labels
-                    nb_clusters += len(np.unique(local_labels[valid_clusters]))
-        else:
-
-            features_folder = tmp_folder / "tsvd_features"
-            features_folder.mkdir(exist_ok=True)
-
-            _ = run_node_pipeline(
-                recording,
-                pipeline_nodes,
-                job_kwargs,
-                job_name="extracting features",
-                gather_mode="npy",
-                gather_kwargs=dict(exist_ok=True),
-                folder=features_folder,
-                names=["sparse_tsvd"],
-            )
-
-            sparse_mask = node1.neighbours_mask
-            neighbours_mask = get_channel_distances(recording) <= radius_um
-
-            # np.save(features_folder / "sparse_mask.npy", sparse_mask)
+        if params["debug"]:
+            np.save(features_folder / "sparse_mask.npy", sparse_mask)
             np.save(features_folder / "peaks.npy", peaks)
 
-            original_labels = peaks["channel_index"]
-            from spikeinterface.sortingcomponents.clustering.split import split_clusters
+        original_labels = peaks["channel_index"]
+        from spikeinterface.sortingcomponents.clustering.split import split_clusters
 
-            min_size = 2 * params["hdbscan_kwargs"].get("min_cluster_size", 20)
+        split_kwargs = params["split_kwargs"].copy()
+        split_kwargs["neighbours_mask"] = neighbours_mask
+        split_kwargs["waveforms_sparse_mask"] = sparse_mask
+        split_kwargs["min_size_split"] = 2 * params["hdbscan_kwargs"].get("min_cluster_size", 50)
+        split_kwargs["clusterer_kwargs"] = params["hdbscan_kwargs"]
 
-            if params["debug"]:
-                debug_folder = tmp_folder / "split"
-            else:
-                debug_folder = None
+        if params["debug"]:
+            debug_folder = tmp_folder / "split"
+        else:
+            debug_folder = None
 
-            peak_labels, _ = split_clusters(
-                original_labels,
-                recording,
-                features_folder,
-                method="local_feature_clustering",
-                method_kwargs=dict(
-                    clusterer="hdbscan",
-                    feature_name="sparse_tsvd",
-                    neighbours_mask=neighbours_mask,
-                    waveforms_sparse_mask=sparse_mask,
-                    min_size_split=min_size,
-                    clusterer_kwargs=d["hdbscan_kwargs"],
-                    n_pca_features=5,
-                ),
-                debug_folder=debug_folder,
-                **params["recursive_kwargs"],
-                **job_kwargs,
-            )
-
-        non_noise = peak_labels > -1
-        labels, inverse = np.unique(peak_labels[non_noise], return_inverse=True)
-        peak_labels[non_noise] = inverse
-        labels = np.unique(inverse)
-
-        spikes = np.zeros(non_noise.sum(), dtype=minimum_spike_dtype)
-        spikes["sample_index"] = peaks[non_noise]["sample_index"]
-        spikes["segment_index"] = peaks[non_noise]["segment_index"]
-        spikes["unit_index"] = peak_labels[non_noise]
-
-        unit_ids = labels
-
-        nbefore = int(params["waveforms"]["ms_before"] * fs / 1000.0)
-        nafter = int(params["waveforms"]["ms_after"] * fs / 1000.0)
+        peak_labels, _ = split_clusters(
+            original_labels,
+            recording,
+            {"peaks": peaks, "sparse_tsvd": peaks_svd},
+            method="local_feature_clustering",
+            method_kwargs=split_kwargs,
+            debug_folder=debug_folder,
+            **params["recursive_kwargs"],
+            **job_kwargs,
+        )
 
         if params["noise_levels"] is None:
             params["noise_levels"] = get_noise_levels(recording, return_scaled=False, **job_kwargs)
 
-        templates_array = estimate_templates(
-            recording,
-            spikes,
-            unit_ids,
-            nbefore,
-            nafter,
-            return_scaled=False,
-            job_name=None,
-            **job_kwargs,
-        )
+        if not params["templates_from_svd"]:
+            from spikeinterface.sortingcomponents.clustering.tools import get_templates_from_peaks_and_recording
 
+            templates = get_templates_from_peaks_and_recording(
+                recording,
+                peaks,
+                peak_labels,
+                ms_before,
+                ms_after,
+                **job_kwargs,
+            )
+        else:
+            from spikeinterface.sortingcomponents.clustering.tools import get_templates_from_peaks_and_svd
+
+            templates = get_templates_from_peaks_and_svd(
+                recording,
+                peaks,
+                peak_labels,
+                ms_before,
+                ms_after,
+                svd_model,
+                peaks_svd,
+                sparse_mask,
+                operator="median",
+            )
+
+        templates_array = templates.templates_array
         best_channels = np.argmax(np.abs(templates_array[:, nbefore, :]), axis=1)
         peak_snrs = np.abs(templates_array[:, nbefore, :])
         best_snrs_ratio = (peak_snrs / params["noise_levels"])[np.arange(len(peak_snrs)), best_channels]
         valid_templates = best_snrs_ratio > params["noise_threshold"]
 
-        if d["rank"] is not None:
-            from spikeinterface.sortingcomponents.matching.circus import compress_templates
-
-            _, _, _, templates_array = compress_templates(templates_array, d["rank"])
+        from spikeinterface.core.template import Templates
 
         templates = Templates(
             templates_array=templates_array[valid_templates],
             sampling_frequency=fs,
-            nbefore=nbefore,
+            nbefore=templates.nbefore,
             sparsity_mask=None,
             channel_ids=recording.channel_ids,
-            unit_ids=unit_ids[valid_templates],
+            unit_ids=templates.unit_ids[valid_templates],
             probe=recording.get_probe(),
             is_scaled=False,
         )
+
+        if params["debug"]:
+            templates_folder = tmp_folder / "dense_templates"
+            templates.to_zarr(folder_path=templates_folder)
 
         sparsity = compute_sparsity(templates, noise_levels=params["noise_levels"], **params["sparsity"])
         templates = templates.to_sparse(sparsity)
@@ -314,4 +232,4 @@ class CircusClustering:
         if verbose:
             print("Kept %d non-duplicated clusters" % len(labels))
 
-        return labels, peak_labels
+        return labels, peak_labels, svd_model, peaks_svd, sparse_mask

--- a/src/spikeinterface/sortingcomponents/clustering/graph_clustering.py
+++ b/src/spikeinterface/sortingcomponents/clustering/graph_clustering.py
@@ -59,6 +59,8 @@ class GraphClustering:
         radius_um = params["radius_um"]
         motion = params["motion"]
         seed = params["seed"]
+        ms_before = params["ms_before"]
+        ms_after = params["ms_after"]
         clustering_method = params["clustering_method"]
         clustering_kwargs = params["clustering_kwargs"]
         graph_kwargs = params["graph_kwargs"]
@@ -70,9 +72,11 @@ class GraphClustering:
         elif graph_kwargs["bin_mode"] == "vertical_bins":
             assert radius_um >= graph_kwargs["bin_um"] * 3
 
-        peaks_svd, sparse_mask, _ = extract_peaks_svd(
+        peaks_svd, sparse_mask, svd_model = extract_peaks_svd(
             recording,
             peaks,
+            ms_before=ms_before,
+            ms_after=ms_after,
             radius_um=radius_um,
             motion_aware=motion_aware,
             motion=None,
@@ -98,7 +102,7 @@ class GraphClustering:
         # print(distances.shape)
         # print("sparsity: ", distances.indices.size / (distances.shape[0]**2))
 
-        print("clustering_method", clustering_method)
+        # print("clustering_method", clustering_method)
 
         if clustering_method == "networkx-louvain":
             # using networkx : very slow (possible backend with cude  backend="cugraph",)
@@ -191,7 +195,7 @@ class GraphClustering:
         labels_set = np.unique(peak_labels)
         labels_set = labels_set[labels_set >= 0]
 
-        return labels_set, peak_labels
+        return labels_set, peak_labels, svd_model, peaks_svd, sparse_mask
 
 
 def _remove_small_cluster(peak_labels, min_size=1):

--- a/src/spikeinterface/sortingcomponents/clustering/graph_tools.py
+++ b/src/spikeinterface/sortingcomponents/clustering/graph_tools.py
@@ -118,7 +118,7 @@ def create_graph_from_peak_features(
         raise ValueError("create_graph_from_peak_features : wrong bin_mode")
 
     if progress_bar:
-        loop = tqdm(loop, desc=f"Construct distance graph looping over {bin_mode}")
+        loop = tqdm(loop, desc=f"Build distance graph over {bin_mode}")
 
     local_graphs = []
     row_indices = []

--- a/src/spikeinterface/sortingcomponents/clustering/tools.py
+++ b/src/spikeinterface/sortingcomponents/clustering/tools.py
@@ -200,6 +200,7 @@ def get_templates_from_peaks_and_recording(
     peak_labels,
     ms_before,
     ms_after,
+    operator="average",
     **job_kwargs,
 ):
     """
@@ -219,6 +220,8 @@ def get_templates_from_peaks_and_recording(
         The time window before the peak in milliseconds.
     ms_after : float
         The time window after the peak in milliseconds.
+    operator : str
+        The operator to use for template estimation. Can be 'average' or 'median'.
     job_kwargs : dict
         Additional keyword arguments for the estimate_templates function.
 
@@ -228,17 +231,34 @@ def get_templates_from_peaks_and_recording(
         The estimated templates object.
     """
     from spikeinterface.core.template import Templates
+    from spikeinterface.core.basesorting import minimum_spike_dtype
 
     mask = peak_labels > -1
-    labels = np.unique(peak_labels[mask])
+    valid_peaks = peaks[mask]
+    valid_labels = peak_labels[mask]
+    labels, indices = np.unique(valid_labels, return_inverse=True)
+
     fs = recording.get_sampling_frequency()
     nbefore = int(ms_before * fs / 1000.0)
     nafter = int(ms_after * fs / 1000.0)
 
+    spikes = np.zeros(valid_peaks.size, dtype=minimum_spike_dtype)
+    spikes["sample_index"] = valid_peaks["sample_index"]
+    spikes["unit_index"] = indices
+    spikes["segment_index"] = valid_peaks["segment_index"]
+
     from spikeinterface.core.waveform_tools import estimate_templates
 
     templates_array = estimate_templates(
-        recording, peaks, labels, nbefore, nafter, return_scaled=False, job_name=None, **job_kwargs
+        recording,
+        spikes,
+        np.arange(len(labels)),
+        nbefore,
+        nafter,
+        operator=operator,
+        return_scaled=False,
+        job_name=None,
+        **job_kwargs,
     )
 
     templates = Templates(
@@ -264,7 +284,7 @@ def get_templates_from_peaks_and_svd(
     svd_model,
     svd_features,
     sparsity_mask,
-    operator="mean",
+    operator="average",
 ):
     """
     Get templates from recording using the SVD components
@@ -287,6 +307,8 @@ def get_templates_from_peaks_and_svd(
         The SVD features array.
     sparsity_mask : numpy.ndarray
         The sparsity mask array.
+    operator : str
+        The operator to use for template estimation. Can be 'average' or 'median'.
 
     Returns
     -------
@@ -295,9 +317,12 @@ def get_templates_from_peaks_and_svd(
     """
     from spikeinterface.core.template import Templates
 
-    assert operator in ["mean", "median"], "operator should be either 'mean' or 'median'"
+    assert operator in ["average", "median"], "operator should be either 'average' or 'median'"
     mask = peak_labels > -1
-    labels = np.unique(peak_labels[mask])
+    valid_peaks = peaks[mask]
+    valid_labels = peak_labels[mask]
+    valid_svd_features = svd_features[mask]
+    labels = np.unique(valid_labels)
 
     fs = recording.get_sampling_frequency()
     nbefore = int(ms_before * fs / 1000.0)
@@ -306,14 +331,14 @@ def get_templates_from_peaks_and_svd(
 
     templates_array = np.zeros((len(labels), nbefore + nafter, num_channels), dtype=np.float32)
     for unit_ind, label in enumerate(labels):
-        mask = peak_labels == label
-        local_peaks = peaks[mask]
-        local_svd = svd_features[mask]
+        mask = valid_labels == label
+        local_peaks = valid_peaks[mask]
+        local_svd = valid_svd_features[mask]
         peak_channels, b = np.unique(local_peaks["channel_index"], return_counts=True)
         best_channel = peak_channels[np.argmax(b)]
         sub_mask = local_peaks["channel_index"] == best_channel
         for count, i in enumerate(np.flatnonzero(sparsity_mask[best_channel])):
-            if operator == "mean":
+            if operator == "average":
                 data = np.mean(local_svd[sub_mask, :, count], 0)
             elif operator == "median":
                 data = np.median(local_svd[sub_mask, :, count], 0)

--- a/src/spikeinterface/sortingcomponents/matching/circus.py
+++ b/src/spikeinterface/sortingcomponents/matching/circus.py
@@ -31,7 +31,7 @@ from .base import BaseTemplateMatching
 
 
 def compress_templates(
-    templates_array, approx_rank, remove_mean=True, return_new_templates=True
+    templates_array, approx_rank, remove_mean=False, return_new_templates=True
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray | None]:
     """Compress templates using singular value decomposition.
 

--- a/src/spikeinterface/sortingcomponents/matching/tools.py
+++ b/src/spikeinterface/sortingcomponents/matching/tools.py
@@ -22,9 +22,9 @@ class FindNearestTemplate(PipelineNode):
         templates_array = templates.get_dense_templates()
         n_templates = templates_array.shape[0]
         num_channels = recording.get_num_channels()
-        self.svd_templates = np.zeros((n_templates, num_channels, pca_model.n_components), 'float32')
+        self.svd_templates = np.zeros((n_templates, pca_model.n_components, num_channels), 'float32')
         for i in range(n_templates):
-            self.svd_templates[i] = pca_model.transform(templates_array[i].T)
+            self.svd_templates[i] = pca_model.transform(templates_array[i].T).T
         self.sparsity_mask = sparsity_mask
         self._dtype = recording.get_dtype()
         self._kwargs.update(
@@ -44,7 +44,7 @@ class FindNearestTemplate(PipelineNode):
             (chan_inds,) = np.nonzero(self.sparsity_mask[main_chan])
             local_svds = waveforms[idx][:, :, :len(chan_inds)]
             XA = local_svds.reshape(local_svds.shape[0], -1)
-            XB = self.svd_templates[:, chan_inds, :].reshape(self.svd_templates.shape[0], -1)
+            XB = self.svd_templates[:, :, chan_inds].reshape(self.svd_templates.shape[0], -1)
             distances= cdist(XA, XB, metric='euclidean')
             peak_labels[idx] = np.argmin(distances, axis=1)
         return peak_labels

--- a/src/spikeinterface/sortingcomponents/matching/tools.py
+++ b/src/spikeinterface/sortingcomponents/matching/tools.py
@@ -1,0 +1,112 @@
+from spikeinterface.core.node_pipeline import run_node_pipeline, ExtractSparseWaveforms, ExtractDenseWaveforms, PeakRetriever, PipelineNode
+from spikeinterface.sortingcomponents.waveforms.temporal_pca import (
+    TemporalPCAProjection,
+)
+from spikeinterface.core.job_tools import fix_job_kwargs
+import numpy as np
+from scipy.spatial.distance import cdist
+
+class FindNearestTemplate(PipelineNode):
+    def __init__(
+        self, 
+        recording, 
+        pca_model,
+        sparsity_mask,
+        templates,
+        name="nn_templates", 
+        return_output=True, 
+        parents=None, 
+        
+    ):
+        PipelineNode.__init__(self, recording, return_output=return_output, parents=parents)
+        templates_array = templates.get_dense_templates()
+        n_templates = templates_array.shape[0]
+        num_channels = recording.get_num_channels()
+        self.svd_templates = np.zeros((n_templates, num_channels, pca_model.n_components), 'float32')
+        for i in range(n_templates):
+            self.svd_templates[i] = pca_model.transform(templates_array[i].T)
+        self.sparsity_mask = sparsity_mask
+        self._dtype = recording.get_dtype()
+        self._kwargs.update(
+            dict(
+                sparsity_mask=self.sparsity_mask,
+                svd_templates=self.svd_templates,
+            )
+        )
+
+    def get_dtype(self):
+        return self._dtype
+
+    def compute(self, traces, peaks, waveforms):
+        peak_labels = np.empty(len(peaks), dtype="int64")
+        for main_chan in np.unique(peaks["channel_index"]):
+            (idx,) = np.nonzero(peaks["channel_index"] == main_chan)
+            (chan_inds,) = np.nonzero(self.sparsity_mask[main_chan])
+            local_svds = waveforms[idx][:, :, :len(chan_inds)]
+            XA = local_svds.reshape(local_svds.shape[0], -1)
+            XB = self.svd_templates[:, chan_inds, :].reshape(self.svd_templates.shape[0], -1)
+            distances= cdist(XA, XB, metric='euclidean')
+            peak_labels[idx] = np.argmin(distances, axis=1)
+        return peak_labels
+
+
+def assign_templates_to_peaks(
+    recording, 
+    peaks, 
+    ms_before,
+    ms_after,
+    svd_model, 
+    sparse_mask, 
+    templates, 
+    **job_kwargs
+) -> np.ndarray | tuple[np.ndarray, dict]:
+    
+    job_kwargs = fix_job_kwargs(job_kwargs)
+    
+    node0 = PeakRetriever(recording, peaks)
+
+    if templates.are_templates_sparse():
+        node1 = ExtractSparseWaveforms(
+            recording,
+            parents=[node0],
+            return_output=False,
+            ms_before=ms_before,
+            ms_after=ms_after,
+            sparsity_mask=sparse_mask,
+        )
+    else:
+        node1 = ExtractDenseWaveforms(
+            recording,
+            parents=[node0],
+            return_output=False,
+            ms_before=ms_before,
+            ms_after=ms_after,
+        )
+
+    node2 = TemporalPCAProjection(
+        recording,
+        parents=[node0, node1],
+        return_output=False,
+        pca_model=svd_model,
+    )
+
+    node3 = FindNearestTemplate(
+        recording,
+        parents=[node0, node2],
+        return_output=True,
+        pca_model=svd_model,
+        templates=templates,
+        sparsity_mask=sparse_mask
+    )
+
+    pipeline_nodes = [node0, node1, node2, node3]
+
+    peak_labels = run_node_pipeline(
+        recording,
+        pipeline_nodes,
+        job_kwargs,
+        job_name=f"assign labels",
+        gather_mode="memory",
+        squeeze_output=True,
+    )
+    return peak_labels


### PR DESCRIPTION
This methods can be useful to benchmark sorters, as it allows to assign a labels to all peaks given some templates, by finding the NN match given a SVD representation. Such a mode would allow SC2 to work without matching, but clustering from only a subset of the spikes, and then assigning labels to everything. This requires also #3847 