### PR TITLE
Clarify docstrings in neuropixels_utils

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/spikeglx.py
+++ b/src/spikeinterface/extractors/neoextractors/spikeglx.py
@@ -87,11 +87,13 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
                 self.set_probe(probe, in_place=True)
 
             # load num_channels_per_adc depending on probe type
-            ptype = probe.annotations["probe_type"]
+            model_name = probe.annotations.get("model_name", None)
+            if model_name is None:
+                model_name = probe.annotations["probe_name"]
 
-            if ptype in [21, 24]:  # NP2.0
+            if "2.0" in model_name:  # Neuropixels 2.0
                 num_channels_per_adc = 16
-                num_cycles_in_adc = 16  # TODO: Check this.
+                num_cycles_in_adc = 16
                 total_channels = 384
             else:  # NP1.0
                 num_channels_per_adc = 12

--- a/src/spikeinterface/extractors/neuropixels_utils.py
+++ b/src/spikeinterface/extractors/neuropixels_utils.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 
 def get_neuropixels_sample_shifts(
-    num_channels: int = 384, num_adcs: int = 12, num_cycles: Optional[int] = None
+    num_channels: int = 384, num_channels_per_adc: int = 12, num_cycles: Optional[int] = None
 ) -> np.ndarray:
     """
     Calculate the relative sampling phase (inter-sample shifts) for each channel
@@ -26,10 +26,10 @@ def get_neuropixels_sample_shifts(
     num_channels : int, default: 384
         Total number of channels in the recording.
         Neuropixels probes typically have 384 channels.
-    num_adcs : int, default: 12
+    num_channels_per_adc : int, default: 12
         Number of channels assigned to each ADC on the probe.
-        Neuropixels 1.0 probes have 12 ADCs, each handling 32 channels.
-        Neuropixels 2.0 probes have 16 ADCs, each handling 24 channels.
+        Neuropixels 1.0 probes have 32 ADCs, each handling 12 channels.
+        Neuropixels 2.0 probes have 24 ADCs, each handling 16 channels.
     num_cycles : int or None, default: None
         Number of cycles in the ADC sampling sequence.
         Neuropixels 1.0 probes have 13 cycles for AP (action potential) signals
@@ -44,14 +44,16 @@ def get_neuropixels_sample_shifts(
         representing the fractional delay within the sampling period due to sequential ADC sampling.
     """
     if num_cycles is None:
-        num_cycles = num_adcs
+        num_cycles = num_channels_per_adc
 
-    adc_indices = np.floor(np.arange(num_channels) / (num_adcs * 2)) * 2 + np.mod(np.arange(num_channels), 2)
+    adc_indices = np.floor(np.arange(num_channels) / (num_channels_per_adc * 2)) * 2 + np.mod(
+        np.arange(num_channels), 2
+    )
 
     sample_shifts = np.zeros_like(adc_indices)
 
     for adc_index in adc_indices:
-        sample_shifts[adc_indices == adc_index] = np.arange(num_adcs) / num_cycles
+        sample_shifts[adc_indices == adc_index] = np.arange(num_channels_per_adc) / num_cycles
     return sample_shifts
 
 

--- a/src/spikeinterface/extractors/neuropixels_utils.py
+++ b/src/spikeinterface/extractors/neuropixels_utils.py
@@ -35,7 +35,7 @@ def get_neuropixels_sample_shifts(
         Neuropixels 1.0 probes have 13 cycles for AP (action potential) signals
         and 12 for LFP (local field potential) signals.
         Neuropixels 2.0 probes have 16 cycles.
-        If None, defaults to the value of `num_adcs`.
+        If None, defaults to the value of `num_channels_per_adc`.
 
     Returns
     -------
@@ -57,7 +57,7 @@ def get_neuropixels_sample_shifts(
     return sample_shifts
 
 
-def get_neuropixels_channel_groups(num_channels=384, num_adcs=12):
+def get_neuropixels_channel_groups(num_channels=384, num_channels_per_adc=12):
     """
     Returns groups of simultaneously sampled channels on a Neuropixels probe.
 
@@ -83,10 +83,10 @@ def get_neuropixels_channel_groups(num_channels=384, num_adcs=12):
     num_channels : int, default: 384
         The total number of channels in a recording.
         All currently available Neuropixels variants have 384 channels.
-    num_adcs : int, default: 12
+    num_channels_per_adc : int, default: 12
         The number of channels per ADC on the probe.
-        Neuropixels 1.0 probes have 12 ADCs.
-        Neuropixels 2.0 probes have 16 ADCs.
+        Neuropixels 1.0 probes have 32 ADCs, each handling 12 channels.
+        Neuropixels 2.0 probes have 24 ADCs, each handling 16 channels.
 
     Returns
     -------
@@ -96,14 +96,14 @@ def get_neuropixels_channel_groups(num_channels=384, num_adcs=12):
 
     groups = []
 
-    for i in range(num_adcs):
+    for i in range(num_channels_per_adc):
         groups.append(
             list(
                 np.sort(
                     np.concatenate(
                         [
-                            np.arange(i * 2, num_channels, num_adcs * 2),
-                            np.arange(i * 2 + 1, num_channels, num_adcs * 2),
+                            np.arange(i * 2, num_channels, num_channels_per_adc * 2),
+                            np.arange(i * 2 + 1, num_channels, num_channels_per_adc * 2),
                         ]
                     )
                 )


### PR DESCRIPTION
Fixes #3894

@billkarsh Do you mind taking a look? I believe that the main error and confusion point was in the use of `num_channels_per_adc` and its description

