### PR TITLE
fix WaveformExtractor backwards compatiblity: run backwards compatiblity migration before validating metrics

### DIFF
--- a/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
+++ b/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
@@ -629,12 +629,16 @@ def _read_old_waveforms_extractor_binary(folder, sorting):
                     pc_all[mask, ...] = pc_one
                 ext.data["pca_projection"] = pc_all
 
-        # update params
-        new_params = ext._set_params()
-        updated_params = make_ext_params_up_to_date(ext, params, new_params)
-        ext.set_params(**updated_params, save=False)
+        # Install raw on-disk params and run compat handler first,
+        # matching what AnalyzerExtension.load does for non-legacy folders.
+        ext.params = dict(params)
         if ext.need_backward_compatibility_on_load:
             ext._handle_backward_compatibility_on_load()
+
+        # Now merge and validate — deprecated names are already migrated.
+        new_params = ext._set_params()
+        updated_params = make_ext_params_up_to_date(ext, ext.params, new_params)
+        ext.set_params(**updated_params, save=False)
         ext.run_info = None
 
         sorting_analyzer.extensions[new_name] = ext


### PR DESCRIPTION
For extensions whose on-disk `params.json` contains metric names that were renamed in 0.104 (e.g. `peak_to_valley`, `velocity_above`, `l_ratio`, …), validation raises a `ValueError` before the compat handler ever runs, which prevents loading these saved metrics.

This is because [`_read_old_waveforms_extractor_binary`](https://github.com/SpikeInterface/spikeinterface/blob/89381fe5b6ad08a160f3b61b5f6e2b1f292ec96b/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py#L632-L637) validates before migrating:

```python
new_params = ext._set_params()                                        # 1. get defaults
updated_params = make_ext_params_up_to_date(ext, params, new_params)  # 2. merge on-disk with defaults
ext.set_params(**updated_params, save=False)                          # 3. validate + set — (errors)
if ext.need_backward_compatibility_on_load:
    ext._handle_backward_compatibility_on_load()                      # 4. migrate — never reached
```

Two things go wrong before the compat handler gets a chance to run:

1. Step 3: `_set_params` rejects deprecated names like `peak_to_valley` or `l_ratio`.
2. Step 2: `make_ext_params_up_to_date` strips any `metric_params` keys that don't exist in the new defaults: deprecated sub-params (e.g. `velocity_above.min_channels_for_velocity`) are silently dropped before the compat handler can migrate them to their new names (e.g. `velocity_fits.min_channels`).

This PR changes the order of operations so the migration handler runs first on the raw on-disk parameters, which are then pruned and validated by `make_ext_params_up_to_date` and `set_params`, respectively. Running the compat handler on the raw on-disk params first is what `SortingAnalyzer` already does for non-legacy folders, so the change would just make `WaveformExtractor` have the same logical flow.

Fixes: #4508