### PR TITLE
Fix container pip install for Singularity (follow-up to #4380)

### DIFF
--- a/src/spikeinterface/sorters/container_tools.py
+++ b/src/spikeinterface/sorters/container_tools.py
@@ -238,8 +238,14 @@ def install_package_in_container(
         pkg = package_name
         if extra is not None:
             pkg += extra
-        cmd = ["pip", "install", "--user", "--upgrade", "--no-input",
-               f"{pkg} @ {github_url}/archive/{tag_or_version}.tar.gz"]
+        cmd = [
+            "pip",
+            "install",
+            "--user",
+            "--upgrade",
+            "--no-input",
+            f"{pkg} @ {github_url}/archive/{tag_or_version}.tar.gz",
+        ]
         res_output = container_client.run_command(cmd)
 
     elif installation_mode == "folder":


### PR DESCRIPTION
## Summary
Pass the pip install command as a list instead of a string in `install_package_in_container()` github mode, so it works on both Docker and Singularity.

## Context
PR #4380 fixed the `#egg=` deprecation by switching to Direct URL syntax, but the quoted string format only works on Docker. The two container backends split command strings differently:

- **Docker** (`exec_run`) uses `shlex.split()`, which is shell-aware and strips quotes
- **Singularity** (`spython`) uses `str.split(" ")`, which splits naively and leaves quotes attached

So a command like `pip install "pkg @ url"` gets parsed correctly by Docker but breaks on Singularity. Passing the command as a list bypasses both splitting mechanisms, keeping the `pkg @ url` requirement as a single argument on both backends. This is already the pattern used in `runsorter.py`.

Tested against real Docker containers with pip 26.0+ simulating both code paths, and confirmed working in a real Singularity workflow.

Fixes #4368