### PR TITLE
Improve NWB Extractor `__del__` method to avoid import errors

### DIFF
--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional, Literal, Dict, BinaryIO
+import sys
 import warnings
 import importlib.util
 


### PR DESCRIPTION
We've encountered this error running the AIND pipeline a few times now in our group; always caused by some 'other problem' above it, _e.g._:

<details>

```text
  Cloning into 'capsule-repo'...
  + python -u run_capsule.py
  Traceback (most recent call last):
    File "capsule/code/run_capsule.py", line 511, in <module>
      motion = spre.compute_motion(
               ^^^^^^^^^^^^^^^^^^^^
    File "/opt/conda/lib/python3.11/site-packages/spikeinterface/preprocessing/motion.py", line 396, in compute_motion
      node2 = method_class(
              ^^^^^^^^^^^^^
    File "/opt/conda/lib/python3.11/site-packages/spikeinterface/sortingcomponents/peak_localization.py", line 402, in __init__
      ) = get_grid_convolution_templates_and_weights(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/conda/lib/python3.11/site-packages/spikeinterface/postprocessing/localization_tools.py", line 562, in get_grid_convolution_templates_and_weights
      np.arange(x_min, x_max + eps, upsampling_um), np.arange(y_min, y_max + eps, upsampling_um)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ValueError: arange: cannot compute length
  Exception ignored in: <function _BaseNWBExtractor.__del__ at 0x14f842b90f40>
  Traceback (most recent call last):
    File "/opt/conda/lib/python3.11/site-packages/spikeinterface/extractors/nwbextractors.py", line 429, in __del__
    File "/opt/conda/lib/python3.11/site-packages/spikeinterface/extractors/nwbextractors.py", line 410, in _close_hdf5_file
  ImportError: sys.meta_path is None, Python is likely shutting down
```

</details>

and while this particular error is harmless, I did want to try to reduce logging noise/distraction from the 'real problem'

Let me know what you think~