### PR TITLE
Automatically install the maxwell plugin in the MaxwellRecordingExtractor 

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/maxwell.py
+++ b/src/spikeinterface/extractors/neoextractors/maxwell.py
@@ -36,7 +36,7 @@ class MaxwellRecordingExtractor(NeoBaseRecordingExtractor):
     rec_name : str, default: None
         When the file contains several recordings you need to specify the one
         you want to extract. (rec_name='rec0000').
-    install_maxwell_plugin : bool, default: False
+    install_maxwell_plugin : bool, default: True
         If True, install the maxwell plugin for neo.
     block_index : int, default: None
         If there are several blocks (experiments), specify the block index you want to load
@@ -52,7 +52,7 @@ class MaxwellRecordingExtractor(NeoBaseRecordingExtractor):
         block_index=None,
         all_annotations=False,
         rec_name=None,
-        install_maxwell_plugin=False,
+        install_maxwell_plugin=True,
         use_names_as_ids: bool = False,
     ):
         if install_maxwell_plugin:


### PR DESCRIPTION
Changed the defaults in the MaxwellRecordingExtractor to automatically download the Maxwell compression library if it is not locally available