### PR TITLE
Implementing sparsity for ComputeTemplates

### DIFF
--- a/src/spikeinterface/core/analyzer_extension_core.py
+++ b/src/spikeinterface/core/analyzer_extension_core.py
@@ -461,13 +461,7 @@ class ComputeTemplates(AnalyzerExtension):
             if self.sparsity is not None:
                 # make average and std dense again
                 for k, arr in data.items():
-                    dense_arr = np.zeros(
-                        (arr.shape[0], arr.shape[1], self.sorting_analyzer.get_num_channels()),
-                        dtype=arr.dtype,
-                    )
-                    for unit_index, unit_id in enumerate(self.sorting_analyzer.unit_ids):
-                        chan_inds = self.sparsity.unit_id_to_channel_indices[unit_id]
-                        dense_arr[unit_index][:, chan_inds] = arr[unit_index, :, : chan_inds.size]
+                    dense_arr = self.sparsity.densify_templates(arr)
                     data[k] = dense_arr
             self.data.update(data)
 

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -247,6 +247,18 @@ class ChannelSparsity:
 
         return sparse_templates
 
+    def densify_templates(self, templates_array: np.ndarray) -> np.ndarray:
+        assert templates_array.shape[0] == self.num_units
+
+        densified_shape = (self.num_units, templates_array.shape[1], self.num_channels)
+        dense_templates = np.zeros(shape=densified_shape, dtype=templates_array.dtype)
+        for unit_index, unit_id in enumerate(self.unit_ids):
+            sparse_template = templates_array[unit_index, ...]
+            dense_template = self.densify_waveforms(waveforms=sparse_template[np.newaxis, :, :], unit_id=unit_id)
+            dense_templates[unit_index, :, :] = dense_template
+
+        return dense_templates
+
     @classmethod
     def from_unit_id_to_channel_ids(cls, unit_id_to_channel_ids, unit_ids, channel_ids):
         """


### PR DESCRIPTION
This implements the use of sparsity to compute templates in the Analyzer. Currently, analzers can handle sparsity mask, and while they are used to compute waveforms, they are not used to estimate templates. This can lead to large memory usage with numerous threads. This PR makes sure the analyzer, if sparse, uses the sparsity masks while estimating templates ONLY in the run() method. For compatibility with downstream extensions, the internal storage is kept dense*


See #4194