### PR TITLE
Update MEArec reference in Quickstart

### DIFF
--- a/examples/get_started/quickstart.py
+++ b/examples/get_started/quickstart.py
@@ -78,7 +78,7 @@ si.set_global_job_kwargs(**global_job_kwargs)
 # https://gin.g-node.org/NeuralEnsemble/ephy_testing_data repo
 # We download the dataset using DataLad but it can also be downloaded directly.
 
-# Then we can open it. Note that [MEArec](https://mearec.readthedocs.io>) simulated files
+# Then we can open it. Note that [MEArec](https://mearec.readthedocs.io) simulated files
 # contain both a "recording" and a "sorting" object.
 
 local_path = si.download_dataset(remote_path="mearec/mearec_test_10s.h5")
@@ -288,7 +288,7 @@ analyzer_TDC.compute(extensions_to_compute, extension_params=extension_params)
 
 # The calculations are saved in the `extensions` subfolder of the `SortingAnalyzer` folder.
 # Similar to the waveforms we can access them using `get_extension` and `get_data`. For example,
-# here we can make a historgram of spike amplitudes
+# here we can make a histogram of spike amplitudes
 
 # +
 amplitudes = analyzer_TDC.get_extension("spike_amplitudes").get_data()
@@ -296,7 +296,7 @@ plt.hist(amplitudes, bins=50)
 plt.show()
 # -
 
-# You can check which extensions have been saved (in your local folder) and which have been loaded (in your enviroment)...
+# You can check which extensions have been saved (in your local folder) and which have been loaded (in your environment)...
 
 # +
 print(analyzer_TDC.get_saved_extension_names())


### PR DESCRIPTION
# PR Summary
This small PR fixes the MEArec reference in Quickstart. Relevant page: https://spikeinterface.readthedocs.io/en/stable/get_started/quickstart.html
It also fixes a few typos along the way.