### PR TITLE
Add peak_sign to sd_ratio

### DIFF
--- a/src/spikeinterface/metrics/quality/misc_metrics.py
+++ b/src/spikeinterface/metrics/quality/misc_metrics.py
@@ -1264,7 +1264,7 @@ def compute_sd_ratio(
     correct_for_template_itself : bool, default:  True
         If true, will take into account that the template itself impacts the standard deviation of the noise,
         and will make a rough estimation of what that impact is (and remove it).
-    peak_sign : str, ("neg", "pos", "both"), default: "neg"
+    peak_sign : "neg" | "pos" | "both", default: "neg"
         The peak sign used to select the template extremum channel.
     **job_kwargs : dict, default: {}
         Keyword arguments sent to get_noise_levels.


### PR DESCRIPTION
sd_ratio uses get_template_extremum_channel to select the "best_channel" for each unit. Similar to other metrics/extensions where this function is used (spike_amplitudes, spike_locations, template_metrics, snr) I think it's worth adding a peak_sign so people can control its behavior. 

Effect is rather minimal because few extremum channels change and nearby channels have similar noise levels anyway but if spike_amplitudes were created with peak_sign='both', it is correct to use peak_sign='both' here too to select the same channel for the std(noise) (as was used for spike_amplitudes).

I also refactored some code for legibility but results are unchanged (for peak_sign='neg', the default).