### PR TITLE
Use probeinterface's renamed Neuropixels readers and new probe detectors

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/openephys.py
+++ b/src/spikeinterface/extractors/neoextractors/openephys.py
@@ -321,14 +321,12 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
             if "NI-DAQmx" not in stream_name:
                 settings_file = node_structure["experiments"][exp_id]["settings_file"]
 
-                if Path(settings_file).is_file():
-                    probe = probeinterface.read_openephys(
-                        settings_file=settings_file, stream_name=oe_stream_name, raise_error=False
+                if Path(settings_file).is_file() and probeinterface.has_neuropixels_probes(
+                    settings_file, stream_name=oe_stream_name
+                ):
+                    probe = probeinterface.read_openephys_neuropixels(
+                        settings_file=settings_file, stream_name=oe_stream_name
                     )
-                else:
-                    probe = None
-
-                if probe is not None:
                     if probe.shank_ids is not None:
                         self.set_probe(probe, in_place=True, group_mode="by_shank")
                     else:

--- a/src/spikeinterface/extractors/neoextractors/spikegadgets.py
+++ b/src/spikeinterface/extractors/neoextractors/spikegadgets.py
@@ -1,7 +1,13 @@
 from pathlib import Path
+import warnings
+import numpy as np
 
 import probeinterface
 from spikeinterface.core.core_tools import define_function_from_class
+from spikeinterface.extractors.neuropixels_utils import (
+    get_neuropixels_sample_shifts_from_probe,
+    compute_saturation_threshold_from_probe,
+)
 
 from .neobaseextractor import NeoBaseRecordingExtractor
 
@@ -55,8 +61,26 @@ class SpikeGadgetsRecordingExtractor(NeoBaseRecordingExtractor):
 
         if probeinterface.has_spikegadgets_neuropixels_probes(file_path):
             probegroup = probeinterface.read_spikegadgets_neuropixels(file_path)
-            # TODO: add adc sample shifts and saturation levels if available in the probe metadata
             self.set_probegroup(probegroup, in_place=True)
+
+            # get inter-sample shifts based on the probe information and mux channels
+            sample_shifts = np.array([])
+            saturation_thresholds_uV = []
+            for probe in probegroup.probes:
+                sample_shifts_probe = get_neuropixels_sample_shifts_from_probe(probe)
+                if sample_shifts_probe is not None:
+                    sample_shifts = np.concatenate([sample_shifts, sample_shifts_probe])
+                # add saturation levels if available
+                saturation_threshold_uV_probe = compute_saturation_threshold_from_probe(probe, self.stream_id)
+                if saturation_threshold_uV_probe is not None:
+                    saturation_thresholds_uV.append(saturation_threshold_uV_probe)
+
+            if len(sample_shifts) > self.get_num_channels():
+                self.set_property("inter_sample_shift", sample_shifts)
+            if len(set(saturation_thresholds_uV)) == 1:
+                self.annotate(saturation_threshold_uV=saturation_thresholds_uV[0])
+            else:
+                warnings.warn("Multiple saturation thresholds found for different probes, unable to annotate.")
 
     @classmethod
     def map_to_neo_kwargs(cls, file_path):

--- a/src/spikeinterface/extractors/neoextractors/spikegadgets.py
+++ b/src/spikeinterface/extractors/neoextractors/spikegadgets.py
@@ -1,8 +1,5 @@
 from pathlib import Path
 
-import packaging
-
-import packaging.version
 import probeinterface
 from spikeinterface.core.core_tools import define_function_from_class
 
@@ -56,11 +53,8 @@ class SpikeGadgetsRecordingExtractor(NeoBaseRecordingExtractor):
         )
         self._kwargs.update(dict(file_path=str(Path(file_path).absolute()), stream_id=stream_id))
 
-        probegroup = None  # TODO remove once probeinterface is updated to 0.2.22 in the pyproject.toml
-        if packaging.version.parse(probeinterface.__version__) > packaging.version.parse("0.2.21"):
-            probegroup = probeinterface.read_spikegadgets(file_path, raise_error=False)
-
-        if probegroup is not None:
+        if probeinterface.has_spikegadgets_neuropixels_probes(file_path):
+            probegroup = probeinterface.read_spikegadgets_neuropixels(file_path)
             self.set_probegroup(probegroup, in_place=True)
 
     @classmethod

--- a/src/spikeinterface/extractors/neoextractors/spikegadgets.py
+++ b/src/spikeinterface/extractors/neoextractors/spikegadgets.py
@@ -61,21 +61,27 @@ class SpikeGadgetsRecordingExtractor(NeoBaseRecordingExtractor):
 
         if probeinterface.has_spikegadgets_neuropixels_probes(file_path):
             probegroup = probeinterface.read_spikegadgets_neuropixels(file_path)
-            self.set_probegroup(probegroup, in_place=True)
 
             # get inter-sample shifts based on the probe information and mux channels
-            sample_shifts = np.array([])
+            # SpikeGadgets writes multiple probes in the same file and the contacts are
+            # interleaved. The `device_channel_indices` of the probe is used to map the
+            # sample shifts to the correct channels.
+            # We instantiate the sample_shifts array with -1 to indicate channels for
+            # which we don't have a sample shift (sample shifts are [0-1] by definition)
+            sample_shifts = -1 * np.ones(self.get_num_channels())
             saturation_thresholds_uV = []
             for probe in probegroup.probes:
                 sample_shifts_probe = get_neuropixels_sample_shifts_from_probe(probe)
                 if sample_shifts_probe is not None:
-                    sample_shifts = np.concatenate([sample_shifts, sample_shifts_probe])
+                    sample_shifts[probe.device_channel_indices] = sample_shifts_probe
                 # add saturation levels if available
                 saturation_threshold_uV_probe = compute_saturation_threshold_from_probe(probe, self.stream_id)
                 if saturation_threshold_uV_probe is not None:
                     saturation_thresholds_uV.append(saturation_threshold_uV_probe)
 
-            if len(sample_shifts) > self.get_num_channels():
+            self.set_probegroup(probegroup, in_place=True)
+
+            if np.all(sample_shifts != -1):
                 self.set_property("inter_sample_shift", sample_shifts)
             if len(set(saturation_thresholds_uV)) == 1:
                 self.annotate(saturation_threshold_uV=saturation_thresholds_uV[0])


### PR DESCRIPTION
probeinterface renamed `read_openephys` to `read_openephys_neuropixels` ([SpikeInterface/probeinterface#427](https://github.com/SpikeInterface/probeinterface/pull/427)) and `read_spikegadgets` to `read_spikegadgets_neuropixels` ([SpikeInterface/probeinterface#440](https://github.com/SpikeInterface/probeinterface/pull/440)) to make the Neuropixels-only scope of those readers explicit; the old names remain as deprecation aliases. The same two PRs add detectors `has_neuropixels_probes(settings_file, stream_name=...)` and `has_spikegadgets_neuropixels_probes(file)` that parse the settings XML / `.rec` header and return whether the recording carries any Neuropixels probe geometry.

This PR switches the OpenEphys and SpikeGadgets extractors to call the new names and gates probe attachment on the detectors. Previously both readers were called unconditionally with `raise_error=False`, so a recording that legitimately had no Neuropixels probe (Intan / Rhythm FPGA / NI-DAQmx for Open Ephys, tetrodes / ECU for SpikeGadgets) silently returned `None` and the extractor finished probe-less. With the detector check up front the no-probe path is a normal control-flow branch, and any real parsing error from the reader now surfaces instead of being swallowed. 
I
I am also removing the version guard and the `packaging` import, since `pyproject.toml` already pins `probeinterface>=0.3.2`.
