### PR TITLE
Patch for levels in Bencharmk

### DIFF
--- a/src/spikeinterface/generation/drifting_generator.py
+++ b/src/spikeinterface/generation/drifting_generator.py
@@ -43,14 +43,6 @@ _toy_probes = {
         contact_shapes="square",
         contact_shape_params={"width": 12},
     ),
-    "Neuropixels2-128": dict(
-        num_columns=2,
-        num_contact_per_column=[64] * 2,
-        xpitch=32,
-        ypitch=15,
-        contact_shapes="square",
-        contact_shape_params={"width": 12},
-    ),
     "Neuropixels1-128": dict(
         num_columns=4,
         num_contact_per_column=[32] * 4,


### PR DESCRIPTION
During #4258 that has been merged, some lines were removed by mistake, leading to a bug in the Benchmark objects that can be without levels. This is a fix