### PR TITLE
Pickle fix for the IBL recording

### DIFF
--- a/src/spikeinterface/extractors/iblextractors.py
+++ b/src/spikeinterface/extractors/iblextractors.py
@@ -264,6 +264,7 @@ class IblRecordingExtractor(BaseRecording):
             "cache_folder": cache_folder,
             "remove_cached": remove_cached,
             "stream": stream,
+            "stream_type": stream_type,
         }
 
 


### PR DESCRIPTION
This is a mini patch to the IBL recording to make sure stream_type is stored in _kwargs, so that the assert which happens in the case where only `pid` is supplied is not triggered when unpickling. 