### PR TITLE
Bug fix in SC2

### DIFF
--- a/src/spikeinterface/sorters/internal/spyking_circus2.py
+++ b/src/spikeinterface/sorters/internal/spyking_circus2.py
@@ -312,7 +312,7 @@ class Spykingcircus2Sorter(ComponentsBasedSorter):
             ]:
                 clustering_params.update(verbose=verbose)
                 clustering_params.update(seed=seed)
-                clustering_params.update(peak_svd=params["general"])
+                clustering_params.update(peaks_svd=params["general"])
                 if debug:
                     clustering_params["debug_folder"] = sorter_output_folder / "clustering"
 


### PR DESCRIPTION
Originaly the function was adding a peak_svd entry into clustering_params but clustering_methods requires peaks_svd instead, so these parameters were not being passed to the methods.