### PR TITLE
Fix openephys tests

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/openephys.py
+++ b/src/spikeinterface/extractors/neoextractors/openephys.py
@@ -351,13 +351,19 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
                     # Ensure device channel index corresponds to channel_ids
                     probe_channel_names = probe.contact_annotations.get("channel_name", None)
                     if probe_channel_names is not None and not np.array_equal(probe_channel_names, self.channel_ids):
-                        device_channel_indices = []
-                        probe_channel_names = list(probe_channel_names)
-                        device_channel_indices = np.zeros(len(self.channel_ids), dtype=int)
-                        for i, ch in enumerate(self.channel_ids):
-                            index_in_probe = probe_channel_names.index(ch)
-                            device_channel_indices[index_in_probe] = i
-                        probe.set_device_channel_indices(device_channel_indices)
+                        if set(probe_channel_names) == set(self.channel_ids):
+                            device_channel_indices = []
+                            probe_channel_names = list(probe_channel_names)
+                            device_channel_indices = np.zeros(len(self.channel_ids), dtype=int)
+                            for i, ch in enumerate(self.channel_ids):
+                                index_in_probe = probe_channel_names.index(ch)
+                                device_channel_indices[index_in_probe] = i
+                            probe.set_device_channel_indices(device_channel_indices)
+                        else:
+                            warnings.warn(
+                                "Channel names in the probe do not match the channel ids from Neo. "
+                                "Cannot set device channel indices, but this might lead to incorrect probe geometries"
+                            )
 
                     if probe.shank_ids is not None:
                         self.set_probe(probe, in_place=True, group_mode="by_shank")

--- a/src/spikeinterface/extractors/tests/test_neoextractors.py
+++ b/src/spikeinterface/extractors/tests/test_neoextractors.py
@@ -121,6 +121,9 @@ class OpenEphysBinaryRecordingTest(RecordingCommonTestSuite, unittest.TestCase):
         ("openephysbinary/v0.5.x_two_nodes", {"stream_id": "0"}),
         ("openephysbinary/v0.5.x_two_nodes", {"stream_id": "1"}),
         ("openephysbinary/v0.6.x_neuropixels_multiexp_multistream", {"stream_id": "0", "block_index": 0}),
+        # TODO: block_indices 1/2 of v0.6.x_neuropixels_multiexp_multistream have a mismatch in the channel names between
+        # the settings files (starting with CH0) and structure.oebin (starting at CH1).
+        # Currently, the extractor will skip remapping to match order in oebin and settings file, raising a warning
         ("openephysbinary/v0.6.x_neuropixels_multiexp_multistream", {"stream_id": "1", "block_index": 1}),
         (
             "openephysbinary/v0.6.x_neuropixels_multiexp_multistream",


### PR DESCRIPTION
The failure is due to a mismatch in the channel names between the settings and structure oebin in 2 test files on GIN.
Added a safeguard mechanism to prevent failures