### PR TITLE
Improvements over chuking refactoring

### DIFF
--- a/src/spikeinterface/core/__init__.py
+++ b/src/spikeinterface/core/__init__.py
@@ -96,12 +96,14 @@ from .job_tools import (
     get_best_job_kwargs,
     ensure_n_jobs,
     ensure_chunk_size,
-    ChunkExecutor,
+    TimeSeriesChunkExecutor,
     split_job_kwargs,
     fix_job_kwargs,
 )
 from .recording_tools import (
     write_binary_recording,
+    write_memory_recording,
+    write_recording_to_zarr,
     write_to_h5_dataset_format,
     get_random_data_chunks,
     get_channel_distances,

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -300,7 +300,7 @@ class BaseRecording(BaseRecordingSnippets, TimeSeries):
 
     def get_data(self, start_frame: int, end_frame: int, segment_index: int | None = None, **kwargs) -> np.ndarray:
         """
-        General retrieval function for chunkable objects
+        General retrieval function for time_series objects
         """
         return self.get_traces(segment_index=segment_index, start_frame=start_frame, end_frame=end_frame, **kwargs)
 
@@ -672,6 +672,6 @@ class BaseRecordingSegment(TimeSeriesSegment):
         self, start_frame: int, end_frame: int, indices: list | np.ndarray | tuple | None = None
     ) -> np.ndarray:
         """
-        General retrieval function for chunkable objects
+        General retrieval function for time_series objects
         """
         return self.get_traces(start_frame=start_frame, end_frame=end_frame, channel_indices=indices)

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -5,13 +5,13 @@ from pathlib import Path
 import numpy as np
 from probeinterface import read_probeinterface, write_probeinterface
 
-from .chunkable import ChunkableSegment, ChunkableMixin
+from .time_series import TimeSeriesSegment, TimeSeries
 from .baserecordingsnippets import BaseRecordingSnippets
 from .core_tools import convert_bytes_to_str, convert_seconds_to_str
 from .job_tools import split_job_kwargs
 
 
-class BaseRecording(BaseRecordingSnippets, ChunkableMixin):
+class BaseRecording(BaseRecordingSnippets, TimeSeries):
     """
     Abstract class representing several a multichannel timeseries (or block of raw ephys traces).
     Internally handle list of RecordingSegment
@@ -311,7 +311,7 @@ class BaseRecording(BaseRecordingSnippets, ChunkableMixin):
         kwargs, job_kwargs = split_job_kwargs(save_kwargs)
 
         if format == "binary":
-            from .chunkable_tools import write_binary
+            from .time_series_tools import write_binary
 
             folder = kwargs["folder"]
             file_paths = [folder / f"traces_cached_seg{i}.raw" for i in range(self.get_num_segments())]
@@ -637,7 +637,7 @@ class BaseRecording(BaseRecordingSnippets, ChunkableMixin):
         return astype(self, dtype=dtype, round=round)
 
 
-class BaseRecordingSegment(ChunkableSegment):
+class BaseRecordingSegment(TimeSeriesSegment):
     """
     Abstract class representing a multichannel timeseries, or block of raw ephys traces
     """

--- a/src/spikeinterface/core/job_tools.py
+++ b/src/spikeinterface/core/job_tools.py
@@ -205,7 +205,7 @@ def divide_segment_into_chunks(num_frames, chunk_size):
     return chunks
 
 
-def divide_chunkable_into_chunks(recording, chunk_size):
+def divide_time_series_into_chunks(recording, chunk_size):
     slices = []
     for segment_index in range(recording.get_num_segments()):
         num_frames = recording.get_num_samples(segment_index)
@@ -242,7 +242,7 @@ def ensure_n_jobs(extractor, n_jobs=1):
     return n_jobs
 
 
-def chunk_duration_to_chunk_size(chunk_duration, chunkable: "ChunkableMixin"):
+def chunk_duration_to_chunk_size(chunk_duration, chunkable: "TimeSeries"):
     if isinstance(chunk_duration, float):
         chunk_size = int(chunk_duration * chunkable.get_sampling_frequency())
     elif isinstance(chunk_duration, str):
@@ -259,7 +259,7 @@ def chunk_duration_to_chunk_size(chunk_duration, chunkable: "ChunkableMixin"):
 
 
 def ensure_chunk_size(
-    chunkable: "ChunkableMixin",
+    chunkable: "TimeSeries",
     total_memory=None,
     chunk_size=None,
     chunk_memory=None,
@@ -320,7 +320,7 @@ def ensure_chunk_size(
     return chunk_size
 
 
-class ChunkExecutor:
+class TimeSeriesChunkExecutor:
     """
     Core class for parallel processing to run a "function" over chunks on a chunkable extractor.
 
@@ -334,7 +334,7 @@ class ChunkExecutor:
 
     Parameters
     ----------
-    chunkable : ChunkableMixin
+    chunkable : TimeSeries
         The chunkable object to be processed.
     func : function
         Function that runs on each chunk
@@ -383,7 +383,7 @@ class ChunkExecutor:
 
     def __init__(
         self,
-        chunkable: "ChunkableMixin",
+        chunkable: "TimeSeries",
         func,
         init_func,
         init_args,
@@ -487,7 +487,7 @@ class ChunkExecutor:
 
         if slices is None:
             # TODO: rename
-            slices = divide_chunkable_into_chunks(self.chunkable, self.chunk_size)
+            slices = divide_time_series_into_chunks(self.chunkable, self.chunk_size)
 
         if self.handle_returns:
             returns = []

--- a/src/spikeinterface/core/job_tools.py
+++ b/src/spikeinterface/core/job_tools.py
@@ -242,9 +242,9 @@ def ensure_n_jobs(extractor, n_jobs=1):
     return n_jobs
 
 
-def chunk_duration_to_chunk_size(chunk_duration, chunkable: "TimeSeries"):
+def chunk_duration_to_chunk_size(chunk_duration, time_series: "TimeSeries"):
     if isinstance(chunk_duration, float):
-        chunk_size = int(chunk_duration * chunkable.get_sampling_frequency())
+        chunk_size = int(chunk_duration * time_series.get_sampling_frequency())
     elif isinstance(chunk_duration, str):
         if chunk_duration.endswith("ms"):
             chunk_duration = float(chunk_duration.replace("ms", "")) / 1000.0
@@ -252,14 +252,14 @@ def chunk_duration_to_chunk_size(chunk_duration, chunkable: "TimeSeries"):
             chunk_duration = float(chunk_duration.replace("s", ""))
         else:
             raise ValueError("chunk_duration must ends with s or ms")
-        chunk_size = int(chunk_duration * chunkable.get_sampling_frequency())
+        chunk_size = int(chunk_duration * time_series.get_sampling_frequency())
     else:
         raise ValueError("chunk_duration must be str or float")
     return chunk_size
 
 
 def ensure_chunk_size(
-    chunkable: "TimeSeries",
+    time_series: "TimeSeries",
     total_memory=None,
     chunk_size=None,
     chunk_memory=None,
@@ -299,20 +299,20 @@ def ensure_chunk_size(
         assert total_memory is None
         # set by memory per worker size
         chunk_memory = convert_string_to_bytes(chunk_memory)
-        chunk_size = int(chunk_memory / chunkable.get_sample_size_in_bytes())
+        chunk_size = int(chunk_memory / time_series.get_sample_size_in_bytes())
     elif total_memory is not None:
         # clip by total memory size
-        n_jobs = ensure_n_jobs(chunkable, n_jobs=n_jobs)
+        n_jobs = ensure_n_jobs(time_series, n_jobs=n_jobs)
         total_memory = convert_string_to_bytes(total_memory)
-        chunk_size = int(total_memory / (chunkable.get_sample_size_in_bytes() * n_jobs))
+        chunk_size = int(total_memory / (time_series.get_sample_size_in_bytes() * n_jobs))
     elif chunk_duration is not None:
-        chunk_size = chunk_duration_to_chunk_size(chunk_duration, chunkable)
+        chunk_size = chunk_duration_to_chunk_size(chunk_duration, time_series)
     else:
         # Edge case to define single chunk per segment for n_jobs=1.
         # All chunking parameters equal None mean single chunk per segment
         if n_jobs == 1:
-            num_segments = chunkable.get_num_segments()
-            samples_in_larger_segment = max([chunkable.get_num_samples(segment) for segment in range(num_segments)])
+            num_segments = time_series.get_num_segments()
+            samples_in_larger_segment = max([time_series.get_num_samples(segment) for segment in range(num_segments)])
             chunk_size = samples_in_larger_segment
         else:
             raise ValueError("For n_jobs >1 you must specify total_memory or chunk_size or chunk_memory")
@@ -322,7 +322,7 @@ def ensure_chunk_size(
 
 class TimeSeriesChunkExecutor:
     """
-    Core class for parallel processing to run a "function" over chunks on a chunkable extractor.
+    Core class for parallel processing to run a "function" over chunks on a time_series extractor.
 
     It supports running a function:
         * in loop with chunk processing (low RAM usage)
@@ -334,8 +334,8 @@ class TimeSeriesChunkExecutor:
 
     Parameters
     ----------
-    chunkable : TimeSeries
-        The chunkable object to be processed.
+    time_series : TimeSeries
+        The time_series object to be processed.
     func : function
         Function that runs on each chunk
     init_func : function
@@ -383,7 +383,7 @@ class TimeSeriesChunkExecutor:
 
     def __init__(
         self,
-        chunkable: "TimeSeries",
+        time_series: "TimeSeries",
         func,
         init_func,
         init_args,
@@ -402,7 +402,7 @@ class TimeSeriesChunkExecutor:
         max_threads_per_worker=1,
         need_worker_index=False,
     ):
-        self.chunkable = chunkable
+        self.time_series = time_series
         self.func = func
         self.init_func = init_func
         self.init_args = init_args
@@ -421,7 +421,7 @@ class TimeSeriesChunkExecutor:
                 else:
                     mp_context = "spawn"
 
-            preferred_mp_context = chunkable.get_preferred_mp_context()
+            preferred_mp_context = time_series.get_preferred_mp_context()
             if preferred_mp_context is not None and preferred_mp_context != mp_context:
                 warnings.warn(
                     f"Your processing chain using pool_engine='process' and mp_context='{mp_context}' is not possible."
@@ -437,7 +437,7 @@ class TimeSeriesChunkExecutor:
         self.handle_returns = handle_returns
         self.gather_func = gather_func
 
-        self.n_jobs = ensure_n_jobs(self.chunkable, n_jobs=n_jobs)
+        self.n_jobs = ensure_n_jobs(self.time_series, n_jobs=n_jobs)
         self.chunk_size = self.ensure_chunk_size(
             total_memory=total_memory,
             chunk_size=chunk_size,
@@ -455,7 +455,7 @@ class TimeSeriesChunkExecutor:
         if verbose:
             chunk_memory = self.get_chunk_memory()
             total_memory = chunk_memory * self.n_jobs
-            chunk_duration = self.chunk_size / chunkable.sampling_frequency
+            chunk_duration = self.chunk_size / time_series.sampling_frequency
             chunk_memory_str = convert_bytes_to_str(chunk_memory)
             total_memory_str = convert_bytes_to_str(total_memory)
             chunk_duration_str = convert_seconds_to_str(chunk_duration)
@@ -471,13 +471,13 @@ class TimeSeriesChunkExecutor:
             )
 
     def get_chunk_memory(self):
-        return self.chunk_size * self.chunkable.get_sample_size_in_bytes()
+        return self.chunk_size * self.time_series.get_sample_size_in_bytes()
 
     def ensure_chunk_size(
         self, total_memory=None, chunk_size=None, chunk_memory=None, chunk_duration=None, n_jobs=1, **other_kwargs
     ):
         return ensure_chunk_size(
-            self.chunkable, total_memory, chunk_size, chunk_memory, chunk_duration, n_jobs, **other_kwargs
+            self.time_series, total_memory, chunk_size, chunk_memory, chunk_duration, n_jobs, **other_kwargs
         )
 
     def run(self, slices=None):
@@ -487,7 +487,7 @@ class TimeSeriesChunkExecutor:
 
         if slices is None:
             # TODO: rename
-            slices = divide_time_series_into_chunks(self.chunkable, self.chunk_size)
+            slices = divide_time_series_into_chunks(self.time_series, self.chunk_size)
 
         if self.handle_returns:
             returns = []

--- a/src/spikeinterface/core/node_pipeline.py
+++ b/src/spikeinterface/core/node_pipeline.py
@@ -11,9 +11,9 @@ from pathlib import Path
 import numpy as np
 
 from spikeinterface.core.base import base_peak_dtype, spike_peak_dtype
-from spikeinterface.core.chunkable import ChunkableMixin
+from spikeinterface.core.time_series import TimeSeries
 from spikeinterface.core import BaseRecording, get_chunk_with_margin
-from spikeinterface.core.job_tools import ChunkExecutor, fix_job_kwargs, _shared_job_kwargs_doc
+from spikeinterface.core.job_tools import TimeSeriesChunkExecutor, fix_job_kwargs, _shared_job_kwargs_doc
 from spikeinterface.core import get_channel_distances
 from spikeinterface.core.core_tools import ms_to_samples
 
@@ -26,7 +26,7 @@ class PipelineNode:
 
     def __init__(
         self,
-        chunkable: ChunkableMixin,
+        chunkable: TimeSeries,
         return_output: bool | tuple[bool] = True,
         parents: list[Type["PipelineNode"]] | None = None,
     ):
@@ -38,7 +38,7 @@ class PipelineNode:
 
         Parameters
         ----------
-        chunkable : ChunkableMixin
+        chunkable : TimeSeries
             The chunkable object.
         return_output : bool or tuple[bool], default: True
             Whether or not the output of the node is returned by the pipeline.
@@ -526,7 +526,7 @@ def check_graph(nodes, check_for_peak_source=True):
 
 
 def run_node_pipeline(
-    chunkable: ChunkableMixin,
+    chunkable: TimeSeries,
     nodes: list[PipelineNode],
     job_kwargs: dict,
     job_name: str = "pipeline",
@@ -566,7 +566,7 @@ def run_node_pipeline(
 
     Parameters
     ----------
-    chunkable: ChunkableMixin
+    chunkable: TimeSeries
         The chunkable object to run the pipeline on. This is typically a recording but it can be anything that have the
         same interface for getting chunks with margin.
     nodes: a list of PipelineNode
@@ -628,7 +628,7 @@ def run_node_pipeline(
 
     init_args = (chunkable, nodes, skip_after_n_peaks_per_worker)
 
-    processor = ChunkExecutor(
+    processor = TimeSeriesChunkExecutor(
         chunkable,
         _compute_peak_pipeline_chunk,
         _init_peak_pipeline,

--- a/src/spikeinterface/core/node_pipeline.py
+++ b/src/spikeinterface/core/node_pipeline.py
@@ -26,7 +26,7 @@ class PipelineNode:
 
     def __init__(
         self,
-        chunkable: TimeSeries,
+        time_series: TimeSeries,
         return_output: bool | tuple[bool] = True,
         parents: list[Type["PipelineNode"]] | None = None,
     ):
@@ -38,8 +38,8 @@ class PipelineNode:
 
         Parameters
         ----------
-        chunkable : TimeSeries
-            The chunkable object.
+        time_series : TimeSeries
+            The time_series object.
         return_output : bool or tuple[bool], default: True
             Whether or not the output of the node is returned by the pipeline.
             When a Node have several toutputs then this can be a tuple of bool
@@ -47,7 +47,7 @@ class PipelineNode:
             Pass parents nodes to perform a previous computation.
         """
 
-        self.chunkable = chunkable
+        self.time_series = time_series
         self.return_output = return_output
         if isinstance(parents, str):
             # only one parents is allowed
@@ -526,7 +526,7 @@ def check_graph(nodes, check_for_peak_source=True):
 
 
 def run_node_pipeline(
-    chunkable: TimeSeries,
+    time_series: TimeSeries,
     nodes: list[PipelineNode],
     job_kwargs: dict,
     job_name: str = "pipeline",
@@ -566,8 +566,8 @@ def run_node_pipeline(
 
     Parameters
     ----------
-    chunkable: TimeSeries
-        The chunkable object to run the pipeline on. This is typically a recording but it can be anything that have the
+    time_series: TimeSeries
+        The time_series object to run the pipeline on. This is typically a recording but it can be anything that have the
         same interface for getting chunks with margin.
     nodes: a list of PipelineNode
         The list of nodes to run in the pipeline. The order of the nodes is important as it defines
@@ -626,10 +626,10 @@ def run_node_pipeline(
         # See need_first_call_before_pipeline : this trigger numba compilation before the run
         node0._first_call_before_pipeline()
 
-    init_args = (chunkable, nodes, skip_after_n_peaks_per_worker)
+    init_args = (time_series, nodes, skip_after_n_peaks_per_worker)
 
     processor = TimeSeriesChunkExecutor(
-        chunkable,
+        time_series,
         _compute_peak_pipeline_chunk,
         _init_peak_pipeline,
         init_args,
@@ -645,10 +645,10 @@ def run_node_pipeline(
     return outs
 
 
-def _init_peak_pipeline(chunkable, nodes, skip_after_n_peaks_per_worker):
+def _init_peak_pipeline(time_series, nodes, skip_after_n_peaks_per_worker):
     # create a local dict per worker
     worker_ctx = {}
-    worker_ctx["chunkable"] = chunkable
+    worker_ctx["time_series"] = time_series
     worker_ctx["nodes"] = nodes
     worker_ctx["max_margin"] = max(node.get_margin() for node in nodes)
     worker_ctx["skip_after_n_peaks_per_worker"] = skip_after_n_peaks_per_worker
@@ -657,12 +657,12 @@ def _init_peak_pipeline(chunkable, nodes, skip_after_n_peaks_per_worker):
 
 
 def _compute_peak_pipeline_chunk(segment_index, start_frame, end_frame, worker_ctx):
-    chunkable = worker_ctx["chunkable"]
+    time_series = worker_ctx["time_series"]
     max_margin = worker_ctx["max_margin"]
     nodes = worker_ctx["nodes"]
     skip_after_n_peaks_per_worker = worker_ctx["skip_after_n_peaks_per_worker"]
 
-    chunkable_segment = chunkable.segments[segment_index]
+    chunkable_segment = time_series.segments[segment_index]
     retrievers = find_parents_of_type(nodes, (SpikeRetriever, PeakRetriever))
     # get peak slices once for all retrievers
     peak_slice_by_retriever = {}

--- a/src/spikeinterface/core/recording_tools.py
+++ b/src/spikeinterface/core/recording_tools.py
@@ -13,16 +13,169 @@ from .job_tools import (
     ensure_chunk_size,
     divide_segment_into_chunks,
     fix_job_kwargs,
-    ChunkExecutor,
+    TimeSeriesChunkExecutor,
     _shared_job_kwargs_doc,
     split_job_kwargs,
 )
 
-from .chunkable_tools import get_random_sample_slices, get_chunks, get_chunk_with_margin
+from .time_series_tools import get_random_sample_slices, get_chunks, get_chunk_with_margin
+from .time_series_tools import write_binary as _write_binary
+from .time_series_tools import write_memory as _write_memory
+from .time_series_tools import _write_time_series_to_zarr
 
-# for back-compatibility imports
-from .chunkable_tools import write_binary as write_binary_recording
-from .chunkable_tools import write_memory as write_memory_recording
+
+def write_binary_recording(
+    recording,
+    file_paths,
+    file_timestamps_paths=None,
+    dtype=None,
+    add_file_extension=True,
+    byte_offset=0,
+    verbose=False,
+    **job_kwargs,
+):
+    """
+    Save the traces of a recording to binary format.
+
+    Parameters
+    ----------
+    recording : BaseRecording
+        The recording to save to binary file.
+    file_paths : list[Path | str] | Path | str
+        The path to the files to save data for each segment.
+    file_timestamps_paths : list[Path | str] | Path | str | None, default: None
+        The path to the timestamps file. If None, timestamps are not saved.
+    dtype : dtype or None, default: None
+        Type of the saved data.
+    add_file_extension : bool, default: True
+        If True, and the file path does not end in "raw", "bin", or "dat" then "raw" is added as an extension.
+    byte_offset : int, default: 0
+        Offset in bytes for the binary file (e.g. to write a header).
+    verbose : bool, default: False
+        Verbosity of the chunk executor.
+    {}
+    """
+    return _write_binary(
+        recording,
+        file_paths=file_paths,
+        file_timestamps_paths=file_timestamps_paths,
+        dtype=dtype,
+        add_file_extension=add_file_extension,
+        byte_offset=byte_offset,
+        verbose=verbose,
+        **job_kwargs,
+    )
+
+
+write_binary_recording.__doc__ = write_binary_recording.__doc__.format(_shared_job_kwargs_doc)
+
+
+def write_memory_recording(
+    recording,
+    dtype=None,
+    verbose=False,
+    buffer_type="auto",
+    job_name="write_memory",
+    **job_kwargs,
+):
+    """
+    Save the traces of a recording into numpy arrays in memory.
+
+    Uses SharedMemory when ``n_jobs > 1``.
+
+    Parameters
+    ----------
+    recording : BaseRecording
+        The recording to save to memory.
+    dtype : dtype, default: None
+        Type of the saved data.
+    verbose : bool, default: False
+        If True, output is verbose (when chunks are used).
+    buffer_type : "auto" | "numpy" | "sharedmem", default: "auto"
+        The type of buffer to use for storing the data.
+    job_name : str, default: "write_memory"
+        Name of the job.
+    {}
+
+    Returns
+    -------
+    arrays : list
+        One array per segment.
+    """
+    return _write_memory(
+        recording,
+        dtype=dtype,
+        verbose=verbose,
+        buffer_type=buffer_type,
+        job_name=job_name,
+        **job_kwargs,
+    )
+
+
+write_memory_recording.__doc__ = write_memory_recording.__doc__.format(_shared_job_kwargs_doc)
+
+
+def write_recording_to_zarr(
+    recording,
+    zarr_group,
+    dataset_paths,
+    dataset_timestamps_paths=None,
+    extra_chunks=None,
+    dtype=None,
+    compressor_data=None,
+    filters_data=None,
+    compressor_times=None,
+    filters_times=None,
+    verbose=False,
+    **job_kwargs,
+):
+    """
+    Save the traces of a recording to zarr format.
+
+    Parameters
+    ----------
+    recording : BaseRecording
+        The recording to save in zarr format.
+    zarr_group : zarr.Group
+        The zarr group to add traces to.
+    dataset_paths : list
+        List of paths to traces datasets in the zarr group.
+    dataset_timestamps_paths : list or None, default: None
+        List of paths to timestamps datasets in the zarr group. If None, timestamps are not saved.
+    extra_chunks : tuple or None, default: None
+        Extra chunking dimensions to use for the zarr dataset. The first dimension is always time and
+        controlled by the job_kwargs. Useful to chunk by channel, with ``extra_chunks=(channel_chunk_size,)``.
+    dtype : dtype, default: None
+        Type of the saved data.
+    compressor_data : zarr compressor or None, default: None
+        Zarr compressor for data.
+    filters_data : list, default: None
+        List of zarr filters for data.
+    compressor_times : zarr compressor or None, default: None
+        Zarr compressor for timestamps.
+    filters_times : list, default: None
+        List of zarr filters for timestamps.
+    verbose : bool, default: False
+        If True, output is verbose (when chunks are used).
+    {}
+    """
+    return _write_time_series_to_zarr(
+        recording,
+        zarr_group=zarr_group,
+        dataset_paths=dataset_paths,
+        dataset_timestamps_paths=dataset_timestamps_paths,
+        extra_chunks=extra_chunks,
+        dtype=dtype,
+        compressor_data=compressor_data,
+        filters_data=filters_data,
+        compressor_times=compressor_times,
+        filters_times=filters_times,
+        verbose=verbose,
+        **job_kwargs,
+    )
+
+
+write_recording_to_zarr.__doc__ = write_recording_to_zarr.__doc__.format(_shared_job_kwargs_doc)
 
 
 def read_binary_recording(file, num_channels, dtype, time_axis=0, offset=0):
@@ -458,7 +611,7 @@ def get_noise_levels(
         func = _noise_level_chunk
         init_func = _noise_level_chunk_init
         init_args = (recording, return_in_uV, method)
-        executor = ChunkExecutor(
+        executor = TimeSeriesChunkExecutor(
             recording,
             func,
             init_func,

--- a/src/spikeinterface/core/tests/test_job_tools.py
+++ b/src/spikeinterface/core/tests/test_job_tools.py
@@ -9,10 +9,10 @@ from spikeinterface.core.job_tools import (
     divide_segment_into_chunks,
     ensure_n_jobs,
     ensure_chunk_size,
-    ChunkExecutor,
+    TimeSeriesChunkExecutor,
     fix_job_kwargs,
     split_job_kwargs,
-    divide_chunkable_into_chunks,
+    divide_time_series_into_chunks,
 )
 
 
@@ -71,7 +71,7 @@ def test_ensure_chunk_size():
 
     # Test edge case to define single chunk for n_jobs=1
     chunk_size = ensure_chunk_size(recording, n_jobs=1, chunk_size=None)
-    chunks = divide_chunkable_into_chunks(recording, chunk_size)
+    chunks = divide_time_series_into_chunks(recording, chunk_size)
     assert len(chunks) == recording.get_num_segments()
     for chunk in chunks:
         segment_index, start_frame, end_frame = chunk
@@ -102,7 +102,7 @@ def test_ChunkExecutor():
     init_args = "a", 120, "yep"
 
     # no chunk
-    processor = ChunkExecutor(
+    processor = TimeSeriesChunkExecutor(
         recording, func, init_func, init_args, verbose=True, progress_bar=False, n_jobs=1, chunk_size=None
     )
     processor.run()
@@ -113,7 +113,7 @@ def test_ChunkExecutor():
         pass
 
     # chunk + loop + gather_func
-    processor = ChunkExecutor(
+    processor = TimeSeriesChunkExecutor(
         recording,
         func,
         init_func,
@@ -139,7 +139,7 @@ def test_ChunkExecutor():
     gathering_func2 = GatherClass()
 
     # process + gather_func
-    processor = ChunkExecutor(
+    processor = TimeSeriesChunkExecutor(
         recording,
         func,
         init_func,
@@ -153,12 +153,12 @@ def test_ChunkExecutor():
         job_name="job_name",
     )
     processor.run()
-    num_chunks = len(divide_chunkable_into_chunks(recording, processor.chunk_size))
+    num_chunks = len(divide_time_series_into_chunks(recording, processor.chunk_size))
 
     assert gathering_func2.pos == num_chunks
 
     # process spawn
-    processor = ChunkExecutor(
+    processor = TimeSeriesChunkExecutor(
         recording,
         func,
         init_func,
@@ -174,7 +174,7 @@ def test_ChunkExecutor():
     processor.run()
 
     # thread
-    processor = ChunkExecutor(
+    processor = TimeSeriesChunkExecutor(
         recording,
         func,
         init_func,
@@ -258,7 +258,7 @@ def test_worker_index():
         # making this 2 times ensure to test that global variables are correctly reset
         for pool_engine in ("process", "thread"):
             # print(pool_engine)
-            processor = ChunkExecutor(
+            processor = TimeSeriesChunkExecutor(
                 recording,
                 func2,
                 init_func2,

--- a/src/spikeinterface/core/tests/test_node_pipeline.py
+++ b/src/spikeinterface/core/tests/test_node_pipeline.py
@@ -5,7 +5,7 @@ import shutil
 
 from spikeinterface import create_sorting_analyzer, get_template_extremum_channel, generate_ground_truth_recording
 from spikeinterface.core.base import spike_peak_dtype
-from spikeinterface.core.job_tools import divide_chunkable_into_chunks
+from spikeinterface.core.job_tools import divide_time_series_into_chunks
 
 # from spikeinterface.sortingcomponents.peak_detection import detect_peaks
 from spikeinterface.core.node_pipeline import (
@@ -220,7 +220,7 @@ def test_skip_after_n_peaks_and_recording_slices():
     assert some_amplitudes.size < spikes.size
 
     # slices : 1 every 4
-    recording_slices = divide_chunkable_into_chunks(recording, 10_000)
+    recording_slices = divide_time_series_into_chunks(recording, 10_000)
     recording_slices = recording_slices[::4]
     some_amplitudes = run_node_pipeline(recording, nodes, job_kwargs, gather_mode="memory", slices=recording_slices)
     tolerance = 1.2

--- a/src/spikeinterface/core/tests/test_time_series_tools.py
+++ b/src/spikeinterface/core/tests/test_time_series_tools.py
@@ -6,7 +6,7 @@ from spikeinterface.core.binaryrecordingextractor import BinaryRecordingExtracto
 from spikeinterface.core.generate import NoiseGeneratorRecording
 
 
-from spikeinterface.core.chunkable_tools import (
+from spikeinterface.core.time_series_tools import (
     write_binary,
     write_memory,
     get_random_sample_slices,

--- a/src/spikeinterface/core/time_series.py
+++ b/src/spikeinterface/core/time_series.py
@@ -7,15 +7,15 @@ import numpy as np
 from spikeinterface.core.base import BaseExtractor, BaseSegment
 
 
-class ChunkableMixin(ABC):
+class TimeSeries(ABC):
     """
-    Abstract mixin class for chunkable objects. Note that the mixin can only be used
-    for classes that inherit from BaseExtractor.
-    Provides methods to handle chunked data access, that can be used for parallelization.
-    In addition, since chunkable objects are continuous data, time handling methods are provided.
+    Abstract base class for time series extractors: continuous data sampled along a time axis
+    that supports chunked access for parallelization. The class can only be used by extractors
+    that inherit from BaseExtractor.
 
-    The Mixin is abstract since all methods need to be implemented in the child class in order
-    for it to function properly.
+    Provides the chunking contract (``get_data``, ``get_shape``, ``get_sample_size_in_bytes``,
+    memory-size helpers, multiprocessing hints) and time-handling methods built on top of it.
+    All abstract methods must be implemented in the child class.
     """
 
     _preferred_mp_context = None
@@ -23,7 +23,7 @@ class ChunkableMixin(ABC):
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         if not issubclass(cls, BaseExtractor):
-            raise TypeError(f"{cls.__name__} must inherit from BaseExtractor to use Chunkable mixin.")
+            raise TypeError(f"{cls.__name__} must inherit from BaseExtractor to use TimeSeries.")
 
     @abstractmethod
     def get_sampling_frequency(self) -> float:
@@ -45,13 +45,13 @@ class ChunkableMixin(ABC):
     def get_data(self, start_frame: int, end_frame: int, segment_index: int | None = None, **kwargs) -> np.ndarray:
         raise NotImplementedError
 
-    def _extra_copy_metadata(self, other: "ChunkableMixin", **kwargs) -> None:
+    def _extra_copy_metadata(self, other: "TimeSeries", **kwargs) -> None:
         """
-        Copy metadata from another Chunkable object.
+        Copy metadata from another TimeSeries object.
 
         Parameters
         ----------
-        other : ChunkableMixin
+        other : TimeSeries
             The object from which to copy metadata.
         """
         # inherit preferred mp context if any
@@ -362,8 +362,9 @@ class ChunkableMixin(ABC):
         return time_vectors
 
 
-class ChunkableSegment(BaseSegment):
-    """Class for chunkable segments, which provide methods to handle time kwargs."""
+class TimeSeriesSegment(BaseSegment):
+    """Per-segment time-series class. Provides time handling methods (sample/time conversion,
+    start/end time, time vectors) on top of ``BaseSegment``."""
 
     def __init__(self, sampling_frequency=None, t_start=None, time_vector=None):
         # sampling_frequency and time_vector are exclusive

--- a/src/spikeinterface/core/time_series_tools.py
+++ b/src/spikeinterface/core/time_series_tools.py
@@ -9,14 +9,14 @@ from .job_tools import (
     chunk_duration_to_chunk_size,
     ensure_n_jobs,
     fix_job_kwargs,
-    ChunkExecutor,
+    TimeSeriesChunkExecutor,
     _shared_job_kwargs_doc,
 )
-from .chunkable import ChunkableMixin, ChunkableSegment
+from .time_series import TimeSeries, TimeSeriesSegment
 
 
 def write_binary(
-    chunkable: ChunkableMixin,
+    chunkable: TimeSeries,
     file_paths: list[Path | str] | Path | str,
     file_timestamps_paths: list[Path | str] | Path | str | None = None,
     dtype: np.typing.DTypeLike = None,
@@ -34,7 +34,7 @@ def write_binary(
 
     Parameters
     ----------
-    chunkable : ChunkableMixin
+    chunkable : TimeSeries
         The chunkable object to be saved to binary file
     file_paths : list[Path | str] | Path | str
         The path to the files to save data for each segment.
@@ -48,7 +48,7 @@ def write_binary(
         Offset in bytes for the binary file (e.g. to write a header). This is useful in case you want to append data
         to an existing file where you wrote a header or other data before.
     verbose : bool
-        This is the verbosity of the ChunkExecutor
+        This is the verbosity of the TimeSeriesChunkExecutor
     {}
     """
     job_kwargs = fix_job_kwargs(job_kwargs)
@@ -96,13 +96,13 @@ def write_binary(
     func = _write_binary_chunk
     init_func = _init_binary_worker
     init_args = (chunkable, file_path_dict, dtype, byte_offset, file_timestamps_path_dict)
-    executor = ChunkExecutor(
+    executor = TimeSeriesChunkExecutor(
         chunkable, func, init_func, init_args, job_name="write_binary", verbose=verbose, **job_kwargs
     )
     executor.run()
 
 
-# used by write_binary + ChunkExecutor
+# used by write_binary + TimeSeriesChunkExecutor
 def _init_binary_worker(chunkable, file_path_dict, dtype, byte_offset, file_timestamps_path_dict=None):
     # create a local dict per worker
     worker_ctx = {}
@@ -117,7 +117,7 @@ def _init_binary_worker(chunkable, file_path_dict, dtype, byte_offset, file_time
     return worker_ctx
 
 
-# used by write_binary + ChunkExecutor
+# used by write_binary + TimeSeriesChunkExecutor
 def _write_binary_chunk(segment_index, start_frame, end_frame, worker_ctx):
     # recover variables of the worker
     chunkable = worker_ctx["chunkable"]
@@ -190,7 +190,7 @@ def _write_memory_chunk(segment_index, start_frame, end_frame, worker_ctx):
 
 
 def write_memory(
-    chunkable: ChunkableMixin, dtype=None, verbose=False, buffer_type="auto", job_name="write_memory", **job_kwargs
+    chunkable: TimeSeries, dtype=None, verbose=False, buffer_type="auto", job_name="write_memory", **job_kwargs
 ):
     """
     Save the traces into numpy arrays (memory).
@@ -198,7 +198,7 @@ def write_memory(
 
     Parameters
     ----------
-    chunkable : ChunkableMixin
+    chunkable : TimeSeries
         The chunkable object to be saved to memory
     dtype : dtype, default: None
         Type of the saved data
@@ -252,7 +252,9 @@ def write_memory(
     else:
         init_args = (chunkable, arrays, None, None, dtype)
 
-    executor = ChunkExecutor(chunkable, func, init_func, init_args, verbose=verbose, job_name=job_name, **job_kwargs)
+    executor = TimeSeriesChunkExecutor(
+        chunkable, func, init_func, init_args, verbose=verbose, job_name=job_name, **job_kwargs
+    )
     executor.run()
 
     return arrays, shms
@@ -261,8 +263,8 @@ def write_memory(
 write_memory.__doc__ = write_memory.__doc__.format(_shared_job_kwargs_doc)
 
 
-def write_chunkable_to_zarr(
-    chunkable: ChunkableMixin,
+def _write_time_series_to_zarr(
+    chunkable: TimeSeries,
     zarr_group,
     dataset_paths,
     dataset_timestamps_paths=None,
@@ -280,7 +282,7 @@ def write_chunkable_to_zarr(
 
     Parameters
     ----------
-    chunkable : ChunkableMixin
+    chunkable : TimeSeries
         The chunkable object to be saved in .dat format
     zarr_group : zarr.Group
         The zarr group to add traces to
@@ -309,7 +311,7 @@ def write_chunkable_to_zarr(
     from .job_tools import (
         ensure_chunk_size,
         fix_job_kwargs,
-        ChunkExecutor,
+        TimeSeriesChunkExecutor,
     )
 
     assert dataset_paths is not None, "Provide 'dataset_paths' to save data in zarr format"
@@ -372,7 +374,7 @@ def write_chunkable_to_zarr(
     func = _write_zarr_chunk
     init_func = _init_zarr_worker
     init_args = (chunkable, zarr_datasets, dtype, zarr_timestamps_datasets)
-    executor = ChunkExecutor(
+    executor = TimeSeriesChunkExecutor(
         chunkable, func, init_func, init_args, verbose=verbose, job_name="write_zarr", **job_kwargs
     )
     executor.run()
@@ -388,7 +390,6 @@ def write_chunkable_to_zarr(
         zarr_group.create_dataset(name="t_starts", data=t_starts, compressor=None)
 
 
-# used by write_zarr_recording + ChunkExecutor
 def _init_zarr_worker(chunkable, zarr_datasets, dtype, zarr_timestamps_datasets=None):
     import zarr
 
@@ -405,7 +406,6 @@ def _init_zarr_worker(chunkable, zarr_datasets, dtype, zarr_timestamps_datasets=
     return worker_ctx
 
 
-# used by write_zarr_recording + ChunkExecutor
 def _write_zarr_chunk(segment_index, start_frame, end_frame, worker_ctx):
     import gc
 
@@ -437,7 +437,7 @@ def _write_zarr_chunk(segment_index, start_frame, end_frame, worker_ctx):
 
 
 def get_random_sample_slices(
-    chunkable: ChunkableMixin,
+    chunkable: TimeSeries,
     method="full_random",
     num_chunks_per_segment=20,
     chunk_duration="500ms",
@@ -450,7 +450,7 @@ def get_random_sample_slices(
 
     Parameters
     ----------
-    chunkable : ChunkableMixin
+    chunkable : TimeSeries
         The chunkable object to get random chunks from
     method : "full_random"
         The method used to get random slices.
@@ -517,7 +517,7 @@ def get_random_sample_slices(
     return slices
 
 
-def get_chunks(chunkable: ChunkableMixin, concatenated=True, get_data_kwargs=None, **random_slices_kwargs):
+def get_chunks(chunkable: TimeSeries, concatenated=True, get_data_kwargs=None, **random_slices_kwargs):
     """
     Extract random chunks across segments.
 
@@ -531,7 +531,7 @@ def get_chunks(chunkable: ChunkableMixin, concatenated=True, get_data_kwargs=Non
 
     Parameters
     ----------
-    chunkable : ChunkableMixin
+    chunkable : TimeSeries
         The chunkable object to get random chunks from
     return_scaled : bool | None, default: None
         DEPRECATED. Use return_in_uV instead.
@@ -568,7 +568,7 @@ def get_chunks(chunkable: ChunkableMixin, concatenated=True, get_data_kwargs=Non
 
 
 def get_chunk_with_margin(
-    chunkable_segment: ChunkableSegment,
+    chunkable_segment: TimeSeriesSegment,
     start_frame,
     end_frame,
     last_dimension_indices,

--- a/src/spikeinterface/core/time_series_tools.py
+++ b/src/spikeinterface/core/time_series_tools.py
@@ -16,7 +16,7 @@ from .time_series import TimeSeries, TimeSeriesSegment
 
 
 def write_binary(
-    chunkable: TimeSeries,
+    time_series: TimeSeries,
     file_paths: list[Path | str] | Path | str,
     file_timestamps_paths: list[Path | str] | Path | str | None = None,
     dtype: np.typing.DTypeLike = None,
@@ -26,7 +26,7 @@ def write_binary(
     **job_kwargs,
 ):
     """
-    Save the data of a chunkable object to binary format.
+    Save the data of a time_series object to binary format.
 
     Note :
         time_axis is always 0 (contrary to previous version.
@@ -34,8 +34,8 @@ def write_binary(
 
     Parameters
     ----------
-    chunkable : TimeSeries
-        The chunkable object to be saved to binary file
+    time_series : TimeSeries
+        The time_series object to be saved to binary file
     file_paths : list[Path | str] | Path | str
         The path to the files to save data for each segment.
     file_timestamps_paths : list[Path | str] | Path | str | None, default: None
@@ -54,17 +54,17 @@ def write_binary(
     job_kwargs = fix_job_kwargs(job_kwargs)
 
     file_path_list = [file_paths] if not isinstance(file_paths, list) else file_paths
-    num_segments = chunkable.get_num_segments()
+    num_segments = time_series.get_num_segments()
     if len(file_path_list) != num_segments:
-        raise ValueError("'file_paths' must be a list of the same size as the number of segments in the chunkable")
+        raise ValueError("'file_paths' must be a list of the same size as the number of segments in the time_series")
 
     file_path_list = [Path(file_path) for file_path in file_path_list]
     if add_file_extension:
         file_path_list = [add_suffix(file_path, ["raw", "bin", "dat"]) for file_path in file_path_list]
 
-    dtype = dtype if dtype is not None else chunkable.get_dtype()
+    dtype = dtype if dtype is not None else time_series.get_dtype()
 
-    sample_size_bytes = chunkable.get_sample_size_in_bytes()
+    sample_size_bytes = time_series.get_sample_size_in_bytes()
 
     file_path_dict = {segment_index: file_path for segment_index, file_path in enumerate(file_path_list)}
     if file_timestamps_paths is not None:
@@ -74,7 +74,7 @@ def write_binary(
     else:
         file_timestamps_path_dict = None
     for segment_index, file_path in file_path_dict.items():
-        num_samples = chunkable.get_num_samples(segment_index=segment_index)
+        num_samples = time_series.get_num_samples(segment_index=segment_index)
         data_size_bytes = sample_size_bytes * num_samples
         file_size_bytes = data_size_bytes + byte_offset
 
@@ -95,18 +95,18 @@ def write_binary(
     # use executor (loop or workers)
     func = _write_binary_chunk
     init_func = _init_binary_worker
-    init_args = (chunkable, file_path_dict, dtype, byte_offset, file_timestamps_path_dict)
+    init_args = (time_series, file_path_dict, dtype, byte_offset, file_timestamps_path_dict)
     executor = TimeSeriesChunkExecutor(
-        chunkable, func, init_func, init_args, job_name="write_binary", verbose=verbose, **job_kwargs
+        time_series, func, init_func, init_args, job_name="write_binary", verbose=verbose, **job_kwargs
     )
     executor.run()
 
 
 # used by write_binary + TimeSeriesChunkExecutor
-def _init_binary_worker(chunkable, file_path_dict, dtype, byte_offset, file_timestamps_path_dict=None):
+def _init_binary_worker(time_series, file_path_dict, dtype, byte_offset, file_timestamps_path_dict=None):
     # create a local dict per worker
     worker_ctx = {}
-    worker_ctx["chunkable"] = chunkable
+    worker_ctx["time_series"] = time_series
     worker_ctx["byte_offset"] = byte_offset
     worker_ctx["dtype"] = np.dtype(dtype)
 
@@ -120,17 +120,17 @@ def _init_binary_worker(chunkable, file_path_dict, dtype, byte_offset, file_time
 # used by write_binary + TimeSeriesChunkExecutor
 def _write_binary_chunk(segment_index, start_frame, end_frame, worker_ctx):
     # recover variables of the worker
-    chunkable = worker_ctx["chunkable"]
+    time_series = worker_ctx["time_series"]
     dtype = worker_ctx["dtype"]
     byte_offset = worker_ctx["byte_offset"]
     file = worker_ctx["file_dict"][segment_index]
     file_timestamps_dict = worker_ctx["file_timestamps_dict"]
-    sample_size_bytes = chunkable.get_sample_size_in_bytes()
+    sample_size_bytes = time_series.get_sample_size_in_bytes()
 
     # Calculate byte offsets for the start frames relative to the entire recording
     start_byte = byte_offset + start_frame * sample_size_bytes
 
-    data = chunkable.get_data(start_frame=start_frame, end_frame=end_frame, segment_index=segment_index)
+    data = time_series.get_data(start_frame=start_frame, end_frame=end_frame, segment_index=segment_index)
     data = data.astype(dtype, order="c", copy=False)
 
     file.seek(start_byte)
@@ -140,7 +140,7 @@ def _write_binary_chunk(segment_index, start_frame, end_frame, worker_ctx):
 
     if file_timestamps_dict is not None:
         file_timestamps = file_timestamps_dict[segment_index]
-        timestamps = chunkable.get_times(start_frame=start_frame, end_frame=end_frame, segment_index=segment_index)
+        timestamps = time_series.get_times(start_frame=start_frame, end_frame=end_frame, segment_index=segment_index)
         timestamps = timestamps.astype("float64", order="c", copy=False)
         timestamp_byte_offset = start_frame * 8  # 8 bytes for float64
         file.seek(timestamp_byte_offset)
@@ -152,10 +152,10 @@ write_binary.__doc__ = write_binary.__doc__.format(_shared_job_kwargs_doc)
 
 
 # used by write_memory
-def _init_memory_worker(chunkable, arrays, shm_names, shapes, dtype):
+def _init_memory_worker(time_series, arrays, shm_names, shapes, dtype):
     # create a local dict per worker
     worker_ctx = {}
-    worker_ctx["chunkable"] = chunkable
+    worker_ctx["time_series"] = time_series
     worker_ctx["dtype"] = np.dtype(dtype)
 
     if arrays is None:
@@ -179,18 +179,18 @@ def _init_memory_worker(chunkable, arrays, shm_names, shapes, dtype):
 # used by write_memory
 def _write_memory_chunk(segment_index, start_frame, end_frame, worker_ctx):
     # recover variables of the worker
-    chunkable = worker_ctx["chunkable"]
+    time_series = worker_ctx["time_series"]
     dtype = worker_ctx["dtype"]
     arr = worker_ctx["arrays"][segment_index]
 
     # apply function
-    traces = chunkable.get_data(start_frame=start_frame, end_frame=end_frame, segment_index=segment_index)
+    traces = time_series.get_data(start_frame=start_frame, end_frame=end_frame, segment_index=segment_index)
     traces = traces.astype(dtype, copy=False)
     arr[start_frame:end_frame, :] = traces
 
 
 def write_memory(
-    chunkable: TimeSeries, dtype=None, verbose=False, buffer_type="auto", job_name="write_memory", **job_kwargs
+    time_series: TimeSeries, dtype=None, verbose=False, buffer_type="auto", job_name="write_memory", **job_kwargs
 ):
     """
     Save the traces into numpy arrays (memory).
@@ -198,8 +198,8 @@ def write_memory(
 
     Parameters
     ----------
-    chunkable : TimeSeries
-        The chunkable object to be saved to memory
+    time_series : TimeSeries
+        The time_series object to be saved to memory
     dtype : dtype, default: None
         Type of the saved data
     verbose : bool, default: False
@@ -217,7 +217,7 @@ def write_memory(
     job_kwargs = fix_job_kwargs(job_kwargs)
 
     if dtype is None:
-        dtype = chunkable.get_dtype()
+        dtype = time_series.get_dtype()
 
     # create sharedmmep
     arrays = []
@@ -225,15 +225,15 @@ def write_memory(
     shms = []
     shapes = []
 
-    n_jobs = ensure_n_jobs(chunkable, n_jobs=job_kwargs.get("n_jobs", 1))
+    n_jobs = ensure_n_jobs(time_series, n_jobs=job_kwargs.get("n_jobs", 1))
     if buffer_type == "auto":
         if n_jobs > 1:
             buffer_type = "sharedmem"
         else:
             buffer_type = "numpy"
 
-    for segment_index in range(chunkable.get_num_segments()):
-        shape = chunkable.get_shape(segment_index=segment_index)
+    for segment_index in range(time_series.get_num_segments()):
+        shape = time_series.get_shape(segment_index=segment_index)
         shapes.append(shape)
         if buffer_type == "sharedmem":
             arr, shm = make_shared_array(shape, dtype)
@@ -248,12 +248,12 @@ def write_memory(
     func = _write_memory_chunk
     init_func = _init_memory_worker
     if n_jobs > 1:
-        init_args = (chunkable, None, shm_names, shapes, dtype)
+        init_args = (time_series, None, shm_names, shapes, dtype)
     else:
-        init_args = (chunkable, arrays, None, None, dtype)
+        init_args = (time_series, arrays, None, None, dtype)
 
     executor = TimeSeriesChunkExecutor(
-        chunkable, func, init_func, init_args, verbose=verbose, job_name=job_name, **job_kwargs
+        time_series, func, init_func, init_args, verbose=verbose, job_name=job_name, **job_kwargs
     )
     executor.run()
 
@@ -264,7 +264,7 @@ write_memory.__doc__ = write_memory.__doc__.format(_shared_job_kwargs_doc)
 
 
 def _write_time_series_to_zarr(
-    chunkable: TimeSeries,
+    time_series: TimeSeries,
     zarr_group,
     dataset_paths,
     dataset_timestamps_paths=None,
@@ -278,12 +278,12 @@ def _write_time_series_to_zarr(
     **job_kwargs,
 ):
     """
-    Save the trace of a chunkable object in several zarr format.
+    Save the trace of a time_series object in several zarr format.
 
     Parameters
     ----------
-    chunkable : TimeSeries
-        The chunkable object to be saved in .dat format
+    time_series : TimeSeries
+        The time_series object to be saved in .dat format
     zarr_group : zarr.Group
         The zarr group to add traces to
     dataset_paths : list
@@ -317,35 +317,35 @@ def _write_time_series_to_zarr(
     assert dataset_paths is not None, "Provide 'dataset_paths' to save data in zarr format"
     if dataset_timestamps_paths is not None:
         assert (
-            len(dataset_timestamps_paths) == chunkable.get_num_segments()
-        ), "dataset_timestamps_paths should have the same length as the number of segments in the chunkable"
+            len(dataset_timestamps_paths) == time_series.get_num_segments()
+        ), "dataset_timestamps_paths should have the same length as the number of segments in the time_series"
     else:
-        dataset_timestamps_paths = [None] * chunkable.get_num_segments()
+        dataset_timestamps_paths = [None] * time_series.get_num_segments()
 
     if not isinstance(dataset_paths, list):
         dataset_paths = [dataset_paths]
-    assert len(dataset_paths) == chunkable.get_num_segments()
+    assert len(dataset_paths) == time_series.get_num_segments()
 
     if dtype is None:
-        dtype = chunkable.get_dtype()
+        dtype = time_series.get_dtype()
 
     job_kwargs = fix_job_kwargs(job_kwargs)
-    chunk_size = ensure_chunk_size(chunkable, **job_kwargs)
+    chunk_size = ensure_chunk_size(time_series, **job_kwargs)
 
     if extra_chunks is not None:
-        assert len(extra_chunks) == len(chunkable.get_shape(0)[1:]), (
+        assert len(extra_chunks) == len(time_series.get_shape(0)[1:]), (
             "extra_chunks should have the same length as the number of dimensions "
-            "of the chunkable minus one (time axis)"
+            "of the time_series minus one (time axis)"
         )
 
     # create zarr datasets files
     zarr_datasets = []
     zarr_timestamps_datasets = []
 
-    for segment_index in range(chunkable.get_num_segments()):
-        num_samples = chunkable.get_num_samples(segment_index)
+    for segment_index in range(time_series.get_num_segments()):
+        num_samples = time_series.get_num_samples(segment_index)
         dset_name = dataset_paths[segment_index]
-        shape = chunkable.get_shape(segment_index)
+        shape = time_series.get_shape(segment_index)
         dset = zarr_group.create_dataset(
             name=dset_name,
             shape=shape,
@@ -373,16 +373,16 @@ def _write_time_series_to_zarr(
     # use executor (loop or workers)
     func = _write_zarr_chunk
     init_func = _init_zarr_worker
-    init_args = (chunkable, zarr_datasets, dtype, zarr_timestamps_datasets)
+    init_args = (time_series, zarr_datasets, dtype, zarr_timestamps_datasets)
     executor = TimeSeriesChunkExecutor(
-        chunkable, func, init_func, init_args, verbose=verbose, job_name="write_zarr", **job_kwargs
+        time_series, func, init_func, init_args, verbose=verbose, job_name="write_zarr", **job_kwargs
     )
     executor.run()
 
     # save t_starts
-    t_starts = np.zeros(chunkable.get_num_segments(), dtype="float64") * np.nan
-    for segment_index in range(chunkable.get_num_segments()):
-        time_info = chunkable.get_time_info(segment_index)
+    t_starts = np.zeros(time_series.get_num_segments(), dtype="float64") * np.nan
+    for segment_index in range(time_series.get_num_segments()):
+        time_info = time_series.get_time_info(segment_index)
         if time_info["t_start"] is not None:
             t_starts[segment_index] = time_info["t_start"]
 
@@ -390,12 +390,12 @@ def _write_time_series_to_zarr(
         zarr_group.create_dataset(name="t_starts", data=t_starts, compressor=None)
 
 
-def _init_zarr_worker(chunkable, zarr_datasets, dtype, zarr_timestamps_datasets=None):
+def _init_zarr_worker(time_series, zarr_datasets, dtype, zarr_timestamps_datasets=None):
     import zarr
 
     # create a local dict per worker
     worker_ctx = {}
-    worker_ctx["chunkable"] = chunkable
+    worker_ctx["time_series"] = time_series
     worker_ctx["zarr_datasets"] = zarr_datasets
     if zarr_timestamps_datasets is not None and len(zarr_timestamps_datasets) > 0:
         worker_ctx["zarr_timestamps_datasets"] = zarr_timestamps_datasets
@@ -410,7 +410,7 @@ def _write_zarr_chunk(segment_index, start_frame, end_frame, worker_ctx):
     import gc
 
     # recover variables of the worker
-    chunkable = worker_ctx["chunkable"]
+    time_series = worker_ctx["time_series"]
     dtype = worker_ctx["dtype"]
     zarr_dataset = worker_ctx["zarr_datasets"][segment_index]
     if worker_ctx["zarr_timestamps_datasets"] is not None:
@@ -419,7 +419,7 @@ def _write_zarr_chunk(segment_index, start_frame, end_frame, worker_ctx):
         zarr_timestamps_dataset = None
 
     # apply function
-    data = chunkable.get_data(
+    data = time_series.get_data(
         start_frame=start_frame,
         end_frame=end_frame,
         segment_index=segment_index,
@@ -428,7 +428,7 @@ def _write_zarr_chunk(segment_index, start_frame, end_frame, worker_ctx):
     zarr_dataset[start_frame:end_frame, :] = data
 
     if zarr_timestamps_dataset is not None:
-        timestamps = chunkable.get_times(start_frame=start_frame, end_frame=end_frame, segment_index=segment_index)
+        timestamps = time_series.get_times(start_frame=start_frame, end_frame=end_frame, segment_index=segment_index)
         zarr_timestamps_dataset[start_frame:end_frame] = timestamps
 
     # fix memory leak by forcing garbage collection
@@ -437,7 +437,7 @@ def _write_zarr_chunk(segment_index, start_frame, end_frame, worker_ctx):
 
 
 def get_random_sample_slices(
-    chunkable: TimeSeries,
+    time_series: TimeSeries,
     method="full_random",
     num_chunks_per_segment=20,
     chunk_duration="500ms",
@@ -446,12 +446,12 @@ def get_random_sample_slices(
     seed=None,
 ):
     """
-    Get random slice of a chunkable object across segments.
+    Get random slice of a time_series object across segments.
 
     Parameters
     ----------
-    chunkable : TimeSeries
-        The chunkable object to get random chunks from
+    time_series : TimeSeries
+        The time_series object to get random chunks from
     method : "full_random"
         The method used to get random slices.
           * "full_random" : legacy method,  used until version 0.101.0, there is no constrain on slices
@@ -484,14 +484,14 @@ def get_random_sample_slices(
     if method == "full_random":
         if chunk_size is None:
             if chunk_duration is not None:
-                chunk_size = chunk_duration_to_chunk_size(chunk_duration, chunkable)
+                chunk_size = chunk_duration_to_chunk_size(chunk_duration, time_series)
             else:
                 raise ValueError("get_random_sample_slices need chunk_size or chunk_duration")
 
         # check chunk size
-        num_segments = chunkable.get_num_segments()
+        num_segments = time_series.get_num_segments()
         for segment_index in range(num_segments):
-            chunk_size_limit = chunkable.get_num_samples(segment_index) - 2 * margin_frames
+            chunk_size_limit = time_series.get_num_samples(segment_index) - 2 * margin_frames
             if chunk_size > chunk_size_limit:
                 chunk_size = chunk_size_limit - 1
                 warnings.warn(
@@ -504,7 +504,7 @@ def get_random_sample_slices(
         low = margin_frames
         size = num_chunks_per_segment
         for segment_index in range(num_segments):
-            num_frames = chunkable.get_num_samples(segment_index)
+            num_frames = time_series.get_num_samples(segment_index)
             high = num_frames - chunk_size - margin_frames
             # here we set endpoint to True, because the this represents the start of the
             # chunk, and should be inclusive
@@ -517,7 +517,7 @@ def get_random_sample_slices(
     return slices
 
 
-def get_chunks(chunkable: TimeSeries, concatenated=True, get_data_kwargs=None, **random_slices_kwargs):
+def get_chunks(time_series: TimeSeries, concatenated=True, get_data_kwargs=None, **random_slices_kwargs):
     """
     Extract random chunks across segments.
 
@@ -531,12 +531,12 @@ def get_chunks(chunkable: TimeSeries, concatenated=True, get_data_kwargs=None, *
 
     Parameters
     ----------
-    chunkable : TimeSeries
-        The chunkable object to get random chunks from
+    time_series : TimeSeries
+        The time_series object to get random chunks from
     return_scaled : bool | None, default: None
         DEPRECATED. Use return_in_uV instead.
     return_in_uV : bool, default: False
-        If True and the chunkable has scaling (gain_to_uV and offset_to_uV properties),
+        If True and the time_series has scaling (gain_to_uV and offset_to_uV properties),
         traces are scaled to uV
     num_chunks_per_segment : int, default: 20
         Number of chunks per segment
@@ -551,12 +551,12 @@ def get_chunks(chunkable: TimeSeries, concatenated=True, get_data_kwargs=None, *
     chunk_list : np.ndarray | list of np.array
         Array of concatenate chunks per segment
     """
-    slices = get_random_sample_slices(chunkable, **random_slices_kwargs)
+    slices = get_random_sample_slices(time_series, **random_slices_kwargs)
 
     chunk_list = []
     get_data_kwargs = get_data_kwargs if get_data_kwargs is not None else {}
     for segment_index, start_frame, end_frame in slices:
-        traces_chunk = chunkable.get_data(
+        traces_chunk = time_series.get_data(
             start_frame=start_frame, end_frame=end_frame, segment_index=segment_index, **get_data_kwargs
         )
         chunk_list.append(traces_chunk)

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -17,7 +17,7 @@ import numpy as np
 from spikeinterface.core.baserecording import BaseRecording
 
 from .baserecording import BaseRecording
-from .job_tools import ChunkExecutor, _shared_job_kwargs_doc
+from .job_tools import TimeSeriesChunkExecutor, _shared_job_kwargs_doc
 from .core_tools import make_shared_array
 from .job_tools import fix_job_kwargs
 
@@ -294,14 +294,16 @@ def distribute_waveforms_to_buffers(
     )
     if job_name is None:
         job_name = f"extract waveforms {mode} multi buffer"
-    processor = ChunkExecutor(recording, func, init_func, init_args, job_name=job_name, verbose=verbose, **job_kwargs)
+    processor = TimeSeriesChunkExecutor(
+        recording, func, init_func, init_args, job_name=job_name, verbose=verbose, **job_kwargs
+    )
     processor.run()
 
 
 distribute_waveforms_to_buffers.__doc__ = distribute_waveforms_to_buffers.__doc__.format(_shared_job_kwargs_doc)
 
 
-# used by ChunkExecutor
+# used by TimeSeriesChunkExecutor
 def _init_worker_distribute_buffers(
     recording, unit_ids, spikes, arrays_info, nbefore, nafter, return_in_uV, inds_by_unit, mode, sparsity_mask
 ):
@@ -348,7 +350,7 @@ def _init_worker_distribute_buffers(
     return worker_dict
 
 
-# used by ChunkExecutor
+# used by TimeSeriesChunkExecutor
 def _worker_distribute_buffers(segment_index, start_frame, end_frame, worker_dict):
     # recover variables of the worker
     recording = worker_dict["recording"]
@@ -561,7 +563,7 @@ def extract_waveforms_to_single_buffer(
         if job_name is None:
             job_name = f"extract waveforms {mode} mono buffer"
 
-        processor = ChunkExecutor(
+        processor = TimeSeriesChunkExecutor(
             recording, func, init_func, init_args, job_name=job_name, verbose=verbose, **job_kwargs
         )
         processor.run()
@@ -618,7 +620,7 @@ def _init_worker_distribute_single_buffer(
     return worker_dict
 
 
-# used by ChunkExecutor
+# used by TimeSeriesChunkExecutor
 def _worker_distribute_single_buffer(segment_index, start_frame, end_frame, worker_dict):
     # recover variables of the worker
     recording = worker_dict["recording"]
@@ -946,7 +948,7 @@ def estimate_templates_with_accumulator(
 
     if job_name is None:
         job_name = "estimate_templates_with_accumulator"
-    processor = ChunkExecutor(
+    processor = TimeSeriesChunkExecutor(
         recording, func, init_func, init_args, job_name=job_name, verbose=verbose, need_worker_index=True, **job_kwargs
     )
     processor.run()
@@ -1033,7 +1035,7 @@ def _init_worker_estimate_templates(
     return worker_dict
 
 
-# used by ChunkExecutor
+# used by TimeSeriesChunkExecutor
 def _worker_estimate_templates(segment_index, start_frame, end_frame, worker_dict):
     # recover variables of the worker
     recording = worker_dict["recording"]

--- a/src/spikeinterface/core/zarrextractors.py
+++ b/src/spikeinterface/core/zarrextractors.py
@@ -569,7 +569,7 @@ def add_traces_to_zarr(
     from .job_tools import (
         ensure_chunk_size,
         fix_job_kwargs,
-        ChunkExecutor,
+        TimeSeriesChunkExecutor,
     )
 
     assert dataset_paths is not None, "Provide 'file_path'"
@@ -606,13 +606,13 @@ def add_traces_to_zarr(
     func = _write_zarr_chunk
     init_func = _init_zarr_worker
     init_args = (recording, zarr_datasets, dtype)
-    executor = ChunkExecutor(
+    executor = TimeSeriesChunkExecutor(
         recording, func, init_func, init_args, verbose=verbose, job_name="write_zarr_recording", **job_kwargs
     )
     executor.run()
 
 
-# used by write_zarr_recording + ChunkExecutor
+# used by write_zarr_recording + TimeSeriesChunkExecutor
 def _init_zarr_worker(recording, zarr_datasets, dtype):
     import zarr
 
@@ -625,7 +625,7 @@ def _init_zarr_worker(recording, zarr_datasets, dtype):
     return worker_ctx
 
 
-# used by write_zarr_recording + ChunkExecutor
+# used by write_zarr_recording + TimeSeriesChunkExecutor
 def _write_zarr_chunk(segment_index, start_frame, end_frame, worker_ctx):
     import gc
 

--- a/src/spikeinterface/exporters/to_ibl.py
+++ b/src/spikeinterface/exporters/to_ibl.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 
 from spikeinterface.core import SortingAnalyzer, BaseRecording, get_random_data_chunks
-from spikeinterface.core.job_tools import fix_job_kwargs, ChunkExecutor, _shared_job_kwargs_doc
+from spikeinterface.core.job_tools import fix_job_kwargs, TimeSeriesChunkExecutor, _shared_job_kwargs_doc
 from spikeinterface.core.template_tools import get_template_extremum_channel
 from spikeinterface.exporters import export_to_phy
 
@@ -258,7 +258,7 @@ def compute_rms(
     func = _compute_rms_chunk
     init_func = _init_rms_worker
     init_args = (recording,)
-    executor = ChunkExecutor(
+    executor = TimeSeriesChunkExecutor(
         recording,
         func,
         init_func,

--- a/src/spikeinterface/postprocessing/principal_component.py
+++ b/src/spikeinterface/postprocessing/principal_component.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from spikeinterface.core.sortinganalyzer import register_result_extension, AnalyzerExtension
 
-from spikeinterface.core.job_tools import ChunkExecutor, _shared_job_kwargs_doc, fix_job_kwargs
+from spikeinterface.core.job_tools import TimeSeriesChunkExecutor, _shared_job_kwargs_doc, fix_job_kwargs
 
 from spikeinterface.core.analyzer_extension_core import _inplace_sparse_realign_waveforms
 
@@ -412,7 +412,7 @@ class ComputePrincipalComponents(AnalyzerExtension):
             unit_channels,
             pca_model,
         )
-        processor = ChunkExecutor(
+        processor = TimeSeriesChunkExecutor(
             recording, func, init_func, init_args, job_name="extract PCs", verbose=verbose, **job_kwargs
         )
         processor.run()

--- a/src/spikeinterface/sortingcomponents/clustering/main.py
+++ b/src/spikeinterface/sortingcomponents/clustering/main.py
@@ -26,7 +26,7 @@ def find_clusters_from_peaks(
     verbose : Bool, default: False
         If True, output is verbose
     job_kwargs : dict
-        Parameters for ChunkExecutor
+        Parameters for TimeSeriesChunkExecutor
 
     {method_doc}
 

--- a/src/spikeinterface/sortingcomponents/matching/main.py
+++ b/src/spikeinterface/sortingcomponents/matching/main.py
@@ -39,7 +39,7 @@ def find_spikes_from_templates(
     verbose : Bool, default: False
         If True, output is verbose
     job_kwargs : dict
-        Parameters for ChunkExecutor
+        Parameters for TimeSeriesChunkExecutor
 
     {method_doc}
 

--- a/src/spikeinterface/sortingcomponents/motion/motion_interpolation.py
+++ b/src/spikeinterface/sortingcomponents/motion/motion_interpolation.py
@@ -223,7 +223,7 @@ def interpolate_motion_on_traces(
 
         # here we use a simple np.matmul even if dirft_kernel can be super sparse.
         # because the speed for a sparse matmul is not so good when we disable multi threaad (due multi processing
-        # in ChunkExecutor)
+        # in TimeSeriesChunkExecutor)
         np.matmul(traces[frames_in_bin], drift_kernel, out=traces_corrected[frames_in_bin])
         current_start_index = next_start_index
 


### PR DESCRIPTION

This PR fixes the Kilosort4 regression reported on #4472. The root cause is that #4472 turned `write_binary_recording` into a plain alias for `write_binary(chunkable, ...)`, so passing `recording=rec` as a keyword argument no longer matched the parameter name and raised `TypeError`. The immediate fix is to make `write_binary_recording` a real wrapper again, with `recording` as its actual parameter:

```python
def write_binary_recording(recording, file_paths, **kwargs):
    return _write_binary(recording, file_paths, **kwargs)
```

I think this points to a more general principle worth keeping in the codebase: the SpikeInterface public API should stay in SpikeInterface vocabulary. A user saving a recording should see `recording` in signatures, docstrings, and IDE autocomplete, not the implementation concept `chunkable`. Keeping the generic functions private (underscore-prefixed, living in `time_series_tools`) and exposing thin recording-centered wrappers as the public surface is what makes this class of regression structurally hard to reintroduce: the parameter name a user types is the one that lives in the signature, and cannot drift when the internals are refactored. `write_memory_recording` is converted the same way for consistency.

The second change is the naming of the abstraction introduced in #4472. We touched on this in the maintenance meeting with @alejoe91: the real abstraction here is not chunkable in general, it is a time series over which we run processes in chunks. My proposal is that the class names should reflect that rather than staying at the overly abstract `Chunkable` level. Concretely:

- `ChunkableMixin` is renamed to `TimeSeries`: what this class actually models is a time series. Slicing methods like `get_data(start_frame, end_frame, ...)` are a natural property of a sliceable time series, not an extra "chunkable" capability. The executor does the chunking; the class just has to expose a time-series contract.
- `ChunkableSegment` is renamed to `TimeSeriesSegment`: the segment class contains no chunking code at all. It is only time handling (`sampling_frequency`, `t_start`, `time_vector`, `get_times`, `sample_index_to_time`, `time_to_sample_index`), and its own docstring describes it as providing "methods to handle time kwargs." Dropping `Chunkable` matches what the class actually is.
- `ChunkExecutor` is renamed to `TimeSeriesChunkExecutor`: this is where the verb "chunk" belongs, because the executor is what performs the chunking. Naming it `TimeSeriesChunkExecutor` also makes the axis of chunking explicit (it chunks along time, not arbitrary axes) and ties the vocabulary together: a `TimeSeries` / `TimeSeriesSegment` is chunked by a `TimeSeriesChunkExecutor`. The module `chunkable_tools.py` and the helper `divide_chunkable_into_chunks` are renamed to `time_series_tools.py` and `divide_time_series_into_chunks` to keep the import path and internal utilities consistent with the new names.

The two ideas come together in the zarr writer. Before this PR the public function was literally named `write_chunkable_to_zarr`: the function name itself asked a SpikeInterface user to learn the internal concept "chunkable" just to save a recording. Now the public entry point is `write_recording_to_zarr(recording, ...)` and the generic implementation has moved to a private `_write_time_series_to_zarr(...)`, so the helper name is honest about the `TimeSeries` contract it operates on. The behavior is identical; only the surface a user sees changes. When `BaseImaging` lands, `write_imaging_to_zarr(imaging, ...)` will be a second thin wrapper over the same private core, and imaging users will never see `chunkable` either.
