### PR TITLE
Cleanup base sorting extractor 

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -49,7 +49,6 @@ class BaseExtractor:
     # kwargs which can be precomputed before being used by the extractor
     _precomputable_kwarg_names = []
 
-
     def __init__(self, main_ids: Sequence) -> None:
         # store init kwargs for nested serialisation
         self._kwargs = {}

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -16,7 +16,6 @@ import numpy as np
 
 from .globals import get_global_tmp_folder, is_set_global_tmp_folder
 from .core_tools import (
-    is_path_remote,
     clean_zarr_folder_name,
     is_dict_extractor,
     SIJsonEncoder,
@@ -51,7 +50,6 @@ class BaseExtractor:
     _precomputable_kwarg_names = []
 
     installation_mesg = ""
-    installed = True
 
     def __init__(self, main_ids: Sequence) -> None:
         # store init kwargs for nested serialisation

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -49,7 +49,6 @@ class BaseExtractor:
     # kwargs which can be precomputed before being used by the extractor
     _precomputable_kwarg_names = []
 
-    installation_mesg = ""
 
     def __init__(self, main_ids: Sequence) -> None:
         # store init kwargs for nested serialisation

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -764,7 +764,7 @@ class BaseRecording(BaseRecordingSnippets):
         sub_recording = FrameSliceRecording(self, start_frame=start_frame, end_frame=end_frame)
         return sub_recording
 
-    def time_slice(self, start_time: float | None, end_time: float) -> BaseRecording:
+    def time_slice(self, start_time: float | None, end_time: float | None)  -> BaseRecording:
         """
         Returns a new recording object, restricted to the time interval [start_time, end_time].
 

--- a/src/spikeinterface/core/baserecordingsnippets.py
+++ b/src/spikeinterface/core/baserecordingsnippets.py
@@ -16,7 +16,6 @@ class BaseRecordingSnippets(BaseExtractor):
     Mixin that handles all probe and channel operations
     """
 
-    has_default_locations = False
 
     def __init__(self, sampling_frequency: float, channel_ids: list[str, int], dtype: np.dtype):
         BaseExtractor.__init__(self, channel_ids)

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -520,44 +520,6 @@ class BaseSorting(BaseExtractor):
 
         return sample_index
 
-    def get_all_spike_trains(self, outputs="unit_id"):
-        """
-        Return all spike trains concatenated.
-        This is deprecated and will be removed in spikeinterface 0.102 use sorting.to_spike_vector() instead
-        """
-
-        warnings.warn(
-            "Sorting.get_all_spike_trains() will be deprecated. Sorting.to_spike_vector() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        assert outputs in ("unit_id", "unit_index")
-        spikes = []
-        for segment_index in range(self.get_num_segments()):
-            spike_times = []
-            spike_labels = []
-            for i, unit_id in enumerate(self.unit_ids):
-                st = self.get_unit_spike_train(unit_id=unit_id, segment_index=segment_index)
-                spike_times.append(st)
-                if outputs == "unit_id":
-                    spike_labels.append(np.array([unit_id] * st.size))
-                elif outputs == "unit_index":
-                    spike_labels.append(np.zeros(st.size, dtype="int64") + i)
-
-            if len(spike_times) > 0:
-                spike_times = np.concatenate(spike_times)
-                spike_labels = np.concatenate(spike_labels)
-                order = np.argsort(spike_times)
-                spike_times = spike_times[order]
-                spike_labels = spike_labels[order]
-            else:
-                spike_times = np.array([], dtype=np.int64)
-                spike_labels = np.array([], dtype=np.int64)
-
-            spikes.append((spike_times, spike_labels))
-        return spikes
-
     def precompute_spike_trains(self, from_spike_vector=None):
         """
         Pre-computes and caches all spike trains for this sorting

--- a/src/spikeinterface/core/tests/test_basesorting.py
+++ b/src/spikeinterface/core/tests/test_basesorting.py
@@ -94,8 +94,6 @@ def test_BaseSorting(create_cache_folder):
     sorting4 = sorting.save(format="memory")
     check_sortings_equal(sorting, sorting4, check_annotations=True, check_properties=True)
 
-    with pytest.warns(DeprecationWarning):
-        num_spikes = sorting.get_all_spike_trains()
     # print(spikes)
 
     spikes = sorting.to_spike_vector()
@@ -198,11 +196,6 @@ def test_empty_sorting():
 
     assert len(sorting.unit_ids) == 0
 
-    with pytest.warns(DeprecationWarning):
-        spikes = sorting.get_all_spike_trains()
-        assert len(spikes) == 1
-        assert len(spikes[0][0]) == 0
-        assert len(spikes[0][1]) == 0
 
     spikes = sorting.to_spike_vector()
     assert spikes.shape == (0,)

--- a/src/spikeinterface/core/tests/test_basesorting.py
+++ b/src/spikeinterface/core/tests/test_basesorting.py
@@ -196,7 +196,6 @@ def test_empty_sorting():
 
     assert len(sorting.unit_ids) == 0
 
-
     spikes = sorting.to_spike_vector()
     assert spikes.shape == (0,)
 

--- a/src/spikeinterface/core/zarrextractors.py
+++ b/src/spikeinterface/core/zarrextractors.py
@@ -382,7 +382,6 @@ def get_default_zarr_compressor(clevel: int = 5):
     Blosc.compressor
         The compressor object that can be used with the save to zarr function
     """
-    assert ZarrRecordingExtractor.installed, ZarrRecordingExtractor.installation_mesg
     from numcodecs import Blosc
 
     return Blosc(cname="zstd", clevel=clevel, shuffle=Blosc.BITSHUFFLE)

--- a/src/spikeinterface/extractors/tridesclousextractors.py
+++ b/src/spikeinterface/extractors/tridesclousextractors.py
@@ -30,7 +30,6 @@ class TridesclousSortingExtractor(BaseSorting):
         except ImportError:
             raise ImportError(self.installation_mesg)
 
-        assert self.installed, self.installation_mesg
         tdc_folder = Path(folder_path)
 
         dataio = tdc.DataIO(str(tdc_folder))

--- a/src/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/src/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -100,7 +100,7 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
         some_channel_ids = sorting_analyzer.channel_ids[::2]
 
         random_spikes_indices = sorting_analyzer.get_extension("random_spikes").get_data()
-        all_num_spikes = sorting_analyzer.sorting.get_total_num_spikes()
+        all_num_spikes = sorting_analyzer.sorting.count_num_spikes_per_unit()
         unit_ids_num_spikes = np.sum(all_num_spikes[unit_id] for unit_id in some_unit_ids)
 
         # this should be all spikes all channels


### PR DESCRIPTION
Some fixes:
* Remove `get_total_num_spikes`
* add some missing typing
* List to list in typing
* removed unused imports and attributes.
* Added some missing docstrings.