### PR TITLE
Try not splitting numpy version based on python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ classifiers = [
 
 
 dependencies = [
-    "numpy>=1.20;python_version<'3.13'",
-    "numpy>=2.0.0;python_version>='3.13'",
+    "numpy",
     "threadpoolctl>=3.0.0",
     "tqdm",
     "zarr>=2.18,<3",


### PR DESCRIPTION
Checking if tests pass when numpy version is not determined by python version.

If tests pass, would mean that `uv` can cleanly install `spikeinterface[full]`, and would help with environments which contain spikeinterface and packages which only support numpy<2.