### PR TITLE
Improve stability of velocity fits in template metrics

### DIFF
--- a/src/spikeinterface/metrics/template/metrics.py
+++ b/src/spikeinterface/metrics/template/metrics.py
@@ -361,7 +361,7 @@ def get_velocity_fits(template, channel_locations, sampling_frequency, **kwargs)
         peak_times_ms_above = np.argmin(template_above, 0) / sampling_frequency * 1000 - max_peak_time
         distances_um_above = np.array([np.linalg.norm(cl - max_channel_location) for cl in channel_locations_above])
         inv_velocity_above, score = fit_line_robust(distances_um_above, peak_times_ms_above)
-        if score > min_r2 and np.abs(inv_velocity_above) > 1e-9:
+        if score > min_r2 and inv_velocity_above != 0:
             velocity_above = 1 / inv_velocity_above
         else:
             velocity_above = np.nan
@@ -376,7 +376,7 @@ def get_velocity_fits(template, channel_locations, sampling_frequency, **kwargs)
         peak_times_ms_below = np.argmin(template_below, 0) / sampling_frequency * 1000 - max_peak_time
         distances_um_below = np.array([np.linalg.norm(cl - max_channel_location) for cl in channel_locations_below])
         inv_velocity_below, score = fit_line_robust(distances_um_below, peak_times_ms_below)
-        if score > min_r2 and np.abs(inv_velocity_below) > 1e-9:
+        if score > min_r2 and inv_velocity_below != 0:
             velocity_below = 1 / inv_velocity_below
         else:
             velocity_below = np.nan


### PR DESCRIPTION
In template metrics, `velocity_above` and `velocity_below` estimate how fast an spike moves along the axon/dendrites by fitting a line where x is distance (template_channel_location - location of soma) and y is time (position of the peak at each template_channel compared to the soma expressed in msecs). A small slope means the spike takes a long time to move through the probe (so mm/msecs), a higher slope means the spike moves fast. Currently when a peak position is the same (or very close) along the template channels, VelocityFits() tries to fit a straight vertical line; which gives an infinite slope (in practice, the fitting fails with NaN because X is ill-conditioned). This is pretty common. 

This PR switches the fitting to regress peak_ms (in y) onto channel_distances (in x) and then take 1/slope to obtain the same velocities as before. This is more stable and also justified in the original source "Because the time difference between the trough of adjacent sites could be 0, to avoid inﬁnite numbers, we calculated the inverse of velocity (ms/mm) instead by ﬁtting a regression line to the time of waveform trough at different sites against the distance of the sites relative to soma" (Jia et al, 2020). I also centered the data before fitting the regressor. Centering helps stability and avoids having to learn an intercept which gives the model a bit more robustness.

Here's the velocities calculated with the current method and the new method (proposed in this PR):
<img width="527" height="432" alt="Untitled" src="https://github.com/user-attachments/assets/9fddea10-44d0-4ab2-b7f6-2b420e1f2914" />
Predicted velocities are consistent for lower velocities (center of the plot) and more stable at higher velocities. It is also able to make predictions for a lot more cases (this is a 3h neuropixels recording and the proportions of NaNs drops from 0.37 to 0.26). I also manually checked some results (where there were nans before) and they look sensible. 

Overall, I think it's just a sensible change for added stability and better predictions.