### PR TITLE
Modularize CI test and runtime dependencies per module

### DIFF
--- a/.github/actions/build-test-environment/action.yml
+++ b/.github/actions/build-test-environment/action.yml
@@ -9,7 +9,7 @@ runs:
         git config --global user.email "CI@example.com"
         git config --global user.name "CI Almighty"
         uv pip install --system tabulate  # This produces summaries at the end
-        uv pip install --system -e .[test,extractors,streaming_extractors,test_extractors,full]
+        uv pip install --system -e .[extractors,streaming_extractors,full] --group test-all
       shell: bash
     - name: Install git-annex
       shell: bash

--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Install packages
         run: |
-          uv pip install --system -e .[test_core]
+          uv pip install --system -e . --group test-core
         shell: bash
 
       - name: Pip list
@@ -145,7 +145,7 @@ jobs:
           HDF5_PLUGIN_PATH: ${{ github.workspace }}/hdf5_plugin_path_maxwell
         if: env.RUN_EXTRACTORS_TESTS == 'true'
         run: |
-          uv pip install --system -e .[extractors,streaming_extractors,test_extractors]
+          uv pip install --system -e .[extractors,streaming_extractors] --group test-extractors
           uv pip list --system
           ./.github/run_tests.sh "extractors and not streaming_extractors" --no-virtual-env
 
@@ -153,7 +153,7 @@ jobs:
         shell: bash
         if: env.RUN_STREAMING_EXTRACTORS_TESTS == 'true'
         run: |
-          uv pip install --system -e .[streaming_extractors,test_extractors]
+          uv pip install --system -e .[streaming_extractors] --group test-streaming-extractors
           uv pip list --system
           ./.github/run_tests.sh "streaming_extractors" --no-virtual-env
 
@@ -161,21 +161,15 @@ jobs:
         shell: bash
         if: env.RUN_PREPROCESSING_TESTS == 'true'
         run: |
-          uv pip install --system -e .[preprocessing,test_preprocessing]
+          uv pip install --system -e .[preprocessing] --group test-preprocessing
           uv pip list --system
           ./.github/run_tests.sh "preprocessing and not deepinterpolation" --no-virtual-env
-
-      - name: Install remaining testing dependencies # TODO: Remove this step once we have better modularization
-        shell: bash
-        run: |
-          uv pip install --system -e .[test]
-          uv pip list --system
 
       - name: Test postprocessing
         shell: bash
         if: env.RUN_POSTPROCESSING_TESTS == 'true'
         run: |
-          uv pip install --system -e .[full]
+          uv pip install --system -e .[postprocessing] --group test-postprocessing
           uv pip list --system
           ./.github/run_tests.sh postprocessing --no-virtual-env
 
@@ -183,7 +177,7 @@ jobs:
         shell: bash
         if: env.RUN_METRICS_TESTS == 'true'
         run: |
-          uv pip install --system -e .[metrics]
+          uv pip install --system -e .[metrics] --group test-metrics
           uv pip list --system
           ./.github/run_tests.sh metrics --no-virtual-env
 
@@ -191,7 +185,7 @@ jobs:
         shell: bash
         if: env.RUN_COMPARISON_TESTS == 'true'
         run: |
-          uv pip install --system -e .[full]
+          uv pip install --system -e .[comparison] --group test-comparison
           uv pip list --system
           ./.github/run_tests.sh comparison --no-virtual-env
 
@@ -199,7 +193,7 @@ jobs:
         shell: bash
         if: env.RUN_SORTERS_TESTS == 'true'
         run: |
-          uv pip install --system -e .[full]
+          uv pip install --system -e .[sorters] --group test-sorters
           uv pip list --system
           ./.github/run_tests.sh sorters --no-virtual-env
 
@@ -207,7 +201,7 @@ jobs:
         shell: bash
         if: env.RUN_INTERNAL_SORTERS_TESTS == 'true'
         run: |
-          uv pip install --system -e .[full]
+          uv pip install --system -e .[sorters_internal] --group test-sorters-internal
           uv pip list --system
           ./.github/run_tests.sh sorters_internal --no-virtual-env
 
@@ -215,7 +209,7 @@ jobs:
         shell: bash
         if: env.RUN_CURATION_TESTS == 'true'
         run: |
-          uv pip install --system -e .[full]
+          uv pip install --system -e .[curation] --group test-curation
           uv pip list --system
           ./.github/run_tests.sh curation --no-virtual-env
 
@@ -225,7 +219,7 @@ jobs:
         env:
           KACHERY_ZONE: "scratch"
         run: |
-          uv pip install --system -e .[full,widgets]
+          uv pip install --system -e .[widgets] --group test-widgets
           uv pip list --system
           ./.github/run_tests.sh widgets --no-virtual-env -s
 
@@ -233,7 +227,7 @@ jobs:
         shell: bash
         if: env.RUN_EXPORTERS_TESTS == 'true'
         run: |
-          uv pip install --system -e .[full]
+          uv pip install --system -e .[exporters] --group test-exporters
           uv pip list --system
           ./.github/run_tests.sh exporters --no-virtual-env
 
@@ -241,7 +235,7 @@ jobs:
         shell: bash
         if: env.RUN_SORTINGCOMPONENTS_TESTS == 'true'
         run: |
-          uv pip install --system -e .[full]
+          uv pip install --system -e .[sortingcomponents] --group test-sortingcomponents
           uv pip list --system
 
           # Internal shell check for platform and env var
@@ -262,6 +256,6 @@ jobs:
         shell: bash
         if: env.RUN_GENERATION_TESTS == 'true'
         run: |
-          uv pip install --system -e .[full]
+          uv pip install --system -e .[generation] --group test-generation
           uv pip list --system
           ./.github/run_tests.sh generation --no-virtual-env

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           git config --global user.email "CI@example.com"
           git config --global user.name "CI Almighty"
-          uv pip install --system -e .[test_core]
+          uv pip install --system -e . --group test-core
       - name: Test core with pytest
         run: |
           pytest -m "core" -vv -ra --durations=0 --durations-min=0.001 | tee report.txt; test $? -eq 0 || exit 1

--- a/.github/workflows/deepinterpolation.yml
+++ b/.github/workflows/deepinterpolation.yml
@@ -46,7 +46,7 @@ jobs:
           uv pip install --system tensorflow==2.8.4
           uv pip install --system deepinterpolation@git+https://github.com/AllenInstitute/deepinterpolation.git
           uv pip install --system numpy==1.26.4
-          uv pip install --system -e .[full,test_core]
+          uv pip install --system -e .[full] --group test-core
       - name: Pip list
         if: ${{ steps.modules-changed.outputs.DEEPINTERPOLATION_CHANGED == 'true' }}
         run: |

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -25,7 +25,7 @@ jobs:
           uv pip install --system pytest
           uv pip install --system zarr
           uv pip install --system setuptools wheel twine build
-          uv pip install --system -e .[test_core]
+          uv pip install --system -e . --group test-core
       - name: Test core with pytest
         run: |
           pytest -v src/spikeinterface/core

--- a/.github/workflows/test_kilosort4.yml
+++ b/.github/workflows/test_kilosort4.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install SpikeInterface
         run: |
-          uv pip install --system -e .[test]
+          uv pip install --system -e .[full] --group test-sorters
         shell: bash
 
       - name: Install legacy setuptools for KS4 < 4.0.19

--- a/doc/development/development.rst
+++ b/doc/development/development.rst
@@ -69,6 +69,14 @@ Note that you should install spikeinterface before running the tests. You can do
 
 You can change the :code:`[extractors,full]` extras to install only the runtime dependencies you need, and swap :code:`--group test-all` for a per-module test group (for example :code:`--group test-postprocessing`). Both lists are defined in :code:`pyproject.toml`: feature extras live under :code:`[project.optional-dependencies]` and test groups under :code:`[dependency-groups]` (PEP 735). Note that :code:`--group` requires pip 25.1+ or uv.
 
+With :code:`uv`, you can run the tests for a single module without creating a virtual environment explicitly by combining :code:`uv run --group` with pytest. For example, to run the preprocessing tests:
+
+.. code-block:: bash
+
+    uv run --group test-preprocessing pytest -s src/spikeinterface/preprocessing/tests
+
+:code:`uv run` resolves the dependency group on the fly into an ephemeral environment, so you do not need to remember which extras and test groups map to which module.
+
 The specific environment for the CI is specified in the :code:`.github/actions/build-test-environment/action.yml` and you can
 find the full tests in the :code:`.github/workflows/full_test.yml` file.
 

--- a/doc/development/development.rst
+++ b/doc/development/development.rst
@@ -73,7 +73,7 @@ With :code:`uv`, you can run the tests for a single module without creating a vi
 
 .. code-block:: bash
 
-    uv run --group test-preprocessing pytest -s src/spikeinterface/preprocessing/tests
+    uv run --group test-preprocessing pytest src/spikeinterface/preprocessing/tests
 
 :code:`uv run` resolves the dependency group on the fly into an ephemeral environment, so you do not need to remember which extras and test groups map to which module.
 

--- a/doc/development/development.rst
+++ b/doc/development/development.rst
@@ -65,9 +65,9 @@ Note that you should install spikeinterface before running the tests. You can do
 
 .. code-block:: bash
 
-    pip install -e .[test,extractors,full]
+    pip install -e .[extractors,full] --group test-all
 
-You can change the :code:`[test,extractors,full]` to install only the dependencies you need. The dependencies are specified in the :code:`pyproject.toml` file in the root of the repository.
+You can change the :code:`[extractors,full]` extras to install only the runtime dependencies you need, and swap :code:`--group test-all` for a per-module test group (for example :code:`--group test-postprocessing`). Both lists are defined in :code:`pyproject.toml`: feature extras live under :code:`[project.optional-dependencies]` and test groups under :code:`[dependency-groups]` (PEP 735). Note that :code:`--group` requires pip 25.1+ or uv.
 
 The specific environment for the CI is specified in the :code:`.github/actions/build-test-environment/action.yml` and you can
 find the full tests in the :code:`.github/workflows/full_test.yml` file.

--- a/doc/development/development.rst
+++ b/doc/development/development.rst
@@ -69,13 +69,26 @@ Note that you should install spikeinterface before running the tests. You can do
 
 You can change the :code:`[extractors,full]` extras to install only the runtime dependencies you need, and swap :code:`--group test-all` for a per-module test group (for example :code:`--group test-postprocessing`). Both lists are defined in :code:`pyproject.toml`: feature extras live under :code:`[project.optional-dependencies]` and test groups under :code:`[dependency-groups]` (PEP 735). Note that :code:`--group` requires pip 25.1+ or uv.
 
-With :code:`uv`, you can run the tests for a single module without creating a virtual environment explicitly by combining :code:`uv run --group` with pytest. For example, to run the preprocessing tests:
+With :code:`uv`, you can run the tests for a single module without creating and activating a virtual environment explicitly. :code:`uv run` resolves the project, extras, and dependency groups on the fly. The general pattern is:
 
 .. code-block:: bash
 
-    uv run --group test-preprocessing pytest src/spikeinterface/preprocessing/tests
+    uv run --extra <module> --group test-<module> pytest src/spikeinterface/<module>/tests
 
-:code:`uv run` resolves the dependency group on the fly into an ephemeral environment, so you do not need to remember which extras and test groups map to which module.
+For example:
+
+.. code-block:: bash
+
+    uv run --extra postprocessing --group test-postprocessing pytest src/spikeinterface/postprocessing/tests
+    uv run --extra sortingcomponents --group test-sortingcomponents pytest src/spikeinterface/sortingcomponents/tests
+
+To replicate the nightly CI environment and run the whole suite at once:
+
+.. code-block:: bash
+
+    uv run --extra extractors --extra streaming_extractors --extra full --group test-all pytest
+
+Both :code:`--extra` and :code:`--group` lists are enumerated in :code:`pyproject.toml`. Some modules' tests happen to work with just :code:`--group test-<module>` because the group pulls the runtime deps transitively (preprocessing is one such case), but declaring the matching :code:`--extra` explicitly is the reliable pattern.
 
 The specific environment for the CI is specified in the :code:`.github/actions/build-test-environment/action.yml` and you can
 find the full tests in the :code:`.github/workflows/full_test.yml` file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,111 +91,97 @@ preprocessing = [
     "scipy",
 ]
 
-
-full = [
-    "h5py",
-    "pandas<3",
+postprocessing = [
+    "spikeinterface[preprocessing]",
     "scipy",
     "scikit-learn<1.8",
-    "networkx",
-    "distinctipy",
-    "matplotlib>=3.6", # matplotlib.colormaps
-    "cuda-python>=11.8.6; platform_system != 'Darwin'",
     "numba>=0.59",
-    "skops",
-    "huggingface_hub"
-]
-
-widgets = [
-    "matplotlib",
-    "ipympl",
-    "ipywidgets",
-    "figpack",
-    "figpack-spike-sorting"
+    "matplotlib>=3.6",
 ]
 
 metrics = [
     "scikit-learn<1.8",
     "scipy",
     "pandas<3",
-    "numba",
+    "numba>=0.59",
 ]
 
-test_core = [
+comparison = [
+    "scipy",
     "pandas<3",
-    "pytest",
-    "psutil",
-
-    # for github test : probeinterface and neo from master
-    # for release we need pypi, so this need to be commented
-    "probeinterface @ git+https://github.com/SpikeInterface/probeinterface.git",
-    "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",
-
-    # for slurm jobs,
-    "pytest-mock"
+    "networkx",
 ]
 
-test_extractors = [
-    # Functions to download data in neo test suite
-    "pooch>=1.8.2",
-    "datalad>=1.0.2",
-    # Commenting out for release
-    "probeinterface @ git+https://github.com/SpikeInterface/probeinterface.git",
-    "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",
+generation = [
+    "scipy",
+    "pandas<3",
 ]
 
-test_preprocessing = [
-    "ibllib>=3.4.1;python_version>='3.10'", # streaming IBL
-    "torch",
-    # for IBL data fetching
-    "pooch",
-    "datalad"
+sorters = [
+    "scipy",
+    "h5py",
+    "cuda-python>=11.8.6; platform_system != 'Darwin'",
 ]
 
+sortingcomponents = [
+    "spikeinterface[preprocessing]",
+    "scipy",
+    "scikit-learn<1.8",
+    "numba>=0.59",
+    "networkx",
+    "hdbscan>=0.8.33",
+    # `torch` is an optional heavy dep used by neural-network peak detection,
+    # motion estimation, and template matching. Install separately if needed:
+    # pip install torch
+]
 
-test = [
-    "pytest",
-    "pytest-cov",
-    "psutil",
+sorters_internal = [
+    "spikeinterface[sortingcomponents]",
+    "spikeinterface[preprocessing]",
+]
 
-    # preprocessing
-    "ibllib>=3.4.1;python_version>='3.10'",
-
-    # streaming templates
-    "s3fs",
-
-    # exporters
-    "pynapple",
-
-    # tridesclous2
-    "numba<0.61.0;python_version<'3.13'",
-    "numba>=0.61.0;python_version>='3.13'",
-    "hdbscan>=0.8.33",  # Previous version had a broken wheel
-
-    # isosplit is needed for trideclous2 noramaly but isosplit is only build until python3.11
-    # so lets wait a new build of isosplit6
-    # "isosplit6",
-
-    # for sortingview backend
-    "sortingview>=0.12.0",
-
-    # for motion and sortingcomponents
-    "torch",
-
-    # curation
+curation = [
+    "spikeinterface[metrics]",
+    "spikeinterface[postprocessing]",
+    "spikeinterface[comparison]",
+    "pandas<3",
+    "scikit-learn<1.8",
     "skops",
     "huggingface_hub",
+    "numba>=0.59",
+    "networkx",
+]
 
-    # widgets
-    "sortingview",
+exporters = [
+    "spikeinterface[postprocessing]",
+    "spikeinterface[widgets]",
+    "pandas<3",
+    "pynapple",
+]
 
-    # for github test : probeinterface and neo from master
-    # for release we need pypi, so this need to be commented
-    "probeinterface @ git+https://github.com/SpikeInterface/probeinterface.git",
-    "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",
+widgets = [
+    "matplotlib>=3.6",
+    "ipympl",
+    "ipywidgets",
+    "figpack",
+    "figpack-spike-sorting",
+    "distinctipy",
+]
 
-    # for slurm jobs
-    "pytest-mock",
+# `full` installs every module's optional feature deps. Defined as the union of
+# per-module extras so adding a dep to a module propagates here automatically.
+full = [
+    "spikeinterface[preprocessing]",
+    "spikeinterface[postprocessing]",
+    "spikeinterface[metrics]",
+    "spikeinterface[comparison]",
+    "spikeinterface[generation]",
+    "spikeinterface[sorters]",
+    "spikeinterface[sortingcomponents]",
+    "spikeinterface[sorters_internal]",
+    "spikeinterface[curation]",
+    "spikeinterface[exporters]",
+    "spikeinterface[widgets]",
 ]
 
 docs = [
@@ -225,11 +211,86 @@ docs = [
 ]
 
 dev = [
-    "spikeinterface[test]",
-    "spikeinterface[test_core]",
     "spikeinterface[docs]",
     "black",
     "pre-commit",
+]
+
+[dependency-groups]
+# Shared test infrastructure used by every per-module group. The neo and
+# probeinterface git pins match CI behavior before the PEP 735 migration.
+# For a release, comment the two git lines out.
+test-common = [
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
+    "psutil",
+    "probeinterface @ git+https://github.com/SpikeInterface/probeinterface.git",
+    "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",
+]
+
+test-core = [
+    {include-group = "test-common"},
+    "pandas<3",
+]
+
+test-extractors = [
+    {include-group = "test-common"},
+    "pooch>=1.8.2",
+    "datalad>=1.0.2",
+]
+
+test-streaming-extractors = [
+    {include-group = "test-common"},
+    "pooch>=1.8.2",
+    "datalad>=1.0.2",
+]
+
+test-preprocessing = [
+    {include-group = "test-common"},
+    "ibllib>=3.4.1;python_version>='3.10'",
+    "pooch",
+    "datalad",
+]
+
+test-postprocessing = [{include-group = "test-common"}]
+test-metrics = [{include-group = "test-common"}]
+test-comparison = [{include-group = "test-common"}]
+test-sorters = [{include-group = "test-common"}]
+test-sorters-internal = [
+    {include-group = "test-common"},
+    "torch",  # spyking_circus2 template matching
+]
+test-curation = [{include-group = "test-common"}]
+
+test-widgets = [
+    {include-group = "test-common"},
+    "sortingview>=0.12.0",
+]
+
+test-exporters = [{include-group = "test-common"}]
+test-sortingcomponents = [
+    {include-group = "test-common"},
+    "torch",  # neural network peak detection, motion, matching
+]
+test-generation = [{include-group = "test-common"}]
+
+# Aggregate group for workflows that run the full test suite (nightly codecov).
+test-all = [
+    {include-group = "test-core"},
+    {include-group = "test-extractors"},
+    {include-group = "test-streaming-extractors"},
+    {include-group = "test-preprocessing"},
+    {include-group = "test-postprocessing"},
+    {include-group = "test-metrics"},
+    {include-group = "test-comparison"},
+    {include-group = "test-sorters"},
+    {include-group = "test-sorters-internal"},
+    {include-group = "test-curation"},
+    {include-group = "test-widgets"},
+    {include-group = "test-exporters"},
+    {include-group = "test-sortingcomponents"},
+    {include-group = "test-generation"},
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,7 @@ test-preprocessing = [
     "ibllib>=3.4.1;python_version>='3.10'",
     "pooch",
     "datalad",
+    "torch",  # preprocessing tests exercise sortingcomponents.motion.dredge
 ]
 
 test-postprocessing = [{include-group = "test-common"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,11 +257,12 @@ test-preprocessing = [
 test-postprocessing = [{include-group = "test-common"}]
 test-metrics = [{include-group = "test-common"}]
 test-comparison = [{include-group = "test-common"}]
-test-sorters = [{include-group = "test-common"}]
 test-sorters-internal = [
     {include-group = "test-common"},
     "torch",  # spyking_circus2 template matching
+    "hdbscan>=0.8.33",  # simplesorter / tridesclous2
 ]
+test-sorters = [{include-group = "test-sorters-internal"}]
 test-curation = [{include-group = "test-common"}]
 
 test-widgets = [


### PR DESCRIPTION
After discussing and confirming with Alessio in #4535, I am finishing the package modularization we started a while ago in #3084. Concretely:

- Moved test-only dependencies out of `[project.optional-dependencies]` into [PEP 735](https://peps.python.org/pep-0735/) `[dependency-groups]`, with one group per module (plus a shared `test-common` and an aggregate `test-all` for the nightly codecov job).
- Added per-module [runtime extras](https://packaging.python.org/en/latest/specifications/pyproject-toml/#dependencies-optional-dependencies) that were missing: `postprocessing`, `comparison`, `generation`, `sorters`, `sortingcomponents`, `sorters_internal`, `curation`, `exporters`.
- Redefined `full` as the union of all per-module extras via self-references, so adding a dep to a module propagates to `full` automatically.
- Each CI test step now installs only its module's runtime extra plus the matching test group (for example, `.[postprocessing] --group test-postprocessing`) instead of the old `.[full]` plus catch-all `.[test]`, so version drift can be pinpointed to a single module.

Close #4535