### PR TITLE
Use legacy numpy versions for ks 4.1.1-4.1.6 tests

### DIFF
--- a/.github/workflows/test_kilosort4.yml
+++ b/.github/workflows/test_kilosort4.yml
@@ -3,11 +3,11 @@ name: Testing Kilosort4
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 12 * * 0"  # Weekly on Sunday at noon UTC
+    - cron: "0 12 * * 0" # Weekly on Sunday at noon UTC
   pull_request:
     paths:
-      - '**/kilosort4.py'
-      - '**/test_kilosort4_ci.py'
+      - "**/kilosort4.py"
+      - "**/test_kilosort4_ci.py"
 
 jobs:
   versions:
@@ -75,6 +75,16 @@ jobs:
       - name: Install legacy setuptools for KS4 < 4.0.19
         if: matrix.ks_version == '4.0.16' || matrix.ks_version == '4.0.17' || matrix.ks_version == '4.0.18'
         run: uv pip install --system setuptools==78.0.2
+
+      - name: Install legacy numpy for KS4 4.1.1 - 4.1.5
+        if: |
+          matrix.ks_version == '4.1.1' ||
+          matrix.ks_version == '4.1.2' ||
+          matrix.ks_version == '4.1.3' ||
+          matrix.ks_version == '4.1.4' ||
+          matrix.ks_version == '4.1.5' ||
+          matrix.ks_version == '4.1.6'
+        run: uv pip install --system "numpy<2.4"
 
       - name: Install Kilosort
         run: |

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -1,4 +1,3 @@
-from spikeinterface.widgets.gtstudy import StudyRunTimesWidget
 import warnings
 from packaging import version
 

--- a/src/spikeinterface/sorters/external/kilosort4.py
+++ b/src/spikeinterface/sorters/external/kilosort4.py
@@ -1,3 +1,4 @@
+from spikeinterface.widgets.gtstudy import StudyRunTimesWidget
 import warnings
 from packaging import version
 
@@ -147,6 +148,7 @@ class Kilosort4Sorter(BaseSorter):
     @classmethod
     def _run_from_folder(cls, sorter_output_folder, params, verbose):
         from kilosort import __version__ as ks_version
+        from numpy import __version__ as np_version
         from kilosort.run_kilosort import (
             set_files,
             initialize_ops,
@@ -160,6 +162,13 @@ class Kilosort4Sorter(BaseSorter):
         )
         from kilosort.io import load_probe, RecordingExtractorAsArray, BinaryFiltered, save_preprocessing
         from kilosort.parameters import DEFAULT_SETTINGS
+
+        if (version.parse("4.1.1") <= version.parse(ks_version) <= version.parse("4.1.6")) and version.parse(
+            np_version
+        ) >= version.parse("2.4.0"):
+            raise RuntimeError(
+                "Kilosort versions between 4.1.1 and 4.1.6 are not compatible with numpy versions above 2.4. Either upgrade Kilosort to 4.1.7 or above, or downgrade numpy to 2.3 or below."
+            )
 
         if version.parse(ks_version) >= version.parse("4.0.33"):
             HAS_DIAGNOSTIC_PLOTS = True


### PR DESCRIPTION
Attempt to fix failing KS4 tests in #4589 

Simply installs numpy<2.4 for KS between 4.1.1 and 4.1.6. Also raises an error if user is using incompatible numpy+ks versions.