### PR TITLE
Change setuptools version for legacy kilosort tests

### DIFF
--- a/.github/workflows/test_kilosort4.yml
+++ b/.github/workflows/test_kilosort4.yml
@@ -64,6 +64,10 @@ jobs:
           pip install -e .[test]
         shell: bash
 
+      - name: Install legacy setuptools for KS4 < 4.0.19
+        if: matrix.ks_version == '4.0.16' || matrix.ks_version == '4.0.17' || matrix.ks_version == '4.0.18'
+        run: pip install setuptools==78.0.2
+
       - name: Install Kilosort
         run: |
           pip install kilosort==${{ matrix.ks_version }}


### PR DESCRIPTION
Kilosort 4.0.16/17/18 require an older version of setuptools.