### PR TITLE
Remove `tmp_data_to_save` when loading old analyzers

### DIFF
--- a/src/spikeinterface/metrics/template/template_metrics.py
+++ b/src/spikeinterface/metrics/template/template_metrics.py
@@ -171,7 +171,7 @@ class ComputeTemplateMetrics(BaseMetricExtension):
 
         # If original analyzer doesn't have "peaks_data" or "main_channel_templates",
         # then we can't save this tmp data (important for merges/splits)
-        if "peaks_data" in self.tmp_data_to_save:
+        if "peaks_data" not in self.data:
             self.tmp_data_to_save = []
 
     def _set_params(


### PR DESCRIPTION
Fixes #4471, replacing #4473

In this PR, if you load an analyzer from version <0.104, we set the tmp_data_to_save to be empty. This means that when you merge units, they don't try and merge this metadata. Note: if you do `analyzer.compute('template_metrics')` the new `tmp_data_to_save` is created.

Loaded a quite-old analyzer and found some more backwards compat parameter bugs. Solve by using `get` rather than indexing.