### PR TITLE
Fix module level test groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,6 +244,11 @@ test-streaming-extractors = [
     {include-group = "test-common"},
     "pooch>=1.8.2",
     "datalad>=1.0.2",
+    "remfile",
+    "requests",
+    "aiohttp",
+    "fsspec",
+    "s3fs",
 ]
 
 test-preprocessing = [
@@ -254,9 +259,17 @@ test-preprocessing = [
     "torch",  # preprocessing tests exercise sortingcomponents.motion.dredge
 ]
 
-test-postprocessing = [{include-group = "test-common"}]
+test-postprocessing = [
+    {include-group = "test-common"},
+    "pandas<3",
+    ]
 test-metrics = [{include-group = "test-common"}]
-test-comparison = [{include-group = "test-common"}]
+
+test-comparison = [
+    {include-group = "test-common"},
+    "numba>=0.59"
+    ]
+
 test-sorters-internal = [
     {include-group = "test-common"},
     "torch",  # spyking_circus2 template matching
@@ -278,8 +291,15 @@ test-exporters = [{include-group = "test-common"}]
 test-sortingcomponents = [
     {include-group = "test-common"},
     "torch",  # neural network peak detection, motion, matching
+    "huggingface_hub", # for `test_single_channel_toy_denoiser_in_peak_pipeline`
 ]
-test-generation = [{include-group = "test-common"}]
+test-generation = [
+    {include-group = "test-common"},
+    "fsspec",
+    "s3fs",
+    "numba>=0.59", # numba and sklearn needed for motion correction of
+    "scikit-learn", # syntheic data used in `test_generate_hybrid_motion`
+    ]
 
 # Aggregate group for workflows that run the full test suite (nightly codecov).
 test-all = [

--- a/src/spikeinterface/generation/tests/test_hybrid_tools.py
+++ b/src/spikeinterface/generation/tests/test_hybrid_tools.py
@@ -39,7 +39,10 @@ def test_generate_hybrid_with_sorting():
 def test_generate_hybrid_motion():
     rec, _ = generate_ground_truth_recording(sampling_frequency=20000, durations=[10], num_channels=16, seed=0)
     _, motion_info = correct_motion(
-        rec, output_motion_info=True, estimate_motion_kwargs={"win_step_um": 20, "win_scale_um": 20}
+        rec,
+        output_motion_info=True,
+        preset="nonrigid_fast_and_accurate",
+        estimate_motion_kwargs={"win_step_um": 20, "win_scale_um": 20},
     )
     motion = motion_info["motion"]
     hybrid, sorting_hybrid = generate_hybrid_recording(rec, motion=motion, seed=0)


### PR DESCRIPTION
When we (beautifully) modularized the module level tests (#4541), the test groups weren't quite complete.

This didn't arise on CI because we don't actually run each module level test suite separately. Instead, we figure out which modules need testing and create an environment with all packages from all affected modules. So errors only arose later, when e.g. a PR only touched one module.

I ran each module level test suite locally, and these are the packages required to get everything working!