### PR TITLE
Update deprecated cuda import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ full = [
     "networkx",
     "distinctipy",
     "matplotlib>=3.6", # matplotlib.colormaps
-    "cuda-python; platform_system != 'Darwin'",
+    "cuda-python>=11.8.6; platform_system != 'Darwin'",
     "numba>=0.59",
     "skops",
     "huggingface_hub"

--- a/src/spikeinterface/sorters/utils/misc.py
+++ b/src/spikeinterface/sorters/utils/misc.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import subprocess  # TODO: decide best format for this
-from subprocess import check_output, CalledProcessError
 import importlib.util
+import subprocess  # TODO: decide best format for this
+from subprocess import CalledProcessError, check_output
 
 
 class SpikeSortingError(RuntimeError):
@@ -13,7 +13,7 @@ def get_bash_path():
     """Return path to existing bash install."""
     try:
         return check_output(["which bash"], shell=True).decode().strip("\n")
-    except CalledProcessError as e:
+    except CalledProcessError:
         raise Exception("Bash is not installed or accessible on your system.")
 
 
@@ -32,14 +32,14 @@ def get_matlab_shell_name():
         # CalledProcessError if not defined
         matlab_shell_name = check_output(["which $MATLAB_SHELL"], shell=True).decode().strip("\n").split("/")[-1]
         return matlab_shell_name
-    except CalledProcessError as e:
+    except CalledProcessError:
         pass
     try:
         # Either of "", "bash", "zsh", "fish",...
         # CalledProcessError if not defined
         df_shell_name = check_output(["which $SHELL"], shell=True).decode().strip("\n").split("/")[-1]
         return df_shell_name
-    except CalledProcessError as e:
+    except CalledProcessError:
         pass
     return "sh"
 
@@ -65,7 +65,7 @@ def has_nvidia():
     """
     cuda_spec = importlib.util.find_spec("cuda")
     if cuda_spec is not None:
-        from cuda import cuda
+        import cuda.bindings.driver as cuda
     else:
         raise Exception(
             "This sorter requires cuda, but the package 'cuda-python' is not installed. You can install it with:\npip install cuda-python"


### PR DESCRIPTION
Closes #4110

This PR also pins the minimum `cuda-python` version to `11.8.6`
> [!NOTE]
> The new module layouts were applied in [11.8.4](https://nvidia.github.io/cuda-python/cuda-bindings/latest/release/11.8.4-notes.html#cuda-namespace-cleanup-with-a-new-module-layout), but I was getting: 
> > Could not find a version that satisfies the requirement cuda-python==11.8.4; platform_system != "Darwin" and extra == "full" (from spikeinterface[full]) (from versions: 11.8.6, 11.8.7, 12.8.0, 12.9.0, 12.9.1, 12.9.2, 13.0.0, 13.0.1)
