### PR TITLE
Fix for file_suffix that is missing

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -852,6 +852,7 @@ class BaseRecording(BaseRecordingSnippets):
         time_axis=None,
         file_paths_length=None,
         file_offset=None,
+        file_suffix=None,
     ):
         """
         Check is the recording is binary compatible with some constrain on


### PR DESCRIPTION
I don't know why, but file_suffix is missing from the arguments, and undefined