### PR TITLE
Don't raise when extension is unknown

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1943,6 +1943,9 @@ extension_params={"waveforms":{"ms_before":1.5, "ms_after": "2.5"}}\
 
         extension_class = get_extension_class(extension_name)
 
+        if extension_class is None:
+            return None
+
         extension_instance = extension_class.load(self)
 
         self.extensions[extension_name] = extension_instance
@@ -2198,7 +2201,10 @@ def get_extension_class(extension_name: str, auto_import=True):
                     f"Extension '{extension_name}' is not registered, please import related module before use: 'import {module}'"
                 )
         else:
-            raise ValueError(f"Extension '{extension_name}' is unknown maybe this is an external extension or a typo.")
+            warnings.warn(
+                f"Extension '{extension_name}' is unknown. Maybe this is an external extension, a typo or was computed by a different version of SpikeInterface."
+            )
+        return None
 
     ext_class = extensions_dict[extension_name]
     return ext_class


### PR DESCRIPTION
This PR changes the `load_extension` and `get_extension_class` so that we do not raise on loading an analyzer/extension.

Why?
Suppose someone uses SpikeInterface 0.104 and computes some `auto_correlogram`s [or they've got a lab-specific extension for behavioral data]. They share the analyzer with a colleague who uses 0.103 [or is outside their lab]. Currently, the colleague cannot open the analyzer - the unknown extension raises an error!

This PR changes this error into a warning, and skips loading the extension. Now the `load` loads all the extensions it can, and skips the ones it can't (with a helpful warning).