### PR TITLE
Fix durations in generate_hybrid_recording

### DIFF
--- a/src/spikeinterface/generation/hybrid_tools.py
+++ b/src/spikeinterface/generation/hybrid_tools.py
@@ -400,7 +400,7 @@ def generate_hybrid_recording(
     num_segments = recording.get_num_segments()
     dtype = recording.dtype
     num_samples = np.array([recording.get_num_samples(segment_index) for segment_index in range(num_segments)])
-    # since the recording can have timestamps with some smalle gaps, we use the number of samples to compute
+    # since the recording can have timestamps with some small gaps, we use the number of samples to compute
     # the duration used for the sorting generation
     durations = num_samples / sampling_frequency
     channel_locations = probe.contact_positions


### PR DESCRIPTION
In the hybrid generation, if the recording has timestamps, they might exceed the (num_samples/sampling_frequency) duration, generating spikes beyond the actual duration of the recording.

For hybrid generation we can simply use num_samples / sampling_frequency