### PR TITLE
Set amplitude scalings equal zero for zero template units

### DIFF
--- a/src/spikeinterface/postprocessing/amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/amplitude_scalings.py
@@ -202,7 +202,7 @@ class AmplitudeScalingNode(PipelineNode):
             self._margin = max_margin_collisions
 
         # for some edge cases a template can be zero, leading to problems later
-        template_is_zero = [np.all(template) == 0 for template in all_templates]
+        template_is_zero = [np.all(template == 0) for template in all_templates]
 
         self._all_templates = all_templates
         self._sparsity_mask = sparsity_mask
@@ -224,6 +224,7 @@ class AmplitudeScalingNode(PipelineNode):
             return_in_uV=return_in_uV,
             handle_collisions=handle_collisions,
             delta_collision_samples=delta_collision_samples,
+            template_is_zero=template_is_zero,
         )
 
     def get_dtype(self):


### PR DESCRIPTION
In some edge cases*, templates can be arrays of zeros. When this is the case, the amplitude scalings compute throws an error as you can't linregress a constant y-vector.

This PR fixes this: if the template of a given unit is equal to an array of zeros, the amplitude scalings computation is skipped (with scalings set to zero)

*This is my edge case: take two recordings, concatenate them and sort. Then make an analyzer for each recording by splitting the sorting in two. The concatenation has caused a artifact at the boundary of the two recordings which leads to a unit with a single spike near the boundary. Spikes within `nbefore` of the boundary get given a waveform equal to an array of zeros (this is because we can't accurately compute a waveform, but want to keep the number of spikes in `random_spikes`, `waveforms` etc the same). Spikes within `nbefore` usually aren't selected by `select_random_spikes` but because it's the only spike in the unit, it is selected.  This is then the only waveform which contributes to the unit template, meaning the template is an array of zeros.