### PR TITLE
First pass of deprecation removals for 0.103.0

### DIFF
--- a/doc/get_started/quickstart.rst
+++ b/doc/get_started/quickstart.rst
@@ -336,7 +336,7 @@ Alternatively we can pass a full dictionary containing the parameters:
 
     # parameters set by params dictionary
     sorting_TDC_2 = ss.run_sorter(
-        sorter_name="tridesclous", recording=recording_preprocessed, output_folder="tdc_output2", **other_params
+        sorter_name="tridesclous", recording=recording_preprocessed, folder="tdc_output2", **other_params
     )
     print(sorting_TDC_2)
 

--- a/doc/how_to/analyze_neuropixels.rst
+++ b/doc/how_to/analyze_neuropixels.rst
@@ -567,7 +567,7 @@ In this example:
     # run kilosort2.5 without drift correction
     params_kilosort2_5 = {'do_correction': False}
 
-    sorting = si.run_sorter('kilosort2_5', rec, output_folder=base_folder / 'kilosort2.5_output',
+    sorting = si.run_sorter('kilosort2_5', rec, folder=base_folder / 'kilosort2.5_output',
                             docker_image=True, verbose=True, **params_kilosort2_5)
 
 .. code:: ipython3

--- a/doc/how_to/process_by_channel_group.rst
+++ b/doc/how_to/process_by_channel_group.rst
@@ -160,7 +160,7 @@ sorting objects in a dictionary for later use.
         sorting = run_sorter(
             sorter_name='kilosort2',
             recording=split_preprocessed_recording,
-            output_folder=f"folder_KS2_group{group}"
+            folder=f"folder_KS2_group{group}"
             )
         sortings[group] = sorting
 

--- a/doc/modules/sorters.rst
+++ b/doc/modules/sorters.rst
@@ -55,15 +55,15 @@ to easily run spike sorters:
     from spikeinterface.sorters import run_sorter
 
     # run Tridesclous
-    sorting_TDC = run_sorter(sorter_name="tridesclous", recording=recording, output_folder="/folder_TDC")
+    sorting_TDC = run_sorter(sorter_name="tridesclous", recording=recording, folder="/folder_TDC")
     # run Kilosort2.5
-    sorting_KS2_5 = run_sorter(sorter_name="kilosort2_5", recording=recording, output_folder="/folder_KS2_5")
+    sorting_KS2_5 = run_sorter(sorter_name="kilosort2_5", recording=recording, folder="/folder_KS2_5")
     # run IronClust
-    sorting_IC = run_sorter(sorter_name="ironclust", recording=recording, output_folder="/folder_IC")
+    sorting_IC = run_sorter(sorter_name="ironclust", recording=recording, folder="/folder_IC")
     # run pyKilosort
-    sorting_pyKS = run_sorter(sorter_name="pykilosort", recording=recording, output_folder="/folder_pyKS")
+    sorting_pyKS = run_sorter(sorter_name="pykilosort", recording=recording, folder="/folder_pyKS")
     # run SpykingCircus
-    sorting_SC = run_sorter(sorter_name="spykingcircus", recording=recording, output_folder="/folder_SC")
+    sorting_SC = run_sorter(sorter_name="spykingcircus", recording=recording, folder="/folder_SC")
 
 
 Then the output, which is a :py:class:`~spikeinterface.core.BaseSorting` object, can be easily
@@ -87,10 +87,10 @@ Spike-sorter-specific parameters can be controlled directly from the
 
 .. code-block:: python
 
-    sorting_TDC = run_sorter(sorter_name='tridesclous', recording=recording, output_folder="/folder_TDC",
+    sorting_TDC = run_sorter(sorter_name='tridesclous', recording=recording, folder="/folder_TDC",
                              detect_threshold=8.)
 
-    sorting_KS2_5 = run_sorter(sorter_name="kilosort2_5", recording=recording, output_folder="/folder_KS2_5"
+    sorting_KS2_5 = run_sorter(sorter_name="kilosort2_5", recording=recording, folder="/folder_KS2_5"
                                do_correction=False, preclust_threshold=6, freq_min=200.)
 
 
@@ -193,7 +193,7 @@ The following code creates a test recording and runs a containerized spike sorte
 
     sorting = ss.run_sorter(sorter_name='kilosort3',
         recording=test_recording,
-        output_folder="kilosort3",
+        folder="kilosort3",
         singularity_image=True)
 
     print(sorting)
@@ -208,7 +208,7 @@ To run in Docker instead of Singularity, use ``docker_image=True``.
 .. code-block:: python
 
     sorting = run_sorter(sorter_name='kilosort3', recording=test_recording,
-                         output_folder="/tmp/kilosort3", docker_image=True)
+                         folder="/tmp/kilosort3", docker_image=True)
 
 To use a specific image, set either ``docker_image`` or ``singularity_image`` to a string,
 e.g. ``singularity_image="spikeinterface/kilosort3-compiled-base:0.1.0"``.
@@ -217,7 +217,7 @@ e.g. ``singularity_image="spikeinterface/kilosort3-compiled-base:0.1.0"``.
 
     sorting = run_sorter(sorter_name="kilosort3",
         recording=test_recording,
-        output_folder="kilosort3",
+        folder="kilosort3",
         singularity_image="spikeinterface/kilosort3-compiled-base:0.1.0")
 
 
@@ -301,10 +301,10 @@ an :code:`engine` that supports parallel processing (such as :code:`joblib` or :
     another_recording = ...
 
     job_list = [
-      {'sorter_name': 'tridesclous', 'recording': recording, 'output_folder': 'folder1','detect_threshold': 5.},
-      {'sorter_name': 'tridesclous', 'recording': another_recording, 'output_folder': 'folder2', 'detect_threshold': 5.},
-      {'sorter_name': 'herdingspikes', 'recording': recording, 'output_folder': 'folder3', 'clustering_bandwidth': 8., 'docker_image': True},
-      {'sorter_name': 'herdingspikes', 'recording': another_recording, 'output_folder': 'folder4', 'clustering_bandwidth': 8., 'docker_image': True},
+      {'sorter_name': 'tridesclous', 'recording': recording, 'folder': 'folder1','detect_threshold': 5.},
+      {'sorter_name': 'tridesclous', 'recording': another_recording, 'folder': 'folder2', 'detect_threshold': 5.},
+      {'sorter_name': 'herdingspikes', 'recording': recording, 'folder': 'folder3', 'clustering_bandwidth': 8., 'docker_image': True},
+      {'sorter_name': 'herdingspikes', 'recording': another_recording, 'folder': 'folder4', 'clustering_bandwidth': 8., 'docker_image': True},
     ]
 
     # run in loop
@@ -380,7 +380,7 @@ In this example, we create a 16-channel recording with 4 tetrodes:
     # here the result is a dict of a sorting object
     sortings = {}
     for group, sub_recording in recordings.items():
-        sorting = run_sorter(sorter_name='kilosort2', recording=recording, output_folder=f"folder_KS2_group{group}")
+        sorting = run_sorter(sorter_name='kilosort2', recording=recording, folder=f"folder_KS2_group{group}")
         sortings[group] = sorting
 
 **Option 2 : Automatic splitting**
@@ -390,7 +390,7 @@ In this example, we create a 16-channel recording with 4 tetrodes:
     # here the result is one sorting that aggregates all sub sorting objects
     aggregate_sorting = run_sorter_by_property(sorter_name='kilosort2', recording=recording_4_tetrodes,
                                                grouping_property='group',
-                                               working_folder='working_path')
+                                               folder='working_path')
 
 
 Handling multi-segment recordings
@@ -546,7 +546,7 @@ From the user's perspective, they behave exactly like the external sorters:
 
 .. code-block:: python
 
-    sorting = run_sorter(sorter_name="spykingcircus2", recording=recording, output_folder="/tmp/folder")
+    sorting = run_sorter(sorter_name="spykingcircus2", recording=recording, folder="/tmp/folder")
 
 
 Contributing

--- a/examples/tutorials/qualitymetrics/plot_3_quality_metrics.py
+++ b/examples/tutorials/qualitymetrics/plot_3_quality_metrics.py
@@ -9,12 +9,10 @@ After spike sorting, you might want to validate the 'goodness' of the sorted uni
 
 import spikeinterface.core as si
 import spikeinterface.extractors as se
-from spikeinterface.postprocessing import compute_principal_components
 from spikeinterface.qualitymetrics import (
     compute_snrs,
     compute_firing_rates,
     compute_isi_violations,
-    calculate_pc_metrics,
     compute_quality_metrics,
 )
 
@@ -70,7 +68,7 @@ print(metrics)
 
 ##############################################################################
 # Some metrics are based on the principal component scores, so the exwtension
-# need to be computed before. For instance:
+# must be computed before. For instance:
 
 analyzer.compute("principal_components", n_components=3, mode="by_channel_global", whiten=True)
 

--- a/installation_tips/check_your_install.py
+++ b/installation_tips/check_your_install.py
@@ -21,7 +21,7 @@ def _run_one_sorter_and_analyzer(sorter_name):
     job_kwargs = dict(n_jobs=-1, progress_bar=True, chunk_duration="1s")
     import spikeinterface.full as si
     recording = si.load_extractor('./toy_example_recording')
-    sorting = si.run_sorter(sorter_name, recording, output_folder=f'./sorter_with_{sorter_name}', verbose=False)
+    sorting = si.run_sorter(sorter_name, recording, folder=f'./sorter_with_{sorter_name}', verbose=False)
 
     sorting_analyzer = si.create_sorting_analyzer(sorting, recording,
                                                 format="binary_folder", folder=f"./analyzer_with_{sorter_name}",

--- a/src/spikeinterface/benchmark/benchmark_motion_interpolation.py
+++ b/src/spikeinterface/benchmark/benchmark_motion_interpolation.py
@@ -53,7 +53,7 @@ class MotionInterpolationBenchmark(Benchmark):
         sorting = run_sorter(
             sorter_name,
             recording,
-            output_folder=self.sorter_folder,
+            folder=self.sorter_folder,
             **sorter_params,
             delete_output_folder=False,
         )

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -369,21 +369,6 @@ class BaseRecording(BaseRecordingSnippets):
                 traces = traces.astype("float32", copy=False) * gains + offsets
         return traces
 
-    def has_scaled_traces(self) -> bool:
-        """Checks if the recording has scaled traces
-
-        Returns
-        -------
-        bool
-            True if the recording has scaled traces, False otherwise
-        """
-        warnings.warn(
-            "`has_scaled_traces` is deprecated and will be removed in 0.103.0. Use has_scaleable_traces() instead",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.has_scaled()
-
     def get_time_info(self, segment_index=None) -> dict:
         """
         Retrieves the timing attributes for a given segment index. As with
@@ -725,17 +710,6 @@ class BaseRecording(BaseRecordingSnippets):
 
         return ChannelSliceRecording(self, renamed_channel_ids=new_channel_ids)
 
-    def _channel_slice(self, channel_ids, renamed_channel_ids=None):
-        from .channelslice import ChannelSliceRecording
-
-        warnings.warn(
-            "Recording.channel_slice will be removed in version 0.103, use `select_channels` or `rename_channels` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        sub_recording = ChannelSliceRecording(self, channel_ids, renamed_channel_ids=renamed_channel_ids)
-        return sub_recording
-
     def _remove_channels(self, remove_channel_ids):
         from .channelslice import ChannelSliceRecording
 
@@ -878,8 +852,6 @@ class BaseRecording(BaseRecordingSnippets):
         time_axis=None,
         file_paths_length=None,
         file_offset=None,
-        file_suffix=None,
-        file_paths_lenght=None,
     ):
         """
         Check is the recording is binary compatible with some constrain on
@@ -890,14 +862,6 @@ class BaseRecording(BaseRecordingSnippets):
           * file_offset
           * file_suffix
         """
-
-        # spelling typo need to fix
-        if file_paths_lenght is not None:
-            warnings.warn(
-                "`file_paths_lenght` is deprecated and will be removed in 0.103.0 please use `file_paths_length`"
-            )
-            if file_paths_length is None:
-                file_paths_length = file_paths_lenght
 
         if not self.is_binary_compatible():
             return False

--- a/src/spikeinterface/core/baserecordingsnippets.py
+++ b/src/spikeinterface/core/baserecordingsnippets.py
@@ -51,14 +51,6 @@ class BaseRecordingSnippets(BaseExtractor):
         else:
             return True
 
-    def has_scaled(self):
-        warn(
-            "`has_scaled` has been deprecated and will be removed in 0.103.0. Please use `has_scaleable_traces()`",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.has_scaleable_traces()
-
     def has_probe(self) -> bool:
         return "contact_vector" in self.get_property_keys()
 
@@ -231,21 +223,6 @@ class BaseRecordingSnippets(BaseExtractor):
         for probe in probegroup.probes:
             probes_info.append(probe.annotations)
         self.annotate(probes_info=probes_info)
-
-        return sub_recording
-
-    def set_probes(self, probe_or_probegroup, group_mode="by_probe", in_place=False):
-
-        warning_msg = (
-            "`set_probes` is now a private function and the public function will be "
-            "removed in 0.103.0. Please use `set_probe` or `set_probegroup` instead"
-        )
-
-        warn(warning_msg, category=DeprecationWarning, stacklevel=2)
-
-        sub_recording = self._set_probes(
-            probe_or_probegroup=probe_or_probegroup, group_mode=group_mode, in_place=in_place
-        )
 
         return sub_recording
 

--- a/src/spikeinterface/core/basesnippets.py
+++ b/src/spikeinterface/core/basesnippets.py
@@ -79,14 +79,6 @@ class BaseSnippets(BaseRecordingSnippets):
     def get_num_segments(self):
         return len(self._snippets_segments)
 
-    def has_scaled_snippets(self):
-        warn(
-            "`has_scaled_snippets` is deprecated and will be removed in version 0.103.0. Please use `has_scaleable_traces()` instead",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.has_scaleable_traces()
-
     def get_frames(self, indices=None, segment_index: Union[int, None] = None):
         segment_index = self._check_segment_index(segment_index)
         spts = self._snippets_segments[segment_index]

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -30,7 +30,6 @@ _sparsity_doc = """
         * "by_property" : sparsity is given by a property of the recording and sorting (e.g. "group").
                          In this case the sparsity for each unit is given by the channels that have the same property
                          value as the unit. Use the "by_property" argument to specify the property name.
-        * "ptp: : deprecated, use the 'snr' method with the 'peak_to_peak' amplitude mode instead.
 
     peak_sign : "neg" | "pos" | "both"
         Sign of the template to compute best channels.
@@ -453,33 +452,6 @@ class ChannelSparsity:
             chan_inds = np.nonzero((np.abs(peak_values[unit_id]) / noise_levels) >= threshold)
             mask[unit_ind, chan_inds] = True
         return cls(mask, unit_ids, channel_ids)
-
-    @classmethod
-    def from_ptp(cls, templates_or_sorting_analyzer, threshold, noise_levels=None):
-        """
-        Construct sparsity from a thresholds based on template peak-to-peak values.
-        Use the "threshold" argument to specify the peak-to-peak threshold.
-
-        Parameters
-        ----------
-        templates_or_sorting_analyzer : Templates | SortingAnalyzer
-            A Templates or a SortingAnalyzer object.
-        threshold : float
-            Threshold for "ptp" method (in units of amplitude).
-
-        Returns
-        -------
-        sparsity : ChannelSparsity
-            The estimated sparsity.
-        """
-        warnings.warn(
-            "The 'ptp' method is deprecated and will be removed in version 0.103.0. "
-            "Please use the 'snr' method with the 'peak_to_peak' amplitude mode instead.",
-            DeprecationWarning,
-        )
-        return cls.from_snr(
-            templates_or_sorting_analyzer, threshold, amplitude_mode="peak_to_peak", noise_levels=noise_levels
-        )
 
     @classmethod
     def from_amplitude(cls, templates_or_sorting_analyzer, threshold, amplitude_mode="extremum", peak_sign="neg"):

--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -53,16 +53,6 @@ def read_file_from_backend(
         else:
             raise RuntimeError(f"{file_path} is not a valid HDF5 file!")
 
-    elif stream_mode == "ros3":
-        import h5py
-
-        assert file_path is not None, "file_path must be specified when using stream_mode='ros3'"
-
-        drivers = h5py.registered_drivers()
-        assertion_msg = "ROS3 support not enbabled, use: install -c conda-forge h5py>=3.2 to enable streaming"
-        assert "ros3" in drivers, assertion_msg
-        open_file = h5py.File(name=file_path, mode="r", driver="ros3")
-
     elif stream_mode == "remfile":
         import remfile
         import h5py
@@ -534,13 +524,6 @@ class NwbRecordingExtractor(BaseRecording, _BaseNWBExtractor):
         storage_options: dict | None = None,
         use_pynwb: bool = False,
     ):
-
-        if stream_mode == "ros3":
-            warnings.warn(
-                "The 'ros3' stream_mode is deprecated and will be removed in version 0.103.0. "
-                "Use 'fsspec' stream_mode instead.",
-                DeprecationWarning,
-            )
 
         if file_path is not None and file is not None:
             raise ValueError("Provide either file_path or file, not both")
@@ -1061,13 +1044,6 @@ class NwbSortingExtractor(BaseSorting, _BaseNWBExtractor):
         storage_options: dict | None = None,
         use_pynwb: bool = False,
     ):
-
-        if stream_mode == "ros3":
-            warnings.warn(
-                "The 'ros3' stream_mode is deprecated and will be removed in version 0.103.0. "
-                "Use 'fsspec' stream_mode instead.",
-                DeprecationWarning,
-            )
 
         self.stream_mode = stream_mode
         self.stream_cache_path = stream_cache_path

--- a/src/spikeinterface/extractors/tests/test_nwbextractors_streaming.py
+++ b/src/spikeinterface/extractors/tests/test_nwbextractors_streaming.py
@@ -73,7 +73,7 @@ def test_recording_s3_nwb_remfile():
         assert full_traces.shape == (num_frames, num_chans)
         assert full_traces.dtype == dtype
 
-    if rec.has_scaled():
+    if rec.has_scaleable_traces():
         trace_scaled = rec.get_traces(segment_index=segment_index, return_scaled=True, end_frame=2)
         assert trace_scaled.dtype == "float32"
 
@@ -103,7 +103,7 @@ def test_recording_s3_nwb_remfile_file_like(tmp_path):
         assert full_traces.shape == (num_frames, num_chans)
         assert full_traces.dtype == dtype
 
-    if rec.has_scaled():
+    if rec.has_scaleable_traces():
         trace_scaled = rec.get_traces(segment_index=segment_index, return_scaled=True, end_frame=2)
         assert trace_scaled.dtype == "float32"
 

--- a/src/spikeinterface/qualitymetrics/pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/pca_metrics.py
@@ -229,28 +229,6 @@ def compute_pc_metrics(
     return pc_metrics
 
 
-def calculate_pc_metrics(
-    sorting_analyzer, metric_names=None, metric_params=None, unit_ids=None, seed=None, n_jobs=1, progress_bar=False
-):
-    warnings.warn(
-        "The `calculate_pc_metrics` function is deprecated and will be removed in 0.103.0. Please use compute_pc_metrics instead",
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-
-    pc_metrics = compute_pc_metrics(
-        sorting_analyzer,
-        metric_names=metric_names,
-        metric_params=metric_params,
-        unit_ids=unit_ids,
-        seed=seed,
-        n_jobs=n_jobs,
-        progress_bar=progress_bar,
-    )
-
-    return pc_metrics
-
-
 #################################################################
 # Code from spikemetrics
 

--- a/src/spikeinterface/qualitymetrics/quality_metric_list.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_list.py
@@ -22,7 +22,6 @@ from .misc_metrics import (
 
 from .pca_metrics import (
     compute_pc_metrics,
-    calculate_pc_metrics,  # remove after 0.103.0
     mahalanobis_metrics,
     lda_metrics,
     nearest_neighbors_metrics,

--- a/src/spikeinterface/qualitymetrics/tests/test_pca_metrics.py
+++ b/src/spikeinterface/qualitymetrics/tests/test_pca_metrics.py
@@ -4,7 +4,7 @@ import numpy as np
 from spikeinterface.qualitymetrics import compute_pc_metrics, get_quality_pca_metric_list
 
 
-def test_calculate_pc_metrics(small_sorting_analyzer):
+def test_compute_pc_metrics(small_sorting_analyzer):
     import pandas as pd
 
     sorting_analyzer = small_sorting_analyzer

--- a/src/spikeinterface/sorters/launcher.py
+++ b/src/spikeinterface/sorters/launcher.py
@@ -239,7 +239,6 @@ def run_sorter_by_property(
     verbose=False,
     docker_image=None,
     singularity_image=None,
-    working_folder: None = None,
     **sorter_params,
 ):
     """
@@ -300,14 +299,6 @@ def run_sorter_by_property(
             DeprecationWarning,
             stacklevel=2,
         )
-
-    if working_folder is not None:
-        warnings.warn(
-            "`working_folder` is deprecated and will be removed in 0.103. Please use folder instead",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        folder = working_folder
 
     working_folder = Path(folder).absolute()
 

--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -95,8 +95,6 @@ _common_param_doc = """
         If True, the output Sorting is returned as a Sorting
     delete_container_files : bool, default: True
         If True, the container temporary files are deleted after the sorting is done
-    output_folder : None, default: None
-        Do not use. Deprecated output function to be removed in 0.103.
     **sorter_params : keyword args
         Spike sorter specific arguments (they can be retrieved with `get_default_sorter_params(sorter_name_or_class)`)
 
@@ -119,7 +117,6 @@ def run_sorter(
     singularity_image: Optional[Union[bool, str]] = False,
     delete_container_files: bool = True,
     with_output: bool = True,
-    output_folder: None = None,
     **sorter_params,
 ):
     """
@@ -131,13 +128,6 @@ def run_sorter(
     --------
     >>> sorting = run_sorter("tridesclous", recording)
     """
-
-    if output_folder is not None and folder is None:
-        deprecation_msg = (
-            "`output_folder` is deprecated and will be removed in version 0.103.0 Please use folder instead"
-        )
-        folder = output_folder
-        warn(deprecation_msg, category=DeprecationWarning, stacklevel=2)
 
     common_kwargs = dict(
         sorter_name=sorter_name,
@@ -210,7 +200,6 @@ def run_sorter_local(
     verbose=False,
     raise_error=True,
     with_output=True,
-    output_folder=None,
     **sorter_params,
 ):
     """
@@ -235,19 +224,10 @@ def run_sorter_local(
         If False, the process continues and the error is logged in the log file
     with_output : bool, default: True
         If True, the output Sorting is returned as a Sorting
-    output_folder : None, default: None
-        Do not use. Deprecated output function to be removed in 0.103.
     **sorter_params : keyword args
     """
     if isinstance(recording, list):
         raise Exception("If you want to run several sorters/recordings use run_sorter_jobs(...)")
-
-    if output_folder is not None and folder is None:
-        deprecation_msg = (
-            "`output_folder` is deprecated and will be removed in version 0.103.0 Please use folder instead"
-        )
-        folder = output_folder
-        warn(deprecation_msg, category=DeprecationWarning, stacklevel=2)
 
     SorterClass = sorter_dict[sorter_name]
 
@@ -294,7 +274,6 @@ def run_sorter_container(
     installation_mode="auto",
     spikeinterface_version=None,
     spikeinterface_folder_source=None,
-    output_folder: None = None,
     **sorter_params,
 ):
     """
@@ -309,8 +288,6 @@ def run_sorter_container(
         The container mode : "docker" or "singularity"
     container_image : str, default: None
         The container image name and tag. If None, the default container image is used
-    output_folder : str, default: None
-        Path to output folder
     remove_existing_folder : bool, default: True
         If True and output_folder exists yet then delete
     delete_output_folder : bool, default: False
@@ -345,13 +322,6 @@ def run_sorter_container(
     """
 
     assert installation_mode in ("auto", "pypi", "github", "folder", "dev", "no-install")
-
-    if output_folder is not None and folder is None:
-        deprecation_msg = (
-            "`output_folder` is deprecated and will be removed in version 0.103.0 Please use folder instead"
-        )
-        folder = output_folder
-        warn(deprecation_msg, category=DeprecationWarning, stacklevel=2)
     spikeinterface_version = spikeinterface_version or si_version
 
     if extra_requirements is None:


### PR DESCRIPTION
I just did a search of the code base for all our dep warnings for removals in 0.103.0 and removed, updated some docs related to the deps and fixed tests that I could find. I probably missed something so I'll keep it on draft for the moment.