### PR TITLE
change to using upset-bombcell package

### DIFF
--- a/src/spikeinterface/widgets/bombcell_curation.py
+++ b/src/spikeinterface/widgets/bombcell_curation.py
@@ -16,7 +16,7 @@ class BombcellUpsetPlotWidget(BaseWidget):
     Plot UpSet plots showing which metrics fail together for each unit label after Bombcell
     curation.
 
-    Requires `upsetplot` package.
+    Requires `upsetplot-bombcell` package.
     Each unit label shows relevant metrics based on the threshold dictionary.
 
     Parameters
@@ -103,7 +103,7 @@ class BombcellUpsetPlotWidget(BaseWidget):
             ax.text(
                 0.5,
                 0.5,
-                "UpSet plots require 'upsetplot' package.\n\npip install upsetplot",
+                "UpSet plots require 'upsetplot-bombcell' package.\n\npip install upsetplot-bombcell",
                 ha="center",
                 va="center",
                 fontsize=14,
@@ -224,7 +224,7 @@ def plot_bombcell_unit_labeling_all(
     thresholds : dict, optional
         Threshold dictionary. If None, uses default thresholds.
     include_upset : bool, default: True
-        Whether to include UpSet plots (requires upsetplot package).
+        Whether to include UpSet plots (requires upsetplot-bombcell package).
     **kwargs
         Additional arguments passed to plot functions.
 


### PR DESCRIPTION
This PR switches from `upsetplot` to `upsetplot-bombcell`, a maintained fork, as the original package has been unmaintained for over 2 years.
The package is still called the same way, you just need to pip install upset-bombcell