### PR TITLE
Remove python 3.14 cap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 description = "Python toolkit for analysis, visualization, and comparison of spike sorting output"
 readme = "README.md"
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
I think we should remove the `<3.14` upper bound on the Python version constraint in `pyproject.toml`.

The Python version constraint has gone through several iterations:
- PR #3480 (Oct 2024): capped at `<3.13` due to NumPy 2.0 compatibility issues on Windows and neo dependency problems
- PR #3640 (Jan 2025): added NumPy 2.0 support with Neo 0.14.0
- PR #3683 (Feb 2025): added Python 3.13 support after fixing MEArec and elephant dependencies

The current `<3.14` cap was preemptive and I think a legacy decision of that period when numpy was doing a lot of breaking changes. This is not longer the case.

As discussed in [this analysis](https://iscinumpy.dev/post/bound-version-constraints/), Python maintains backward compatibility between minor versions (3.x), so basic code rarely breaks. If our code breaks with a new Python version, it will likely be due to dependency incompatibilities, which will surface at installation time. By removing the cap, we allow these dependency issues to be identified specifically (e.g., "package X doesn't support Python 3.14") rather than being masked by a blanket restriction on SpikeInterface. This helps us identify and fix actual compatibility issues faster.

Related to:
https://github.com/SpikeInterface/spikeinterface/pull/4173
