### PR TITLE
Fix soft vs hard merge issue in analyzer

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -960,6 +960,7 @@ class SortingAnalyzer:
             mergeable, masks = self.are_units_mergeable(
                 merge_unit_groups,
                 sparsity_overlap=sparsity_overlap,
+                merging_mode=merging_mode,
                 return_masks=True,
             )
 
@@ -967,21 +968,14 @@ class SortingAnalyzer:
                 if unit_id in new_unit_ids:
                     merge_unit_group = tuple(merge_unit_groups[new_unit_ids.index(unit_id)])
                     if not mergeable[merge_unit_group]:
-                        # if someone wants soft mode we error if they try to use an inappropriate sparsity overlap
-                        # if hard mode we can still use a sparsity if all units have good sparsity overlap
-                        # but if any merge_unit_group doesn't have an overlap then we have to not use the old
-                        # sparsity and instead use a new sparsity
-                        if merging_mode == "soft":
-                            raise Exception(
-                                f"The sparsity of {merge_unit_group} do not overlap enough for a soft merge using "
-                                f"a sparsity threshold of {sparsity_overlap}. You can either lower the threshold or use "
-                                "a hard merge."
-                            )
-                        else:
-                            sparsity = None
-                            break
-                    else:
-                        sparsity_mask[unit_index] = masks[merge_unit_group]
+                        # unit groups can be not mergeable only in "soft" mode
+                        # see are_units_mergeable() function
+                        raise Exception(
+                            f"The sparsity of {merge_unit_group} do not overlap enough for a soft merge using "
+                            f"a sparsity threshold of {sparsity_overlap}. You can either lower the threshold "
+                            "or use a hard merge."
+                        )
+                    sparsity_mask[unit_index] = masks[merge_unit_group]
                 else:
                     # This means that the unit is already in the previous sorting
                     index = self.sorting.id_to_index(unit_id)

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -967,11 +967,19 @@ class SortingAnalyzer:
                 if unit_id in new_unit_ids:
                     merge_unit_group = tuple(merge_unit_groups[new_unit_ids.index(unit_id)])
                     if not mergeable[merge_unit_group]:
-                        raise Exception(
-                            f"The sparsity of {merge_unit_group} do not overlap enough for a soft merge using "
-                            f"a sparsity threshold of {sparsity_overlap}. You can either lower the threshold or use "
-                            "a hard merge."
-                        )
+                        # if someone wants soft mode we error if they try to use an inappropriate sparsity overlap
+                        # if hard mode we can still use a sparsity if all units have good sparsity overlap
+                        # but if any merge_unit_group doesn't have an overlap then we have to not use the old
+                        # sparsity and instead use a new sparsity
+                        if merging_mode == "soft":
+                            raise Exception(
+                                f"The sparsity of {merge_unit_group} do not overlap enough for a soft merge using "
+                                f"a sparsity threshold of {sparsity_overlap}. You can either lower the threshold or use "
+                                "a hard merge."
+                            )
+                        else:
+                            sparsity = None
+                            break
                     else:
                         sparsity_mask[unit_index] = masks[merge_unit_group]
                 else:


### PR DESCRIPTION
Currently the code doesn't actually care if you are doing a soft or hard merge, it verifies the sparsity overlap for all units whether soft or hard and then errors even on hard merge if there is not an overlap. Confirmed by a labmate who ran

```python
merged_analyzer = analyzer.merge_units(
    new_merges,
    merging_mode='hard'
    sparsity_overlap = 0.75
)
```
and got an error
![image](https://github.com/user-attachments/assets/ddb1951b-21cd-4121-bd06-7ff3c2544c47)


To be honest I don't understand the merging mechanism well enough to know just setting sparsity to None for a hard merge is desired so I'm submitting this as a reminder that we should probably fix this before the next version. Sorry I don't really know how to make a MRE for this.

so help writing a test would be great.