### PR TITLE
Set num_histogram_bins in amplitude_cutoff (back) to 100

### DIFF
--- a/src/spikeinterface/metrics/quality/misc_metrics.py
+++ b/src/spikeinterface/metrics/quality/misc_metrics.py
@@ -1024,7 +1024,9 @@ def compute_amplitude_cutoffs(
     units_with_few_spikes = [unit_id for unit_id, amp_cutoff in all_fraction_missing.items() if np.isnan(amp_cutoff)]
     if len(units_with_few_spikes) > 0:
         min_num_spikes = amplitudes_bins_min_ratio * num_histogram_bins
-        warnings.warn(f"Amplitude cutoff set to NaN for units {units_with_few_spikes}: too few spikes (< {min_num_spikes}).")
+        warnings.warn(
+            f"Amplitude cutoff set to NaN for units {units_with_few_spikes}: too few spikes (< {min_num_spikes})."
+        )
 
     return all_fraction_missing
 


### PR DESCRIPTION
#4353 changed the default `num_histogram_bins` in AmplitudeCutoff from 100 to 200 to get a more granular histogram/estimate.
https://github.com/SpikeInterface/spikeinterface/blob/797f0e876ef5835dc212a5274cfaa0e698a6c8b5/src/spikeinterface/metrics/quality/misc_metrics.py#L1034

But given the default `amplitudes_bins_min_ratio`=5, any cell with less than 1000 spikes will return amplitude_cutoff = NaN. That is (I think?) too big a hurdle (a unit with 0.1Hz firing rate will require 2.8 hours to spike 1000 times). 

Assuming 500 spikes are enough to model the amplitude distribution, I change it back to 100 here. I also change the default value on the low-level `amplitude_cutoff()`to match this default.

EDIT: Even if we don't think 500 spikes are enough to model the distribution, the right parameter to change would be `amplitudes_bins_min_ratio` and not `num_histogram_bins` as we would rather have more samples per bin (lower variance)