### PR TITLE
Fix shift times when `t_start` is None

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -547,7 +547,8 @@ class BaseRecording(BaseRecordingSnippets):
             if self.has_time_vector(segment_index=idx):
                 rs.time_vector += shift
             else:
-                rs.t_start += shift
+                new_start_time = 0 + shift if rs.t_start is None else rs.t_start + shift
+                rs.t_start = new_start_time
 
     def sample_index_to_time(self, sample_ind, segment_index=None):
         """

--- a/src/spikeinterface/core/tests/test_time_handling.py
+++ b/src/spikeinterface/core/tests/test_time_handling.py
@@ -435,3 +435,12 @@ class TestTimeHandling:
         assert sorting.has_recording()
 
         return sorting
+
+
+def test_shift_times_with_None_as_t_start():
+    """Ensures we can shift times even when t_stat is None which is interpeted as zero"""
+    recording = generate_recording(num_channels=4, durations=[10])
+
+    assert recording._recording_segments[0].t_start is None
+    recording.shift_times(shift=1.0)  # Shift by one seconds should not generate an error
+    assert recording.get_start_time() == 1.0


### PR DESCRIPTION
Currently, trying to use `recording.shift_times` when the the segment `t_start` is None produces an error:

This PR fixes this so this situation is interpreted as t_start being 0 as we do in many other places of the code base. Here is a concrete example but other methods do the same implicitly:

https://github.com/h-mayorquin/spikeinterface/blob/252c8f85fbac2af67ff663330a009219994f6717/src/spikeinterface/core/baserecording.py#L929-L934



