### PR TITLE
cleanup __init__ of exporters + cleanup imports

### DIFF
--- a/src/spikeinterface/exporters/__init__.py
+++ b/src/spikeinterface/exporters/__init__.py
@@ -1,3 +1,3 @@
-from .to_phy import export_to_phy
-from .report import export_report
-from .to_ibl import export_to_ibl_gui
+from .to_phy import export_to_phy as export_to_phy
+from .report import export_report as export_report
+from .to_ibl import export_to_ibl_gui as export_to_ibl_gui

--- a/src/spikeinterface/exporters/tests/test_export_to_ibl.py
+++ b/src/spikeinterface/exporters/tests/test_export_to_ibl.py
@@ -5,7 +5,6 @@ from spikeinterface.exporters import export_to_ibl_gui
 
 from spikeinterface.exporters.tests.common import (
     make_sorting_analyzer,
-    sorting_analyzer_sparse_for_export,
 )
 
 required_output_files = [

--- a/src/spikeinterface/exporters/tests/test_export_to_phy.py
+++ b/src/spikeinterface/exporters/tests/test_export_to_phy.py
@@ -7,9 +7,6 @@ from spikeinterface.exporters import export_to_phy
 
 from spikeinterface.exporters.tests.common import (
     make_sorting_analyzer,
-    sorting_analyzer_dense_for_export,
-    sorting_analyzer_sparse_for_export,
-    sorting_analyzer_with_group_for_export,
 )
 
 

--- a/src/spikeinterface/exporters/to_ibl.py
+++ b/src/spikeinterface/exporters/to_ibl.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from importlib.util import find_spec
 import re
 import shutil
-import warnings
 from pathlib import Path
 
 import numpy as np
@@ -11,7 +10,6 @@ import numpy as np
 from spikeinterface.core import SortingAnalyzer, BaseRecording, get_random_data_chunks
 from spikeinterface.core.job_tools import fix_job_kwargs, ChunkRecordingExecutor, _shared_job_kwargs_doc
 from spikeinterface.core.template_tools import get_template_extremum_channel
-from spikeinterface.exporters import export_to_phy
 
 
 def export_to_ibl_gui(

--- a/src/spikeinterface/exporters/to_phy.py
+++ b/src/spikeinterface/exporters/to_phy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Optional
 
 import numpy as np
 import numpy.typing as npt


### PR DESCRIPTION
importing with
```python
from x import y as y
```

allows for full linter support in the future. If this is too contentious feel free to close this one :) 