### PR TITLE
Fix loading data from the sync stream in spikeglx

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/spikeglx.py
+++ b/src/spikeinterface/extractors/neoextractors/spikeglx.py
@@ -75,13 +75,18 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
 
         self._kwargs.update(dict(folder_path=str(Path(folder_path).absolute()), load_sync_channel=load_sync_channel))
 
+        stream_is_nidq_or_sync = "nidq" in self.stream_id or "SYNC" in self.stream_id
+        if stream_is_nidq_or_sync:
+            # Do not add probe information for the sync or nidq stream. Early return
+            return None
+
         # Checks if the probe information is available and adds location, shanks and sample shift if available.
         signals_info_dict = {e["stream_name"]: e for e in self.neo_reader.signals_info_list}
         meta_filename = signals_info_dict[self.stream_id]["meta_file"]
+
         ap_meta_filename = meta_filename.replace(".lf", ".ap") if "lf" in self.stream_id else meta_filename
         ap_meta_file_exists = Path(ap_meta_filename).exists()
-        stream_is_not_nidq = "nidq" not in self.stream_id
-        add_probe_properties = ap_meta_file_exists and stream_is_not_nidq and not load_sync_channel
+        add_probe_properties = ap_meta_file_exists and not load_sync_channel
 
         if add_probe_properties:
             probe = probeinterface.read_spikeglx(ap_meta_filename)

--- a/src/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/src/spikeinterface/extractors/tests/test_neoextractors.py
@@ -67,9 +67,9 @@ class SpikeGLXRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
     downloads = ["spikeglx"]
     entities = [
         ("spikeglx/Noise4Sam_g0", {"stream_id": "imec0.ap"}),
-        ("spikeglx/Noise4Sam_g0", {"stream_id": "imec0.ap", "load_sync_channel": True}),
         ("spikeglx/Noise4Sam_g0", {"stream_id": "imec0.lf"}),
         ("spikeglx/Noise4Sam_g0", {"stream_id": "nidq"}),
+        ("spikeglx/Noise4Sam_g0", {"stream_id": "imec0.ap-SYNC"}),
     ]
 
 


### PR DESCRIPTION
After this PR on neo:
https://github.com/NeuralEnsemble/python-neo/pull/1683

the sync channel is separated into its own stream. However, if someone wants to load the stream-sync there is an error:


```python
from pathlib import Path

from spikeinterface.extractors import SpikeGLXRecordingExtractor

recording = SpikeGLXRecordingExtractor(folder_path=folder_path, stream_name="imec0.ap-SYNC")
recording


KeyError: 'imec0.ap-SYNC'
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[4], line 5
      1 from pathlib import Path
      3 from spikeinterface.extractors import SpikeGLXRecordingExtractor
----> 5 recording = SpikeGLXRecordingExtractor(folder_path=folder_path, stream_name="imec0.ap-SYNC")
      6 recording

File ~/development/spikeinterface/src/spikeinterface/extractors/neoextractors/spikeglx.py:80, in SpikeGLXRecordingExtractor.__init__(self, folder_path, load_sync_channel, stream_id, stream_name, all_annotations, use_names_as_ids)
     78 # Checks if the probe information is available and adds location, shanks and sample shift if available.
     79 signals_info_dict = {e["stream_name"]: e for e in self.neo_reader.signals_info_list}
---> 80 meta_filename = signals_info_dict[self.stream_id]["meta_file"]
     81 ap_meta_filename = meta_filename.replace(".lf", ".ap") if "lf" in self.stream_id else meta_filename
     82 ap_meta_file_exists = Path(ap_meta_filename).exists()

KeyError: 'imec0.ap-SYNC'
```


The reason for this is that stream id is [built on the fly](https://github.com/NeuralEnsemble/python-neo/blob/ab821e727a4081fa7e8ace0e0aa79591f67096a4/neo/rawio/spikeglxrawio.py#L221-L224) for the synch data  and therefore is not available in the `neo_reader.signals_info_list` so this fails.

This PR fixes it by just avoiding this lookup when the sync stream is requested. It also adds a test and removes a test for loading the sync channel as that feature is going to be removed.