### PR TITLE
Prepare 0.104.6

### DIFF
--- a/doc/releases/0.104.6.rst
+++ b/doc/releases/0.104.6.rst
@@ -3,7 +3,7 @@
 SpikeInterface 0.104.6 release notes
 ------------------------------------
 
-June 35th 2026
+June 25th 2026
 
 Minor release with bug fixes to make release compatible with NEO 0.14.5
 

--- a/doc/releases/0.104.6.rst
+++ b/doc/releases/0.104.6.rst
@@ -1,0 +1,16 @@
+.. _release0.104.6:
+
+SpikeInterface 0.104.6 release notes
+------------------------------------
+
+June 35th 2026
+
+Minor release with bug fixes to make release compatible with NEO 0.14.5
+
+extractors:
+
+* Remove load sync channel (#4466)
+
+Contributors:
+
+* @h-mayorquin

--- a/doc/whatisnew.rst
+++ b/doc/whatisnew.rst
@@ -8,6 +8,7 @@ Release notes
 .. toctree::
   :maxdepth: 1
 
+  releases/0.104.6.rst
   releases/0.104.5.rst
   releases/0.104.4.rst
   releases/0.104.3.rst
@@ -57,30 +58,10 @@ Release notes
   releases/0.9.9.rst
   releases/0.9.1.rst
 
-Version 0.104.5
-===============
+Versions 0.104.1/6
+==================
 
-* Minor release with bug fixes
-
-Version 0.104.4
-===============
-
-* Minor release with bug fixes
-
-Version 0.104.3
-===============
-
-* Minor release with bug fixes
-
-Version 0.104.2
-===============
-
-* Minor release with bug fixes
-
-Version 0.104.1
-===============
-
-* Minor release with bug fixes
+* Minor releases with bug fixes
 
 Version 0.104.0
 ===============
@@ -105,16 +86,11 @@ Version 0.104.0
     * The function to do UnitRefine curation has been renamed from ``auto_label_units`` to ``unitrefine_label_units`` (see :py:func:`~spikeinterface.curation.unitrefine_label_units`)
     * Remove support for Python 3.9
 
-Version 0.103.2
-===============
+Versions 0.103.1/2
+==================
 
-* Minor release with bug fixes
+* Minor releases with bug fixes
 
-
-Version 0.103.1
-===============
-
-* Minor release with bug fixes
 
 Version 0.103.0
 ===============
@@ -132,20 +108,10 @@ Version 0.103.0
     * Unsigned integers not automatically cast to signed integers anymore in preprocessing (#3982) (see :ref:`unsigned_to_signed`)
 
 
-Version 0.102.3
-===============
+Versions 0.102.1/3
+==================
 
-* Minor release with bug fixes
-
-Version 0.102.2
-===============
-
-* Minor release with bug fixes
-
-Version 0.102.1
-===============
-
-* Minor release with bug fixes
+* Minor releases with bug fixes
 
 Version 0.102.0
 ===============
@@ -157,10 +123,10 @@ Version 0.102.0
 * Multi-segment handling of motion interpolation (#3659)
 * Support for Numpy 2.0 and Zarr<3.0 (#3481,#3598)
 
-Version 0.101.2
-===============
+Versions 0.101.1/2
+==================
 
-* Minor release with bug fixes
+* Minor releases with bug fixes
 
 Version 0.101.1
 ===============

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spikeinterface"
-version = "0.104.5"
+version = "0.104.6"
 authors = [
   { name="Alessio Buccino", email="alessiop.buccino@gmail.com" },
   { name="Samuel Garcia", email="sam.garcia.die@gmail.com" },

--- a/src/spikeinterface/extractors/neoextractors/openephys.py
+++ b/src/spikeinterface/extractors/neoextractors/openephys.py
@@ -130,10 +130,6 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
         Alternative way to specify which experiment to load using a zero-based index.
         block_index=0 corresponds to experiment1, block_index=1 to experiment2, etc.
         Cannot be used together with experiment_name.
-    load_sync_channel : bool, default: False
-        **DEPRECATED: Use stream_name or stream_id to load sync streams. Will be removed in version 0.104.0**
-        If False (default) and a SYNC channel is present (e.g., Neuropixels), this is not loaded.
-        If True, the SYNC channel is loaded and can be accessed in the analog signals.
     load_sync_timestamps : bool, default: False
         If True, the synchronized_timestamps are loaded and set as times to the recording.
         If False (default), only the t_start and sampling rate are set, and timestamps are assumed
@@ -224,7 +220,6 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
         stream_id: str = None,
         stream_name: str = None,
         block_index: int = None,
-        load_sync_channel: bool = False,
         load_sync_timestamps: bool = False,
         experiment_names: str | list | None = None,
         all_annotations: bool = False,
@@ -277,16 +272,9 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
             # Single experiment: no filtering needed, let base class handle it
             block_index = None
 
-        if load_sync_channel:
-            warning_message = (
-                "OpenEphysBinaryRecordingExtractor: `load_sync_channel` is deprecated and will "
-                "be removed in version 0.104, use the `stream_name` or `stream_id` to load the sync stream if needed"
-            )
-            warnings.warn(warning_message, DeprecationWarning, stacklevel=2)
-
         stream_is_not_specified = stream_name is None and stream_id is None
         if stream_is_not_specified:
-            available_stream_names, _ = self.get_streams(folder_path, load_sync_channel, experiment_names_for_neo)
+            available_stream_names, _ = self.get_streams(folder_path, experiment_names_for_neo)
 
             # Auto-select neural data stream when there are exactly two streams (neural + sync)
             # and no stream was explicitly specified
@@ -296,7 +284,7 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
                     neural_stream_name = next(stream for stream in available_stream_names if "SYNC" not in stream)
                     stream_name = neural_stream_name
 
-        neo_kwargs = self.map_to_neo_kwargs(folder_path, load_sync_channel, experiment_names_for_neo)
+        neo_kwargs = self.map_to_neo_kwargs(folder_path, experiment_names_for_neo)
         NeoBaseRecordingExtractor.__init__(
             self,
             stream_id=stream_id,
@@ -309,7 +297,7 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
         stream_is_sync = "SYNC" in self.stream_name
         if not stream_is_sync:
             # get streams to find correct probe
-            stream_names, stream_ids = self.get_streams(folder_path, load_sync_channel, experiment_names_for_neo)
+            stream_names, stream_ids = self.get_streams(folder_path, experiment_names_for_neo)
             if stream_name is None and stream_id is None:
                 stream_name = stream_names[0]
             elif stream_name is None:
@@ -329,8 +317,8 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
                 exp_id = exp_ids[block_index]
             rec_ids = sorted(list(node_structure["experiments"][exp_id]["recordings"].keys()))
 
-            # do not load probe for NIDQ stream or if load_sync_channel is True
-            if "NI-DAQmx" not in stream_name and not load_sync_channel:
+            # do not load probe for NIDQ stream
+            if "NI-DAQmx" not in stream_name:
                 settings_file = node_structure["experiments"][exp_id]["settings_file"]
 
                 if Path(settings_file).is_file():
@@ -386,16 +374,14 @@ class OpenEphysBinaryRecordingExtractor(NeoBaseRecordingExtractor):
             dict(
                 folder_path=str(Path(folder_path).absolute()),
                 experiment_name=experiment_name,
-                load_sync_channel=load_sync_channel,
                 load_sync_timestamps=load_sync_timestamps,
             )
         )
 
     @classmethod
-    def map_to_neo_kwargs(cls, folder_path, load_sync_channel=False, experiment_names=None):
+    def map_to_neo_kwargs(cls, folder_path, experiment_names=None):
         neo_kwargs = {
             "dirname": str(folder_path),
-            "load_sync_channel": load_sync_channel,
             "experiment_names": experiment_names,
         }
         return neo_kwargs
@@ -511,11 +497,6 @@ def read_openephys(folder_path, **kwargs):
         Cannot be used together with experiment_name.
     all_annotations : bool, default: False
         Load exhaustively all annotation from neo
-    load_sync_channel : bool, default: False
-        **DEPRECATED: Use stream_name or stream_id to load sync streams**
-        If False (default) and a SYNC channel is present (e.g. Neuropixels), this is not loaded.
-        If True, the SYNC channel is loaded and can be accessed in the analog signals.
-        For open ephys binary format only
     load_sync_timestamps : bool, default: False
         If True, the synchronized_timestamps are loaded and set as times to the recording.
         If False (default), only the t_start and sampling rate are set, and timestamps are assumed


### PR DESCRIPTION
Minor release with #4466 to make 0.104.* compatible with latest NEO release (0.14.5), which removed `load_sync_channel`:  https://neo.readthedocs.io/en/latest/releases/0.14.5.html