### PR TITLE
Upgraded missing numba to ModuleNotFoundError instead of a warning.

### DIFF
--- a/src/spikeinterface/metrics/quality/misc_metrics.py
+++ b/src/spikeinterface/metrics/quality/misc_metrics.py
@@ -327,9 +327,7 @@ def compute_refrac_period_violations(
     res = namedtuple("rp_violations", ["rp_contamination", "rp_violations"])
 
     if not HAVE_NUMBA:
-        warnings.warn("Error: numba is not installed.")
-        warnings.warn("compute_refrac_period_violations cannot run without numba.")
-        return None
+        raise ModuleNotFoundError("numba is not installed. compute_refrac_period_violations cannot run without numba.")
 
     sorting = sorting_analyzer.sorting
     fs = sorting_analyzer.sampling_frequency


### PR DESCRIPTION
Fixes #4290

Note that metric.compute is actually handled inside a try-except block. So this still only raises a warning when Numba is not installed. Just a more informative one. 

https://github.com/SpikeInterface/spikeinterface/blob/53c247a7c8d2cbe53cbf2579f2581ddf82070aab/src/spikeinterface/core/analyzer_extension_core.py#L1127-L1141