### PR TITLE
Fix kcoords for non-int groups

### DIFF
--- a/.github/scripts/test_kilosort4_ci.py
+++ b/.github/scripts/test_kilosort4_ci.py
@@ -112,6 +112,9 @@ if parse(kilosort.__version__) >= parse("4.0.33"):
     PARAMS_TO_TEST_DICT.update({"cluster_neighbors": 11})
     PARAMETERS_NOT_AFFECTING_RESULTS.append("cluster_neighbors")
 
+if parse(kilosort.__version__) >= parse("4.0.37"):
+    PARAMS_TO_TEST_DICT.update({"max_cluster_subset": 20})
+
 
 PARAMS_TO_TEST = list(PARAMS_TO_TEST_DICT.keys())
 
@@ -254,6 +257,8 @@ class TestKilosort4Long:
             "device",
             "save_preprocessed_copy",
         ]
+        if parse(kilosort.__version__) >= parse("4.0.37"):
+            expected_arguments += ["gui_mode"]
 
         self._check_arguments(
             initialize_ops,

--- a/.github/scripts/test_kilosort4_ci.py
+++ b/.github/scripts/test_kilosort4_ci.py
@@ -114,6 +114,7 @@ if parse(kilosort.__version__) >= parse("4.0.33"):
 
 if parse(kilosort.__version__) >= parse("4.0.37"):
     PARAMS_TO_TEST_DICT.update({"max_cluster_subset": 20})
+    PARAMETERS_NOT_AFFECTING_RESULTS.append("max_cluster_subset")
 
 
 PARAMS_TO_TEST = list(PARAMS_TO_TEST_DICT.keys())

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -440,7 +440,7 @@ class Kilosort4Sorter(BaseSorter):
         yc = positions[:, 1]
         unique_groups = set(groups)
         group_map = {group: idx for idx, group in enumerate(unique_groups)}
-        kcoords = np.array(group_map.values(), dtype=int)
+        kcoords = np.array(list(group_map.values()), dtype=int)
 
         probe = {
             "chanMap": chanMap,

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -438,9 +438,9 @@ class Kilosort4Sorter(BaseSorter):
         chanMap = np.arange(n_chan)
         xc = positions[:, 0]
         yc = positions[:, 1]
-        unique_groups = np.unique(groups)
+        unique_groups = set(groups)
         group_map = {group: idx for idx, group in enumerate(unique_groups)}
-        kcoords = np.array([group_map[group] for group in groups], dtype=int)
+        kcoords = np.array(group_map.values(), dtype=int)
 
         probe = {
             "chanMap": chanMap,

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -440,7 +440,7 @@ class Kilosort4Sorter(BaseSorter):
         yc = positions[:, 1]
         unique_groups = set(groups)
         group_map = {group: idx for idx, group in enumerate(unique_groups)}
-        kcoords = np.array(list(group_map.values()), dtype=int)
+        kcoords = np.array([group_map[group] for group in groups], dtype=int)
 
         probe = {
             "chanMap": chanMap,

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -438,7 +438,9 @@ class Kilosort4Sorter(BaseSorter):
         chanMap = np.arange(n_chan)
         xc = positions[:, 0]
         yc = positions[:, 1]
-        kcoords = groups.astype(float)
+        unique_groups = np.unique(groups)
+        group_map = {group: idx for idx, group in enumerate(unique_groups)}
+        kcoords = np.array([group_map[group] for group in groups], dtype=int)
 
         probe = {
             "chanMap": chanMap,


### PR DESCRIPTION
Introduced by #3852, if the channel groups are not strings they cannot be cast to float. This makes a map to integers