### PR TITLE
basesorting.py `get_spike_trains` method

### DIFF
--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -653,6 +653,18 @@ class BaseSorting(BaseExtractor):
 
         return spikes
 
+    def get_spike_trains(self):
+        """
+        spike trains of sorter in recording time (seconds) of all units
+
+        Returns: dictionary with unit_id as keys and spike train in seconds as values
+        """
+        spike_trains = {}
+        for unit_id in self.get_unit_ids():
+            spike_trains[unit_id] = self.get_unit_spike_train(unit_id) / self.sampling_frequency
+        # self.spike_trains = spike_trains
+        return spike_trains
+    
     def to_numpy_sorting(self, propagate_cache=True):
         """
         Turn any sorting in a NumpySorting.

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -664,7 +664,7 @@ class BaseSorting(BaseExtractor):
             spike_trains[unit_id] = self.get_unit_spike_train(unit_id) / self.sampling_frequency
         # self.spike_trains = spike_trains
         return spike_trains
-    
+
     def to_numpy_sorting(self, propagate_cache=True):
         """
         Turn any sorting in a NumpySorting.


### PR DESCRIPTION
convienient function to get spike trains of all units as dict

an alternative method could be
```
spike_vector = sorting.to_spike_vector()
for unit_id in sorting.unit_ids:
    spikes = spike_vector[spike_vector["unit_index"]==sorting.id_to_index(unit_id)]
    # np.unique(spike_vector["unit_index"],return_counts=True) # number of spikes per unit
    ...
```
