### PR TITLE
Speed up `test_sorting_s3_nwb_zarr`

### DIFF
--- a/src/spikeinterface/extractors/tests/test_nwbextractors_streaming.py
+++ b/src/spikeinterface/extractors/tests/test_nwbextractors_streaming.py
@@ -220,12 +220,17 @@ def test_sorting_s3_nwb_zarr(tmp_path):
 
     # test to/from dict
     sorting_loaded = load(sorting.to_dict())
-
     # just take 3 random units to test
     rng = np.random.default_rng(seed=2205)
     three_unit_ids = rng.choice(sorting.unit_ids, size=3)
-    sorting_sub = sorting.select_units(unit_ids=three_unit_ids)
-    sorting_loaded_sub = sorting_loaded.select_units(unit_ids=three_unit_ids)
+
+    first_spike_sample_index = 21864115
+    sorting_sub = sorting.select_units(unit_ids=three_unit_ids).frame_slice(
+        start_frame=first_spike_sample_index, end_frame=first_spike_sample_index + 10_000
+    )
+    sorting_loaded_sub = sorting_loaded.select_units(unit_ids=three_unit_ids).frame_slice(
+        start_frame=first_spike_sample_index, end_frame=first_spike_sample_index + 10_000
+    )
 
     check_sortings_equal(sorting_sub, sorting_loaded_sub)
 


### PR DESCRIPTION
While investigating the speed regression for full tests from #4515, I noticed that one of our longest tests `test_sorting_s3_nwb_zarr` was slow (before, took 4 minutes here https://github.com/SpikeInterface/spikeinterface/actions/runs/23709486678 and after, took 15 minutes here: https://github.com/SpikeInterface/spikeinterface/actions/runs/24629667731/job/72014705334 - the reason for this regression is still unknown).

The reason is that `check_sortings_equal` has to stream the entire file. We can prevent this by `frame_slice`ing, and only doing a `check_sortings_equal` to the time sliced sorting. Should speed our full test suite up by 10%!