### PR TITLE
Fix false-positive margin warning in forkserver workers

### DIFF
--- a/src/spikeinterface/core/__init__.py
+++ b/src/spikeinterface/core/__init__.py
@@ -83,6 +83,7 @@ from .globals import (
     get_global_job_kwargs,
     set_global_job_kwargs,
     reset_global_job_kwargs,
+    is_set_global_job_kwargs_set,
 )
 
 # tools

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -3,7 +3,12 @@ import warnings
 import numpy as np
 
 from spikeinterface.core.core_tools import define_function_handling_dict_from_class
-from spikeinterface.core import get_chunk_with_margin, ensure_chunk_size, get_global_job_kwargs
+from spikeinterface.core import (
+    get_chunk_with_margin,
+    ensure_chunk_size,
+    get_global_job_kwargs,
+    is_set_global_job_kwargs_set,
+)
 
 from .basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 
@@ -118,7 +123,7 @@ class FilterRecording(BasePreprocessor):
         margin = int(margin_ms * fs / 1000.0)
 
         global_job_kwargs_chunk_size = ensure_chunk_size(recording, **get_global_job_kwargs())
-        if margin > MARGIN_TO_CHUNK_PERCENT_WARNING * global_job_kwargs_chunk_size:
+        if is_set_global_job_kwargs_set() and margin > MARGIN_TO_CHUNK_PERCENT_WARNING * global_job_kwargs_chunk_size:
             warnings.warn(
                 f"The margin size ({margin} samples) is more than {int(MARGIN_TO_CHUNK_PERCENT_WARNING * 100)}% "
                 f"of the global chunk size {global_job_kwargs_chunk_size} samples. This may lead to performance bottlenecks when "


### PR DESCRIPTION
The margin-vs-chunk-size warning in `FilterRecording.__init__` fires at filter construction time using `get_global_job_kwargs()`. With `forkserver` (or `spawn`), worker processes start fresh and don't inherit the parent's global job kwargs, so `get_global_job_kwargs()` returns the default `chunk_duration="1s"`. This makes the margin appear huge relative to the chunk size, triggering a spurious warning even though the actual processing uses the correct (larger) chunk size.

The fix guards the warning with `is_set_global_job_kwargs_set()`. If global job kwargs haven't been explicitly set in the current process, the check is skipped because the default values are not meaningful for this comparison.

Closes #4469