### PR TITLE
Use probeinterface and neo source when using spikeinterface source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,11 @@ dependencies = [
     "threadpoolctl>=3.0.0",
     "tqdm",
     "zarr>=2.18,<3",
-    "neo>=0.14.4",
-    "probeinterface>=0.3.2",
+    # for release we need pypi, so this needs to be commented
+    "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",
+    "probeinterface @ git+https://github.com/SpikeInterface/probeinterface.git",
+    # "neo>=0.14.4",
+    # "probeinterface>=0.3.2",
     "packaging",
     "pydantic",
     "numcodecs<0.16.0", # For supporting zarr < 3
@@ -224,10 +227,6 @@ docs = [
     "skops", # For automated curation
     "scikit-learn<1.8", # For automated curation
     "huggingface_hub", # For automated curation
-
-    # for release we need pypi, so this needs to be commented
-    "probeinterface @ git+https://github.com/SpikeInterface/probeinterface.git",  # We always build from the latest version
-    "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",  # We always build from the latest version
 ]
 
 dev = [
@@ -237,16 +236,12 @@ dev = [
 ]
 
 [dependency-groups]
-# Shared test infrastructure used by every per-module group. The neo and
-# probeinterface git pins match CI behavior before the PEP 735 migration.
-# For a release, comment the two git lines out.
+# Shared test infrastructure used by every per-module group.
 test-common = [
     "pytest",
     "pytest-cov",
     "pytest-mock",
     "psutil",
-    "probeinterface @ git+https://github.com/SpikeInterface/probeinterface.git",
-    "neo @ git+https://github.com/NeuralEnsemble/python-neo.git",
 ]
 
 test-core = [


### PR DESCRIPTION
As discussed in #4593

Currently, when you install SpikeInterface from source, the dependencies are release versions of ProbeInterface and Python-Neo. `pip` obeys this. `uv` looks at the other dependency groups and decides that the source versions should be used. Hence we have a mismatch in behavior between `uv` and `pip`.

Additionally, if you are using SpikeInterface from source, you almost certainly want ProbeInterface and Neo from source. This PR makes this the default.

Note: now when you release, you only need to change two lines in the pyproject.toml, not six!
Note: the development docs still make sense after this change.