### PR TITLE
Warn about non-binary compatible recordings using KS4

### DIFF
--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -237,7 +237,7 @@ class Kilosort4Sorter(BaseSorter):
                 warning_msg = (
                     "Recording is not binary compatible with Kilosort4. This might slow down the sorting process."
                 )
-                warning.warn(warning_msg)
+                warnings.warn(warning_msg)
                 logger.warning(warning_msg)
                 filename = ""
                 file_object = RecordingExtractorAsArray(recording_extractor=recording)


### PR DESCRIPTION
Following #4224, @chrishalcrow mentionned that non binary compatibility is silent. Just added a small warning message using `warning` and the sorter `logger` to keep a trace.