### PR TITLE
patch for sc2: propagate real ms_before/after to template extension of final analyzer

### DIFF
--- a/src/spikeinterface/sorters/internal/spyking_circus2.py
+++ b/src/spikeinterface/sorters/internal/spyking_circus2.py
@@ -373,6 +373,10 @@ class Spykingcircus2Sorter(ComponentsBasedSorter):
                 # this release the peak_svd memmap file
                 templates = dense_templates.to_sparse(new_sparse_mask)
 
+            # To be sure that templates have appropriate ms_before and ms_after, up to rounding
+            templates.ms_before = ms_before
+            templates.ms_after = ms_after
+
             del more_outs
 
             cleaning_kwargs = params.get("cleaning", {}).copy()

--- a/src/spikeinterface/sortingcomponents/tools.py
+++ b/src/spikeinterface/sortingcomponents/tools.py
@@ -455,9 +455,11 @@ def create_sorting_analyzer_with_existing_templates(
     sa = create_sorting_analyzer(non_empty_sorting, recording, format="memory", sparsity=sparsity)
     sa.compute("random_spikes")
     sa.extensions["templates"] = ComputeTemplates(sa)
-    sa.extensions["templates"].params = {"ms_before": templates.ms_before, 
-                                         "ms_after": templates.ms_after,
-                                         "operators": ["average", "std"]}
+    sa.extensions["templates"].params = {
+        "ms_before": templates.ms_before,
+        "ms_after": templates.ms_after,
+        "operators": ["average", "std"],
+    }
     sa.extensions["templates"].data["average"] = templates_array
     sa.extensions["templates"].data["std"] = np.zeros(templates_array.shape, dtype=np.float32)
     sa.extensions["templates"].run_info["run_completed"] = True


### PR DESCRIPTION
Internally, SC2 creates an analyzer on the fly using precomputed templates and thus "hack" the way templates are computed within the analyzer. To be reused properly later by the GUI, one needs an "operator" field, now added