### PR TITLE
Skip loading extensions when instantiating benchmarks

### DIFF
--- a/src/spikeinterface/benchmark/benchmark_base.py
+++ b/src/spikeinterface/benchmark/benchmark_base.py
@@ -176,17 +176,11 @@ class BenchmarkStudy:
         self.levels = self.info["levels"]
 
         for key, folder in self.analyzers_path.items():
-            analyzer = load_sorting_analyzer(folder)
+            analyzer = load_sorting_analyzer(folder, load_extensions=False)
             self.analyzers[key] = analyzer
             # the sorting is in memory here we take the saved one because comparisons need to pickle it later
             sorting = load(analyzer.folder / "sorting")
             self.datasets[key] = analyzer.recording, sorting
-
-        # for rec_file in (self.folder / "datasets" / "recordings").glob("*.pickle"):
-        #     key = rec_file.stem
-        #     rec = load(rec_file)
-        #     gt_sorting = load(self.folder / f"datasets" / "gt_sortings" / key)
-        #     self.datasets[key] = (rec, gt_sorting)
 
         with open(self.folder / "cases.pickle", "rb") as f:
             self.cases = pickle.load(f)

--- a/src/spikeinterface/benchmark/benchmark_plot_tools.py
+++ b/src/spikeinterface/benchmark/benchmark_plot_tools.py
@@ -494,7 +494,9 @@ def plot_performances_vs_snr(
 
         colors = study.get_colors(levels_to_group_by=levels_to_keep)
 
-        assert all([key in colors for key in case_keys]), f"colors must have a color for each case key: {case_keys}"
+        assert all(
+            [key in colors for key in case_group_keys]
+        ), f"colors must have a color for each case key: {case_group_keys}"
 
         for key, key_list in case_group_keys.items():
             color = colors[key]


### PR DESCRIPTION
With many cases and large recordings, loading everything in RAM can cause out of mem issues.

We don't really need loading extensions at this point