### PR TITLE
Fix pip 26.0+ compatibility in container_tools

### DIFF
--- a/src/spikeinterface/sorters/container_tools.py
+++ b/src/spikeinterface/sorters/container_tools.py
@@ -268,9 +268,6 @@ def install_package_in_container(
         raise ValueError(f"install_package_incontainer, wrong installation_mode={installation_mode}")
 
     if isinstance(res_output, str) and "ERROR" in res_output.upper():
-        warnings.warn(
-            f"pip install of {package_name} in container may have failed. "
-            f"pip output:\n{res_output}"
-        )
+        warnings.warn(f"pip install of {package_name} in container may have failed. " f"pip output:\n{res_output}")
 
     return res_output


### PR DESCRIPTION
## Summary
  - Replace deprecated ``#egg=`` fragment syntax with PEP 440 Direct URL format (``"package[extras] @ URL"``) in
  ``install_package_in_container()`` github mode
  - Add warning when pip install output contains errors, so container install failures are no longer silent

  ## Context
  pip 26.0+ rejects the ``#egg=`` syntax when package extras are specified, causing ``run_sorter()`` to fail with a
  confusing ``ModuleNotFoundError`` instead of a clear install error.

  Fixes #4368