### PR TITLE
channel names  to singular as property

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -293,7 +293,7 @@ class NeoBaseRecordingExtractor(_NeoBaseExtractor, BaseRecording):
             warnings.warn(warning_msg)
 
         if not use_names_as_ids:
-            self.set_property("channel_names", signal_channels["name"])
+            self.set_property("channel_name", signal_channels["name"])
 
         if all_annotations:
             block_ann = self.neo_reader.raw_annotations["blocks"][self.block_index]
@@ -316,9 +316,9 @@ class NeoBaseRecordingExtractor(_NeoBaseExtractor, BaseRecording):
             array_annotations = sig_ann["__array_annotations__"]
             # We do not add this because is confusing for the user to have this repeated
             array_annotations.pop("channel_ids", None)
-            # This is duplicated when using channel_names as ids
+            # This is duplicated when using `use_names_as_ids`
             if use_names_as_ids:
-                array_annotations.pop("channel_names", None)
+                array_annotations.pop("channel_name", None)
 
             # vector array_annotations are channel properties
             for key, values in array_annotations.items():


### PR DESCRIPTION
When we were discussing the scaling properties, @alejoe91 preferred the property names to be singular. I just realized that channel_names is plural, not channel_name, which would be more consistent with that approach