### PR TITLE
Fix HerdingspikesSorter due to breaking changed API in #3525

### DIFF
--- a/src/spikeinterface/sorters/external/herdingspikes.py
+++ b/src/spikeinterface/sorters/external/herdingspikes.py
@@ -160,6 +160,4 @@ class HerdingspikesSorter(BaseSorter):
 
     @classmethod
     def _get_result_from_folder(cls, sorter_output_folder):
-        return HerdingspikesSortingExtractor(
-            file_path=Path(sorter_output_folder) / "HS2_sorted.hdf5", load_unit_info=True
-        )
+        return HerdingspikesSortingExtractor(file_path=Path(sorter_output_folder) / "HS2_sorted.hdf5")


### PR DESCRIPTION
#3525 changed the API of `HerdingspikesSortingExtractor`, leading to `spikeinterface.sorters.external.herdingspikes.HerdingspikesSorter._get_result_from_folder` failed.

Removing `load_unit_info` could fix this issue.