### PR TITLE
Add `experiment_name`  argument to  `OpenEphysBinaryRecordingExtractor`

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/openephys.py
+++ b/src/spikeinterface/extractors/neoextractors/openephys.py
@@ -161,7 +161,8 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
     Open Ephys Binary Format Structure:
         folder_path/
         ├── Record Node 102/              # Recording hardware node
-        │   ├── settings.xml
+        │   ├── settings.xml              # Settings for the first experiment
+        │   ├── settings_2.xml            # Settings for experiment 2
         │   ├── experiment1/              # Experiment folder
         │   │   ├── recording1/           # Recording session (SpikeInterface segment)
         │   │   │   ├── structure.oebin   # JSON metadata file


### PR DESCRIPTION
The current `block_index` parameter exposes a Neo implementation detail that most users won't understand. Since Open Ephys organizes data into named experiment folders (experiment1, experiment2, etc.), I've added an `experiment_name` parameter that lets users specify experiments directly by folder name (e.g., `experiment_name="experiment2"`). I've also improved error messages to list available experiments instead of just mentioning `block_index`.

I add the `experiment_name` parameter to `OpenEphysBinaryRecordingExtractor` with full backward compatibility. I deprecate `block_index` with a `FutureWarning` (removal in 0.105.0) and add a `get_available_experiments()` class method for discovery. My implementation passes `experiment_names=[experiment_name]` to Neo to filter efficiently. I've enhanced the docstring with the Open Ephys binary format and how it maps to SpikeInterface concepts.

I'm also deprecating `experiment_names` (plural). This parameter was added to Neo in [PR #1159](https://github.com/NeuralEnsemble/python-neo/pull/1159) to handle inconsistent stream configurations across experiments, but this doesn't apply to SpikeInterface since we only load one experiment at a time. The new `experiment_name` (singular) is clearer for our single-block loading model and achieves the same goal of filtering out incompatible streams so the data can be loaded.

[EDIT] After discussion below, we are keeping block index.
