### PR TITLE
`sd_ratio`: avoid recomputing noise levels

### DIFF
--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -1602,21 +1602,11 @@ def compute_sd_ratio(
 
     from spikeinterface.curation.curation_tools import find_duplicated_spikes
 
-    kwargs, job_kwargs = split_job_kwargs(kwargs)
-    job_kwargs = fix_job_kwargs(job_kwargs)
-
     sorting = sorting_analyzer.sorting
 
     censored_period = int(round(censored_period_ms * 1e-3 * sorting_analyzer.sampling_frequency))
     if unit_ids is None:
         unit_ids = sorting_analyzer.unit_ids
-
-    if not sorting_analyzer.has_recording():
-        warnings.warn(
-            "The `sd_ratio` metric cannot work with a recordless SortingAnalyzer object"
-            "SD ratio metric will be set to NaN"
-        )
-        return {unit_id: np.nan for unit_id in unit_ids}
 
     _has_required_extensions(sorting_analyzer, metric_name="sd_ratio")
 

--- a/src/spikeinterface/qualitymetrics/misc_metrics.py
+++ b/src/spikeinterface/qualitymetrics/misc_metrics.py
@@ -1628,9 +1628,7 @@ def compute_sd_ratio(
             "SD ratio metric will be set to NaN"
         )
         return {unit_id: np.nan for unit_id in unit_ids}
-    noise_levels = get_noise_levels(
-        sorting_analyzer.recording, return_in_uV=sorting_analyzer.return_in_uV, method="std", **job_kwargs
-    )
+    noise_levels = sorting_analyzer.get_extension("noise_levels").get_data()
     best_channels = get_template_extremum_channel(sorting_analyzer, outputs="index", **kwargs)
     n_spikes = sorting.count_num_spikes_per_unit()
 

--- a/src/spikeinterface/qualitymetrics/quality_metric_list.py
+++ b/src/spikeinterface/qualitymetrics/quality_metric_list.py
@@ -9,7 +9,7 @@ metric_extension_dependencies = {
     "amplitude_median": ["spike_amplitudes|waveforms", "templates"],
     "amplitude_cv": ["spike_amplitudes|amplitude_scalings", "templates"],
     "drift": ["spike_locations"],
-    "sd_ratio": ["templates", "spike_amplitudes"],
+    "sd_ratio": ["templates", "noise_levels", "spike_amplitudes"],
     "noise_cutoff": ["spike_amplitudes"],
 }
 


### PR DESCRIPTION
Added `noise_levels` as a dependency to `sd_ratio`, to avoid recomputing noise levels if already available. This makes the metric recordingless compatible too