### PR TITLE
Fix silence period and job_kwargs

### DIFF
--- a/src/spikeinterface/preprocessing/silence_periods.py
+++ b/src/spikeinterface/preprocessing/silence_periods.py
@@ -5,8 +5,9 @@ import numpy as np
 from spikeinterface.core.core_tools import define_function_handling_dict_from_class
 from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 
-from spikeinterface.core import get_random_data_chunks, get_noise_levels
+from spikeinterface.core import get_noise_levels
 from spikeinterface.core.generate import NoiseGeneratorRecording
+from spikeinterface.core.job_tools import split_job_kwargs
 
 
 class SilencedPeriodsRecording(BasePreprocessor):
@@ -48,6 +49,8 @@ class SilencedPeriodsRecording(BasePreprocessor):
         available_modes = ("zeros", "noise")
         num_seg = recording.get_num_segments()
 
+        random_chunk_kwargs, job_kwargs = split_job_kwargs(random_chunk_kwargs) 
+
         if num_seg == 1:
             if isinstance(list_periods, (list, np.ndarray)) and np.array(list_periods).ndim == 2:
                 # when unique segment accept list instead of of list of list/arrays
@@ -74,7 +77,7 @@ class SilencedPeriodsRecording(BasePreprocessor):
                 random_slices_kwargs = random_chunk_kwargs.copy()
                 random_slices_kwargs["seed"] = seed
                 noise_levels = get_noise_levels(
-                    recording, return_scaled=False, random_slices_kwargs=random_slices_kwargs
+                    recording, return_scaled=False, random_slices_kwargs=random_slices_kwargs, **job_kwargs
                 )
             noise_generator = NoiseGeneratorRecording(
                 num_channels=recording.get_num_channels(),
@@ -97,7 +100,7 @@ class SilencedPeriodsRecording(BasePreprocessor):
             rec_segment = SilencedPeriodsRecordingSegment(parent_segment, periods, mode, noise_generator, seg_index)
             self.add_recording_segment(rec_segment)
 
-        self._kwargs = dict(recording=recording, list_periods=list_periods, mode=mode, seed=seed)
+        self._kwargs = dict(recording=recording, list_periods=list_periods, mode=mode, seed=seed, noise_levels=noise_levels)
         self._kwargs.update(random_chunk_kwargs)
 
 

--- a/src/spikeinterface/preprocessing/silence_periods.py
+++ b/src/spikeinterface/preprocessing/silence_periods.py
@@ -37,6 +37,12 @@ class SilencedPeriodsRecording(BasePreprocessor):
         - "noise": The periods are filled with a gaussion noise that has the
                    same variance that the one in the recordings, on a per channel
                    basis
+    job_kwargs : dict
+        Keyword arguments for the joblib parallelization. If you want to use
+        `job_kwargs`, you need to pass them as a dictionary with the key "job_kwargs".
+        For example, `job_kwargs={"num_workers": 4}`.
+        Note that this is not used for the `get_noise_levels` function, which has its own
+        `random_slices_kwargs` argument.
     **random_chunk_kwargs : Keyword arguments for `spikeinterface.core.get_random_data_chunk()` function
 
     Returns
@@ -45,11 +51,9 @@ class SilencedPeriodsRecording(BasePreprocessor):
         The recording extractor after silencing some periods
     """
 
-    def __init__(self, recording, list_periods, mode="zeros", noise_levels=None, seed=None, **random_chunk_kwargs):
+    def __init__(self, recording, list_periods, mode="zeros", noise_levels=None, seed=None, job_kwargs=dict(), **random_chunk_kwargs):
         available_modes = ("zeros", "noise")
         num_seg = recording.get_num_segments()
-
-        random_chunk_kwargs, job_kwargs = split_job_kwargs(random_chunk_kwargs) 
 
         if num_seg == 1:
             if isinstance(list_periods, (list, np.ndarray)) and np.array(list_periods).ndim == 2:


### PR DESCRIPTION
Putative attempt to fix #4038, by explicitly exposing job_kwargs to the silence_period function, in order to allow the user to set them explicitly. In addition, noise_levels are now saved explicitly in extra_kwargs. In theory, once a first call to noise_levels has been made, they should be cached and thus no recomputation should be made. 