### PR TITLE
kilosort4 may fail due to the undesirable instantiation of `logger`

### DIFF
--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -191,17 +191,17 @@ class Kilosort4Sorter(BaseSorter):
             # v4.0.16, v4.0.17, v4.0.18
             setup_logger(sorter_output_folder)
 
+        if logger_is_named:
+            # v4.0.21 and above
+            logger = logging.getLogger("kilosort")
+        else:
+            # v4.0.16, v4.0.17, v4.0.18, v4.0.19, v4.0.20
+            logger = logging.getLogger("")
+
         # if verbose is False, set the stream handler's log
         # level to logging.WARNING to preserve original
         # behavior prior to addition of setup_logger() above
         if not verbose:
-            if logger_is_named:
-                # v4.0.21 and above
-                logger = logging.getLogger("kilosort")
-            else:
-                # v4.0.16, v4.0.17, v4.0.18, v4.0.19, v4.0.20
-                logger = logging.getLogger("")
-
             # find the stream handler
             stream_handler = None
             for handler in logger.handlers:
@@ -238,8 +238,7 @@ class Kilosort4Sorter(BaseSorter):
                     "Recording is not binary compatible with Kilosort4. This might slow down the sorting process."
                 )
                 warnings.warn(warning_msg)
-                if verbose:
-                    logger.warning(warning_msg)
+                logger.warning(warning_msg)
                 filename = ""
                 file_object = RecordingExtractorAsArray(recording_extractor=recording)
         elif params["use_binary_file"]:


### PR DESCRIPTION
## Situation

A minor fix to the logging behavior in the Kilosort4 sorter integration.

The logger is only instantiated when `verbose is False`, so when calling it with `verbose=True` and `params["use_binary_file"] is None` may trigger a `UnboundLocalError` near line 241.

## Workaround

The instantiation of the logger should not be conditioned on the value of verbose; therefore, it should be removed from the if block. The external behavior of the logger with respect to verbosity must remain unchanged.

## Appendix

This issue is found when I set `use_binary_file=None`. Here is the complex traceback for reference:

```python
25-12-19 14:21:40 - ERROR - base.py:__call__:144 - Error in processor SpikeInterfaceSorter: Spike sorting error trace:
Traceback (most recent call last):
  File "/home/zhangyiqin/workspace/mgam_repos/spikeinterface/src/spikeinterface/sorters/basesorter.py", line 270, in run_from_folder
    SorterClass._run_from_folder(sorter_output_folder, sorter_params, verbose)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zhangyiqin/workspace/mgam_repos/spikeinterface/src/spikeinterface/sorters/external/kilosort4.py", line 241, in _run_from_folder
    logger.warning(warning_msg)
    ^^^^^^
UnboundLocalError: cannot access local variable 'logger' where it is not associated with a value

Spike sorting failed. You can inspect the runtime trace in /tmp/tmpez4qmgac/Sorter/spikeinterface_log.json.
25-12-19 14:21:40 - ERROR - task_runner.py:validate:241 - Validation dry run failed at PROCESS_STAGES.SORT - SpikeInterfaceSorter
Traceback (most recent call last):
  File "/home/zhangyiqin/miniforge3/envs/dbci/bin/neovibe", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/zhangyiqin/workspace/mgam_projects/NeoVibe/src/neovibe/fabric/pipeline_entry.py", line 69, in main
    args.func(args)
    ~~~~~~~~~^^^^^^
  File "/home/zhangyiqin/workspace/mgam_projects/NeoVibe/src/neovibe/fabric/pipeline_entry.py", line 31, in handle_convert
    final_context = runner.run(context, skip_dry_run=args.skip_dry_run)
  File "/home/zhangyiqin/workspace/mgam_projects/NeoVibe/src/neovibe/fabric/task_runner.py", line 100, in run
    self.validate()
    ~~~~~~~~~~~~~^^
  File "/home/zhangyiqin/workspace/mgam_projects/NeoVibe/src/neovibe/fabric/task_runner.py", line 239, in validate
    demo_context = processor(demo_context)
  File "/home/zhangyiqin/workspace/mgam_projects/NeoVibe/src/neovibe/processor/base.py", line 142, in __call__
    context = self._process(context)
  File "/home/zhangyiqin/workspace/mgam_projects/NeoVibe/src/neovibe/processor/sort/SpikeInterfaceSorting.py", line 56, in _process
    context.spikeinterface_data.sorting = ss.run_sorter_local(
                                          ~~~~~~~~~~~~~~~~~~~^
        sorter_name=self.sorter_name,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
        **self.sorter_params
        ^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/zhangyiqin/workspace/mgam_repos/spikeinterface/src/spikeinterface/sorters/runsorter.py", line 302, in run_sorter_local
    SorterClass.run_from_folder(folder, raise_error, verbose)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zhangyiqin/workspace/mgam_repos/spikeinterface/src/spikeinterface/sorters/basesorter.py", line 310, in run_from_folder
    raise SpikeSortingError(
    ...<2 lines>...
    )
spikeinterface.sorters.utils.misc.SpikeSortingError: Spike sorting error trace:
Traceback (most recent call last):
  File "/home/zhangyiqin/workspace/mgam_repos/spikeinterface/src/spikeinterface/sorters/basesorter.py", line 270, in run_from_folder
    SorterClass._run_from_folder(sorter_output_folder, sorter_params, verbose)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zhangyiqin/workspace/mgam_repos/spikeinterface/src/spikeinterface/sorters/external/kilosort4.py", line 241, in _run_from_folder
    logger.warning(warning_msg)
    ^^^^^^
UnboundLocalError: cannot access local variable 'logger' where it is not associated with a value

Spike sorting failed. You can inspect the runtime trace in /tmp/tmpez4qmgac/Sorter/spikeinterface_log.json.
```  