### PR TITLE
Binary recording bacward-compatibility

### DIFF
--- a/src/spikeinterface/core/binaryrecordingextractor.py
+++ b/src/spikeinterface/core/binaryrecordingextractor.py
@@ -71,6 +71,7 @@ class BinaryRecordingExtractor(BaseRecording):
         else:
             assert len(channel_ids) == num_channels, "Provided recording channels have the wrong length"
 
+        # DO NOT DELETE! This is for backward compatibility
         if num_chan is not None:
             assert num_channels is None, "When both num_channels and num_chan are provided, num_channels is used"
             num_channels = num_chan


### PR DESCRIPTION
We removed the `num_chan` argument from the `BinaryRecordingExtractor`, which makes old binary folders not loadable anymore with the current version.

This PR adds it back (but doesn't add it to the docstring).

@magland with this PR you should be able to use the current version to load the compression benchmark data