### PR TITLE
Add `get_start_time`, `get_end_time`, and `get_last_spike_frame` to `BaseSorting`

### DIFF
--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -322,11 +322,11 @@ class BaseSorting(BaseExtractor):
                     "Might be necessary for further postprocessing."
                 )
         self._recording = recording
-        # The recording is now the source of truth for timestamps.
-        # Reset the sorting's own time offset so it doesn't conflict
-        # with the recording's t_start when accessed through get_start_time/get_end_time.
-        for segment in self.segments:
-            segment._t_start = 0
+        # Copy the recording's start times into the sorting segments so that
+        # get_start_time can just read _t_start without branching.
+        # This also prevents double-counting if the extractor had set its own _t_start at init.
+        for segment_index, segment in enumerate(self.segments):
+            segment._t_start = recording.get_start_time(segment_index=segment_index)
 
     @property
     def sorting_info(self):
@@ -355,9 +355,6 @@ class BaseSorting(BaseExtractor):
     def get_start_time(self, segment_index: int | None = None) -> float:
         """Get the start time of the sorting segment.
 
-        If a recording is registered, returns the recording's start time.
-        Otherwise returns the sorting segment's own t_start (or 0.0).
-
         Parameters
         ----------
         segment_index : int or None, default: None
@@ -369,17 +366,14 @@ class BaseSorting(BaseExtractor):
             The start time in seconds
         """
         segment_index = self._check_segment_index(segment_index)
-        if self.has_recording():
-            return self._recording.get_start_time(segment_index=segment_index)
-        else:
-            segment = self.segments[segment_index]
-            return segment._t_start if segment._t_start is not None else 0.0
+        segment = self.segments[segment_index]
+        return segment._t_start if segment._t_start is not None else 0.0
 
-    def get_end_time(self, segment_index: int | None = None) -> float | None:
+    def get_end_time(self, segment_index: int | None = None) -> float:
         """Get the end time of the sorting segment.
 
         If a recording is registered, returns the recording's end time.
-        Otherwise returns None (the sorting doesn't know the recording duration).
+        Otherwise returns the time of the last spike in the segment.
 
         Parameters
         ----------
@@ -388,14 +382,35 @@ class BaseSorting(BaseExtractor):
 
         Returns
         -------
-        float or None
-            The end time in seconds, or None if no recording is registered.
+        float
+            The end time in seconds
         """
         segment_index = self._check_segment_index(segment_index)
         if self.has_recording():
             return self._recording.get_end_time(segment_index=segment_index)
         else:
-            return None
+            last_spike_frame = self.get_last_spike_frame(segment_index=segment_index)
+            return self.sample_index_to_time(last_spike_frame, segment_index=segment_index)
+
+    def get_last_spike_frame(self, segment_index: int | None = None) -> int:
+        """Get the frame index of the last spike in a segment across all units.
+
+        Parameters
+        ----------
+        segment_index : int or None, default: None
+            The segment index (required for multi-segment)
+
+        Returns
+        -------
+        int
+            The frame index of the last spike, or 0 if no spikes exist.
+        """
+        segment_index = self._check_segment_index(segment_index)
+        spike_vector = self.to_spike_vector(concatenated=False)
+        spikes_in_segment = spike_vector[segment_index]
+        if len(spikes_in_segment) == 0:
+            return 0
+        return int(np.max(spikes_in_segment["sample_index"]))
 
     def get_times(self, segment_index=None):
         """

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -322,6 +322,11 @@ class BaseSorting(BaseExtractor):
                     "Might be necessary for further postprocessing."
                 )
         self._recording = recording
+        # The recording is now the source of truth for timestamps.
+        # Reset the sorting's own time offset so it doesn't conflict
+        # with the recording's t_start when accessed through get_start_time/get_end_time.
+        for segment in self.segments:
+            segment._t_start = 0
 
     @property
     def sorting_info(self):
@@ -346,6 +351,51 @@ class BaseSorting(BaseExtractor):
             return self._recording.has_time_vector(segment_index=segment_index)
         else:
             return False
+
+    def get_start_time(self, segment_index: int | None = None) -> float:
+        """Get the start time of the sorting segment.
+
+        If a recording is registered, returns the recording's start time.
+        Otherwise returns the sorting segment's own t_start (or 0.0).
+
+        Parameters
+        ----------
+        segment_index : int or None, default: None
+            The segment index (required for multi-segment)
+
+        Returns
+        -------
+        float
+            The start time in seconds
+        """
+        segment_index = self._check_segment_index(segment_index)
+        if self.has_recording():
+            return self._recording.get_start_time(segment_index=segment_index)
+        else:
+            segment = self.segments[segment_index]
+            return segment._t_start if segment._t_start is not None else 0.0
+
+    def get_end_time(self, segment_index: int | None = None) -> float | None:
+        """Get the end time of the sorting segment.
+
+        If a recording is registered, returns the recording's end time.
+        Otherwise returns None (the sorting doesn't know the recording duration).
+
+        Parameters
+        ----------
+        segment_index : int or None, default: None
+            The segment index (required for multi-segment)
+
+        Returns
+        -------
+        float or None
+            The end time in seconds, or None if no recording is registered.
+        """
+        segment_index = self._check_segment_index(segment_index)
+        if self.has_recording():
+            return self._recording.get_end_time(segment_index=segment_index)
+        else:
+            return None
 
     def get_times(self, segment_index=None):
         """

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -322,11 +322,11 @@ class BaseSorting(BaseExtractor):
                     "Might be necessary for further postprocessing."
                 )
         self._recording = recording
-        # The recording is now the source of truth for timestamps.
-        # Reset the sorting's own time offset so it doesn't conflict
-        # with the recording's t_start when accessed through get_start_time/get_end_time.
-        for segment in self.segments:
-            segment._t_start = None
+        # Copy the recording's start times into the sorting segments. This way,
+        # the sorting preserves the start time even if the recording is later
+        # detached (e.g. analyzer saved and reloaded without the recording).
+        for segment_index, segment in enumerate(self.segments):
+            segment._t_start = recording.get_start_time(segment_index=segment_index)
 
     @property
     def sorting_info(self):
@@ -355,9 +355,6 @@ class BaseSorting(BaseExtractor):
     def get_start_time(self, segment_index: int | None = None) -> float:
         """Get the start time of the sorting segment.
 
-        If a recording is registered, returns the recording's start time.
-        Otherwise returns the sorting's own start time (0.0 if it was not set).
-
         Parameters
         ----------
         segment_index : int or None, default: None
@@ -369,11 +366,8 @@ class BaseSorting(BaseExtractor):
             The start time in seconds
         """
         segment_index = self._check_segment_index(segment_index)
-        if self.has_recording():
-            return self._recording.get_start_time(segment_index=segment_index)
-        else:
-            segment = self.segments[segment_index]
-            return segment._t_start if segment._t_start is not None else 0.0
+        segment = self.segments[segment_index]
+        return segment._t_start if segment._t_start is not None else 0.0
 
     def get_end_time(self, segment_index: int | None = None) -> float:
         """Get the end time of the sorting segment.

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -326,7 +326,7 @@ class BaseSorting(BaseExtractor):
         # Reset the sorting's own time offset so it doesn't conflict
         # with the recording's t_start when accessed through get_start_time/get_end_time.
         for segment in self.segments:
-            segment._t_start = 0
+            segment._t_start = None
 
     @property
     def sorting_info(self):

--- a/src/spikeinterface/core/tests/test_time_handling.py
+++ b/src/spikeinterface/core/tests/test_time_handling.py
@@ -445,3 +445,56 @@ def test_shift_times_with_None_as_t_start():
     assert recording.segments[0].t_start is None
     recording.shift_times(shift=1.0)  # Shift by one seconds should not generate an error
     assert recording.get_start_time() == 1.0
+
+
+class TestSortingTimeNoRecording:
+    """Tests for time methods on BaseSorting without a registered recording."""
+
+    def test_get_start_time_default(self):
+        sorting = generate_sorting(num_units=5, durations=[10])
+        assert sorting.get_start_time(segment_index=0) == 0.0
+
+    def test_get_end_time_default(self):
+        sorting = generate_sorting(num_units=5, durations=[10])
+        assert sorting.get_end_time(segment_index=0) is None
+
+    def test_get_start_time_with_t_start(self):
+        sorting = generate_sorting(num_units=5, durations=[10])
+        sorting.segments[0]._t_start = 100.0
+        assert sorting.get_start_time(segment_index=0) == 100.0
+
+
+class TestSortingTimeWithRecording:
+    """
+    Tests for time methods on BaseSorting with a registered recording.
+    The key invariant: the recording is the source of truth for timestamps.
+    """
+
+    def test_get_start_end_time(self):
+        recording = generate_recording(num_channels=4, durations=[10])
+        sorting = generate_sorting(num_units=5, durations=[10])
+        sorting.register_recording(recording)
+
+        assert sorting.get_start_time(segment_index=0) == recording.get_start_time(segment_index=0)
+        assert sorting.get_end_time(segment_index=0) == recording.get_end_time(segment_index=0)
+
+    def test_register_recording_resets_t_start(self):
+        """Registering a recording resets _t_start so the recording is the sole source of truth."""
+        sorting = generate_sorting(num_units=5, durations=[10])
+        sorting.segments[0]._t_start = 100.0
+
+        recording = generate_recording(num_channels=4, durations=[10])
+        sorting.register_recording(recording)
+
+        assert sorting.segments[0]._t_start == 0
+        assert sorting.get_start_time(segment_index=0) == recording.get_start_time(segment_index=0)
+
+    def test_with_recording_shifted_start(self):
+        """Recording with a non-zero t_start is reflected in the sorting."""
+        recording = generate_recording(num_channels=4, durations=[10])
+        recording.shift_times(shift=50.0)
+
+        sorting = generate_sorting(num_units=5, durations=[10])
+        sorting.register_recording(recording)
+
+        assert sorting.get_start_time(segment_index=0) == 50.0

--- a/src/spikeinterface/core/tests/test_time_handling.py
+++ b/src/spikeinterface/core/tests/test_time_handling.py
@@ -480,16 +480,19 @@ class TestSortingTimeWithRecording:
         assert sorting.get_start_time(segment_index=0) == recording.get_start_time(segment_index=0)
         assert sorting.get_end_time(segment_index=0) == recording.get_end_time(segment_index=0)
 
-    def test_register_recording_resets_t_start(self):
-        """Registering a recording resets _t_start so the recording is the sole source of truth."""
+    def test_register_recording_copies_start_times(self):
+        """Registering a recording copies its start times into the sorting segments."""
         sorting = generate_sorting(num_units=5, durations=[10])
         sorting.segments[0]._t_start = 100.0
 
         recording = generate_recording(num_channels=4, durations=[10])
+        recording.shift_times(shift=50.0)
         sorting.register_recording(recording)
 
-        assert sorting.segments[0]._t_start is None
-        assert sorting.get_start_time(segment_index=0) == recording.get_start_time(segment_index=0)
+        # _t_start now mirrors the recording's start time, preserving it across
+        # save/load cycles even when the recording is not attached.
+        assert sorting.segments[0]._t_start == recording.get_start_time(segment_index=0)
+        assert sorting.get_start_time(segment_index=0) == 50.0
 
     def test_with_recording_shifted_start(self):
         """Recording with a non-zero t_start is reflected in the sorting."""

--- a/src/spikeinterface/core/tests/test_time_handling.py
+++ b/src/spikeinterface/core/tests/test_time_handling.py
@@ -454,9 +454,11 @@ class TestSortingTimeNoRecording:
         sorting = generate_sorting(num_units=5, durations=[10])
         assert sorting.get_start_time(segment_index=0) == 0.0
 
-    def test_get_end_time_default(self):
+    def test_get_end_time_is_last_spike(self):
         sorting = generate_sorting(num_units=5, durations=[10])
-        assert sorting.get_end_time(segment_index=0) is None
+        last_frame = sorting.get_last_spike_frame(segment_index=0)
+        expected_time = last_frame / sorting.get_sampling_frequency()
+        assert sorting.get_end_time(segment_index=0) == expected_time
 
     def test_get_start_time_with_t_start(self):
         sorting = generate_sorting(num_units=5, durations=[10])
@@ -478,15 +480,16 @@ class TestSortingTimeWithRecording:
         assert sorting.get_start_time(segment_index=0) == recording.get_start_time(segment_index=0)
         assert sorting.get_end_time(segment_index=0) == recording.get_end_time(segment_index=0)
 
-    def test_register_recording_resets_t_start(self):
-        """Registering a recording resets _t_start so the recording is the sole source of truth."""
+    def test_register_recording_sets_t_start_from_recording(self):
+        """Registering a recording copies the recording's start times into the sorting segments."""
         sorting = generate_sorting(num_units=5, durations=[10])
         sorting.segments[0]._t_start = 100.0
 
         recording = generate_recording(num_channels=4, durations=[10])
         sorting.register_recording(recording)
 
-        assert sorting.segments[0]._t_start == 0
+        # _t_start was overwritten with the recording's start time
+        assert sorting.segments[0]._t_start == recording.get_start_time(segment_index=0)
         assert sorting.get_start_time(segment_index=0) == recording.get_start_time(segment_index=0)
 
     def test_with_recording_shifted_start(self):


### PR DESCRIPTION
`BaseSorting` has no public way to query the start or end time of a segment. `BaseRecording` has both (#3623). This PR adds `get_start_time` and `get_end_time` to `BaseSorting`, plus a `get_last_spike_frame` helper. With a registered recording, `get_end_time` returns the recording's end time. Without one, it returns the time of the last spike in the segment (the best the sorting can do on its own). `get_start_time` reads `_t_start` directly in both cases.

Adding these accessors however creates an ambiguity: some sorting extractors set `_t_start` on their segments at init. For example, neo sorting extractors [set `_t_start` from the signal stream](https://github.com/SpikeInterface/spikeinterface/blob/main/src/spikeinterface/extractors/neoextractors/neobaseextractor.py#L625) (e.g. Neuralynx [infers it here](https://github.com/SpikeInterface/spikeinterface/blob/main/src/spikeinterface/extractors/neoextractors/neobaseextractor.py#L422-L424)). If that sorting registers a recording that also starts at 100.0s, `get_start_time` would need to decide which value to return.

The decision here is that registering a recording is a statement that "these are the right timestamps" (see #4519). In consequence, `register_recording` now copies the recording's start times into the sorting segments' `_t_start`. This replaces whatever the extractor had set at init, so `get_start_time` returns consistent values.
