### PR TITLE
Warn about non-mergeable units instead of raising an error

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1264,7 +1264,7 @@ class SortingAnalyzer:
         censor_ms: float | None = None,
         merging_mode: str = "soft",
         sparsity_overlap: float = 0.75,
-        error_if_overlap_fails: bool = False,
+        raise_error_if_overlap_fails: bool = True,
         new_id_strategy: str = "append",
         return_new_unit_ids: bool = False,
         format: str = "memory",
@@ -1295,8 +1295,9 @@ class SortingAnalyzer:
         sparsity_overlap : float, default 0.75
             The percentage of overlap that units should share in order to accept merges. If this criteria is not
             achieved for a pair of units, soft merging will not be applied to them.
-        error_if_overlap_fails : bool, default: False
-            If True and `sparsity_overlap` fails for any unit, this will raise an error.
+        raise_error_if_overlap_fails : bool, default: True
+            If True and `sparsity_overlap` fails for any unit merges, this will raise an error. If False, units which fail the
+            `sparsity_overlap` threshold will be skipped in the merge.
         new_id_strategy : "append" | "take_first", default: "append"
             The strategy that should be used, if `new_unit_ids` is None, to create new unit_ids.
 
@@ -1348,11 +1349,12 @@ class SortingAnalyzer:
                     unmergeable_unit_groups.append(merge_unit_group)
 
             if len(unmergeable_unit_groups) > 0:
-                error_or_warning_message = f"The sparsity of the units in the merge groups {unmergeable_unit_groups} do not overlap enough for a soft merge using a sparsity threshold of {sparsity_overlap}. They will not be merged."
-                if error_if_overlap_fails:
-                    raise Exception(error_or_warning_message)
+                if raise_error_if_overlap_fails:
+                    error_message = f"The sparsity of the units in the merge groups {unmergeable_unit_groups} do not overlap enough for a soft merge using a sparsity threshold of {sparsity_overlap}. Either lower your `sparsity_overlap` or use the flag `raise_error_if_overlap_fails = False` to skip these units in your merge."
+                    raise Exception(error_message)
                 else:
-                    warnings.warn(error_or_warning_message)
+                    warning_message = f"The sparsity of the units in the merge groups {unmergeable_unit_groups} do not overlap enough for a soft merge using a sparsity threshold of {sparsity_overlap}. They will not be merged."
+                    warnings.warn(warning_message)
         else:
             mergeable_unit_groups = merge_unit_groups
 

--- a/src/spikeinterface/curation/curation_format.py
+++ b/src/spikeinterface/curation/curation_format.py
@@ -143,6 +143,7 @@ def apply_curation(
     new_id_strategy: str = "append",
     merging_mode: str = "soft",
     sparsity_overlap: float = 0.75,
+    raise_error_if_overlap_fails: bool = True,
     verbose: bool = False,
     **job_kwargs,
 ):
@@ -181,6 +182,9 @@ def apply_curation(
     sparsity_overlap : float, default 0.75
         The percentage of overlap that units should share in order to accept merges. If this criteria is not
         achieved, soft merging will not be possible and an error will be raised. This is for use with a SortingAnalyzer input.
+    raise_error_if_overlap_fails : bool, default: True
+        If True and `sparsity_overlap` fails for any unit merges, this will raise an error. If False, units which fail the
+        `sparsity_overlap` threshold will be skipped in the merge.
     verbose : bool, default: False
         If True, output is verbose
     **job_kwargs : dict
@@ -234,6 +238,7 @@ def apply_curation(
                 censor_ms=censor_ms,
                 merging_mode=merging_mode,
                 sparsity_overlap=sparsity_overlap,
+                raise_error_if_overlap_fails=raise_error_if_overlap_fails,
                 new_id_strategy=new_id_strategy,
                 return_new_unit_ids=True,
                 format="memory",


### PR DESCRIPTION
This PR slightly changes the merging logic. It checks to see which units are mergeable (wrt to the sparsity threshold) before trying to merge.

Now we warn and don't merge the units, rather than error the entire process, if individual units cannot be merged.

I tried implementing this inside of `_save_or_select_or_merge_or_split` but it was a mess. I think it's best to know your new unit ids and final merge groups before this function is called.

@samuelgarcia @yger feedback welcome! I need to add some tests...
