### PR TITLE
More possibilities for gt generation

### DIFF
--- a/src/spikeinterface/generation/drifting_generator.py
+++ b/src/spikeinterface/generation/drifting_generator.py
@@ -435,8 +435,9 @@ def generate_drifting_recording(
         num_units = sorting.get_num_units()
         sampling_frequency = sorting.sampling_frequency
         if sorting._recording is not None:
-            assert sorting.get_total_duration() == duration, "Sorting should have the same duration as the generated data"
-            
+            assert (
+                sorting.get_total_duration() == duration
+            ), "Sorting should have the same duration as the generated data"
 
     # probe
     if probe is None:


### PR DESCRIPTION
Currently, one can not provide custom parameters to the drifting_gt generation. This PR fixes such behavior, such that users can not provide their own sorting, NoiseGenerator, Template kwargs, ... in order to reproduce more closely one behavior or refine benchmarks