### PR TITLE
Remove `n_jobs=-1` from curation tests

### DIFF
--- a/src/spikeinterface/curation/tests/common.py
+++ b/src/spikeinterface/curation/tests/common.py
@@ -35,9 +35,12 @@ def make_sorting_analyzer(sparse=True, num_units=5, durations=[300.0]):
     sorting = sorting.rename_units(new_unit_ids=unit_ids_as_integers)
 
     sorting_analyzer = create_sorting_analyzer(
-        sorting=sorting, recording=recording, format="memory", sparse=sparse, **job_kwargs
+        sorting=sorting,
+        recording=recording,
+        format="memory",
+        sparse=sparse,
     )
-    sorting_analyzer.compute(extensions, **job_kwargs)
+    sorting_analyzer.compute(extensions)
 
     return sorting_analyzer
 
@@ -57,7 +60,7 @@ def make_sorting_analyzer_with_splits(sorting_analyzer, num_unit_splitted=1, num
     sorting_analyzer_with_splits = create_sorting_analyzer(
         sorting=sorting_with_split, recording=sorting_analyzer.recording, format="memory", sparse=True
     )
-    sorting_analyzer_with_splits.compute(extensions, **job_kwargs)
+    sorting_analyzer_with_splits.compute(extensions)
 
     return sorting_analyzer_with_splits, num_unit_splitted, other_ids
 

--- a/src/spikeinterface/curation/tests/test_auto_merge.py
+++ b/src/spikeinterface/curation/tests/test_auto_merge.py
@@ -38,7 +38,6 @@ def test_compute_merge_unit_groups(sorting_analyzer_with_splits, preset):
             # adaptative_window_thresh=0.5,
             # firing_contamination_balance=1.5,
             extra_outputs=True,
-            **job_kwargs,
         )
         if preset == "x_contaminations":
             assert len(merge_unit_groups) == num_unit_splitted
@@ -53,7 +52,6 @@ def test_compute_merge_unit_groups(sorting_analyzer_with_splits, preset):
             sorting_analyzer,
             preset=preset,
             steps=["num_spikes", "snr", "remove_contaminated", "unit_locations"],
-            **job_kwargs,
         )
 
 
@@ -67,7 +65,6 @@ def test_compute_merge_unit_groups_multi_segment(sorting_analyzer_multi_segment_
     merge_unit_groups = compute_merge_unit_groups(
         sorting_analyzer,
         preset=preset,
-        **job_kwargs,
     )
 
 
@@ -75,7 +72,7 @@ def test_auto_merge_units(sorting_analyzer_for_curation):
     recording = sorting_analyzer_for_curation.recording
     new_sorting, _ = split_sorting_by_times(sorting_analyzer_for_curation)
     new_sorting_analyzer = create_sorting_analyzer(new_sorting, recording, format="memory")
-    merged_analyzer = auto_merge_units(new_sorting_analyzer, presets="x_contaminations", **job_kwargs)
+    merged_analyzer = auto_merge_units(new_sorting_analyzer, presets="x_contaminations")
     assert len(merged_analyzer.unit_ids) < len(new_sorting_analyzer.unit_ids)
 
     step_merged_analyzer = auto_merge_units(
@@ -83,7 +80,6 @@ def test_auto_merge_units(sorting_analyzer_for_curation):
         presets=None,
         steps=["num_spikes", "remove_contaminated", "unit_locations", "template_similarity", "quality_score"],
         steps_params={"num_spikes": {"min_spikes": 150}},
-        **job_kwargs,
     )
     assert len(step_merged_analyzer.unit_ids) < len(new_sorting_analyzer.unit_ids)
 
@@ -92,9 +88,7 @@ def test_auto_merge_units_iterative(sorting_analyzer_for_curation):
     recording = sorting_analyzer_for_curation.recording
     new_sorting, _ = split_sorting_by_times(sorting_analyzer_for_curation)
     new_sorting_analyzer = create_sorting_analyzer(new_sorting, recording, format="memory")
-    merged_analyzer = auto_merge_units(
-        new_sorting_analyzer, presets=["x_contaminations", "x_contaminations"], **job_kwargs
-    )
+    merged_analyzer = auto_merge_units(new_sorting_analyzer, presets=["x_contaminations", "x_contaminations"])
     assert len(merged_analyzer.unit_ids) < len(new_sorting_analyzer.unit_ids)
 
 

--- a/src/spikeinterface/curation/tests/test_remove_redundant.py
+++ b/src/spikeinterface/curation/tests/test_remove_redundant.py
@@ -18,7 +18,7 @@ def test_remove_redundant_units(sorting_analyzer_for_curation):
 
     sorting_analyzer = create_sorting_analyzer(sorting_with_dup, recording, format="memory")
     sorting_analyzer.compute("random_spikes")
-    sorting_analyzer.compute("waveforms", **job_kwargs)
+    sorting_analyzer.compute("waveforms")
     sorting_analyzer.compute("templates")
 
     for remove_strategy in ("max_spikes", "minimum_shift", "highest_amplitude"):


### PR DESCRIPTION
Locally, the curation tests run 50% faster when `n_jobs=1` rather than `n_jobs=-1`. Testing to see if this is true on our CI too.

RESULTS:

OS | n_jobs=-1 | n_jobs= 1 |
---|-------------|------------|
Mac 3.10 | 68.55 | 63.08 |
Win 3.10 | 208.2 | 101.7 |
Linux 3.10 | 96.21 | 98.35 |
Mac 3.13 | 76.08 | 43.4 |
Win 3.13 | 158.13 | 72.2 |
Linux 3.13 | 68.37 | 73.4 |

I vote to merge the PR!