### PR TITLE
Let the user defines if he want to get a warning for filtering wrt margin

### DIFF
--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -70,7 +70,7 @@ class FilterRecording(BasePreprocessor):
     display_margin_to_chunk_percent_warning : float | None, default: 0.2
         If not None, a warning is displayed if the margin size is more than this fraction of
         the chunk size during get_traces calls.
-        
+
     Returns
     -------
     filter_recording : FilterRecording
@@ -119,9 +119,9 @@ class FilterRecording(BasePreprocessor):
             self.set_channel_offsets(0)
 
         if display_margin_to_chunk_percent_warning is not None:
-            assert 0.0 < display_margin_to_chunk_percent_warning < 1.0, (
-                "display_margin_to_chunk_percent_warning must be between 0 and 1"
-            )
+            assert (
+                0.0 < display_margin_to_chunk_percent_warning < 1.0
+            ), "display_margin_to_chunk_percent_warning must be between 0 and 1"
 
         assert margin_ms is not None, "margin_ms must be provided!"
         margin = int(margin_ms * fs / 1000.0)
@@ -136,7 +136,7 @@ class FilterRecording(BasePreprocessor):
                     dtype,
                     add_reflect_padding=add_reflect_padding,
                     direction=direction,
-                    display_margin_to_chunk_percent_warning=display_margin_to_chunk_percent_warning
+                    display_margin_to_chunk_percent_warning=display_margin_to_chunk_percent_warning,
                 )
             )
 
@@ -152,7 +152,7 @@ class FilterRecording(BasePreprocessor):
             add_reflect_padding=add_reflect_padding,
             dtype=dtype.str,
             direction=direction,
-            display_margin_to_chunk_percent_warning=display_margin_to_chunk_percent_warning
+            display_margin_to_chunk_percent_warning=display_margin_to_chunk_percent_warning,
         )
 
 
@@ -166,7 +166,7 @@ class FilterRecordingSegment(BasePreprocessorSegment):
         dtype,
         add_reflect_padding=False,
         direction="forward-backward",
-        display_margin_to_chunk_percent_warning=0.2
+        display_margin_to_chunk_percent_warning=0.2,
     ):
         BasePreprocessorSegment.__init__(self, parent_recording_segment)
         self.coeff = coeff


### PR DESCRIPTION
Currently, we hard coded a value of MARGIN_TO_CHUNK_PERCENT_WARNING = 0.2 # 20% that pops a warning each time the user is requesting a small chunk compared to the margin. 

But this has very annoying side effects when dealing with analyzers. Users providing a filtered signal as an input will have tons of warning messages when extracting waveforms (that are snippets rather small). For now, this PR, at the very least, offer the possibilities for user to create a filtered object that will display marging warnings OR not. 

Should it be done automatically in case of an analyzer ? This is an open question here