### PR TITLE
Add `discard_spikes` to curation, and update to `v3`

### DIFF
--- a/src/spikeinterface/core/analyzer_extension_core.py
+++ b/src/spikeinterface/core/analyzer_extension_core.py
@@ -604,8 +604,9 @@ class ComputeTemplates(AnalyzerExtension):
                             arr = np.std(wfs, axis=0)
                         elif operator == "median":
                             arr = np.median(wfs, axis=0)
-                        elif "percentile" in operator:
-                            _, percentile = operator.splot("_")
+                        # old versions have spelling error in "percentile"
+                        elif "percentile" in operator or "pencentile" in operator:
+                            _, percentile = operator.split("_")
                             arr = np.percentile(wfs, float(percentile), axis=0)
                         new_array[split_unit_index, ...] = arr
                 else:
@@ -1126,6 +1127,7 @@ class BaseMetricExtension(AnalyzerExtension):
             column_names = list(metric.metric_columns.keys())
             try:
                 metric_params = self.params["metric_params"].get(metric_name, {})
+                # TODO: deal with number_of_peaks and velocity_fits here
                 res = metric.compute(
                     sorting_analyzer,
                     unit_ids=unit_ids,

--- a/src/spikeinterface/core/sorting_tools.py
+++ b/src/spikeinterface/core/sorting_tools.py
@@ -754,17 +754,17 @@ def generate_unit_ids_for_split(
         # the new units made from the discard_spikes must be at the *front* of the new_units_for_split list.
         if new_id_strategy == "append":
             if just_discard:
-                # give the discard unit the id `max_id` so that the cleaned unit's id doesn't change.
+                # give the discard unit the highest possible id, leaving the cleaned unit's id untouched.
                 new_units_for_split = [highest_possible_unit_id, unit_to_split]
                 highest_possible_unit_id -= 1
             elif discard_and_split:
                 # give the discard unit the id `unit_to_split`, and the other units their expected append ids
                 new_units_for_split = [unit_to_split] + list(next_max_unit_id + np.arange(num_splits - 1))
-                next_max_unit_id += 1
+                next_max_unit_id += len(new_units_for_split) - 1
             else:
                 # there is no discard unit
                 new_units_for_split = list(next_max_unit_id + np.arange(num_splits))
-                next_max_unit_id += 1
+                next_max_unit_id += len(new_units_for_split)
 
         elif new_id_strategy == "split":
             if just_discard:

--- a/src/spikeinterface/core/sorting_tools.py
+++ b/src/spikeinterface/core/sorting_tools.py
@@ -736,7 +736,9 @@ def generate_unit_ids_for_split(
 
     if new_id_strategy == "append":
         next_max_unit_id = max(old_unit_ids) + 1
-        highest_possible_unit_id = max(old_unit_ids) + len(discard_spikes_unit_ids)
+        highest_possible_unit_id = max(old_unit_ids)
+        for split_indices in unit_splits.values():
+            highest_possible_unit_id += len(split_indices)
 
     for unit_to_split, split_indices in unit_splits.items():
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1386,6 +1386,7 @@ class SortingAnalyzer:
         new_unit_ids: list[list[int | str]] | None = None,
         new_id_strategy: str = "append",
         return_new_unit_ids: bool = False,
+        discard_spikes_unit_ids=None,
         format: str = "memory",
         folder: Path | str | None = None,
         verbose: bool = False,
@@ -1435,7 +1436,9 @@ class SortingAnalyzer:
 
         check_unit_splits_consistency(split_units, self.sorting)
 
-        new_unit_ids = generate_unit_ids_for_split(self.unit_ids, split_units, new_unit_ids, new_id_strategy)
+        new_unit_ids = generate_unit_ids_for_split(
+            self.unit_ids, split_units, new_unit_ids, new_id_strategy, discard_spikes_unit_ids
+        )
         all_unit_ids = _get_ids_after_splitting(self.unit_ids, split_units, new_unit_ids=new_unit_ids)
 
         new_analyzer = self._save_or_select_or_merge_or_split(

--- a/src/spikeinterface/curation/curation_format.py
+++ b/src/spikeinterface/curation/curation_format.py
@@ -218,12 +218,18 @@ def apply_curation(
     else:
         curated_sorting_or_analyzer = sorting_or_analyzer
 
-    # 3. Split and discard spikes from units
+    # 3. Split and discard_spikes from units
     # Do this at the same time, otherwise have to do a lot of spike index shuffling.
     # Strategy: put the discarded spikes in a new unit when splitting, then remove them at the end.
     if len(curation_model.splits) > 0 or len(curation_model.discard_spikes) > 0:
+
+        split_spikes_unit_ids = []
+        split_new_unit_ids_from_user = None
         if len(curation_model.splits) > 0:
             split_spikes_unit_ids = [split.unit_id for split in curation_model.splits]
+            split_new_unit_ids_from_user = [s.new_unit_ids for s in curation_model.splits if s.new_unit_ids is not None]
+
+        discard_spikes_unit_ids = []
         if len(curation_model.discard_spikes) > 0:
             discard_spikes_unit_ids = [discard_spike.unit_id for discard_spike in curation_model.discard_spikes]
 
@@ -233,63 +239,62 @@ def apply_curation(
             curated_sorting_or_analyzer if isinstance(sorting_or_analyzer, BaseSorting) else sorting_or_analyzer.sorting
         )
 
+        num_spikes_per_unit = sorting.count_num_spikes_per_unit()
+
         for unit_id in curation_model.unit_ids:
 
             if unit_id in split_spikes_unit_ids:
+                split_spikes_list_index = np.where(np.array(split_spikes_unit_ids) == unit_id)[0][0]
+                split = curation_model.splits[split_spikes_list_index]
 
-                split_spikes_arg = np.where(np.array(split_spikes_unit_ids) == unit_id)[0][0]
-                split = curation_model.splits[split_spikes_arg]
                 split_units[unit_id] = split.get_full_spike_indices(sorting)
 
-            # If the unit is not split, but does contain spikes to discard, make an initial "split"
-            # unit containing the full spike train.
-            elif unit_id in discard_spikes_unit_ids and unit_id not in split_spikes_unit_ids:
+            # If the unit is not split but does contain spikes to discard, make an initial "split"
+            # unit containing the indices of the entire spike train.
+            elif unit_id in discard_spikes_unit_ids:
+                split_units[unit_id] = [np.arange(num_spikes_per_unit[unit_id])]
 
-                split_units[unit_id] = [sorting.get_unit_spike_train(unit_id)]
-
-            # Now find all spikes which are in discard_spikes, and remove them from the units-to-split.
-            # Put the discarded spikes in their own split-unit, at the end of the list of split units.
+            # If there are spikes to discard, find these, and remove them from the units-to-split.
+            # Put the discarded spikes in their own unit, at the start of the list of split units.
             if unit_id in discard_spikes_unit_ids:
 
-                discard_spikes_arg = np.where(np.array(discard_spikes_unit_ids) == unit_id)[0][0]
-                discard_spikes = np.array(curation_model.discard_spikes[discard_spikes_arg].indices)
+                discard_spikes_list_index = np.where(np.array(discard_spikes_unit_ids) == unit_id)[0][0]
+                discard_spikes_indices = np.array(curation_model.discard_spikes[discard_spikes_list_index].indices)
 
-                split_units_with_discard = []
-                for split_spike_train in split_units[split.unit_id]:
-                    split_spike_train_cleaned = np.setdiff1d(split_spike_train, discard_spikes, assume_unique=True)
+                split_units_with_discard = [discard_spikes_indices]
+                for split_spike_train in split_units[unit_id]:
+                    split_spike_train_cleaned = np.setdiff1d(split_spike_train, discard_spikes_indices)
                     split_units_with_discard.append(split_spike_train_cleaned)
-                split_units_with_discard.append(discard_spikes)
+
                 split_units[unit_id] = split_units_with_discard
 
-        split_new_unit_ids = [s.new_unit_ids for s in curation_model.splits if s.new_unit_ids is not None]
-        unit_ids_to_discard = []
-
-        # We need to know which units to remove, so need control of the new unit ids here
-        if len(split_new_unit_ids) == 0:
-            split_new_unit_ids = None
-            new_unit_ids = generate_unit_ids_for_split(
-                sorting.unit_ids, split_units, new_unit_ids=None, new_id_strategy=new_id_strategy
-            )
-            for old_unit_id, new_unit_id_list in zip(split_units.keys(), new_unit_ids):
-                if old_unit_id in discard_spikes_unit_ids:
-                    unit_ids_to_discard.append(new_unit_id_list[-1])
-
         if isinstance(sorting_or_analyzer, BaseSorting):
-            curated_sorting_or_analyzer = apply_splits_to_sorting(
+            curated_sorting_or_analyzer, new_ids = apply_splits_to_sorting(
                 curated_sorting_or_analyzer,
                 split_units,
-                new_unit_ids=split_new_unit_ids,
+                new_id_strategy=new_id_strategy,
+                new_unit_ids=split_new_unit_ids_from_user,
+                discard_spikes_unit_ids=discard_spikes_unit_ids,
+                return_extra=True,
             )
         else:
-            curated_sorting_or_analyzer = curated_sorting_or_analyzer.split_units(
+            curated_sorting_or_analyzer, new_ids = curated_sorting_or_analyzer.split_units(
                 split_units,
                 new_id_strategy=new_id_strategy,
-                new_unit_ids=split_new_unit_ids,
+                new_unit_ids=split_new_unit_ids_from_user,
+                discard_spikes_unit_ids=discard_spikes_unit_ids,
                 format="memory",
                 verbose=verbose,
+                return_new_unit_ids=True,
             )
-        if len(unit_ids_to_discard) > 0:
-            curated_sorting_or_analyzer = sorting_or_analyzer.remove_units(unit_ids_to_discard)
+
+        if len(discard_spikes_unit_ids) > 0:
+            ids_to_remove = []
+            for new_id_set in new_ids:
+                if new_id_set[0] in discard_spikes_unit_ids or new_id_set[1] in discard_spikes_unit_ids:
+                    ids_to_remove.append(new_id_set[0])
+
+            curated_sorting_or_analyzer = curated_sorting_or_analyzer.remove_units(ids_to_remove)
 
     # 4. Merge units
     if len(curation_model.merges) > 0:

--- a/src/spikeinterface/curation/tests/test_curation_model.py
+++ b/src/spikeinterface/curation/tests/test_curation_model.py
@@ -13,7 +13,7 @@ def test_format_version():
 
     # Invalid format version
     with pytest.raises(ValidationError):
-        CurationModel(format_version="3", unit_ids=[1, 2, 3])
+        CurationModel(format_version="4", unit_ids=[1, 2, 3])
     with pytest.raises(ValidationError):
         CurationModel(format_version="0.1", unit_ids=[1, 2, 3])
 
@@ -213,6 +213,34 @@ def test_split_units():
         CurationModel(**invalid_new_ids)
 
 
+# Test discard_spikes functionality
+def test_discard_spikes():
+    # Test indices mode with list format
+    valid_discard_spikes_indices = {
+        "format_version": "3",
+        "unit_ids": [1, 2, 3],
+        "discard_spikes": [
+            {
+                "unit_id": 1,
+                "indices": [0, 1, 2],
+            }
+        ],
+    }
+
+    model = CurationModel(**valid_discard_spikes_indices)
+    assert len(model.discard_spikes) == 1
+    assert len(model.discard_spikes[0].indices) == 3
+
+    # Test invalid unit ID
+    invalid_unit_id = {
+        "format_version": "3",
+        "unit_ids": [1, 2, 3],
+        "discard_spikes": [{"unit_id": 4, "indices": [0, 1]}],  # Non-existent unit
+    }
+    with pytest.raises(ValidationError):
+        CurationModel(**invalid_unit_id)
+
+
 # Test removed units
 def test_removed_units():
     valid_remove = {"format_version": "2", "unit_ids": [1, 2, 3], "removed": [2]}
@@ -252,7 +280,7 @@ def test_complete_model():
     }
 
     model = CurationModel(**complete_model)
-    assert model.format_version == "2"
+    assert model.format_version == "3"
     assert len(model.unit_ids) == 5
     assert len(model.label_definitions) == 2
     assert len(model.manual_labels) == 1
@@ -275,7 +303,7 @@ def test_complete_model():
     }
 
     model = CurationModel(**complete_model_dict)
-    assert model.format_version == "2"
+    assert model.format_version == "3"
     assert len(model.unit_ids) == 5
     assert len(model.label_definitions) == 2
     assert len(model.manual_labels) == 1

--- a/src/spikeinterface/curation/tests/test_discard_spikes.py
+++ b/src/spikeinterface/curation/tests/test_discard_spikes.py
@@ -1,0 +1,299 @@
+import numpy as np
+from spikeinterface.core import NumpySorting
+from spikeinterface.curation import apply_curation
+from numpy.random import default_rng
+
+
+def test_discard_and_split():
+    rng = default_rng()
+    spike_indices = [
+        {
+            0: np.sort(rng.choice(100, size=20, replace=False)),
+            1: np.arange(17),
+            2: np.arange(17) + 5,
+            4: np.concatenate([np.arange(10), np.arange(20, 30)]),
+            5: np.arange(9),
+        },
+        {0: np.arange(15), 1: np.arange(17), 2: np.arange(40, 140), 4: np.arange(40, 140), 5: np.arange(40, 140)},
+    ]
+    original_sort = NumpySorting.from_unit_dict(spike_indices, sampling_frequency=1000)  # to have 1 sample=1ms
+
+    discard_spikes = [4, 11, 13, 22, 30]
+    discard_spikes_segs = [[4, 11, 13], np.array([22, 30]) - len(spike_indices[0][0])]
+
+    discard_spikes_curation = {
+        "format_version": "3",
+        "unit_ids": original_sort.unit_ids,
+        "discard_spikes": [
+            {
+                "unit_id": 0,
+                "indices": discard_spikes,
+            }
+        ],
+    }
+
+    curated_sort = apply_curation(original_sort, discard_spikes_curation)
+
+    for segment_index in [0, 1]:
+
+        original_spike_train = original_sort.get_unit_spike_train(unit_id=0, segment_index=segment_index)
+        curated_spike_train = curated_sort.get_unit_spike_train(unit_id=0, segment_index=segment_index)
+
+        discard_spike_times = set(original_spike_train).difference(set(curated_spike_train))
+        spike_times_of_discarded_spikes = original_spike_train[discard_spikes_segs[segment_index]]
+
+        assert set(discard_spike_times) == set(spike_times_of_discarded_spikes)
+
+    split_indices = [2, 4, 5, 10, 13, 18, 22, 31, 33]
+    split_spikes_segs_50 = [
+        [2, 4, 5, 10, 13, 18],
+        [22 - len(spike_indices[0][0]), 31 - len(spike_indices[0][0]), 33 - len(spike_indices[0][0])],
+    ]
+    indices_in_51_seg_2 = np.array([20, 21, 23, 24, 25, 26, 27, 28, 29, 30, 32, 34])
+    split_spikes_segs_51 = [
+        [0, 1, 3, 6, 7, 8, 9, 11, 12, 14, 15, 16, 17, 19],
+        indices_in_51_seg_2 - len(spike_indices[0][0]),
+    ]
+    split_spikes_segs = [split_spikes_segs_50, split_spikes_segs_51]
+
+    discard_spikes_curation_with_split = {
+        "format_version": "3",
+        "unit_ids": original_sort.unit_ids,
+        "discard_spikes": [
+            {
+                "unit_id": 0,
+                "indices": discard_spikes,
+            }
+        ],
+        "splits": [{"unit_id": 0, "mode": "indices", "indices": [split_indices], "new_unit_ids": [50, 51]}],
+    }
+
+    # 4 and 13 should be discarded
+    should_be_discarded_spikes = [[[4, 13], [22 - len(spike_indices[0][0])]], [[11], [30 - len(spike_indices[0][0])]]]
+
+    curated_sort_with_split = apply_curation(original_sort, discard_spikes_curation_with_split)
+
+    for new_unit_id, discarded_spikes_each_unit, split_spikes_seg in zip(
+        [50, 51], should_be_discarded_spikes, split_spikes_segs
+    ):
+        for segment_index in [0, 1]:
+
+            original_spike_train = original_sort.get_unit_spike_train(unit_id=0, segment_index=segment_index)
+            curated_spike_train = curated_sort_with_split.get_unit_spike_train(
+                unit_id=new_unit_id, segment_index=segment_index
+            )
+
+            discard_spike_times = set(original_spike_train[split_spikes_seg[segment_index]]).difference(
+                set(curated_spike_train)
+            )
+
+            spike_times_of_discarded_spikes = original_spike_train[discarded_spikes_each_unit[segment_index]]
+
+            assert set(discard_spike_times) == set(spike_times_of_discarded_spikes)
+
+    # test with "append" unit_id strategy
+
+    split_indices = [2, 4, 5, 10, 13, 18, 22, 31, 33]
+    split_spikes_segs_50 = [[2, 4, 5, 10, 13, 18], np.array([22, 31, 33]) - len(spike_indices[0][0])]
+    indices_in_51_seg_2 = np.array([20, 21, 23, 24, 25, 26, 27, 28, 29, 30, 32, 34])
+    split_spikes_segs_51 = [
+        [0, 1, 3, 6, 7, 8, 9, 11, 12, 14, 15, 16, 17, 19],
+        indices_in_51_seg_2 - len(spike_indices[0][0]),
+    ]
+    split_spikes_segs = [split_spikes_segs_50, split_spikes_segs_51]
+
+    discard_spikes_curation_with_split_append = {
+        "format_version": "3",
+        "unit_ids": original_sort.unit_ids,
+        "discard_spikes": [
+            {
+                "unit_id": 0,
+                "indices": discard_spikes,
+            }
+        ],
+        "splits": [{"unit_id": 0, "mode": "indices", "indices": [split_indices]}],
+    }
+
+    # since we're using append, the new units will have id 6 and 7
+    curated_sort_with_split_append = apply_curation(original_sort, discard_spikes_curation_with_split_append)
+
+    print(f"{curated_sort_with_split_append.unit_ids=}", flush=True)
+
+    for new_unit_id, discarded_spikes_each_unit, split_spikes_seg in zip(
+        [6, 7], should_be_discarded_spikes, split_spikes_segs
+    ):
+        for segment_index in [0, 1]:
+
+            original_spike_train = original_sort.get_unit_spike_train(unit_id=0, segment_index=segment_index)
+            curated_spike_train = curated_sort_with_split_append.get_unit_spike_train(
+                unit_id=new_unit_id, segment_index=segment_index
+            )
+
+            discard_spike_times = set(original_spike_train[split_spikes_seg[segment_index]]).difference(
+                set(curated_spike_train)
+            )
+
+            spike_times_of_discarded_spikes = original_spike_train[discarded_spikes_each_unit[segment_index]]
+
+            assert set(discard_spike_times) == set(spike_times_of_discarded_spikes)
+
+
+def test_discard_and_split_string_ids():
+    rng = default_rng()
+    spike_indices = [
+        {
+            "0": np.sort(rng.choice(100, size=20, replace=False)),
+            "1": np.arange(17),
+            "2": np.arange(17) + 5,
+            "4": np.concatenate([np.arange(10), np.arange(20, 30)]),
+            "5": np.arange(9),
+        },
+        {
+            "0": np.arange(15),
+            "1": np.arange(17),
+            "2": np.arange(40, 140),
+            "4": np.arange(40, 140),
+            "5": np.arange(40, 140),
+        },
+    ]
+    original_sort = NumpySorting.from_unit_dict(spike_indices, sampling_frequency=1000)  # to have 1 sample=1ms
+
+    discard_spikes = [4, 11, 13, 22, 30]
+    discard_spikes_segs = [[4, 11, 13], np.array([22, 30]) - len(spike_indices[0]["0"])]
+
+    discard_spikes_curation = {
+        "format_version": "3",
+        "unit_ids": original_sort.unit_ids,
+        "discard_spikes": [
+            {
+                "unit_id": "0",
+                "indices": discard_spikes,
+            }
+        ],
+    }
+
+    curated_sort = apply_curation(original_sort, discard_spikes_curation)
+
+    for segment_index in [0, 1]:
+
+        original_spike_train = original_sort.get_unit_spike_train(unit_id="0", segment_index=segment_index)
+        curated_spike_train = curated_sort.get_unit_spike_train(unit_id="0", segment_index=segment_index)
+
+        discard_spike_times = set(original_spike_train).difference(set(curated_spike_train))
+        spike_times_of_discarded_spikes = original_spike_train[discard_spikes_segs[segment_index]]
+
+        assert set(discard_spike_times) == set(spike_times_of_discarded_spikes)
+
+    split_indices = [2, 4, 5, 10, 13, 18, 22, 31, 33]
+    split_spikes_segs_50 = [[2, 4, 5, 10, 13, 18], np.array([22, 31, 33]) - len(spike_indices[0]["0"])]
+    indices_in_51_seg_2 = np.array([20, 21, 23, 24, 25, 26, 27, 28, 29, 30, 32, 34])
+    split_spikes_segs_51 = [
+        [0, 1, 3, 6, 7, 8, 9, 11, 12, 14, 15, 16, 17, 19],
+        indices_in_51_seg_2 - len(spike_indices[0]["0"]),
+    ]
+    split_spikes_segs = [split_spikes_segs_50, split_spikes_segs_51]
+
+    discard_spikes_curation_with_split = {
+        "format_version": "3",
+        "unit_ids": original_sort.unit_ids,
+        "discard_spikes": [
+            {
+                "unit_id": "0",
+                "indices": discard_spikes,
+            }
+        ],
+        "splits": [{"unit_id": "0", "mode": "indices", "indices": [split_indices], "new_unit_ids": ["50", "51"]}],
+    }
+
+    # 4 and 13 should be discarded
+    should_be_discarded_spikes = [
+        [[4, 13], [22 - len(spike_indices[0]["0"])]],
+        [[11], [30 - len(spike_indices[0]["0"])]],
+    ]
+
+    curated_sort_with_split = apply_curation(original_sort, discard_spikes_curation_with_split)
+
+    for new_unit_id, discarded_spikes_each_unit, split_spikes_seg in zip(
+        ["50", "51"], should_be_discarded_spikes, split_spikes_segs
+    ):
+        for segment_index in [0, 1]:
+
+            original_spike_train = original_sort.get_unit_spike_train(unit_id="0", segment_index=segment_index)
+            curated_spike_train = curated_sort_with_split.get_unit_spike_train(
+                unit_id=new_unit_id, segment_index=segment_index
+            )
+
+            discard_spike_times = set(original_spike_train[split_spikes_seg[segment_index]]).difference(
+                set(curated_spike_train)
+            )
+
+            spike_times_of_discarded_spikes = original_spike_train[discarded_spikes_each_unit[segment_index]]
+
+            assert set(discard_spike_times) == set(spike_times_of_discarded_spikes)
+
+    # test with "append" unit_id strategy
+
+    split_indices = [2, 4, 5, 10, 13, 18, 22, 31, 33]
+    split_spikes_segs_50 = [[2, 4, 5, 10, 13, 18], np.array([22, 31, 33]) - len(spike_indices[0]["0"])]
+    indices_in_51_seg_2 = np.array([20, 21, 23, 24, 25, 26, 27, 28, 29, 30, 32, 34])
+    split_spikes_segs_51 = [
+        [0, 1, 3, 6, 7, 8, 9, 11, 12, 14, 15, 16, 17, 19],
+        indices_in_51_seg_2 - len(spike_indices[0]["0"]),
+    ]
+    split_spikes_segs = [split_spikes_segs_50, split_spikes_segs_51]
+
+    discard_spikes_curation_with_split_append = {
+        "format_version": "3",
+        "unit_ids": original_sort.unit_ids,
+        "discard_spikes": [
+            {
+                "unit_id": "0",
+                "indices": discard_spikes,
+            }
+        ],
+        "splits": [{"unit_id": "0", "mode": "indices", "indices": [split_indices]}],
+    }
+
+    # since we're using append, the new units will have id 6 and 7
+    curated_sort_with_split_append = apply_curation(original_sort, discard_spikes_curation_with_split_append)
+
+    for new_unit_id, discarded_spikes_each_unit, split_spikes_seg in zip(
+        ["6", "7"], should_be_discarded_spikes, split_spikes_segs
+    ):
+        for segment_index in [0, 1]:
+
+            original_spike_train = original_sort.get_unit_spike_train(unit_id="0", segment_index=segment_index)
+            curated_spike_train = curated_sort_with_split_append.get_unit_spike_train(
+                unit_id=new_unit_id, segment_index=segment_index
+            )
+
+            discard_spike_times = set(original_spike_train[split_spikes_seg[segment_index]]).difference(
+                set(curated_spike_train)
+            )
+
+            spike_times_of_discarded_spikes = original_spike_train[discarded_spikes_each_unit[segment_index]]
+
+            assert set(discard_spike_times) == set(spike_times_of_discarded_spikes)
+
+    # since we're using append, the new units will have id 6 and 7
+    curated_sort_with_split_split = apply_curation(
+        original_sort, discard_spikes_curation_with_split_append, new_id_strategy="split"
+    )
+
+    for new_unit_id, discarded_spikes_each_unit, split_spikes_seg in zip(
+        ["0-0", "0-1"], should_be_discarded_spikes, split_spikes_segs
+    ):
+        for segment_index in [0, 1]:
+
+            original_spike_train = original_sort.get_unit_spike_train(unit_id="0", segment_index=segment_index)
+            curated_spike_train = curated_sort_with_split_split.get_unit_spike_train(
+                unit_id=new_unit_id, segment_index=segment_index
+            )
+
+            discard_spike_times = set(original_spike_train[split_spikes_seg[segment_index]]).difference(
+                set(curated_spike_train)
+            )
+
+            spike_times_of_discarded_spikes = original_spike_train[discarded_spikes_each_unit[segment_index]]
+
+            assert set(discard_spike_times) == set(spike_times_of_discarded_spikes)

--- a/src/spikeinterface/metrics/quality/misc_metrics.py
+++ b/src/spikeinterface/metrics/quality/misc_metrics.py
@@ -326,10 +326,13 @@ def compute_refrac_period_violations(
 
     res = namedtuple("rp_violations", ["rp_contamination", "rp_violations"])
 
+    if unit_ids is None:
+        unit_ids = sorting_analyzer.unit_ids
+
     if not HAVE_NUMBA:
         warnings.warn("Error: numba is not installed.")
         warnings.warn("compute_refrac_period_violations cannot run without numba.")
-        return None
+        return {unit_id: np.nan for unit_id in unit_ids}
 
     sorting = sorting_analyzer.sorting
     fs = sorting_analyzer.sampling_frequency
@@ -337,9 +340,6 @@ def compute_refrac_period_violations(
     num_segments = sorting_analyzer.get_num_segments()
 
     spikes = sorting.to_spike_vector(concatenated=False)
-
-    if unit_ids is None:
-        unit_ids = sorting_analyzer.unit_ids
 
     num_spikes = compute_num_spikes(sorting_analyzer)
 

--- a/src/spikeinterface/metrics/template/template_metrics.py
+++ b/src/spikeinterface/metrics/template/template_metrics.py
@@ -244,7 +244,7 @@ class ComputeTemplateMetrics(BaseMetricExtension):
             # templates_multi is a list of 2D arrays of shape (n_times, n_channels)
             tmp_data["templates_multi"] = templates_multi
             tmp_data["channel_locations_multi"] = channel_locations_multi
-            tmp_data["depth_direction"] = self.params["depth_direction"]
+            tmp_data["depth_direction"] = self.params.get("depth_direction")
 
         return tmp_data
 


### PR DESCRIPTION
Would close #4261

Docs: https://spikeinterface--4287.org.readthedocs.build/en/4287/modules/curation.html

(Note: PR looks big but mostly tests+docs - main changes are updating the id strategy in `sorting_tools.py` (~100 lines) and updating the `apply_merges` function (~50 lines))

This PR allows you to remove spikes from a unit during curation by specifying the following in your curation json file:

```
"discard_spikes": [
    {
        "unit_id": "u10",
        "indices": [
            56,
            57,
            59,
            60
        ]
    },
    {
        "unit_id": "u14",
        "indices": [
            123,
            321
        ]
    }
]
```

This new feature means that the curation format gets bumped to v3!

You can discard at the same time as merging and splitting.

Tricky bit 1
-----------
How to apply it to an analyzer. Decided to discard spikes at the same time as splitting. During the splitting step, we re-wrangle discard spikes into another split unit (call them "discard units") and keep track of the discard unit id. Then remove the full discard units after the splitting. This allows us to use the existing splitting machinery (including splitting extension etc) for discards - nice! 

Tricky bit 2
-----------
Much of the complexity is now related to the id strategy (ughh - why do we give the user THREE new id strategies!!!). It's difficult because we want a cleaned unit to retains its id. This is true even if there are other units which are just split, and the user is using the "append" or "split" new_unit_id_strategy.

So suppose the user does the following:

Unit 1: clean
Unit 2: split
Unit 3: clean and split

With strategy append, we want

Unit 1 -> Unit 1 + Unit 1 dirty 
Unit 2 -> Unit 4 + Unit 5
Unit 3 -> Unit 6 + Unit 7 + Unit 3 dirty

We do this by slotting in the dirty units into places we know to split later. For "append" strategy, I chose to put "Unit 1 dirty" to the last possible unit id, and unit 3 dirty to "unit 3". 

Other stuff
-----------

We have to do merges after splitting+discarding. This is because the spike indices change after merging. To avoid wrangling spike indices (gross!) we just do discarding first.

Tests to do:
- test curation format
- test v2 -> v3 update
- test actual discarding when also splitting / merging