### PR TITLE
Ignore AppleDouble format files on analyzer extension load

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -2219,6 +2219,7 @@ class AnalyzerExtension:
                     ext_data_file.name == "params.json"
                     or ext_data_file.name == "info.json"
                     or ext_data_file.name == "run_info.json"
+                    or str(ext_data_file.name).startswith("._")  # ignore AppleDouble format files
                 ):
                     continue
                 ext_data_name = ext_data_file.stem


### PR DESCRIPTION
MacOS sometimes saves shadow files in the AppleDouble format to help manage the filesystem. E.g. in one of my `analyzer/extensions/spike_locations` folders, this is the contens:

``` bash
❯ ls -la
total 257859
drwx------@ 1 christopherhalcrow  staff      16384 24 Jun 12:59 .
-rwx------  1 christopherhalcrow  staff       4096 27 Jan 11:18 ._info.json
drwx------  1 christopherhalcrow  staff      16384 22 Apr 18:32 ..
-rwx------@ 1 christopherhalcrow  staff        144 27 Jan 11:18 info.json
-rwx------  1 christopherhalcrow  staff        231 24 Jun 12:59 params.json
-rwx------  1 christopherhalcrow  staff         66 24 Jun 12:59 run_info.json
-rwx------  1 christopherhalcrow  staff  131828480 24 Jun 12:59 spike_locations.npy
```

The `._info.json` file is the AppleDouble format: they always begin in `._`.

When the extension is loaded, it tries to read the `._info.json` file and errors.

This PR tells the analyzer to ignore these files on an extension load.

This hasn't been a problem before: no idea if there's been a change in MacOS, pathlib or our Uni DataStore system.