### PR TITLE
Fix file size calculation in `write_binary()`

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -187,9 +187,15 @@ class BaseRecording(BaseRecordingSnippets, TimeSeries):
         """
         super().add_segment(recording_segment)
 
-    def get_sample_size_in_bytes(self):
+    def get_sample_size_in_bytes(self, dtype=None):
         """
         Returns the size of a single sample across all channels in bytes.
+
+        Parameters
+        ----------
+        dtype : data-type, optional
+            The data type to use for calculating the sample size. If None,
+            the recording's dtype is used.
 
         Returns
         -------
@@ -197,7 +203,8 @@ class BaseRecording(BaseRecordingSnippets, TimeSeries):
             The size of a single sample in bytes
         """
         num_channels = self.get_num_channels()
-        dtype_size_bytes = self.get_dtype().itemsize
+        dtype = self.get_dtype() if dtype is None else np.dtype(dtype)
+        dtype_size_bytes = dtype.itemsize
         sample_size = num_channels * dtype_size_bytes
         return sample_size
 

--- a/src/spikeinterface/core/time_series.py
+++ b/src/spikeinterface/core/time_series.py
@@ -34,7 +34,7 @@ class TimeSeries(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_sample_size_in_bytes(self) -> int:
+    def get_sample_size_in_bytes(self, dtype=None) -> int:
         raise NotImplementedError
 
     @abstractmethod

--- a/src/spikeinterface/core/time_series_tools.py
+++ b/src/spikeinterface/core/time_series_tools.py
@@ -62,9 +62,7 @@ def write_binary(
     if add_file_extension:
         file_path_list = [add_suffix(file_path, ["raw", "bin", "dat"]) for file_path in file_path_list]
 
-    dtype = dtype if dtype is not None else time_series.get_dtype()
-
-    sample_size_bytes = np.dtype(dtype).itemsize * time_series.get_num_channels()
+    sample_size_bytes = time_series.get_sample_size_in_bytes(dtype=dtype)
 
     file_path_dict = {segment_index: file_path for segment_index, file_path in enumerate(file_path_list)}
     if file_timestamps_paths is not None:
@@ -125,7 +123,7 @@ def _write_binary_chunk(segment_index, start_frame, end_frame, worker_ctx):
     byte_offset = worker_ctx["byte_offset"]
     file = worker_ctx["file_dict"][segment_index]
     file_timestamps_dict = worker_ctx["file_timestamps_dict"]
-    sample_size_bytes = dtype.itemsize * time_series.get_num_channels()
+    sample_size_bytes = time_series.get_sample_size_in_bytes(dtype=dtype)
 
     # Calculate byte offsets for the start frames relative to the entire recording
     start_byte = byte_offset + start_frame * sample_size_bytes

--- a/src/spikeinterface/core/time_series_tools.py
+++ b/src/spikeinterface/core/time_series_tools.py
@@ -64,7 +64,7 @@ def write_binary(
 
     dtype = dtype if dtype is not None else time_series.get_dtype()
 
-    sample_size_bytes = time_series.get_sample_size_in_bytes()
+    sample_size_bytes = np.dtype(dtype).itemsize * time_series.get_num_channels()
 
     file_path_dict = {segment_index: file_path for segment_index, file_path in enumerate(file_path_list)}
     if file_timestamps_paths is not None:
@@ -125,7 +125,7 @@ def _write_binary_chunk(segment_index, start_frame, end_frame, worker_ctx):
     byte_offset = worker_ctx["byte_offset"]
     file = worker_ctx["file_dict"][segment_index]
     file_timestamps_dict = worker_ctx["file_timestamps_dict"]
-    sample_size_bytes = time_series.get_sample_size_in_bytes()
+    sample_size_bytes = dtype.itemsize * time_series.get_num_channels()
 
     # Calculate byte offsets for the start frames relative to the entire recording
     start_byte = byte_offset + start_frame * sample_size_bytes


### PR DESCRIPTION
`write_binary()` was determining the file size and seek offests based on the source dtype's itemsize, but the data is cast to the target dtype before writing. This means that if the target dtype has a different itemsize than the source dtype, a corrupted file of the wrong size and layout was produced.

The solution was just just use the target dtype's itemsize for all file size and seek offset calculations.