### PR TITLE
Handle `peak_sign` for quality metrics in `_handle_backward_compatibility_on_load`

### DIFF
--- a/src/spikeinterface/metrics/quality/quality_metrics.py
+++ b/src/spikeinterface/metrics/quality/quality_metrics.py
@@ -77,6 +77,20 @@ class ComputeQualityMetrics(BaseMetricExtension):
             if "peak_sign" in self.params["metric_params"]["amplitude_median"]:
                 del self.params["metric_params"]["amplitude_median"]["peak_sign"]
 
+        # TODO: update this once `main_channel_index` PR is merged
+        # global peak_sign used to find appropriate channels for pca metric computation
+        # If not found, use a "peak_sign" set by any metric
+        global_peak_sign_from_params = self.params.get("peak_sign")
+        if global_peak_sign_from_params is None:
+            for metric_params in self.params["metric_params"].values():
+                if "peak_sign" in metric_params:
+                    global_peak_sign_from_params = metric_params["peak_sign"]
+                    break
+            # If still not found, use <0.104.0 default, "neg"
+            if global_peak_sign_from_params is None:
+                global_peak_sign_from_params = "neg"
+            self.params["peak_sign"] = global_peak_sign_from_params
+
     def _set_params(
         self,
         metric_names: list[str] | None = None,


### PR DESCRIPTION
In #4403, we passed `peak_sign` to `get_template_extremum_channel` in `_prepare_data` for quality metrics.

In the past, the default `peak_sign` here was `None` but this is not allowed: we assert that it must be in `["pos", "neg", "both"]`. Hence if you load an old analyzer (with `peak_sign = None`) and recompute (e.g. when merging) this assertion fails! This PR fixes this issue by trying to set `peak_sign` in `_handle_backward_compatibility_on_load`. It looks through all the other metric's params to see if the user set peak_sign somewhere. If not, it uses the old default, "neg".

At the top of my dev to-do list is: make a gh-actions test suite for backwards compatibility. Will do it soon!!