### PR TITLE
Fix return in wrong block in `get_extension_class`

### DIFF
--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -2198,7 +2198,7 @@ def get_extension_class(extension_name: str, auto_import=True):
             warnings.warn(
                 f"Extension '{extension_name}' is unknown. Maybe this is an external extension, a typo or was computed by a different version of SpikeInterface."
             )
-        return None
+            return None
 
     ext_class = extensions_dict[extension_name]
     return ext_class


### PR DESCRIPTION
Bug added in #4406 (sorry!)

Bug is: if you've only imported core, then do `analyzer.compute('quality_metrics')`, `get_extension_class` should import the quality metrics module, then return the quality metrics class. Instead, I introduced a bug and it returned `None`.

Can't figure out how to test this, because it's about which extensions are available depending on which modules have been imported. But in the test suite, we don't have much control over which order modules are imported in.