### PR TITLE
Fix writing to binary recording in Kilosort

### DIFF
--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -138,7 +138,7 @@ class Kilosort4Sorter(BaseSorter):
                 # local copy needed
                 binary_file_path = sorter_output_folder / "recording.dat"
                 write_binary_recording(
-                    recording=recording,
+                    recording,
                     file_paths=[binary_file_path],
                     **get_job_kwargs(params, verbose),
                 )

--- a/src/spikeinterface/sorters/external/kilosortbase.py
+++ b/src/spikeinterface/sorters/external/kilosortbase.py
@@ -151,7 +151,7 @@ class KilosortBase:
             else:
                 padded_recording = recording
             write_binary_recording(
-                recording=padded_recording,
+                padded_recording,
                 file_paths=[binary_file_path],
                 dtype="int16",
                 **get_job_kwargs(params, verbose),


### PR DESCRIPTION
Just in case #4533 takes a little while to complete, this is a quick fix to solve the issue posted here: https://github.com/SpikeInterface/spikeinterface/pull/4472#issuecomment-4275657676

Note: at the moment in main, default `run_sorter` with kilosort4 doesn't work.