### PR TITLE
Add missing functions in API

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -176,6 +176,7 @@ spikeinterface.preprocessing
     .. autofunction:: clip
     .. autofunction:: common_reference
     .. autofunction:: correct_lsb
+    .. autofunction:: compute_motion
     .. autofunction:: correct_motion
     .. autofunction:: get_motion_presets
     .. autofunction:: get_motion_parameters_preset
@@ -183,6 +184,8 @@ spikeinterface.preprocessing
     .. autofunction:: save_motion_info
     .. autofunction:: depth_order
     .. autofunction:: detect_bad_channels
+    .. autofunction:: detect_and_interpolate_bad_channels
+    .. autofunction:: detect_and_remove_bad_channels
     .. autofunction:: directional_derivative
     .. autofunction:: filter
     .. autofunction:: gaussian_filter

--- a/src/spikeinterface/preprocessing/interpolate_bad_channels.py
+++ b/src/spikeinterface/preprocessing/interpolate_bad_channels.py
@@ -133,11 +133,11 @@ class DetectAndInterpolateBadChannelsRecording(InterpolateBadChannelsRecording):
         self._kwargs.update(all_bad_channels_kwargs)
 
 
-detect_and_interpolate_bad_channels = define_function_handling_dict_from_class(
-    source_class=DetectAndInterpolateBadChannelsRecording, name="detect_and_interpolate_bad_channels"
-)
 DetectAndInterpolateBadChannelsRecording.__doc__ = DetectAndInterpolateBadChannelsRecording.__doc__.format(
     _bad_channel_detection_kwargs_doc
+)
+detect_and_interpolate_bad_channels = define_function_handling_dict_from_class(
+    source_class=DetectAndInterpolateBadChannelsRecording, name="detect_and_interpolate_bad_channels"
 )
 
 


### PR DESCRIPTION
A few missing entries in the API and fix docstrings for `detect_and_interpolate_bad_channels`
