### PR TITLE
Add plotting functions for drift and diagnostics to KS4

### DIFF
--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -398,7 +398,7 @@ class Kilosort4Sorter(BaseSorter):
         if save_preprocessed_copy:
             save_preprocessing(results_dir / "temp_wh.dat", ops, bfile)
 
-        if HAS_DIAGNOSTIC_PLOTS and ops['dshift'] is not None:
+        if HAS_DIAGNOSTIC_PLOTS and ops["dshift"] is not None:
             kplots.plot_drift_amount(ops, results_dir)
             kplots.plot_drift_scatter(st0, results_dir)
 


### PR DESCRIPTION
In KS4 `4.0.33` drift maps and other diagnostic plots were added as output. These lines are added here.

More generally, I wonder if we can switch to just wrapping the kilosort entry function `run_kilosort` rather than recreating the internals? A benefit is we wouldn't have to worry about the internal API, and would just need to track changes to this entry function signature. There are some functionality we would need them to ask adding to kilosort:

1) skip all preprocessing (at the moment it's not possible to skip highpass filter)

I'm sure there is other stuff I'm overlooking though