### PR TITLE
Add `concatenated` to `_get_data` for amps and locs; use in `_get_amplitudes_by_units`

### DIFF
--- a/src/spikeinterface/postprocessing/spike_amplitudes.py
+++ b/src/spikeinterface/postprocessing/spike_amplitudes.py
@@ -111,7 +111,7 @@ class ComputeSpikeAmplitudes(AnalyzerExtension):
         )
         self.data["amplitudes"] = amps
 
-    def _get_data(self, outputs="numpy"):
+    def _get_data(self, outputs="numpy", concatenated=False):
         all_amplitudes = self.data["amplitudes"]
         if outputs == "numpy":
             return all_amplitudes
@@ -125,6 +125,16 @@ class ComputeSpikeAmplitudes(AnalyzerExtension):
                 for unit_id in unit_ids:
                     inds = spike_indices[segment_index][unit_id]
                     amplitudes_by_units[segment_index][unit_id] = all_amplitudes[inds]
+
+            if concatenated:
+                amplitudes_by_units_concatenated = {
+                    unit_id: np.concatenate(
+                        [amps_in_segment[unit_id] for amps_in_segment in amplitudes_by_units.values()]
+                    )
+                    for unit_id in unit_ids
+                }
+                return amplitudes_by_units_concatenated
+
             return amplitudes_by_units
         else:
             raise ValueError(f"Wrong .get_data(outputs={outputs}); possibilities are `numpy` or `by_unit`")

--- a/src/spikeinterface/postprocessing/spike_locations.py
+++ b/src/spikeinterface/postprocessing/spike_locations.py
@@ -142,7 +142,7 @@ class ComputeSpikeLocations(AnalyzerExtension):
         )
         self.data["spike_locations"] = spike_locations
 
-    def _get_data(self, outputs="numpy"):
+    def _get_data(self, outputs="numpy", concatenated=False):
         all_spike_locations = self.data["spike_locations"]
         if outputs == "numpy":
             return all_spike_locations
@@ -156,6 +156,16 @@ class ComputeSpikeLocations(AnalyzerExtension):
                 for unit_id in unit_ids:
                     inds = spike_indices[segment_index][unit_id]
                     spike_locations_by_units[segment_index][unit_id] = all_spike_locations[inds]
+
+            if concatenated:
+                locations_by_units_concatenated = {
+                    unit_id: np.concatenate(
+                        [locs_in_segment[unit_id] for locs_in_segment in spike_locations_by_units.values()]
+                    )
+                    for unit_id in unit_ids
+                }
+                return locations_by_units_concatenated
+
             return spike_locations_by_units
         else:
             raise ValueError(f"Wrong .get_data(outputs={outputs})")

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -805,17 +805,12 @@ _default_params["amplitude_cv"] = dict(
 
 def _get_amplitudes_by_units(sorting_analyzer, unit_ids, peak_sign):
     # used by compute_amplitude_cutoffs and compute_amplitude_medians
-    amplitudes_by_units = {}
-    if sorting_analyzer.has_extension("spike_amplitudes"):
-        spikes = sorting_analyzer.sorting.to_spike_vector()
-        ext = sorting_analyzer.get_extension("spike_amplitudes")
-        all_amplitudes = ext.get_data()
-        for unit_id in unit_ids:
-            unit_index = sorting_analyzer.sorting.id_to_index(unit_id)
-            spike_mask = spikes["unit_index"] == unit_index
-            amplitudes_by_units[unit_id] = all_amplitudes[spike_mask]
+
+    if (spike_amplitudes_extension := sorting_analyzer.get_extension("spike_amplitudes")) is not None:
+        return spike_amplitudes_extension.get_data(outputs="by_unit", concatenated=True)
 
     elif sorting_analyzer.has_extension("waveforms"):
+        amplitudes_by_units = {}
         waveforms_ext = sorting_analyzer.get_extension("waveforms")
         before = waveforms_ext.nbefore
         extremum_channels_ids = get_template_extremum_channel(sorting_analyzer, peak_sign=peak_sign)


### PR DESCRIPTION
Closes #4028

PR implements a `concatenated` argument in `get_data` method for the `spike_ampltiudes` and `spike_locations` extensions. This returns the data per unit, concatenated per segment. I think this is a helpful thing to have, and was easy to implement.

Then used this new functionality in `_get_amplitudes_by_units`.

Benchmarked using:
``` python
import spikeinterface.full as si
from spikeinterface.qualitymetrics.misc_metrics import _get_amplitudes_by_units
from time import perf_counter
import numpy as np

# an hour-long NP2-kilosort4 analyzer
sa_path = "/Users/christopherhalcrow/Downloads/kilosort4_sa"

times = []
for _ in range(10):
    
    sa = si.load_sorting_analyzer(sa_path, load_extensions=False)
    sa.load_extension("spike_amplitudes")
    t1 = perf_counter()
    amps = _get_amplitudes_by_units(sa, unit_ids=sa.unit_ids, peak_sign="neg")
    t2 = perf_counter()
    times.append(t2-t1)
    del sa

print(np.median(times))
```

On main: 1.68s
This PR, without numba: 1.13s 
This PR, with numba: 0.0806s

So a 20x speedup if numba is around :)