### PR TITLE
Fix interpolate tests after probeinterface to_numpy change

### DIFF
--- a/src/spikeinterface/preprocessing/tests/test_interpolate_bad_channels.py
+++ b/src/spikeinterface/preprocessing/tests/test_interpolate_bad_channels.py
@@ -127,7 +127,7 @@ def test_compare_input_argument_ranges_against_ibl(shanks, p, sigma_um, num_chan
     rng = np.random.default_rng(seed=None)
     x = rng.choice(shanks, num_channels)
     for idx, __ in enumerate(recording._properties["contact_vector"]):
-        recording._properties["contact_vector"][idx][1] = x[idx]
+        recording._properties["contact_vector"][idx]["x"] = x[idx]
 
     # generate random bad channel locations
     bad_channel_indexes = rng.choice(num_channels, rng.integers(1, int(num_channels / 5)), replace=False)
@@ -171,8 +171,8 @@ def test_output_values():
     ]  # all others equal distance away.
     # Overwrite the probe information with the new locations
     for idx, (x, y) in enumerate(zip(*new_probe_locs)):
-        recording._properties["contact_vector"][idx][1] = x
-        recording._properties["contact_vector"][idx][2] = y
+        recording._properties["contact_vector"][idx]["x"] = x
+        recording._properties["contact_vector"][idx]["y"] = y
 
     # Run interpolation in SI and check the interpolated channel
     # 0 is a linear combination of other channels
@@ -186,8 +186,8 @@ def test_output_values():
     # Shift the last channel position so that it is 4 units, rather than 2
     # away. Setting sigma_um = p = 1 allows easy calculation of the expected
     # weights.
-    recording._properties["contact_vector"][-1][1] = 5
-    recording._properties["contact_vector"][-1][2] = 9
+    recording._properties["contact_vector"][-1]["x"] = 5
+    recording._properties["contact_vector"][-1]["y"] = 9
     expected_weights = np.r_[np.tile(np.exp(-2), 3), np.exp(-4)]
     expected_weights /= np.sum(expected_weights)
 


### PR DESCRIPTION
In probeinterface https://github.com/SpikeInterface/probeinterface/pull/446 added a `probe_id` field to the `to_numpy`. The interpolate bad channel tests was indecing the array directly. Switched to using field name for robustness