### PR TITLE
Fix numpy and scipy failures on the CI

### DIFF
--- a/src/spikeinterface/extractors/tests/test_iblextractors.py
+++ b/src/spikeinterface/extractors/tests/test_iblextractors.py
@@ -68,11 +68,11 @@ class TestDefaultIblRecordingExtractorApBand(TestCase):
 
     def test_gains(self):
         expected_gains = 2.34375 * np.ones(shape=384)
-        assert_array_equal(x=self.recording.get_channel_gains(), y=expected_gains)
+        assert_array_equal(self.recording.get_channel_gains(), expected_gains)
 
     def test_offsets(self):
         expected_offsets = np.zeros(shape=384)
-        assert_array_equal(x=self.recording.get_channel_offsets(), y=expected_offsets)
+        assert_array_equal(self.recording.get_channel_offsets(), expected_offsets)
 
     def test_probe_representation(self):
         probe = self.recording.get_probe()
@@ -142,11 +142,11 @@ class TestIblStreamingRecordingExtractorApBandWithLoadSyncChannel(TestCase):
 
     def test_gains(self):
         expected_gains = np.concatenate([2.34375 * np.ones(shape=384), [1171.875]])
-        assert_array_equal(x=self.recording.get_channel_gains(), y=expected_gains)
+        assert_array_equal(self.recording.get_channel_gains(), expected_gains)
 
     def test_offsets(self):
         expected_offsets = np.zeros(shape=385)
-        assert_array_equal(x=self.recording.get_channel_offsets(), y=expected_offsets)
+        assert_array_equal(self.recording.get_channel_offsets(), expected_offsets)
 
     def test_probe_representation(self):
         expected_exception = ValueError

--- a/src/spikeinterface/postprocessing/tests/test_principal_component.py
+++ b/src/spikeinterface/postprocessing/tests/test_principal_component.py
@@ -101,7 +101,7 @@ class TestPrincipalComponentsExtension(AnalyzerExtensionCommonTestSuite):
 
         random_spikes_ext = sorting_analyzer.get_extension("random_spikes")
         random_spikes_indices = random_spikes_ext.get_data()
-        unit_ids_num_random_spikes = np.sum(random_spikes_ext.params["max_spikes_per_unit"] for _ in some_unit_ids)
+        unit_ids_num_random_spikes = sum(random_spikes_ext.params["max_spikes_per_unit"] for _ in some_unit_ids)
 
         # this should be all spikes all channels
         some_projections, spike_unit_index = ext.get_some_projections(channel_ids=None, unit_ids=None)

--- a/src/spikeinterface/preprocessing/tests/test_filter.py
+++ b/src/spikeinterface/preprocessing/tests/test_filter.py
@@ -50,7 +50,7 @@ class TestCausalFilter:
 
         # Then, change all kwargs to ensure they are propagated
         # and check the backwards version.
-        options["band"] = [671]
+        options["band"] = 671
         options["btype"] = "highpass"
         options["filter_order"] = 8
         options["ftype"] = "bessel"


### PR DESCRIPTION
Three tests rely on lenient behavior that newer numpy and scipy have since tightened, and this PR adjusts the test code to match what the assertions actually mean. These failures went unnoticed because they only manifest on the Python 3.13 slot of the `Complete tests` matrix, which resolves to numpy 2.4.4 and scipy 1.17.1, while the Python 3.10 and 3.12 slots and the nightly codecov job all resolve to numpy 2.0.2 where the old behavior still holds. It is unclear to me why 3.13 resolves so much higher than 3.10 and 3.12 on the same workflow. Maybe #4515 but unclear.
