### PR TITLE
Make version mismatch warning informative and actionable

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -1144,11 +1144,14 @@ def _load_extractor_from_dict(dic) -> "BaseExtractor":
     extractor_class = _get_class_from_string(class_name)
 
     assert extractor_class is not None and class_name is not None, "Could not load spikeinterface class"
-    is_old_version = not _check_same_version(class_name, dic["version"])
+    module_name = class_name.split(".")[0]
+    current_version = importlib.import_module(module_name).__version__
+    saved_version = dic["version"]
+    is_old_version = not _check_same_version(class_name, saved_version)
     if is_old_version:
         warnings.warn(
-            f"Versions are not the same. This might lead to compatibility errors. "
-            f"Using {class_name.split('.')[0]}=={dic['version']} is recommended"
+            f"This object was saved with {module_name}=={saved_version} and you are running {module_name}=={current_version}. "
+            f"To update the saved version, re-save the object with `save()` or `save_to_folder()`/`save_to_zarr()`."
         )
 
         if hasattr(extractor_class, "_handle_backward_compatibility"):

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -1144,19 +1144,9 @@ def _load_extractor_from_dict(dic) -> "BaseExtractor":
     extractor_class = _get_class_from_string(class_name)
 
     assert extractor_class is not None and class_name is not None, "Could not load spikeinterface class"
-    module_name = class_name.split(".")[0]
-    current_version = importlib.import_module(module_name).__version__
-    saved_version = dic["version"]
-    is_old_version = not _check_same_version(class_name, saved_version)
-    if is_old_version:
-        warnings.warn(
-            f"This object was saved with {module_name}=={saved_version} and you are running {module_name}=={current_version}. "
-            f"This may lead to differences in default parameters or minor changes in behavior. "
-            f"To remove this warning, re-save the object with `save()` or `save_to_folder()`/`save_to_zarr()`."
-        )
-
-        if hasattr(extractor_class, "_handle_backward_compatibility"):
-            new_kwargs = extractor_class._handle_backward_compatibility(new_kwargs, dic)
+    is_old_version = not _check_same_version(class_name, dic["version"])
+    if is_old_version and hasattr(extractor_class, "_handle_backward_compatibility"):
+        new_kwargs = extractor_class._handle_backward_compatibility(new_kwargs, dic)
 
     # Initialize the extractor
     extractor = extractor_class(**new_kwargs)

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -1151,7 +1151,8 @@ def _load_extractor_from_dict(dic) -> "BaseExtractor":
     if is_old_version:
         warnings.warn(
             f"This object was saved with {module_name}=={saved_version} and you are running {module_name}=={current_version}. "
-            f"To update the saved version, re-save the object with `save()` or `save_to_folder()`/`save_to_zarr()`."
+            f"This may lead to differences in default parameters or minor changes in behavior. "
+            f"To remove this warning, re-save the object with `save()` or `save_to_folder()`/`save_to_zarr()`."
         )
 
         if hasattr(extractor_class, "_handle_backward_compatibility"):


### PR DESCRIPTION
The version mismatch warning in `_load_extractor_from_dict` told users to downgrade, which is unhelpful when they upgraded on purpose. If the object loads successfully it is probably fine, so the warning should convey two things: that there may be minor differences in default parameters or behavior across versions, and that re-saving the object (via `save()`, `save_to_folder()`, or `save_to_zarr()`) stamps the current version and removes the warning. Known backward-compatibility issues continue to be handled silently by `_handle_backward_compatibility`.

Closes #4495
