### PR TITLE
Remove `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,0 @@
-import setuptools
-import warnings
-
-warnings.warn("Using `python setup.py` is legacy! See https://spikeinterface.readthedocs.io/en/latest/installation.html for installation")
-
-if __name__ == "__main__":
-    setuptools.setup()


### PR DESCRIPTION
Copied from `setup.py` information (link below for those that want to read the full explanation.

```
nd setup.py is a valid configuration file for [Setuptools](https://packaging.python.org/en/latest/key_projects/#setuptools) that happens to be written in Python, instead of in TOML for example (a similar practice is used by other tools like nox and its noxfile.py configuration file, or pytest and conftest.py).

However, python setup.py and the use of setup.py as a command line tool are deprecated.

This means that commands such as the following MUST NOT be run anymore:

python setup.py install
python setup.py develop
python setup.py sdist
python setup.py bdist_wheel
```
https://packaging.python.org/en/latest/discussions/setup-py-deprecated/

We only have the `setup.py` as a deprecated command line tool, which is not to be used anymore. We are not using it as a config file. So we should remove it as users should not use it to build the package.