### PR TITLE
Avoid crash of SC2 if no templates are detected after clustering

### DIFF
--- a/src/spikeinterface/sorters/internal/spyking_circus2.py
+++ b/src/spikeinterface/sorters/internal/spyking_circus2.py
@@ -382,7 +382,8 @@ class Spykingcircus2Sorter(ComponentsBasedSorter):
                     sorting.save(folder=curation_folder)
                     # np.save(fitting_folder / "amplitudes", guessed_amplitudes)
 
-                sorting = final_cleaning_circus(recording_w, sorting, templates, **merging_params, **job_kwargs)
+                if sorting.get_non_empty_unit_ids().size > 0:
+                    sorting = final_cleaning_circus(recording_w, sorting, templates, **merging_params, **job_kwargs)
 
                 if verbose:
                     print(f"Kept {len(sorting.unit_ids)} units after final merging")

--- a/src/spikeinterface/sortingcomponents/matching/main.py
+++ b/src/spikeinterface/sortingcomponents/matching/main.py
@@ -9,6 +9,13 @@ import numpy as np
 from spikeinterface.core.job_tools import fix_job_kwargs
 from spikeinterface.core.node_pipeline import run_node_pipeline
 
+spike_dtype = [
+    ("sample_index", "int64"),
+    ("channel_index", "int64"),
+    ("cluster_index", "int64"),
+    ("amplitude", "float64"),
+    ("segment_index", "int64"),
+]
 
 def find_spikes_from_templates(
     recording, method="naive", method_kwargs={}, extra_outputs=False, verbose=False, **job_kwargs
@@ -46,6 +53,9 @@ def find_spikes_from_templates(
     method_class = matching_methods[method]
     node0 = method_class(recording, **method_kwargs)
     nodes = [node0]
+    assert "templates" in method_kwargs, "You must provide templates in method_kwargs"
+    if len(method_kwargs["templates"].unit_ids) == 0:
+        return np.zeros(0, dtype=spike_dtype)
 
     spikes = run_node_pipeline(
         recording,


### PR DESCRIPTION
It can be that after clustering, no proper templates are detected. This is unlikely, but if so, the code is crashing. This PR prevents it and make sure that for any template matching based engine, the templates object has more than 0 templates