### PR TITLE
Add Literals to lots of function arguments

### DIFF
--- a/src/spikeinterface/preprocessing/detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/detect_bad_channels.py
@@ -7,10 +7,12 @@ from typing import Literal
 from .filter import highpass_filter
 from spikeinterface.core import get_random_data_chunks, order_channels_by_depth, BaseRecording
 
+detect_bad_channels_method_names = ("std", "mad", "coherence+psd", "neighborhood_r2")
+
 
 def detect_bad_channels(
     recording: BaseRecording,
-    method: str = "coherence+psd",
+    method: Literal["std", "mad", "coherence+psd", "neighborhood_r2"] = "coherence+psd",
     std_mad_threshold: float = 5,
     psd_hf_threshold: float = 0.02,
     dead_channel_threshold: float = -0.5,
@@ -121,8 +123,9 @@ def detect_bad_channels(
     """
     import scipy.stats
 
-    method_list = ("std", "mad", "coherence+psd", "neighborhood_r2")
-    assert method in method_list, f"{method} is not a valid method. Available methods are {method_list}"
+    assert (
+        method in detect_bad_channels_method_names
+    ), f"{method} is not a valid method. Available methods are {detect_bad_channels_method_names}."
 
     # Get random subset of data to estimate from
     random_chunk_kwargs = dict(

--- a/src/spikeinterface/preprocessing/tests/test_detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/tests/test_detect_bad_channels.py
@@ -8,7 +8,7 @@ from spikeinterface.core import generate_recording
 from spikeinterface.preprocessing import detect_bad_channels, highpass_filter
 from spikeinterface.preprocessing.detect_bad_channels import detect_bad_channels_method_names
 
-from typing import get_type_hints, get_args
+from typing import get_args, Literal
 
 try:
     # WARNING : this is not this package https://pypi.org/project/neurodsp/
@@ -26,7 +26,7 @@ def test_literal_hardcoded_values():
     The possible strings allowed by the `method` argument are hardcoded. Here we check they are consistent
     with the methods list.
     """
-    detect_bad_channels_method_literals = get_args(get_type_hints(detect_bad_channels)["method"])
+    detect_bad_channels_method_literals = get_args(eval(detect_bad_channels.__annotations__["method"]))
     assert set(detect_bad_channels_method_literals) == set(detect_bad_channels_method_names)
 
 

--- a/src/spikeinterface/preprocessing/tests/test_detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/tests/test_detect_bad_channels.py
@@ -6,6 +6,9 @@ from probeinterface import generate_linear_probe
 
 from spikeinterface.core import generate_recording
 from spikeinterface.preprocessing import detect_bad_channels, highpass_filter
+from spikeinterface.preprocessing.detect_bad_channels import detect_bad_channels_method_names
+
+from typing import get_type_hints, get_args
 
 try:
     # WARNING : this is not this package https://pypi.org/project/neurodsp/
@@ -16,6 +19,15 @@ try:
     HAVE_NPIX = True
 except:  # Catch relevant exception
     HAVE_NPIX = False
+
+
+def test_literal_hardcoded_values():
+    """
+    The possible strings allowed by the `method` argument are hardcoded. Here we check they are consistent
+    with the methods list.
+    """
+    detect_bad_channels_method_literals = get_args(get_type_hints(detect_bad_channels)["method"])
+    assert set(detect_bad_channels_method_literals) == set(detect_bad_channels_method_names)
 
 
 def test_detect_bad_channels_std_mad():


### PR DESCRIPTION
This PR improves the user experience by adding Literals to LOTS of function arguments (eventually...). They are in a few function arguments at the moment.

Allows for auto-complete for string arguments, like so:

<img width="561" alt="Screenshot 2025-05-06 at 12 38 11" src="https://github.com/user-attachments/assets/bea4211e-f8e3-49b6-a2c4-30dcc4a4ed10" />

Plan is to go through each module and add `Literal`s everywhere. Will be _especially_ helpful for `compute`! Before I do so, thought I'd use one concrete example to generate some discussion. I've added Literals for the `method` argument of `detect_bad_channels`. To do so, I've done three things:

1. Added the Literal to the typing in the argument list
2. Moved the list of allowed arguments outside the function, just above it. So that we can...
3. Add a test to compare the Literal to the list of allowed arguments

As far I can figure out, Literals have to be hardcoded for static type checkers to pick up on them. To check this hardcoding, I think it's worth adding tests like this for any arguments that might be extended in the future. Any other opinions?

EDIT: The steps 1. 2. 3. might be overkill?? Should I just do 1.?