### PR TITLE
Use np.load(..., mmap_mode="r") for time_vector in `BaseRecording._extra_metadata_from_folder`

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -409,7 +409,7 @@ class BaseRecording(BaseRecordingSnippets, TimeSeries):
         for segment_index, rs in enumerate(self.segments):
             time_file = folder / f"times_cached_seg{segment_index}.npy"
             if time_file.is_file():
-                time_vector = np.load(time_file)
+                time_vector = np.load(time_file, mmap_mode="r")
                 rs.time_vector = time_vector
 
     def _extra_metadata_to_folder(self, folder):

--- a/src/spikeinterface/core/tests/test_time_handling.py
+++ b/src/spikeinterface/core/tests/test_time_handling.py
@@ -375,6 +375,33 @@ class TestTimeHandling:
                 times_recording.get_times(segment_index=idx), loaded_recording.get_times(segment_index=idx)
             )
 
+    @pytest.mark.parametrize("save_format", ["binary", "zarr"])
+    def test_shift_times_after_load(self, request, save_format, tmp_path):
+        """
+        Shift times on a recording loaded from disk as a read-only np.memmap
+        (binary folder) and a lazy zarr.Array (zarr). Neither supports an in-place
+        `+=`, so `shift_times` must shift a writable copy. 
+        """
+        _, times_recording, all_times = self._get_fixture_data(request, "time_vector_recording")
+
+        folder = tmp_path / "rec"
+        times_recording.save(format=save_format, folder=folder)
+        load_path = folder.with_suffix(".zarr") if save_format == "zarr" else folder
+        loaded = si.load(load_path)
+
+        # Confirm we are actually exercising a non-writeable / non-ndarray path.
+        for idx in range(loaded.get_num_segments()):
+            tv = loaded.segments[idx].time_vector
+            assert not (isinstance(tv, np.ndarray) and tv.flags.writeable)
+
+        shift = 123.456
+        loaded.shift_times(shift)  
+
+        for idx in range(loaded.get_num_segments()):
+            assert np.allclose(
+                loaded.get_times(segment_index=idx), all_times[idx] + shift, rtol=0, atol=1e-8
+            )
+
     def _store_all_times(self, recording):
         """
         Convenience function to store original times of all segments to a dict.

--- a/src/spikeinterface/core/tests/test_time_handling.py
+++ b/src/spikeinterface/core/tests/test_time_handling.py
@@ -380,7 +380,7 @@ class TestTimeHandling:
         """
         Shift times on a recording loaded from disk as a read-only np.memmap
         (binary folder) and a lazy zarr.Array (zarr). Neither supports an in-place
-        `+=`, so `shift_times` must shift a writable copy. 
+        `+=`, so `shift_times` must shift a writable copy.
         """
         _, times_recording, all_times = self._get_fixture_data(request, "time_vector_recording")
 
@@ -395,12 +395,10 @@ class TestTimeHandling:
             assert not (isinstance(tv, np.ndarray) and tv.flags.writeable)
 
         shift = 123.456
-        loaded.shift_times(shift)  
+        loaded.shift_times(shift)
 
         for idx in range(loaded.get_num_segments()):
-            assert np.allclose(
-                loaded.get_times(segment_index=idx), all_times[idx] + shift, rtol=0, atol=1e-8
-            )
+            assert np.allclose(loaded.get_times(segment_index=idx), all_times[idx] + shift, rtol=0, atol=1e-8)
 
     def _store_all_times(self, recording):
         """

--- a/src/spikeinterface/core/time_series.py
+++ b/src/spikeinterface/core/time_series.py
@@ -1,10 +1,25 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, TYPE_CHECKING, TypeAlias
 import warnings
 
 import numpy as np
 
 from spikeinterface.core.base import BaseExtractor, BaseSegment
+
+if TYPE_CHECKING:
+    import zarr
+
+# A recording segment's time vector: a 1-D array of per-sample times (in seconds).
+# The backing store depends on how the recording was created/loaded:
+#   - np.ndarray : set_times() (writeable, in-memory)
+#   - np.memmap  : BinaryFolderRecording load via np.load(..., mmap_mode="r")
+#                  -- *read-only* ; see BaseRecording._extra_metadata_from_folder
+#   - zarr.Array : ZarrRecordingExtractor load
+#                  -- *read-only* ; see ZarrRecordingExtractor.__init__
+# Code reading `.time_vector` must not assume it is writeable (see `shift_times`).
+TimeVector: TypeAlias = "np.ndarray | zarr.Array"  # np.memmap is an np.ndarray subclass
 
 
 class TimeSeries(ABC):
@@ -146,8 +161,8 @@ class TimeSeries(ABC):
 
         Returns
         -------
-        np.array
-            The 1d times array
+        np.ndarray
+            The 1d times array. If the times were mem-mapped, loads them into memory.
         """
         segment_index = self._check_segment_index(segment_index)
         rs = self.segments[segment_index]
@@ -211,8 +226,9 @@ class TimeSeries(ABC):
 
         Parameters
         ----------
-        times : 1d np.array
-            The time vector
+        times : 1d array-like
+            The time vector. Lazy/read-only input (e.g. memmap or zarr.Array) is loaded
+            into memory and cast to float64 before being stored on the segment.
         segment_index : int or None, default: None
             The segment index (required for multi-segment)
         with_warning : bool, default: True
@@ -371,7 +387,23 @@ class TimeSeriesSegment(BaseSegment):
     """Per-segment time-series class. Provides time handling methods (sample/time conversion,
     start/end time, time vectors) on top of ``BaseSegment``."""
 
-    def __init__(self, sampling_frequency=None, t_start=None, time_vector=None):
+    def __init__(
+        self,
+        sampling_frequency: float | None = None,
+        t_start: float | None = None,
+        time_vector: TimeVector | None = None,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        sampling_frequency : float | None, default: None
+            Sampling frequency in Hz. Mutually exclusive with `time_vector`.
+        t_start : float | None, default: None
+            Start time (s) used when times are regular (no `time_vector`).
+        time_vector : TimeVector | None, default: None
+            Explicit per-sample times. May be a writeable np.ndarray, a read-only
+            np.memmap, or a lazy zarr.Array.
+        """
         # sampling_frequency and time_vector are exclusive
         if sampling_frequency is None:
             assert time_vector is not None, "Pass either 'sampling_frequency' or 'time_vector'"
@@ -382,7 +414,7 @@ class TimeSeriesSegment(BaseSegment):
 
         self.sampling_frequency = sampling_frequency
         self.t_start = t_start
-        self.time_vector = time_vector
+        self.time_vector: TimeVector | None = time_vector
 
         BaseSegment.__init__(self)
 

--- a/src/spikeinterface/core/time_series.py
+++ b/src/spikeinterface/core/time_series.py
@@ -277,8 +277,8 @@ class TimeSeries(ABC):
                     # If the time_vector is writeable, shift in-place to avoid a copy.
                     rs.time_vector += shift
                 else:
-                    # If the time_vector is a memmap from `np.load(..., mmap_mode='r')`, 
-                    # in-place modification would error, so we shift a writable copy. 
+                    # If the time_vector is a memmap from `np.load(..., mmap_mode='r')`,
+                    # in-place modification would error, so we shift a writable copy.
                     rs.time_vector = rs.time_vector + shift
             else:
                 new_start_time = 0 + shift if rs.t_start is None else rs.t_start + shift

--- a/src/spikeinterface/core/time_series.py
+++ b/src/spikeinterface/core/time_series.py
@@ -273,7 +273,13 @@ class TimeSeries(ABC):
             rs = self.segments[segment_index]
 
             if self.has_time_vector(segment_index=segment_index):
-                rs.time_vector += shift
+                if rs.time_vector.flags.writeable:
+                    # If the time_vector is writeable, shift in-place to avoid a copy.
+                    rs.time_vector += shift
+                else:
+                    # If the time_vector is a memmap from `np.load(..., mmap_mode='r')`, 
+                    # in-place modification would error, so we shift a writable copy. 
+                    rs.time_vector = rs.time_vector + shift
             else:
                 new_start_time = 0 + shift if rs.t_start is None else rs.t_start + shift
                 rs.t_start = new_start_time

--- a/src/spikeinterface/core/time_series.py
+++ b/src/spikeinterface/core/time_series.py
@@ -273,13 +273,12 @@ class TimeSeries(ABC):
             rs = self.segments[segment_index]
 
             if self.has_time_vector(segment_index=segment_index):
-                if rs.time_vector.flags.writeable:
-                    # If the time_vector is writeable, shift in-place to avoid a copy.
-                    rs.time_vector += shift
+                if isinstance(rs.time_vector, np.ndarray) and rs.time_vector.flags.writeable:
+                    # If this is an in-memory numpy array
+                    rs.time_vector += shift  # in-place, no copy
                 else:
-                    # If the time_vector is a memmap from `np.load(..., mmap_mode='r')`,
-                    # in-place modification would error, so we shift a writable copy.
-                    rs.time_vector = rs.time_vector + shift
+                    # If this is a read-only memmap or zarr.Array
+                    rs.time_vector = np.asarray(rs.time_vector) + shift
             else:
                 new_start_time = 0 + shift if rs.t_start is None else rs.t_start + shift
                 rs.t_start = new_start_time


### PR DESCRIPTION
`BaseRecording._extra_metadata_from_folder` was eagerly loading a `BinaryFolderRecording`'s time vector, which can be tens of GB on long recordings.

I ran into this because `run_sorter_by_property` (I was sorting tetrodes) reconstructs the recording _once per joblib worker_, so every worker was loading the whole time vector, even when only a short frame slice was needed.

Another consequence of the eager loading was that `si.load` on a 48h recording with a time_vector was using 1.6GB of memory, even if the time vector was never touched.

I switched the load to `mmap_mode="r"`, so memory use no longer scales with both recording duration and number of workers. It is bounded to what's actually touched, and the memmap can be shared by the joblib workers.

The cost is that this time vector is read-only, so in-place operations on it would raise an error.

Thankfully there was only 1: `TimeSeries.shift_times`! I made it shift in place only when the vector is writeable and fall back to an out-of-place op for the now read-only memmap. (For simplicity, we could scrap the conditional altogether and just keep the out-of-place path, since this is presumably a pretty rare op -- but I chose to keep the in-place, no-copy path for best performance). 