### PR TITLE
Adapt template metrics to work with positive spiking neurons (peak_sign='pos')

### DIFF
--- a/src/spikeinterface/metrics/template/metrics.py
+++ b/src/spikeinterface/metrics/template/metrics.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 from spikeinterface.core.analyzer_extension_core import BaseMetric
 
 
-def get_trough_and_peak_idx(template, peak_sign='neg'):
+def get_trough_and_peak_idx(template, peak_sign="neg"):
     """
     Return the indices into the input template of the detected trough
     (minimum of template) and peak (maximum of template, after trough).
@@ -27,9 +27,9 @@ def get_trough_and_peak_idx(template, peak_sign='neg'):
     assert template.ndim == 1
 
     # If peak_sign is 'pos', invert the template
-    if peak_sign == 'pos':
+    if peak_sign == "pos":
         template = -template
-    elif peak_sign == 'both':
+    elif peak_sign == "both":
         max_idx = np.abs(template).argmax()
         if template[max_idx] > 0:
             template = -template
@@ -358,9 +358,9 @@ def get_velocity_fits(template, channel_locations, sampling_frequency, **kwargs)
     template, channel_locations = sort_template_and_locations(template, channel_locations, depth_direction)
 
     # If peak_sign is 'pos', invert the template
-    if peak_sign == 'pos':
+    if peak_sign == "pos":
         template = -template
-    elif peak_sign == 'both':
+    elif peak_sign == "both":
         peak_value = template.flat[np.abs(template).argmax()]
         if peak_value > 0:
             template = -template

--- a/src/spikeinterface/metrics/template/template_metrics.py
+++ b/src/spikeinterface/metrics/template/template_metrics.py
@@ -245,6 +245,7 @@ class ComputeTemplateMetrics(BaseMetricExtension):
             tmp_data["templates_multi"] = templates_multi
             tmp_data["channel_locations_multi"] = channel_locations_multi
             tmp_data["depth_direction"] = self.params["depth_direction"]
+            tmp_data["peak_sign"] = self.params["peak_sign"]
 
         return tmp_data
 

--- a/src/spikeinterface/metrics/template/template_metrics.py
+++ b/src/spikeinterface/metrics/template/template_metrics.py
@@ -70,7 +70,7 @@ class ComputeTemplateMetrics(BaseMetricExtension):
     metric_params : dict of dicts or None, default: None
         Dictionary with parameters for template metrics calculation.
         Default parameters can be obtained with: `si.metrics.template_metrics.get_default_template_metrics_params()`
-    peak_sign : {"neg", "pos"}, default: "neg"
+    peak_sign : {"neg", "pos", "both"}, default: "neg"
         Whether to use the positive ("pos") or negative ("neg") peaks to estimate extremum channels.
     upsampling_factor : int, default: 10
         The upsampling factor to upsample the templates
@@ -209,8 +209,7 @@ class ComputeTemplateMetrics(BaseMetricExtension):
                 template_upsampled = resample_poly(template_single, up=upsampling_factor, down=1)
             else:
                 template_upsampled = template_single
-                sampling_frequency_up = sampling_frequency
-            trough_idx, peak_idx = get_trough_and_peak_idx(template_upsampled)
+            trough_idx, peak_idx = get_trough_and_peak_idx(template_upsampled, peak_sign=peak_sign)
 
             templates_single.append(template_upsampled)
             troughs[unit_id] = trough_idx


### PR DESCRIPTION
Template metrics are currently designed to only work for negative spiking neurons (large negative trough followed by small positive peak) but many units spike higher in the positive side (very common in NHP). I adapted here those metrics to deal properly with positive spiking units when peak_sign='pos' (or 'both'). When peak_sign='neg' (default), results are the same.

For reference, here are the templates for a positive spiking unit (each line is a channel).
<img width="554" height="413" alt="pos_templates" src="https://github.com/user-attachments/assets/c0c51bd3-17cc-4926-93c9-83b2df64d666" />
Currently, the cyan line will be picked as the template, trough will be at ~40 (the dip) and peak will be the largest value after trough (so probably that small peak at 60 or the one at 75). That will produce non-sensical metrics (in this case, peak-to-through distance will be overestimated, halfwidth will be overestimated, peak-to-trough valley might be understimated). This is true for all positive spiking units. I propose that when the unit spikes upwards (as declared by peak_sign='pos'), the positive peak should be the "trough" and the negative dip post-positive spike should be the "peak", which will result in metrics that make sense for this units and is consistent with how peak_sign='pos' is dealt with in other parts of spikeinterface. I don't love the overriding of the name "trough" and "peak" (maybe there are more general terms for that but I didn't wanna change much of the code and the names make sense for the default, more common, peak_sign='neg')

Most metrics work fine whether the spike is positive or negative. A few needed some tweaks; I describe what I changed here (per metric):
* halfwidth: halfwidth: currently implemented as find the first index before through and last index after through where template is **less** than threshold; in this PR it is implemented as find the last index before trough and first index after trough where the threshold is crossed (regardless of direction). This computes the halfwidth of the spike ("trough") whether it points downwards or upwards.  The slight logic change in how indices are picked is intentional, it deals better with the edge case where another spike in the same template also crosses the threshold (see image)*
![PXL_20260123_151253013 MP](https://github.com/user-attachments/assets/972900fa-67fe-42f6-aa33-499b85fb1b68)
* repolarization_slope: current implementation finds the first index after trough that is greater than zero; this PR changes it to find the first index after trough where the zero is crossed (which works for negative and positive spikes). if using peak_sign='both', the slope will then be positive for negative/downward spiking units and negative for upwards spiking units, which is nice.
* velocity_fits: I invert the templates if using peak_sign='pos' so it fits the speed of the positive peaks rather than the negative peaks.

Note: in halfwidth, there is another small change that will affect peak_sign='neg' data. Currently, if a template was [0, -1, 0, 0, 0], code will say the halfwidth was 2, if a template was [0, -1, -1, 0, 0] it will say the half_width is 3 and so on. So there was a one-off error. I fixed that so now if x indices are above the threshold, the halfwidth is x (rather than x + 1), but then most new data will differ by one from previous data (e.g., 30 microseconds shorter halfwidth for neuropixels)
