### PR TITLE
Fix a small static type error on `BaseExtractor.save_to_folder`

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -879,7 +879,7 @@ class BaseExtractor:
         self,
         name: str | None = None,
         folder: str | Path | None = None,
-        overwrite: str = False,
+        overwrite: bool = False,
         verbose: bool = True,
         **save_kwargs,
     ):


### PR DESCRIPTION
Just a small issue:

```python
def save_to_folder(
    self,
    name: str | None = None,
    folder: str | Path | None = None,
    overwrite: str = False, # Incorrect type annotation here
    verbose: bool = True,
    **save_kwargs,
):
```

Corrected to:

```python
def save_to_folder(
    self,
    name: str | None = None,
    folder: str | Path | None = None,
    overwrite: bool = False, # Corrected
    verbose: bool = True,
    **save_kwargs,
):
```