### PR TITLE
Fix set_properties_after_merging when property is boolean.

### DIFF
--- a/src/spikeinterface/core/sorting_tools.py
+++ b/src/spikeinterface/core/sorting_tools.py
@@ -361,8 +361,14 @@ def set_properties_after_merging(
     keep_pre_inds = sorting_pre_merge.ids_to_indices(kept_unit_ids)
     keep_post_inds = sorting_post_merge.ids_to_indices(kept_unit_ids)
 
+    default_missing_values = BaseExtractor.default_missing_property_values
+
     for key in prop_keys:
         parent_values = sorting_pre_merge.get_property(key)
+        if parent_values.dtype.kind not in default_missing_values:
+            # if the property is boolean or integer there is no missing values so we skip
+            # for instance reccussive "is_merged" will not be propagated
+            continue
 
         # propagate keep values
         shape = (len(sorting_post_merge.unit_ids),) + parent_values.shape[1:]
@@ -377,7 +383,7 @@ def set_properties_after_merging(
                 # and new values only if they are all similar
                 new_values[new_index] = merge_values[0]
             else:
-                default_missing_values = BaseExtractor.default_missing_property_values
+                
                 new_values[new_index] = default_missing_values[parent_values.dtype.kind]
         sorting_post_merge.set_property(key, new_values)
 


### PR DESCRIPTION
Fix set_properties_after_merging when property is boolean.
This was introducing bugs in auto_merge