### PR TITLE
Implementing KNN referencing and a backup referencing mechanism for common_reference

### DIFF
--- a/src/spikeinterface/preprocessing/common_reference.py
+++ b/src/spikeinterface/preprocessing/common_reference.py
@@ -8,7 +8,6 @@ from spikeinterface.core import get_closest_channels
 from spikeinterface.core.baserecording import BaseRecording
 
 from .filter import fix_dtype
-from functools import cache
 
 
 class CommonReferenceRecording(BasePreprocessor):


### PR DESCRIPTION
PR based on this issue: https://github.com/SpikeInterface/spikeinterface/issues/4193

The new features are designed for ungrouped local referencing.

# Changes in parameters:
* `reference`: include `knn` as an option
* `backup_reference`: allowing `global`, `single` and `knn` (`local` is unstable) to take effect when local referencing cannot get enough #channels, default as global
* `nneighbors`: used for knn referencing, i.e. #channels nearby used for referencing
* `backup_thr`: when #channel found locally is below this, turn to `backup_reference`, default as 1, i.e. no channel found.  (we may also consider None to force explicit assignment)

# Changes in workflow:
* Verification in parameters. Since `reference` and `backup_reference` both need preprocessing, all the elif are turned as if.
* Removing assertion of no local reference found as it would be judged dynamically.
* Add `knn` preprocessing in __init__ (similar to `local`).
* Changing the ungrouped part in get_traces.
  * Defining each reference method as local functions to call.
  * In `local`, setup if else to choose backup when #channels not meeting the requirement.