### PR TITLE
Add `DeAutozero` preprocessing step

### DIFF
--- a/src/spikeinterface/preprocessing/deautozero.py
+++ b/src/spikeinterface/preprocessing/deautozero.py
@@ -1,0 +1,115 @@
+import numpy as np
+
+from spikeinterface.core.core_tools import define_function_handling_dict_from_class
+from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
+from spikeinterface.core.base import base_period_dtype
+
+
+class DeAutozeroRecording(BasePreprocessor):
+
+    def __init__(
+        self,
+        recording,
+        az_samples,
+        az_periods,
+        voltage_cumsum,
+        firmwave_version=None,
+    ):
+        BasePreprocessor.__init__(self, recording)
+        num_channels = recording.get_num_channels()
+
+        for parent_segment in recording._recording_segments:
+            rec_segment = DeAutozeroRecordingSegment(
+                parent_segment, az_samples, az_periods, voltage_cumsum, num_channels
+            )
+            self.add_recording_segment(rec_segment)
+
+        self._kwargs = dict(
+            recording=recording,
+            az_samples=az_samples,
+            az_periods=az_periods,
+            voltage_cumsum=voltage_cumsum,
+            firmwave_version=firmwave_version,
+        )
+
+
+class DeAutozeroRecordingSegment(BasePreprocessorSegment):
+    def __init__(
+        self,
+        parent_recording_segment,
+        az_samples,
+        az_periods,
+        voltage_cumsum,
+        num_channels,
+    ):
+        BasePreprocessorSegment.__init__(self, parent_recording_segment)
+
+        self.az_samples = az_samples
+        self.az_periods = az_periods
+        self.voltage_cumsum = voltage_cumsum
+        self.num_channels = num_channels
+
+    def get_traces(self, start_frame, end_frame, channel_indices):
+
+        traces = self.parent_recording_segment.get_traces(start_frame, end_frame, channel_indices)
+
+        az_sample_in_range = (self.az_samples > start_frame) & (self.az_samples < end_frame)
+
+        indices = np.where(az_sample_in_range)[0]
+        index_before = indices[0] - 1
+        index_after = indices[-1] + 1
+
+        recording_shift = np.zeros(np.shape(traces))
+
+        for az_index in range(index_before, index_after):
+
+            if az_index == -1:
+                continue
+
+            previous_az_event = max(0, self.az_samples[az_index] - start_frame)
+            next_az_event = min(self.az_samples[az_index + 1] - start_frame, end_frame - start_frame)
+
+            recording_shift[previous_az_event:next_az_event, :] = self.voltage_cumsum[az_index, channel_indices]
+
+        return traces - recording_shift
+
+
+deautozero = define_function_handling_dict_from_class(source_class=DeAutozeroRecording, name="deautozero")
+
+# Tools
+
+
+def get_autozero_periods_sinaps(recording, autozero_channel, period_method="simple"):
+
+    az_event_occured = np.transpose(autozero_channel.get_traces() == 1024)[0]
+    az_samples = np.arange(0, len(az_event_occured)).astype("int64")[az_event_occured]
+
+    az_periods = np.zeros(len(az_samples), dtype=base_period_dtype)
+    az_periods["start_sample_index"] = az_samples - 3
+    az_periods["end_sample_index"] = az_samples + 3
+
+    return az_samples, az_periods
+
+
+def get_autozero_information(recording, autozero_channel, baseline_estimate_sample_size=10):
+
+    az_samples, az_periods = get_autozero_periods_sinaps(recording, autozero_channel)
+    num_channels = recording.get_num_channels()
+
+    voltage_differences = np.zeros((len(az_periods), num_channels), "int64")
+
+    for az_index_index, az_period in enumerate(az_periods):
+
+        az_envelope = recording.get_traces(
+            start_frame=az_period["start_sample_index"] - baseline_estimate_sample_size,
+            end_frame=az_period["end_sample_index"] + baseline_estimate_sample_size,
+        )
+
+        voltage_before = np.median(az_envelope[:baseline_estimate_sample_size, :], axis=0)
+        voltage_after = np.median(az_envelope[-baseline_estimate_sample_size:, :], axis=0)
+        voltage_difference = voltage_after - voltage_before
+        voltage_differences[az_index_index, :] = voltage_difference
+
+    voltage_cumsum = np.cumsum(voltage_differences, axis=0)
+
+    return az_samples, az_periods, voltage_cumsum

--- a/src/spikeinterface/preprocessing/preprocessing_classes.py
+++ b/src/spikeinterface/preprocessing/preprocessing_classes.py
@@ -49,6 +49,7 @@ from .depth_order import DepthOrderRecording, depth_order
 from .astype import AstypeRecording, astype
 from .unsigned_to_signed import UnsignedToSignedRecording, unsigned_to_signed
 from .silence_artifacts import SilencedArtifactsRecording, silence_artifacts
+from .deautozero import DeAutozeroRecording, deautozero
 
 _all_preprocesser_dict = {
     # filter stuff
@@ -89,6 +90,7 @@ _all_preprocesser_dict = {
     AstypeRecording: astype,
     UnsignedToSignedRecording: unsigned_to_signed,
     SilencedArtifactsRecording: silence_artifacts,
+    DeAutozeroRecording: deautozero,
 }
 # we control import in the preprocessing init by setting an __all__
 


### PR DESCRIPTION
This PR adds a de-zeroing preprocessing step, designed for SiNAPS probes.

There are several levels of complexity in how you can do this. Currently, the PR implements the simplest possible algorithm on the simplest data, so that we have a reasonable starting point to make further progress.

Background: SINAPs probes "auto zero" their signal every now and again, to ensure the raw data remains in some reasonable range of values. These "auto zero" events shift the raw voltage reading on each channel by some amount, over a (very small) number of samples. Here's an example:

<img width="1084" height="429" alt="Screenshot 2026-03-03 at 12 50 52" src="https://github.com/user-attachments/assets/1b423ffc-4d91-4068-abc9-7fc7072358e7" />

The strategy to "deautozero" the signal (any have a better name??):

1. find all samples where zeroing occurs, and the window around the sample which is affected by the zeroing. [For now, use the samples provided by the probe and use a $\pm 4$ sample window around that]
2. find the size of the jump at each event, and the cumulative sum of the jumps. Note: these are different at each zeroing event and on each channel.
3. De-zero the jumps. In practice: when you `get_traces`, compute a `recording_shift` array equal to the cumulative jumps in each interval between jumps.

This deals with the overall signal, but there are artifacts left behind by the jumps. This is because the jump does not occur at a single sample value. Instead, it is smeared across a few samples. An example of dezeroed data is shown below:

<img width="1079" height="445" alt="Screenshot 2026-03-03 at 12 58 12" src="https://github.com/user-attachments/assets/f068c5f3-98cf-44bb-9293-b19e7d98612f" />

The jump has been taken care of, but either it's zeroed at the wrong place or there's an artifact on the few samples near the jump. I suggest that a good way of dealing with this, using existing tools, is

4. Use `silence_periods` on the samples affected by the zeroing (found in 1.)

The lab I'm in touch with do a linear interpolation on these samples, which also sounds like a good idea. We don't have an implementation of this yet, right?

You now (hopefully) have an artifact-free, de-zeroed recording.

In practice, you compute the autozero information first (this requires scanning through the recording once):

```
autozero_samples, autozero_periods, voltage_cumsum = get_sinaps_autozero_information(raw_recording, az_channel)
```

Then use this information to make your dezeroed recording:

```
dezeroed_recording = dezero_sinaps(raw_recording, autozero_samples, autozero_periods, voltage_cumsum)
```

Many issues:
A. Finding all samples where zeroing is not straightforward and, depending on hardware, can be channel-specific. But there might only be 4 groups of channels, so maybe we could split the recording into these 4 groups with `split_by`...
B. The de-zeroed signal trends in one direction, and will saturate. Hence we'll need to upcast to int64(?) at some point. You could then apply other preprocessing and downcast again, but all a bit awkward.

EDIT: I'm also curious if all this might be overkill. You might just be able to silence the auto-zero periods and apply a bandpass filter...
