### PR TITLE
Add numba check to `sd_ratio`

### DIFF
--- a/src/spikeinterface/curation/curation_tools.py
+++ b/src/spikeinterface/curation/curation_tools.py
@@ -127,10 +127,10 @@ def find_duplicated_spikes(
         assert seed is not None, "The 'seed' has to be provided if method=='random'"
         return _find_duplicated_spikes_random(spike_train, censored_period, seed)
     elif method == "keep_first_iterative":
-        assert HAVE_NUMBA, "'keep_first' method requires numba. Install it with >>> pip install numba"
+        assert HAVE_NUMBA, "'keep_first_iterative' method requires numba. Install it with >>> pip install numba"
         return _find_duplicated_spikes_keep_first_iterative(spike_train.astype(np.int64), censored_period)
     elif method == "keep_last_iterative":
-        assert HAVE_NUMBA, "'keep_last' method requires numba. Install it with >>> pip install numba"
+        assert HAVE_NUMBA, "'keep_last_iterative' method requires numba. Install it with >>> pip install numba"
         return _find_duplicated_spikes_keep_last_iterative(spike_train.astype(np.int64), censored_period)
     else:
         raise ValueError(f"Method '{method}' isn't a valid method for find_duplicated_spikes. Use one of {_methods}")


### PR DESCRIPTION
Hello,

If you don't have numba installed and try to compute `sd_ratio`, like so:

``` python
import spikeinterface.full as si

rec, sort = si.generate_ground_truth_recording()
sa = si.create_sorting_analyzer(recording=rec, sorting=sort)
sa.compute(["noise_levels", "random_spikes", "templates", "spike_amplitudes"])
si.compute_quality_metrics(sa, metric_names=["sd_ratio"])
```

you get a tricky error message:
```
File "/Users/christopherhalcrow/Work/fromgit/spikeinterface/src/spikeinterface/qualitymetrics/misc_metrics.py", line 1472, in compute_sd_ratio
    from spikeinterface.curation.curation_tools import _find_duplicated_spikes_keep_first_iterative
ImportError: cannot import name '_find_duplicated_spikes_keep_first_iterative' from 'spikeinterface.curation.curation_tools' (/Users/christopherhalcrow/Work/fromgit/spikeinterface/src/spikeinterface/curation/curation_tools.py)
```

This is because `sd_ratio` uses `_find_duplicated_spikes_keep_first_iterative` which needs numba.

This PR checks for numba in `compute_sd_ratio` and gives a _warning_ if it's not installed (I'd be mad if my pipeline crashed because of one quality metric):
```
UserWarning: 'sd_ratio' metric computation requires numba. Install it with >>> pip install numba. SD ratio metric will be set to NaN
```
 I also use the conveinence function `find_duplicated_spikes` instead of `_find_duplicated_spikes_keep_first_iterative`, which would give a better error message if someone tried to use it.

EDIT: Also fixed a couple of typos and remove some commented out code.

Another option: if there's no numba, use a different `find_duplicated_spikes` method. Unfortunately, the different methods are genuinely different algorithms and give different results. Hence this is not a good idea for reproducibility.