### PR TITLE
have cron jobs running only in upstream repo

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -19,6 +19,8 @@ concurrency:  # Cancel previous workflows on the same pull request
 jobs:
   run:
     name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+    # Run only in upstream repo to avoid unnecessary runs in forks
+    if: github.repository == 'SpikeInterface/spikeinterface'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   create-gin-data-cache-if-missing:
     name: Caching data env
+    # Run only in upstream repo to avoid unnecessary runs in forks
+    if: github.repository == 'SpikeInterface/spikeinterface'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/full-test-with-codecov.yml
+++ b/.github/workflows/full-test-with-codecov.yml
@@ -11,6 +11,8 @@ env:
 jobs:
   full-tests-with-codecov:
     name: Codecov in Ubuntu
+    # Run only in upstream repo to avoid unnecessary runs in forks
+    if: github.repository == 'SpikeInterface/spikeinterface'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/installation-tips-test.yml
+++ b/.github/workflows/installation-tips-test.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   installation-tips-testing:
     name: Build Conda Env on ${{ matrix.os }} OS
+    # Run only in upstream repo to avoid unnecessary runs in forks
+    if: github.repository == 'SpikeInterface/spikeinterface'
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/test_kilosort4.yml
+++ b/.github/workflows/test_kilosort4.yml
@@ -13,6 +13,8 @@ jobs:
     # Poll Pypi for all released KS4 versions >4.0.16, save to JSON
     # and store them in a matrix for the next job.
     runs-on: ubuntu-latest
+    # Run only in upstream repo to avoid unnecessary runs in forks
+    if: github.repository == 'SpikeInterface/spikeinterface'
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:


### PR DESCRIPTION
Some Actions are scheduled to run automatically following CRON rules, which might eventually incur in costs to anyone forking the repo. This adds a conditional to run these jobs only in the upstream repo.