### PR TITLE
Resolve warnings of NumPy library

### DIFF
--- a/src/spikeinterface/sortingcomponents/clustering/merge.py
+++ b/src/spikeinterface/sortingcomponents/clustering/merge.py
@@ -61,7 +61,7 @@ def merge_clusters(
         A vector of sample shift to be reverse applied on original sample_index on peak detection
         Negative shift means too early.
         Posituve shift means too late.
-        So the correction must be applied like this externaly:
+        So the correction must be applied like this externally:
         final_peaks = peaks.copy()
         final_peaks['sample_index'] -= peak_shifts
 
@@ -132,7 +132,7 @@ def merge_clusters(
     peak_shifts = np.zeros(peak_labels.size, dtype="int64")
     for merge, shifts in zip(merges, group_shifts):
         label0 = merge[0]
-        mask = np.in1d(peak_labels, merge)
+        mask = np.isin(peak_labels, merge)
         merge_peak_labels[mask] = label0
         for l, label1 in enumerate(merge):
             if l == 0:
@@ -265,7 +265,7 @@ def find_merge_pairs(
     # progress_bar=True,
 ):
     """
-    Searh some possible merge 2 by 2.
+    Search some possible merge 2 by 2.
     """
     job_kwargs = fix_job_kwargs(job_kwargs)
 
@@ -605,7 +605,7 @@ class ProjectDistribution:
 class NormalizedTemplateDiff:
     """
     Compute the normalized (some kind of) template differences.
-    And merge if below a threhold.
+    And merge if below a threshold.
     Do this at several shift.
 
     """

--- a/src/spikeinterface/sortingcomponents/clustering/tools.py
+++ b/src/spikeinterface/sortingcomponents/clustering/tools.py
@@ -10,7 +10,7 @@ import numpy as np
 
 class FeaturesLoader:
     """
-    Feature can be computed in memory or in a folder contaning npy files.
+    Feature can be computed in memory or in a folder containing npy files.
 
     This class read the folder and behave like a dict of array lazily.
 
@@ -52,7 +52,7 @@ def aggregate_sparse_features(peaks, peak_indices, sparse_feature, sparse_mask, 
     """
     Aggregate sparse features that have unaligned channels and realigned then on target_channels.
 
-    This is usefull to aligned back peaks waveform or pca or tsvd when detected a differents channels.
+    This is useful to aligned back peaks waveform or pca or tsvd when detected a differents channels.
 
 
     Parameters
@@ -87,7 +87,7 @@ def aggregate_sparse_features(peaks, peak_indices, sparse_feature, sparse_mask, 
         peak_inds = np.flatnonzero(local_peaks["channel_index"] == chan)
         if np.all(np.isin(target_channels, sparse_chans)):
             # peaks feature channel have all target_channels
-            source_chans = np.flatnonzero(np.in1d(sparse_chans, target_channels))
+            source_chans = np.flatnonzero(np.isin(sparse_chans, target_channels))
             aligned_features[peak_inds, :, :] = sparse_feature[peak_indices[peak_inds], :, :][:, :, source_chans]
         else:
             # some channel are missing, peak are not removde
@@ -149,7 +149,7 @@ def apply_waveforms_shift(waveforms, peak_shifts, inplace=False):
     """
     Apply a shift a spike level to realign waveforms buffers.
 
-    This is usefull to compute template after merge when to cluster are shifted.
+    This is useful to compute template after merge when to cluster are shifted.
 
     A negative shift need the waveforms to be moved toward the right because the trough was too early.
     A positive shift need the waveforms to be moved toward the left because the trough was too late.


### PR DESCRIPTION
# PR Summary
This small PR resolves the NumPy deprecation warnings of `np.in1d` which you can find in the CI Logs:
```python
DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
```
It also fixes a few typos along the way.