### PR TITLE
Fix `read_mclust` returning zero units for `.t` files

### DIFF
--- a/src/spikeinterface/extractors/mclustextractors.py
+++ b/src/spikeinterface/extractors/mclustextractors.py
@@ -34,7 +34,9 @@ class MClustSortingExtractor(BaseSorting):
         ext = None
 
         for e in ext_list:
-            files = Path(folder_path).glob(f"*.{e}")
+            # `glob` returns a lazy generator, which is always truthy; materialize it so the
+            # `if files` check actually reflects whether any file with this extension exists.
+            files = sorted(Path(folder_path).glob(f"*.{e}"))
             if files:
                 ext = e
                 break
@@ -61,6 +63,13 @@ class MClustSortingExtractor(BaseSorting):
                     line = f.readline()
                     reading_header = not line.decode("utf-8").startswith(end_header_str)
                 times = np.fromfile(f, dtype=dataformat)
+            # MClust 3.x writes big-endian uint64 timestamps into the plain `.t` suffix, but
+            # `dataformat` is uint32 for any non-`64` extension. Reading 64-bit values as 32-bit
+            # produces interleaved zero/value word pairs (the high word is zero for timestamps that
+            # fit in 32 bits), so dropping zero words lets both 32- and 64-bit `.t` files load. This
+            # matches the community reference loader.
+            if ext.startswith("t") and dataformat == ">u4":
+                times = times[times > 0]
             if ext.startswith("t"):
                 times = times / 10000
             else:

--- a/src/spikeinterface/extractors/tests/test_mclustextractors.py
+++ b/src/spikeinterface/extractors/tests/test_mclustextractors.py
@@ -1,0 +1,29 @@
+import importlib.util
+import shutil
+
+import pytest
+
+from spikeinterface.core import download_dataset
+from spikeinterface.extractors.extractor_classes import read_mclust
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("pooch") is None or importlib.util.find_spec("datalad") is None,
+    reason="Either pooch or datalad is not installed",
+)
+def test_read_mclust(tmp_path):
+    # The mclust dataset on gin stores big-endian uint64 timestamps in the plain `.t` suffix
+    # (MClust 3.x). This previously made read_mclust return zero units: the extension was always
+    # detected as `t64` and the uint64 data was misread as uint32 (GH-4602).
+    folder = download_dataset(remote_path="mclust")
+
+    # The dataset has two `.t` files whose names both end in `_1`, so they parse to the same unit
+    # id. Isolate one of them (the smaller TT06 file) so read_mclust sees a single unit.
+    single_folder = tmp_path / "mclust_single"
+    single_folder.mkdir()
+    shutil.copy(folder / "M040-2020-04-28-TT06_1.t", single_folder / "M040-2020-04-28-TT06_1.t")
+
+    sorting = read_mclust(single_folder, sampling_frequency=32000.0)
+
+    assert sorting.get_num_units() == 1
+    assert len(sorting.get_unit_spike_train(unit_id=1)) == 5988


### PR DESCRIPTION
Two bugs in `MClustSortingExtractor` made `read_mclust` silently return a sorting with zero units for plain `.t` files (reported in #4602). First, the extension search relied on the truthiness of `Path.glob(...)`, which returns a generator and is therefore always truthy, so the format was always detected as `t64` regardless of which files were present; materializing the glob with `sorted(...)` makes the check reflect what is actually on disk. Second, MClust 3.x writes big-endian uint64 timestamps into the plain `.t` suffix while the reader assigns uint32 to any non-`64` extension, so each 64-bit value was read as two 32-bit words; dropping the zero high words (only for the `t` family read as uint32) recovers the timestamps, matching the community reference loader.



Closes #4602.
