### PR TITLE
Add motion functions to api docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -76,7 +76,7 @@ Low-level
     .. autoclass:: ChunkRecordingExecutor
 
 
-Back-compatibility with ``WaveformExtractor`` (version < 0.101.0)
+Back-compatibility with ``WaveformExtractor`` (version > 0.100.0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: spikeinterface.core
@@ -179,6 +179,8 @@ spikeinterface.preprocessing
     .. autofunction:: correct_motion
     .. autofunction:: get_motion_presets
     .. autofunction:: get_motion_parameters_preset
+    .. autofunction:: load_motion_info
+    .. autofunction:: save_motion_info
     .. autofunction:: depth_order
     .. autofunction:: detect_bad_channels
     .. autofunction:: directional_derivative

--- a/doc/how_to/handle_drift.rst
+++ b/doc/how_to/handle_drift.rst
@@ -1322,8 +1322,6 @@ A preset is a nested dict that contains theses methods/parameters.
 Run motion correction with one function!
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Correcting for drift is easy! You just need to run a single function. We
-will try this function with some presets.
 
 Here we also save the motion correction results into a folder to be able
 to load them later.

--- a/examples/how_to/handle_drift.py
+++ b/examples/how_to/handle_drift.py
@@ -109,9 +109,6 @@ one_preset_params
 
 # ### Run motion correction with one function!
 #
-# Correcting for drift is easy! You just need to run a single function.
-# We will try this function with some presets.
-#
 # Here we also save the motion correction results into a folder to be able to load them later.
 
 # lets try theses presets

--- a/src/spikeinterface/preprocessing/motion.py
+++ b/src/spikeinterface/preprocessing/motion.py
@@ -568,6 +568,19 @@ def correct_motion(
 
 
 def save_motion_info(motion_info, folder, overwrite=False):
+    """
+    Saves motion info
+
+    Parameters
+    ----------
+    motion_info : dict
+        The returned motion_info from running `compute_motion`
+    folder : str | Path
+        The path for saving the `motion_info`
+    overwrite : bool, default: False
+        Whether to overwrite the folder location when saving motion info
+
+    """
     folder = Path(folder)
     if folder.is_dir():
         if not overwrite:
@@ -590,6 +603,18 @@ def save_motion_info(motion_info, folder, overwrite=False):
 
 
 def load_motion_info(folder):
+    """
+    Loads a motion info dict from folder
+    Parameters
+    ----------
+    folder : str | Path
+        The folder containing the motion info to load
+
+    Notes
+    -----
+    Loads both current Motion implmemntation as well as the
+    legacy Motion format
+    """
     from spikeinterface.core.motion import Motion
 
     folder = Path(folder)

--- a/src/spikeinterface/preprocessing/motion.py
+++ b/src/spikeinterface/preprocessing/motion.py
@@ -605,6 +605,7 @@ def save_motion_info(motion_info, folder, overwrite=False):
 def load_motion_info(folder):
     """
     Loads a motion info dict from folder
+
     Parameters
     ----------
     folder : str | Path
@@ -612,8 +613,9 @@ def load_motion_info(folder):
 
     Notes
     -----
-    Loads both current Motion implmemntation as well as the
+    Loads both current Motion implementation as well as the
     legacy Motion format
+
     """
     from spikeinterface.core.motion import Motion
 


### PR DESCRIPTION
Fixes #3083.

The second half of missing api functions. Now added to the api.rst.

Also a tiny fix. The semantic (that Chris and I discussed) for saying backward compatible would be to save that it is for versions greater than what we are being compatible to. So I think we want to actually list this compatibility as > 100 rather than < 101. Otherwise I think we would rewrite that whole statement.