### PR TITLE
Add `zarr_class_info` attribute to zarr files for unambiguous and extendible zarr read

### DIFF
--- a/src/spikeinterface/core/zarrextractors.py
+++ b/src/spikeinterface/core/zarrextractors.py
@@ -5,7 +5,7 @@ import zarr
 
 from probeinterface import ProbeGroup
 
-from .base import minimum_spike_dtype
+from .base import minimum_spike_dtype, _get_class_from_string
 from .baserecording import BaseRecording, BaseRecordingSegment
 from .basesorting import BaseSorting, SpikeVectorSortingSegment
 from .core_tools import define_function_from_class, check_json, retrieve_importing_provenance


### PR DESCRIPTION
Instead of relying on channel_ids/unit_ids, this PR adds a full class provenance to the zarr attributes.

This change has two major pros:
- makes reader unambiguous, also adding version/module etc
- makes reader extendible and usable by other packages (e.g., [`photon-mosaic`](https://github.com/photon-mosaic/photon-mosaic/blob/dev/src/photon_mosaic/core/zarrimaging.py#L206))