### PR TITLE
faster write_binary_recording()

### DIFF
--- a/src/spikeinterface/core/recording_tools.py
+++ b/src/spikeinterface/core/recording_tools.py
@@ -156,7 +156,7 @@ def _write_binary_chunk(segment_index, start_frame, end_frame, worker_ctx):
 
     traces = recording.get_traces(start_frame=start_frame, end_frame=end_frame, segment_index=segment_index)
     traces = traces.astype(dtype, order="c", copy=False)
-    
+
     file.seek(start_byte)
     file.write(traces.data)
     # flush is important!!

--- a/src/spikeinterface/core/tests/test_baserecording.py
+++ b/src/spikeinterface/core/tests/test_baserecording.py
@@ -473,6 +473,7 @@ def test_time_slice_with_time_vector():
 
 if __name__ == "__main__":
     import tempfile
+
     tmp_path = Path(tempfile.mkdtemp())
 
     test_BaseRecording(tmp_path)


### PR DESCRIPTION
The `write_binary_recording()` was using the memmap machinery but this is a bad idea for writing because it synchronize the buffer with the disk before writing with a read and this make it more slow.

Of some system with netowrk drive this PR make the writing to binary 2 times faster witth this simple PR.

@h-mayorquin : I did also some test on the reading side, but there is no effect on perf so for now I keep memmap machinery on reading side. But maybe we could switch to this also in binary extarctor : simple seek and np.fromfile

