### PR TITLE
Make `create_analyzer_sorting` check for excess spikes

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -22,6 +22,7 @@ import probeinterface
 import spikeinterface
 
 from spikeinterface.core import BaseRecording, BaseSorting, aggregate_channels, aggregate_units
+from spikeinterface.core.waveform_tools import has_exceeding_spikes
 
 from .recording_tools import check_probe_do_not_overlap, get_rec_attributes, do_recording_attributes_match
 from .core_tools import (
@@ -371,6 +372,15 @@ class SortingAnalyzer:
         # check that multiple probes are non-overlapping
         all_probes = recording.get_probegroup().probes
         check_probe_do_not_overlap(all_probes)
+
+        if has_exceeding_spikes(sorting=sorting, recording=recording):
+            warnings.warn(
+                "Your sorting has spikes with samples times greater than your recording length. These spikes have been removed."
+            )
+            # import here to avoid circular import
+            from spikeinterface.curation.remove_excess_spikes import RemoveExcessSpikesSorting
+
+            sorting = RemoveExcessSpikesSorting(sorting=sorting, recording=recording)
 
         if format == "memory":
             sorting_analyzer = cls.create_memory(sorting, recording, sparsity, return_in_uV, rec_attributes=None)

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -606,6 +606,16 @@ def test_extension():
         register_result_extension(DummyAnalyzerExtension2)
 
 
+def test_excess_spikes(dataset):
+    """
+    If there are spikes that occur after the recording end time,
+    `create_sorting_analyzer` should cut them off and warn the user.
+    """
+    recording, sorting = dataset
+    with pytest.warns(UserWarning):
+        create_sorting_analyzer(sorting=sorting, recording=recording.time_slice(0, 1))
+
+
 def test_extensions_sorting():
 
     # nothing happens if all parents are on the left of the children


### PR DESCRIPTION
As mentioned in #4103, it can be very annoying if your sorting has excess spikes, because the issue only rears its head when you compute spike locations/amplitudes.

This PR would make `create_analyzer_sorting` check for excess spikes and automatically remove them if they are there. If this happens, it will warn the user.

Also added a test.