### PR TITLE
Add lower bound version to numba

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ full = [
     "distinctipy",
     "matplotlib>=3.6", # matplotlib.colormaps
     "cuda-python; platform_system != 'Darwin'",
-    "numba",
+    "numba>=0.59",
     "skops",
     "huggingface_hub"
 ]


### PR DESCRIPTION
When using `uv` to install packages which depend on spikeinterface[full] (e.g. spikeinterface-gui), it somehow tries to install numba v0.53.1 (I can't figure out why...). This fails to install if you're using python>3.9.

This PR puts a lower bound on numba (0.59), which matches our python support (since numba 0.59  dropped support for python 3.8). This forces `uv` to resolve a numba version which will work with all python versions we support. Idea to try this came from https://github.com/astral-sh/uv/issues/14484#issuecomment-3044877590 "We recommend always adding lower bounds to dependencies, to avoid such problems."

In conclusion: this makes `uv run sigui` work out of the box.