### PR TITLE
Fix ks4 tests and support ks4>=4.0.34

### DIFF
--- a/.github/scripts/test_kilosort4_ci.py
+++ b/.github/scripts/test_kilosort4_ci.py
@@ -110,7 +110,7 @@ if parse(kilosort.__version__) >= parse("4.0.24"):
 
 if parse(kilosort.__version__) >= parse("4.0.33"):
     PARAMS_TO_TEST_DICT.update({"cluster_neighbors": 11})
-    PARAMETERS_NOT_AFFECTING_RESULTS.append("position_limit")
+    PARAMETERS_NOT_AFFECTING_RESULTS.append("cluster_neighbors")
 
 
 PARAMS_TO_TEST = list(PARAMS_TO_TEST_DICT.keys())

--- a/src/spikeinterface/sorters/basesorter.py
+++ b/src/spikeinterface/sorters/basesorter.py
@@ -266,21 +266,21 @@ class BaseSorter:
         }
         t0 = time.perf_counter()
 
-        try:
-            SorterClass._run_from_folder(sorter_output_folder, sorter_params, verbose)
-            t1 = time.perf_counter()
-            run_time = float(t1 - t0)
-            has_error = False
-        except Exception as err:
-            has_error = True
-            run_time = None
-            log["error"] = True
-            error_log_to_display = traceback.format_exc()
-            trace_lines = error_log_to_display.strip().split("\n")
-            error_to_json = ["Traceback (most recent call last):"] + [
-                f"  {line}" if not line.startswith(" ") else line for line in trace_lines[1:]
-            ]
-            log["error_trace"] = error_to_json
+        # try:
+        SorterClass._run_from_folder(sorter_output_folder, sorter_params, verbose)
+        t1 = time.perf_counter()
+        run_time = float(t1 - t0)
+        has_error = False
+        # except Exception as err:
+        #     has_error = True
+        #     run_time = None
+        #     log["error"] = True
+        #     error_log_to_display = traceback.format_exc()
+        #     trace_lines = error_log_to_display.strip().split("\n")
+        #     error_to_json = ["Traceback (most recent call last):"] + [
+        #         f"  {line}" if not line.startswith(" ") else line for line in trace_lines[1:]
+        #     ]
+        #     log["error_trace"] = error_to_json
 
         log["error"] = has_error
         log["run_time"] = run_time

--- a/src/spikeinterface/sorters/basesorter.py
+++ b/src/spikeinterface/sorters/basesorter.py
@@ -266,21 +266,21 @@ class BaseSorter:
         }
         t0 = time.perf_counter()
 
-        # try:
-        SorterClass._run_from_folder(sorter_output_folder, sorter_params, verbose)
-        t1 = time.perf_counter()
-        run_time = float(t1 - t0)
-        has_error = False
-        # except Exception as err:
-        #     has_error = True
-        #     run_time = None
-        #     log["error"] = True
-        #     error_log_to_display = traceback.format_exc()
-        #     trace_lines = error_log_to_display.strip().split("\n")
-        #     error_to_json = ["Traceback (most recent call last):"] + [
-        #         f"  {line}" if not line.startswith(" ") else line for line in trace_lines[1:]
-        #     ]
-        #     log["error_trace"] = error_to_json
+        try:
+            SorterClass._run_from_folder(sorter_output_folder, sorter_params, verbose)
+            t1 = time.perf_counter()
+            run_time = float(t1 - t0)
+            has_error = False
+        except Exception as err:
+            has_error = True
+            run_time = None
+            log["error"] = True
+            error_log_to_display = traceback.format_exc()
+            trace_lines = error_log_to_display.strip().split("\n")
+            error_to_json = ["Traceback (most recent call last):"] + [
+                f"  {line}" if not line.startswith(" ") else line for line in trace_lines[1:]
+            ]
+            log["error_trace"] = error_to_json
 
         log["error"] = has_error
         log["run_time"] = run_time

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -235,7 +235,8 @@ class Kilosort4Sorter(BaseSorter):
         settings_ks["n_chan_bin"] = recording.get_num_channels()
         settings_ks["fs"] = recording.sampling_frequency
         if not do_CAR:
-            print("Skipping common average reference.")
+            if verbose:
+                print("Skipping common average reference.")
 
         tic0 = time.time()
 
@@ -252,7 +253,7 @@ class Kilosort4Sorter(BaseSorter):
         bad_channels = params["bad_channels"]
         clear_cache = params["clear_cache"]
 
-        filename, data_dir, results_dir, probe = set_files(
+        set_files_kwargs = dict(
             settings=settings,
             filename=filename,
             probe=probe,
@@ -261,6 +262,10 @@ class Kilosort4Sorter(BaseSorter):
             results_dir=results_dir,
             bad_channels=bad_channels,
         )
+        if version.parse(ks_version) >= version.parse("4.0.34"):
+            set_files_kwargs.update(dict(shank_idx=None))
+
+        filename, data_dir, results_dir, probe = set_files(**set_files_kwargs)
 
         ops = initialize_ops(
             settings=settings,
@@ -271,6 +276,8 @@ class Kilosort4Sorter(BaseSorter):
             device=device,
             save_preprocessed_copy=save_preprocessed_copy,
         )
+        if version.parse(ks_version) >= version.parse("4.0.34"):
+            ops = ops[0]
 
         n_chan_bin, fs, NT, nt, twav_min, chan_map, dtype, do_CAR, invert, _, _, tmin, tmax, artifact, _, _ = (
             get_run_parameters(ops)
@@ -280,7 +287,8 @@ class Kilosort4Sorter(BaseSorter):
         if not params["skip_kilosort_preprocessing"]:
             ops = compute_preprocessing(ops=ops, device=device, tic0=tic0, file_object=file_object)
         else:
-            print("Skipping kilosort preprocessing.")
+            if verbose:
+                print("Skipping kilosort preprocessing.")
             bfile = BinaryFiltered(
                 filename=ops["filename"],
                 n_chan_bin=n_chan_bin,
@@ -309,7 +317,8 @@ class Kilosort4Sorter(BaseSorter):
         torch.random.manual_seed(1)
 
         if not params["do_correction"]:
-            print("Skipping drift correction.")
+            if verbose:
+                print("Skipping drift correction.")
             ops["nblocks"] = 0
 
         drift_kwargs = dict(


### PR DESCRIPTION
- skip `"templates_from_data"` from testing (since it results in failures: https://github.com/MouseLand/Kilosort/issues/932)
- support KS API changes from 4.0.34