### PR TITLE
Use peak_sign in quality metrics.prepare_data to find template extremum

### DIFF
--- a/src/spikeinterface/metrics/quality/quality_metrics.py
+++ b/src/spikeinterface/metrics/quality/quality_metrics.py
@@ -80,7 +80,7 @@ class ComputeQualityMetrics(BaseMetricExtension):
         use_valid_periods=False,
         periods=None,
         # common extension kwargs
-        peak_sign=None,
+        peak_sign="neg",
         seed=None,
         skip_pc_metrics=False,
     ):
@@ -137,7 +137,7 @@ class ComputeQualityMetrics(BaseMetricExtension):
         all_labels = sorting_analyzer.sorting.unit_ids[spike_unit_indices]
 
         # Get extremum channels for neighbor selection in sparse mode
-        extremum_channels = get_template_extremum_channel(sorting_analyzer)
+        extremum_channels = get_template_extremum_channel(sorting_analyzer, peak_sign=self.params["peak_sign"])
 
         # Pre-compute spike counts and firing rates if advanced NN metrics are requested
         advanced_nn_metrics = ["nn_advanced"]  # Our grouped advanced NN metric


### PR DESCRIPTION
ComputeQualityMetrics has a peak_sign argument (similar to the one in ComputeTemplateMetrics), this PR sends it to get_template_extremum_channel in prepare_data. This affects pca_metrics (if set to "pos" or "both") as it will change how the neighborhood of each unit is defined (l.154), Default behavior, peak_sign='neg', is not changed.

Note: This was originally in #4363 but I took it out as peak_sign-related issues were gonna be taken care by #4374. As #4374 will be delayed I think it's worth having this in 0.104.0.