### PR TITLE
Expose `match_score` to benchmark compute_results

### DIFF
--- a/src/spikeinterface/benchmark/benchmark_matching.py
+++ b/src/spikeinterface/benchmark/benchmark_matching.py
@@ -40,7 +40,11 @@ class MatchingBenchmark(Benchmark):
 
     def compute_result(self, with_collision=False, **result_params):
         sorting = self.result["sorting"]
-        comp = compare_sorter_to_ground_truth(self.gt_sorting, sorting, exhaustive_gt=True)
+        exhaustive_gt = result_params.get("exhaustive_gt", True)
+        match_score = result_params.get("match_score", None)
+        comp = compare_sorter_to_ground_truth(
+            self.gt_sorting, sorting, exhaustive_gt=exhaustive_gt, match_score=match_score
+        )
         self.result["gt_comparison"] = comp
         if with_collision:
             self.result["gt_collision"] = CollisionGTComparison(self.gt_sorting, sorting, exhaustive_gt=True)

--- a/src/spikeinterface/benchmark/benchmark_merging.py
+++ b/src/spikeinterface/benchmark/benchmark_merging.py
@@ -37,7 +37,11 @@ class MergingBenchmark(Benchmark):
 
     def compute_result(self, **result_params):
         sorting = self.result["sorting"]
-        comp = compare_sorter_to_ground_truth(self.gt_sorting, sorting, exhaustive_gt=True)
+        exhaustive_gt = result_params.get("exhaustive_gt", True)
+        match_score = result_params.get("match_score", None)
+        comp = compare_sorter_to_ground_truth(
+            self.gt_sorting, sorting, exhaustive_gt=exhaustive_gt, match_score=match_score
+        )
         self.result["gt_comparison"] = comp
 
     _run_key_saved = [("sorting", "sorting"), ("merges", "pickle"), ("merged_pairs", "pickle"), ("outs", "pickle")]

--- a/src/spikeinterface/benchmark/benchmark_sorter.py
+++ b/src/spikeinterface/benchmark/benchmark_sorter.py
@@ -26,10 +26,14 @@ class SorterBenchmark(Benchmark):
         sorting = NumpySorting.from_sorting(raw_sorting)
         self.result = {"sorting": sorting}
 
-    def compute_result(self, exhaustive_gt=True):
+    def compute_result(self, **result_params):
         # run becnhmark result
         sorting = self.result["sorting"]
-        comp = compare_sorter_to_ground_truth(self.gt_sorting, sorting, exhaustive_gt=exhaustive_gt)
+        exhaustive_gt = result_params.get("exhaustive_gt", True)
+        match_score = result_params.get("match_score", None)
+        comp = compare_sorter_to_ground_truth(
+            self.gt_sorting, sorting, exhaustive_gt=exhaustive_gt, match_score=match_score
+        )
         self.result["gt_comparison"] = comp
 
     _run_key_saved = [


### PR DESCRIPTION
By default, match_score is 0.5, which means that all performance metrics for units with agreement below that are 0. This PR at least exposes the option to pass match_score