### PR TITLE
Add whitening_seed parameter to MountainSort5

### DIFF
--- a/src/spikeinterface/sorters/external/mountainsort5.py
+++ b/src/spikeinterface/sorters/external/mountainsort5.py
@@ -43,6 +43,7 @@ class Mountainsort5Sorter(BaseSorter):
         "freq_max": 6000,
         "filter": True,
         "whiten": True,  # Important to do whitening
+        "whitening_seed": None,  # seed for whitening's random chunk selection (None = nondeterministic)
         "delete_temporary_recording": True,
     }
 
@@ -67,6 +68,7 @@ class Mountainsort5Sorter(BaseSorter):
         "freq_max": "Low-pass filter cutoff frequency",
         "filter": "Enable or disable filter",
         "whiten": "Enable or disable whitening",
+        "whitening_seed": "Seed for the random data chunks used to estimate the whitening matrix. Set an int for reproducible (deterministic) whitening; None (default) uses fresh randomness each run.",
         "delete_temporary_recording": "If True, the temporary recording file is deleted after sorting (this may fail on Windows requiring the end-user to delete the file themselves later)",
     }
 
@@ -142,7 +144,7 @@ class Mountainsort5Sorter(BaseSorter):
         if p["whiten"]:
             if verbose:
                 print("whitening")
-            recording = whiten(recording=recording, dtype="float32")
+            recording = whiten(recording=recording, dtype="float32", seed=p["whitening_seed"])
         else:
             warn("Not whitening (MountainSort5 expects whitened data)")
 


### PR DESCRIPTION
MountainSort5 whitens the recording before sorting, and the whitening matrix is estimated from randomly-selected data chunks (`spikeinterface.preprocessing.whiten` -> `get_random_data_chunks`).

Without control of the seed, sorting isn't reproducible, even on identical input.

Added a `whitening_seed` parameter (default `None`, preserves current behavior) that is forwarded to `whiten(seed=...)`.

There is still some very, very small residual indeterminism (on my test recording: 100% of units match, but ~0.04% of spikes differ) between runs with identical input. Not sure where it comes from -- maybe BLAS multithreading? Not worried about it. 

Looks okay @magland ? 

(The reason I'm trying to get deterministic output is so that I can evaluate whether the lossy `WavPack(bps=2.25)` compression that [has negligible impact on Neuropixel sortings](https://elifesciences.org/reviewed-preprints/110170) is also safe for some tetrode recordings. @alejoe91 )