### PR TITLE
Add channel_filter parameter for bad channel detection

### DIFF
--- a/src/spikeinterface/preprocessing/detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/detect_bad_channels.py
@@ -173,7 +173,7 @@ def detect_bad_channels(
     neighborhood_r2_threshold: float = 0.9,
     neighborhood_r2_radius_um: float = 30.0,
     seed: int | None = None,
-    channel_filters: set | None  = None,
+    channel_filters: set | None = None,
 ):
     """
     Perform bad channel detection.
@@ -310,9 +310,7 @@ def detect_bad_channels(
             channel_filters = allowed_filters
 
         if not isinstance(channel_filters, set):
-            raise ValueError(
-                f"channel_filters must be None or a set of the following values : {allowed_filters} "
-            )
+            raise ValueError(f"channel_filters must be None or a set of the following values : {allowed_filters} ")
 
         if not channel_filters.issubset(allowed_filters):
             raise ValueError(


### PR DESCRIPTION
Hey, so i though it could be useful to add the possibility to filter the bad_channel_ids based on their labels. 

The idea is to add a new `channel_filter : str | set  = { "noise", "dead", "out" }`  arg to the `preprocessing.detect_bad_channels` function. This one would only apply to the coherence+psd method and would filter the returned `bad_channel_ids` based on their corresponding label. 

The main use case would be with usage of the `PreprocessingPipeline`. 
For example, based on the [preprocessing pipeline of the IBL](https://doi.org/10.6084/m9.figshare.19705522.v3) that would allow us to use `detect_and_remove_bad_channels`  only on channels labeled as "out" or "dead", and then to perform interpolate only the "noise" labeled channels using `detect_and_interpolate_bad_channels` using a kwargs dictionnary similar to this one : 
```
preprocessing_kwargs = {
    "highpass_filter": { 'ftype': 'bessel', 'dtype': 'float32' },
    "phase_shift": { },
    "common_reference": { },
    "detect_and_remove_bad_channels": { 'channel_filter': {'dead', 'out'} },
    "detect_and_interpolate_bad_channels": { },
    ...
}
```

This would allow to add a little complexity to `PreprocessingPipeline` while keeping it's main philosophy intact.