### PR TITLE
Deprecated `spikeinterface.compraison.hybrid` module

### DIFF
--- a/src/spikeinterface/comparison/hybrid.py
+++ b/src/spikeinterface/comparison/hybrid.py
@@ -76,7 +76,7 @@ class HybridUnitsRecording(InjectTemplatesRecording):
     ):
 
         warnings.warn(
-            "create_hybrid_units_recording() will be removed in 0.104.0 please use spiekinterface.generation.hybrid_tools instead",
+            "create_hybrid_units_recording() will be removed in 0.104.0 please use `spikeinterface.generation.hybrid_tools` instead",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -181,7 +181,7 @@ class HybridSpikesRecording(InjectTemplatesRecording):
     ) -> None:
 
         warnings.warn(
-            "create_hybrid_spikes_recording() will be removed in 0.104.0 please use spiekinterface.generation.hybrid_tools instead",
+            "create_hybrid_spikes_recording() will be removed in 0.104.0 please use `spikeinterface.generation.hybrid_tools`  instead",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
deprecated `spikeinterface.compraison.hybrid` module so we can safetly remove in 0.104.0