### PR TITLE
Improve assertion error message of SortingAnalyzer job kwargs

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1635,7 +1635,8 @@ extension_params={"waveforms":{"ms_before":1.5, "ms_after": "2.5"}}\
         elif isinstance(input, dict):
             params_, job_kwargs = split_job_kwargs(kwargs)
             assert len(params_) == 0, (
-                "Too many arguments for SortingAnalyzer.compute_several_extensions(), " f"they are: {set(params_)}"
+                "Too many arguments for SortingAnalyzer.compute_several_extensions(), "
+                f"please remove the arguments {set(params_)} from the compute function."
             )
             self.compute_several_extensions(extensions=input, save=save, verbose=verbose, **job_kwargs)
         elif isinstance(input, list):


### PR DESCRIPTION
When using `SortingAnalyzer` and `compute`, if user specifies too many args, there will be an assertion error. But the assertion message does not contain the detailed message about which arg violates the API.

So I wish to improve the assertion message. The modification is simple and straightforward, should not introduce any logical breaking.