### PR TITLE
Remove check of `len(inter_sample_shifts)` matching `num_readout_channels`

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/openephys.py
+++ b/src/spikeinterface/extractors/neoextractors/openephys.py
@@ -358,16 +358,6 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
                     # get inter-sample shifts based on the probe information and mux channels
                     sample_shifts = get_neuropixels_sample_shifts_from_probe(probe, stream_name=self.stream_name)
                     if sample_shifts is not None:
-                        num_readout_channels = probe.annotations.get("num_readout_channels")
-                        if self.get_num_channels() != num_readout_channels:
-                            # need slice because not all channels are saved
-                            chans = probeinterface.get_saved_channel_indices_from_openephys_settings(
-                                settings_file, oe_stream
-                            )
-                            # lets clip to num_readout_channels because this contains also the synchro channel
-                            if chans is not None:
-                                chans = chans[chans < num_readout_channels]
-                                sample_shifts = sample_shifts[chans]
                         self.set_property("inter_sample_shift", sample_shifts)
 
             # load synchronized timestamps and set_times to recording

--- a/src/spikeinterface/extractors/neoextractors/spikeglx.py
+++ b/src/spikeinterface/extractors/neoextractors/spikeglx.py
@@ -98,13 +98,6 @@ class SpikeGLXRecordingExtractor(NeoBaseRecordingExtractor):
             # get inter-sample shifts based on the probe information and mux channels
             sample_shifts = get_neuropixels_sample_shifts_from_probe(probe, stream_name=self.stream_name)
             if sample_shifts is not None:
-                num_readout_channels = probe.annotations.get("num_readout_channels")
-                if self.get_num_channels() != num_readout_channels:
-                    # need slice because not all channels are saved
-                    chans = probeinterface.get_saved_channel_indices_from_spikeglx_meta(meta_filename)
-                    # lets clip to num_readout_channels because this contains also the synchro channel
-                    chans = chans[chans < num_readout_channels]
-                    sample_shifts = sample_shifts[chans]
                 self.set_property("inter_sample_shift", sample_shifts)
         else:
             warning_message = (


### PR DESCRIPTION
Should fix #4311

Since ProbeInterface 0.3.1, we moved the generation of `inter_sample_shifts` to Probeinterface, rather than Spikeinterface. Before, when you recorded from a subset of channels, we kept the `inter_sample_shifts` for all channels, then sliced on the `SpikeInterface` side. Now, when you only record from a subset of channels, only that subset of channel metadata (including the `inter_sample_shifts`) are kept. When updating, we did not remove the slicing on the SpikeInterface side.

This PR removes the slicing on the SpikeInterface side.

We don't have SpikeGLX and OpenEphys test data with only a subset of channels kept. Anyone have idea about how to add this to the test suite?