### PR TITLE
Update generate.py

### DIFF
--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -1733,7 +1733,7 @@ def generate_templates(
         An optional dict containing parameters per units.
         Keys are parameter names:
 
-            * "alpha": amplitude of the action potential in a.u. (default range: (6'000-9'000))
+            * "alpha": amplitude of the action potential in a.u. (default range: (100.0 - 500.0))
             * "depolarization_ms": the depolarization interval in ms (default range: (0.09-0.14))
             * "repolarization_ms": the repolarization interval in ms (default range: (0.5-0.8))
             * "recovery_ms": the recovery interval in ms (default range: (1.0-1.5))


### PR DESCRIPTION
Hello.,

The docstring of `generate_templates` says:

```
    unit_params : dict[np.array] | dict[float] | dict[tuple] | None, default: None
        An optional dict containing parameters per units.
        Keys are parameter names:

            * "alpha": amplitude of the action potential in a.u. (default range: (6'000-9'000))
```

However, in `default_unit_params_range` (line 1649), alpha is defined differently

```python
default_unit_params_range = dict(
    alpha=(100.0, 500.0),
    ...
```

I have updated the docstring to reflect this

Best,
Ole