### PR TITLE
Bug fix: cast corrected motion recording to float

### DIFF
--- a/src/spikeinterface/preprocessing/motion.py
+++ b/src/spikeinterface/preprocessing/motion.py
@@ -443,9 +443,6 @@ def compute_motion(
     t1 = time.perf_counter()
     run_times["estimate_motion"] = t1 - t0
 
-    if recording.get_dtype().kind != "f":
-        recording = recording.astype("float32")
-
     motion_info = dict(
         parameters=parameters,
         run_times=run_times,
@@ -553,6 +550,9 @@ def correct_motion(
         output_motion_info=True,
         **job_kwargs,
     )
+
+    if recording.get_dtype().kind != "f":
+        recording = recording.astype("float32")
 
     recording_corrected = interpolate_motion(recording, motion, **interpolate_motion_kwargs)
 

--- a/src/spikeinterface/preprocessing/tests/test_motion.py
+++ b/src/spikeinterface/preprocessing/tests/test_motion.py
@@ -32,6 +32,13 @@ def test_estimate_and_correct_motion(create_cache_folder):
     assert motion_info_loaded["motion"] == motion_info["motion"]
 
 
+def test_estimate_and_correct_motion_int(create_cache_folder):
+
+    rec = generate_recording(durations=[30.0], num_channels=12).astype(int)
+    rec_corrected = correct_motion(rec, estimate_motion_kwargs={"win_step_um": 50, "win_scale_um": 100})
+    assert rec_corrected.get_dtype().kind == "f"
+
+
 def test_get_motion_parameters_preset():
     from pprint import pprint
 

--- a/src/spikeinterface/preprocessing/tests/test_motion.py
+++ b/src/spikeinterface/preprocessing/tests/test_motion.py
@@ -32,7 +32,7 @@ def test_estimate_and_correct_motion(create_cache_folder):
     assert motion_info_loaded["motion"] == motion_info["motion"]
 
 
-def test_estimate_and_correct_motion_int(create_cache_folder):
+def test_estimate_and_correct_motion_int():
 
     rec = generate_recording(durations=[30.0], num_channels=12).astype(int)
     rec_corrected = correct_motion(rec, estimate_motion_kwargs={"win_step_um": 50, "win_scale_um": 100})


### PR DESCRIPTION
Fixes #3927

When we recently updated the `correct_motion` object, we didn't move the casting of the recording. This fixes the bug, restoring behaviour to that of the previous version.

Added a test to apply a motion correction to a `int`-typed recording.