### PR TITLE
Fix plot traces when t_start is defined

### DIFF
--- a/src/spikeinterface/widgets/motion.py
+++ b/src/spikeinterface/widgets/motion.py
@@ -214,7 +214,9 @@ class DriftRasterMapWidget(BaseRasterWidget):
                 amps /= q_95
                 c = cmap(amps)
             else:
-                norm_function = Normalize(vmin=dp.clim[0], vmax=dp.clim[1], clip=True)
+                from matplotlib.colors import Normalize
+
+                norm_function = Normalize(vmin=clim[0], vmax=clim[1], clip=True)
                 c = cmap(norm_function(amps))
             color_kwargs = dict(
                 color=None,

--- a/src/spikeinterface/widgets/traces.py
+++ b/src/spikeinterface/widgets/traces.py
@@ -128,12 +128,10 @@ class TracesWidget(BaseWidget):
 
         if not rec0.has_time_vector(segment_index=segment_index):
             times = None
-            t_start = 0
-            t_end = rec0.get_duration(segment_index=segment_index)
         else:
             times = rec0.get_times(segment_index=segment_index)
-            t_start = times[0]
-            t_end = times[-1]
+        t_start = rec0.get_start_time(segment_index=segment_index)
+        t_end = rec0.get_end_time(segment_index=segment_index)
 
         layer_keys = list(recordings.keys())
 
@@ -680,11 +678,10 @@ def _get_trace_list(recordings, channel_ids, time_range, segment_index, return_s
         frame_range = np.searchsorted(times, time_range)
         times = times[frame_range[0] : frame_range[1]]
     else:
-        frame_range = (time_range * fs).astype("int64", copy=False)
+        frame_range = rec0.time_to_sample_index(time_range, segment_index=segment_index)
         a_max = rec0.get_num_frames(segment_index=segment_index)
         frame_range = np.clip(frame_range, 0, a_max)
-        time_range = frame_range / fs
-        times = np.arange(frame_range[0], frame_range[1]) / fs
+        times = np.arange(frame_range[0], frame_range[1]) / fs + rec0.get_start_time(segment_index=segment_index)
 
     list_traces = []
     for rec_name, rec in recordings.items():

--- a/src/spikeinterface/widgets/traces.py
+++ b/src/spikeinterface/widgets/traces.py
@@ -126,6 +126,11 @@ class TracesWidget(BaseWidget):
         else:
             channel_locations = None
 
+        if segment_index is None:
+            if rec0.get_num_segments() != 1:
+                raise ValueError('You must provide "segment_index" for multisegment recordings.')
+            segment_index = 0
+
         if not rec0.has_time_vector(segment_index=segment_index):
             times = None
         else:
@@ -134,11 +139,6 @@ class TracesWidget(BaseWidget):
         t_end = rec0.get_end_time(segment_index=segment_index)
 
         layer_keys = list(recordings.keys())
-
-        if segment_index is None:
-            if rec0.get_num_segments() != 1:
-                raise ValueError('You must provide "segment_index" for multisegment recordings.')
-            segment_index = 0
 
         fs = rec0.get_sampling_frequency()
         if time_range is None:


### PR DESCRIPTION
We were not handling correctly the case when time_vector is None, but t_starts are present