### PR TITLE
Fix a function call spelling mistake in `pykilosort`

### DIFF
--- a/src/spikeinterface/sorters/external/pykilosort.py
+++ b/src/spikeinterface/sorters/external/pykilosort.py
@@ -142,7 +142,7 @@ class PyKilosortSorter(BaseSorter):
 
     @classmethod
     def _setup_recording(cls, recording, sorter_output_folder, params, verbose):
-        if not recording.binary_compatible_with(time_axis=0, file_paths_lenght=1):
+        if not recording.binary_compatible_with(time_axis=0, file_paths_length=1):
             # local copy needed
             write_binary_recording(
                 recording,


### PR DESCRIPTION
The `BaseRecording.binary_compatible_with` has the following API:

```python
def binary_compatible_with(
    self,
    dtype=None,
    time_axis=None,
    file_paths_length=None,
    file_offset=None,
    file_suffix=None,
):
    ...
```

And in `src/spikeinterface/sorters/external/pykilosort.py`, It involves a wrong call to `binary_compatible_with`, where `length` is spelled as `lenght`:

```python
@classmethod
def _setup_recording(cls, recording, sorter_output_folder, params, verbose):
    if not recording.binary_compatible_with(time_axis=0, file_paths_lenght=1): # WRONG SPELLING
        # local copy needed
        write_binary_recording(
            recording,
            file_paths=sorter_output_folder / "recording.dat",
            **get_job_kwargs(params, verbose),
        ):
    ...
```

This mistake causes `pykilosort` not happy now.