### PR TITLE
Drop cold-start sample from import-time profiling

### DIFF
--- a/.github/scripts/import_test.py
+++ b/.github/scripts/import_test.py
@@ -23,6 +23,19 @@ markdown_output = f"## \n\n| Imported Module ({n_samples=}) | Importing Time (se
 exceptions = []
 
 for import_statement in import_statement_list:
+    # Warm-up subprocess. Discarded from the timing data because the first
+    # `python -c "import X"` after a fresh install pays cold-start cost
+    # (filesystem cache priming, DLL loading, antivirus scanning a new
+    # package) that has nothing to do with spikeinterface's actual import
+    # weight. On Windows this can be 10x+ the steady-state and dominate
+    # the average.
+    warmup_script = (
+        f"import timeit \n"
+        f"import_statement = '{import_statement}' \n"
+        f"timeit.timeit(import_statement, number=1) \n"
+    )
+    subprocess.run(["python", "-c", warmup_script], capture_output=True, text=True)
+
     time_taken_list = []
     for _ in range(n_samples):
         script_to_execute = (
@@ -45,8 +58,7 @@ for import_statement in import_statement_list:
         time_taken_list.append(time_taken)
 
     for time in time_taken_list:
-        # TODO: lower this back toward 3.0 s once the Windows runner outliers are diagnosed.
-        import_time_threshold = 6.0
+        import_time_threshold = 3.0
         if time >= import_time_threshold:
             exceptions.append(
                 f"Importing {import_statement} took: {time:.2f} s. Should be <: {import_time_threshold} s."

--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: ["3.10", "3.13"]  # Lower and higher versions we support
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
@@ -111,7 +111,7 @@ jobs:
       - name: Cache datasets
         if: env.RUN_EXTRACTORS_TESTS == 'true' || env.RUN_PREPROCESSING_TESTS == 'true'
         id: cache-datasets
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/spikeinterface_datasets
           key: ${{ runner.os }}-datasets-${{ steps.repo_hash.outputs.dataset_hash }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,7 +9,7 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: conda-incubator/setup-miniconda@v2
         with:
           environment-file: environment_rtd.yml

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -35,7 +35,7 @@ jobs:
           echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
           echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
         shell: bash
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache-datasets
         with:
           path: ~/spikeinterface_datasets

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'

--- a/.github/workflows/deepinterpolation.yml
+++ b/.github/workflows/deepinterpolation.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'

--- a/.github/workflows/full-test-with-codecov.yml
+++ b/.github/workflows/full-test-with-codecov.yml
@@ -19,7 +19,7 @@ jobs:
         # "macos-latest", "windows-latest"
         os: ["ubuntu-latest", ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
@@ -42,7 +42,7 @@ jobs:
         run: |
           echo "HASH_EPHY_DATASET=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
       - name: Restore cached gin data for extractors tests
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: cache-datasets
         env:
           # the key depends on the last comit repo https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git
@@ -64,7 +64,7 @@ jobs:
           python ./.github/scripts/build_job_summary.py report_full.txt >> $GITHUB_STEP_SUMMARY
           cat $GITHUB_STEP_SUMMARY
           rm report_full.txt
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/installation-tips-test.yml
+++ b/.github/workflows/installation-tips-test.yml
@@ -17,7 +17,7 @@ jobs:
           - os: macos-latest
           - os: windows-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: actions/setup-python@v6
       with:
         python-version: '3.12'

--- a/.github/workflows/issue-on-change-matlab.yml
+++ b/.github/workflows/issue-on-change-matlab.yml
@@ -15,7 +15,7 @@ jobs:
       changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v46.0.1
@@ -32,7 +32,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Parse files names
         id: parse-files-names
         run: |

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/test_containers_docker.yml
+++ b/.github/workflows/test_containers_docker.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'

--- a/.github/workflows/test_containers_singularity.yml
+++ b/.github/workflows/test_containers_singularity.yml
@@ -13,7 +13,7 @@ jobs:
         # "macos-latest", "windows-latest"
         os: ["ubuntu-latest", ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'

--- a/.github/workflows/test_containers_singularity_gpu.yml
+++ b/.github/workflows/test_containers_singularity_gpu.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: iterative/setup-cml@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Deploy runner on EC2
         env:
           REPO_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
       image: docker://iterativeai/cml:0-dvc2-base1-gpu
       options: --privileged --gpus all
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_imports.yml
+++ b/.github/workflows/test_imports.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"

--- a/.github/workflows/test_kilosort4.yml
+++ b/.github/workflows/test_kilosort4.yml
@@ -18,7 +18,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -56,7 +56,7 @@ jobs:
         ks_version: ${{ fromJson(needs.versions.outputs.matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6


### PR DESCRIPTION
The previous PR (#4532) raised the per-sample threshold to 6.0 s as a temporary measure and added the per-sample table to the step summary so we could see the actual distribution. After looking at the data of some rounds I think it is just that the first sample is dominated by OS side-effects on running python for the first time. In Windows this must be worse, as that cost is dominated by OS-side effects (filesystem cache priming, DLL loading, Defender scanning a freshly-installed package). This is not a property of SpikeInterface and should not be measured on the import weight.

This PR adds a discarded warm-up subprocess before the timed loop for each import statement, so the table only contains steady-state samples. With the cold-start outlier removed, the per-sample threshold goes back to 3.0 s and the average gate stays at 2.0 s. The gate is now more sensitive to real regressions (a heavy import added to a top-level `__init__.py` shows up on every sample, not just the cold one), and the noise floor on Windows drops to the ~0.4 s steady-state we already see on the other runners.

I have also bumped `actions/checkout`, `actions/cache`, `actions/cache/restore`, and `codecov/codecov-action` to their current Node.js 24 majors across the workflows to clear the Node.js 20 deprecation warnings.
