### PR TITLE
Infer `sampling_frequency` from `Units.resolution` in `NwbSortingExtractor`

### DIFF
--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -571,7 +571,7 @@ class _NWBReader:
             return {column.name: column for column in self.units_table.columns}["spike_times_index"].data
         return self.units_table["spike_times_index"]
 
-    def sampling_frequency_from_units_metadata(self):
+    def _sampling_frequency_from_units_metadata(self):
         # The Units.resolution attribute documents the precision of the spike times, typically
         # 1 / sampling_rate (in seconds). When present it lets a units-only file (one with no
         # ElectricalSeries) report a sampling frequency. It is spike-native, so it is preferred over
@@ -589,7 +589,7 @@ class _NWBReader:
             return None
         return 1.0 / resolution
 
-    def has_electrical_series(self):
+    def _has_electrical_series(self):
         # Whether the file contains any ElectricalSeries at all. Used to decide, for a sorting, whether
         # there is a recording to align to: if there is none, t_start has no origin and defaults to 0.
         if self.reading_method == "use_pynwb":
@@ -604,7 +604,7 @@ class _NWBReader:
         file_has_electrical_series = len(electrical_series) > 0
         return file_has_electrical_series
 
-    def fetch_unit_properties(self):
+    def _fetch_unit_properties(self):
         # Return the unit-table columns as a name -> per-unit values mapping in a backend-independent
         # format. Skips id / spike-time columns, index columns, nested ragged arrays, and ragged
         # columns whose per-unit shapes are unequal.
@@ -1180,8 +1180,9 @@ class NwbSortingExtractor(BaseSorting):
         Path to NWB file.
     electrical_series_path : str or None, default: None
         Path of the ElectricalSeries to read the time base (`sampling_frequency` and `t_start`) from.
-        When given, it is the source of the time base. When omitted, the time base must be provided
-        directly (see `t_start` / `sampling_frequency`); no ElectricalSeries is ever auto-selected.
+        When given, it is the sole source of the time base and cannot be combined with an explicit
+        `sampling_frequency` or `t_start` (passing both raises). When omitted, the time base must be
+        provided directly (see `t_start` / `sampling_frequency`); no ElectricalSeries is auto-selected.
         See Notes.
     sampling_frequency : float or None, default: None
         The sampling frequency in Hz. If None, it is read from the named ElectricalSeries, or (when no
@@ -1222,14 +1223,16 @@ class NwbSortingExtractor(BaseSorting):
     Notes
     -----
     A `Units` table stores spikes as times in seconds, so the sorting needs a time base
-    (`sampling_frequency` and `t_start`) to convert them to samples. There are two ways to supply it:
-    name an ElectricalSeries with `electrical_series_path`, or provide it directly. No ElectricalSeries
-    is consulted unless it is named. Explicit `sampling_frequency` / `t_start` arguments always take
-    precedence. The time base is resolved as follows::
+    (`sampling_frequency` and `t_start`) to convert them to samples. There are two mutually exclusive
+    ways to supply it: name an ElectricalSeries with `electrical_series_path` (which yields both values
+    and cannot be combined with an explicit `sampling_frequency` or `t_start`), or provide the time base
+    directly. No ElectricalSeries is consulted unless it is named. The time base is resolved as follows::
 
         You provide                                   sampling_frequency            t_start
         --------------------------------------------  ----------------------------  --------------------------
-        electrical_series_path                        from that ElectricalSeries    from that ElectricalSeries
+        electrical_series_path (only)                 from that ElectricalSeries    from that ElectricalSeries
+        electrical_series_path AND sampling_frequency raises (mutually exclusive)   raises (mutually exclusive)
+          or t_start
         t_start (no electrical_series_path)           argument or Units.resolution  argument
                                                       (raises if neither)
         no t_start, file HAS an ElectricalSeries      n/a                           raises (name it or pass
@@ -1305,40 +1308,48 @@ class NwbSortingExtractor(BaseSorting):
         # (which yields both values), or provide it directly. No ElectricalSeries is ever consulted
         # unless it is named, because the ElectricalSeries in a file is not necessarily the one the
         # sorting was computed from.
+
+        # First, look for any ElectricalSeries in the file.
+        file_has_electrical_series = self._reader._has_electrical_series()
+        electrical_series_path_is_provided = electrical_series_path is not None
+        sampling_frequency_is_provided = self.provided_sampling_frequency is not None
+        t_start_is_provided = self.t_start is not None
         sampling_frequency = self.provided_sampling_frequency
 
-        if electrical_series_path is not None:
-            # Read both the rate and t_start from the named ElectricalSeries.
-            series_sampling_frequency, series_t_start = self._reader.rate_and_t_start_from_electrical_series(
+        if electrical_series_path_is_provided:
+            # The named ElectricalSeries is the sole source of the time base; it is not combined with an
+            # explicit sampling_frequency or t_start.
+            if sampling_frequency_is_provided or t_start_is_provided:
+                raise ValueError(
+                    "Provide either 'electrical_series_path' or the time base ('sampling_frequency' and "
+                    "'t_start'), not both."
+                )
+            sampling_frequency, self.t_start = self._reader.rate_and_t_start_from_electrical_series(
                 samples_for_rate_estimation
             )
-            if sampling_frequency is None:
-                sampling_frequency = series_sampling_frequency
-            if self.t_start is None:
-                self.t_start = series_t_start
         else:
-            # No ElectricalSeries named: the user supplies the time base. sampling_frequency may be
-            # omitted when the Units table carries a 'resolution' attribute (read as 1 / resolution).
-            if sampling_frequency is None:
-                sampling_frequency = self._reader.sampling_frequency_from_units_metadata()
+            # No ElectricalSeries named. An unnamed recording is ambiguous (it may not be the one the
+            # sorting was computed from), so t_start must be given explicitly. With no recording in the
+            # file, anchor the frame grid at 0 (the spike times in seconds are preserved regardless).
+            unnamed_recording_needs_t_start = file_has_electrical_series and not t_start_is_provided
+            if unnamed_recording_needs_t_start:
+                raise ValueError(
+                    "The file contains an ElectricalSeries but 't_start' was not provided. Pass "
+                    "'electrical_series_path' to read the time base from it, or pass 't_start' explicitly."
+                )
 
-            # t_start has no origin to derive from. If a recording exists in the file but was not named,
-            # refuse to guess (defaulting to 0 would mis-anchor spikes against a real recording) and
-            # require it explicitly. If there is no recording at all, anchor the frame grid at 0.
-            if self.t_start is None:
-                if self._reader.has_electrical_series():
-                    raise ValueError(
-                        "The file contains an ElectricalSeries but 't_start' was not provided. Pass "
-                        "'electrical_series_path' to read the time base from it, or pass 't_start' "
-                        "explicitly."
-                    )
+            no_recording_to_align_to = not file_has_electrical_series and not t_start_is_provided
+            if no_recording_to_align_to:
                 self.t_start = 0.0
 
-        if sampling_frequency is None:
-            raise ValueError(
-                "Couldn't determine the sampling frequency. Provide it with the 'sampling_frequency' "
-                "argument, set the Units table 'resolution' attribute, or pass 'electrical_series_path'."
-            )
+            # sampling_frequency: the argument, or the Units.resolution attribute.
+            if sampling_frequency is None:
+                sampling_frequency = self._reader._sampling_frequency_from_units_metadata()
+            if sampling_frequency is None:
+                raise ValueError(
+                    "Couldn't determine the sampling frequency. Provide it with the 'sampling_frequency' "
+                    "argument, set the Units table 'resolution' attribute, or pass 'electrical_series_path'."
+                )
 
         unit_ids = self._reader.unit_ids()
         spike_times_data = self._reader.spike_times()
@@ -1356,7 +1367,7 @@ class NwbSortingExtractor(BaseSorting):
 
         # fetch and add sorting properties
         if load_unit_properties:
-            for property_name, property_values in self._reader.fetch_unit_properties().items():
+            for property_name, property_values in self._reader._fetch_unit_properties().items():
                 self.set_property(property_name, property_values)
 
         if reading_method == "use_pynwb":

--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -577,6 +577,16 @@ class _NWBReader:
             return None
         return 1.0 / resolution
 
+    def has_electrical_series(self):
+        # Whether the file contains any ElectricalSeries at all. Used to decide, for a sorting, whether
+        # there is a recording to align to: if there is none, t_start has no origin and defaults to 0.
+        if self.reading_method == "use_pynwb":
+            from pynwb.ecephys import ElectricalSeries
+
+            return any(isinstance(item, ElectricalSeries) for item in self.nwbfile.all_children())
+        backend = "zarr" if self.reading_method == "use_zarr" else "hdf5"
+        return len(_find_neurodata_type_from_backend(self.file, neurodata_type="ElectricalSeries", backend=backend)) > 0
+
     def rate_and_t_start_from_electrical_series(self, samples_for_rate_estimation):
         # Locate the ElectricalSeries the sorting came from and read its rate / t_start.
         if self.reading_method == "use_pynwb":
@@ -1107,7 +1117,8 @@ class NwbSortingExtractor(BaseSorting):
     electrical_series_path : str or None, default: None
         The name of the ElectricalSeries (if multiple ElectricalSeries are present).
     sampling_frequency : float or None, default: None
-        The sampling frequency in Hz (required if no ElectricalSeries is available).
+        The sampling frequency in Hz. If None, it is taken from the Units table ``resolution``
+        attribute, or from an ElectricalSeries. See Notes for the full resolution order.
     unit_table_path : str or None, default: "units"
         The path of the unit table in the NWB file.
     samples_for_rate_estimation : int, default: 100000
@@ -1120,18 +1131,10 @@ class NwbSortingExtractor(BaseSorting):
     load_unit_properties : bool, default: True
         If True, all the unit properties are loaded from the NWB file and stored as properties.
     t_start : float or None, default: None
-        This is the time at which the corresponding ElectricalSeries start. NWB stores its spikes as times
-        and the `t_start` is used to convert the times to seconds. Concrently, the returned frames are computed as:
-
-        ``frames = (times - t_start) * sampling_frequency``
-
-        As SpikeInterface always considers the first frame to be at the beginning of the recording independently
-        of the `t_start`.
-
-        When a `t_start` is not provided it will be inferred from the corresponding ElectricalSeries with name equal
-        to `electrical_series_path`. The `t_start` then will be either the `ElectricalSeries.starting_time` or the
-        first timestamp in the `ElectricalSeries.timestamps`.
-
+        Time (in seconds, on the NWB session clock) of the recording's first sample. NWB stores spikes
+        as times; frames are computed as ``frames = (times - t_start) * sampling_frequency``. The first
+        frame is always the start of the recording, independent of `t_start`. If None, it is taken from
+        an ElectricalSeries, or defaults to 0 when the file has no ElectricalSeries. See Notes.
     cache : bool, default: False
         If True, the file is cached in the file passed to stream_cache_path
         if False, the file is not cached.
@@ -1146,6 +1149,36 @@ class NwbSortingExtractor(BaseSorting):
     -------
     sorting : NwbSortingExtractor
         The sorting extractor for the NWB file.
+
+    Notes
+    -----
+    A `Units` table stores spikes as times in seconds, so the sorting needs a time base
+    (`sampling_frequency` and `t_start`) to convert them to samples. An explicit `sampling_frequency`
+    or `t_start` argument always takes precedence; otherwise the time base is resolved from the file
+    contents as follows::
+
+        File / arguments                    sampling_frequency            t_start
+        ----------------------------------  ----------------------------  ----------------------------
+        electrical_series_path given        from named ElectricalSeries   from named ElectricalSeries
+        ElectricalSeries present, unnamed   Units.resolution else raises  required (see below)
+        no ElectricalSeries in the file     Units.resolution else raises  defaults to 0
+
+    When an ElectricalSeries is present but not named, the current release auto-selects it (emitting a
+    FutureWarning); from version 0.107.0 this will raise and error, and the time base must be set explicitly by
+    passing `electrical_series_path`, or `t_start` together with `sampling_frequency`.
+
+    Justification:
+
+    - `Units.resolution` (the `1 / sampling_rate` precision of the spike times) is preferred over the
+      ElectricalSeries rate because it is spike-native: the ElectricalSeries present in a file is not
+      necessarily the one the sorting was computed from (for example an LFP series next to a full-band
+      sorting).
+    - `t_start` only anchors the frame grid; the spike times in seconds are preserved regardless. So
+      when there is no recording to align to, it safely defaults to 0. When a recording is present but
+      not named, defaulting would silently mis-anchor spikes against a real recording, so an explicit
+      choice is required instead.
+    - `sampling_frequency` has no safe default (a wrong rate is a scale error that corrupts every
+      frame), so it is required when available from none of the three sources.
 
     """
 
@@ -1198,22 +1231,21 @@ class NwbSortingExtractor(BaseSorting):
         )
         self.units_table = self._reader.units_table
 
-        # A sorting needs a sampling_frequency and t_start. Resolve the sampling_frequency in order of
-        # preference: the provided argument, then the spike-native Units.resolution attribute, then the
-        # ElectricalSeries rate. Units.resolution is preferred over the ElectricalSeries because the
-        # ElectricalSeries in the file is not necessarily the one the sorting was computed from.
+        # Resolve the time base (sampling_frequency, t_start). See the class docstring for the full
+        # contract. sampling_frequency: the provided argument, then the spike-native Units.resolution
+        # attribute, then an ElectricalSeries. Units.resolution is preferred over the ElectricalSeries
+        # because the ElectricalSeries in the file is not necessarily the one the sorting came from.
         sampling_frequency = self.provided_sampling_frequency
         if sampling_frequency is None:
             sampling_frequency = self._reader.sampling_frequency_from_units_metadata()
 
-        # The ElectricalSeries still supplies t_start (Units.resolution carries no time origin), and the
-        # sampling_frequency as a last resort when Units.resolution was absent.
         if sampling_frequency is None or self.t_start is None:
-            # Without an explicit electrical_series_path this auto-selects the file's single
-            # ElectricalSeries, which may not be the one the sorting was computed from. That implicit
-            # behavior is deprecated: from version 0.107.0 the ElectricalSeries must be requested
-            # explicitly, or the time base must be provided via sampling_frequency and t_start.
-            if electrical_series_path is None:
+            file_has_electrical_series = self._reader.has_electrical_series()
+
+            # Auto-selecting an unnamed ElectricalSeries is deprecated: from version 0.107.0 it must be
+            # requested with electrical_series_path, or the time base provided via sampling_frequency
+            # and t_start.
+            if electrical_series_path is None and file_has_electrical_series:
                 warnings.warn(
                     "Determining the sorting's sampling_frequency / t_start by auto-selecting an "
                     "ElectricalSeries is deprecated and will raise an error in version 0.107.0. "
@@ -1225,19 +1257,25 @@ class NwbSortingExtractor(BaseSorting):
                     FutureWarning,
                     stacklevel=2,
                 )
-            series_sampling_frequency, series_t_start = self._reader.rate_and_t_start_from_electrical_series(
-                samples_for_rate_estimation
-            )
-            if sampling_frequency is None:
-                sampling_frequency = series_sampling_frequency
-            if self.t_start is None:
-                self.t_start = series_t_start
-        assert (
-            sampling_frequency is not None
-        ), "Couldn't load sampling frequency. Please provide it with the 'sampling_frequency' argument"
-        assert (
-            self.t_start is not None
-        ), "Couldn't load a starting time for the sorting. Please provide it with the 't_start' argument"
+
+            if electrical_series_path is not None or file_has_electrical_series:
+                # An ElectricalSeries provides both the rate (if still missing) and t_start.
+                series_sampling_frequency, series_t_start = self._reader.rate_and_t_start_from_electrical_series(
+                    samples_for_rate_estimation
+                )
+                if sampling_frequency is None:
+                    sampling_frequency = series_sampling_frequency
+                if self.t_start is None:
+                    self.t_start = series_t_start
+            elif self.t_start is None:
+                # No recording in the file: t_start has no origin to align to, so anchor the frame grid
+                # at 0 (the spike times in seconds are preserved regardless of this choice).
+                self.t_start = 0.0
+
+        assert sampling_frequency is not None, (
+            "Couldn't determine the sampling frequency. Provide it with the 'sampling_frequency' "
+            "argument, set the Units table 'resolution' attribute, or pass 'electrical_series_path'."
+        )
 
         unit_ids = self._reader.unit_ids()
         spike_times_data = self._reader.spike_times()

--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -1209,6 +1209,22 @@ class NwbSortingExtractor(BaseSorting):
         # The ElectricalSeries still supplies t_start (Units.resolution carries no time origin), and the
         # sampling_frequency as a last resort when Units.resolution was absent.
         if sampling_frequency is None or self.t_start is None:
+            # Without an explicit electrical_series_path this auto-selects the file's single
+            # ElectricalSeries, which may not be the one the sorting was computed from. That implicit
+            # behavior is deprecated: from version 0.107.0 the ElectricalSeries must be requested
+            # explicitly, or the time base must be provided via sampling_frequency and t_start.
+            if electrical_series_path is None:
+                warnings.warn(
+                    "Determining the sorting's sampling_frequency / t_start by auto-selecting an "
+                    "ElectricalSeries is deprecated and will raise an error in version 0.107.0. "
+                    "Set the time base explicitly, in one of two ways: "
+                    "(1) pass 'electrical_series_path' to name the ElectricalSeries to read it from, or "
+                    "(2) pass 't_start' together with 'sampling_frequency' (you may omit "
+                    "'sampling_frequency' if the Units table has a 'resolution' attribute, which is read "
+                    "as 1 / resolution).",
+                    FutureWarning,
+                    stacklevel=2,
+                )
             series_sampling_frequency, series_t_start = self._reader.rate_and_t_start_from_electrical_series(
                 samples_for_rate_estimation
             )

--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -1164,8 +1164,8 @@ class NwbSortingExtractor(BaseSorting):
         no ElectricalSeries in the file     Units.resolution else raises  defaults to 0
 
     When an ElectricalSeries is present but not named, the current release auto-selects it (emitting a
-    FutureWarning); from version 0.107.0 this will raise and error, and the time base must be set explicitly by
-    passing `electrical_series_path`, or `t_start` together with `sampling_frequency`.
+    FutureWarning); from version 0.107.0 this will raise an error, and the time base must be set
+    explicitly by passing `electrical_series_path`, or `t_start` together with `sampling_frequency`.
 
     Justification:
 

--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -559,6 +559,24 @@ class _NWBReader:
             return {column.name: column for column in self.units_table.columns}["spike_times_index"].data
         return self.units_table["spike_times_index"]
 
+    def sampling_frequency_from_units_metadata(self):
+        # The Units.resolution attribute documents the precision of the spike times, typically
+        # 1 / sampling_rate (in seconds). When present it lets a units-only file (one with no
+        # ElectricalSeries) report a sampling frequency. It is spike-native, so it is preferred over
+        # the ElectricalSeries rate, which may belong to a series the sorting was not computed from.
+        # pynwb exposes it as Units.resolution; the raw hdf5 / zarr layout stores it as an attribute
+        # of the spike_times dataset.
+        if self.reading_method == "use_pynwb":
+            resolution = getattr(self.units_table, "resolution", None)
+        else:
+            resolution = self.units_table["spike_times"].attrs.get("resolution", None)
+        if resolution is None:
+            return None
+        resolution = float(resolution)
+        if not np.isfinite(resolution) or resolution <= 0:
+            return None
+        return 1.0 / resolution
+
     def rate_and_t_start_from_electrical_series(self, samples_for_rate_estimation):
         # Locate the ElectricalSeries the sorting came from and read its rate / t_start.
         if self.reading_method == "use_pynwb":
@@ -1155,7 +1173,7 @@ class NwbSortingExtractor(BaseSorting):
         self.electrical_series_path = electrical_series_path
         self.file_path = file_path
         self.t_start = t_start
-        self.provided_or_electrical_series_sampling_frequency = sampling_frequency
+        self.provided_sampling_frequency = sampling_frequency
         self.storage_options = storage_options
 
         if use_pynwb and not HAVE_PYNWB:
@@ -1180,18 +1198,26 @@ class NwbSortingExtractor(BaseSorting):
         )
         self.units_table = self._reader.units_table
 
-        # A sorting needs a sampling_frequency and t_start; when not provided, take them from the
-        # ElectricalSeries the sorting was computed from.
-        if self.provided_or_electrical_series_sampling_frequency is None or self.t_start is None:
+        # A sorting needs a sampling_frequency and t_start. Resolve the sampling_frequency in order of
+        # preference: the provided argument, then the spike-native Units.resolution attribute, then the
+        # ElectricalSeries rate. Units.resolution is preferred over the ElectricalSeries because the
+        # ElectricalSeries in the file is not necessarily the one the sorting was computed from.
+        sampling_frequency = self.provided_sampling_frequency
+        if sampling_frequency is None:
+            sampling_frequency = self._reader.sampling_frequency_from_units_metadata()
+
+        # The ElectricalSeries still supplies t_start (Units.resolution carries no time origin), and the
+        # sampling_frequency as a last resort when Units.resolution was absent.
+        if sampling_frequency is None or self.t_start is None:
             series_sampling_frequency, series_t_start = self._reader.rate_and_t_start_from_electrical_series(
                 samples_for_rate_estimation
             )
-            if self.provided_or_electrical_series_sampling_frequency is None:
-                self.provided_or_electrical_series_sampling_frequency = series_sampling_frequency
+            if sampling_frequency is None:
+                sampling_frequency = series_sampling_frequency
             if self.t_start is None:
                 self.t_start = series_t_start
         assert (
-            self.provided_or_electrical_series_sampling_frequency is not None
+            sampling_frequency is not None
         ), "Couldn't load sampling frequency. Please provide it with the 'sampling_frequency' argument"
         assert (
             self.t_start is not None
@@ -1201,9 +1227,7 @@ class NwbSortingExtractor(BaseSorting):
         spike_times_data = self._reader.spike_times()
         spike_times_index_data = self._reader.spike_times_index()
 
-        BaseSorting.__init__(
-            self, sampling_frequency=self.provided_or_electrical_series_sampling_frequency, unit_ids=unit_ids
-        )
+        BaseSorting.__init__(self, sampling_frequency=sampling_frequency, unit_ids=unit_ids)
 
         sorting_segment = NwbSortingSegment(
             spike_times_data=spike_times_data,

--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -595,9 +595,14 @@ class _NWBReader:
         if self.reading_method == "use_pynwb":
             from pynwb.ecephys import ElectricalSeries
 
-            return any(isinstance(item, ElectricalSeries) for item in self.nwbfile.all_children())
-        backend = "zarr" if self.reading_method == "use_zarr" else "hdf5"
-        return len(_find_neurodata_type_from_backend(self.file, neurodata_type="ElectricalSeries", backend=backend)) > 0
+            electrical_series = [item for item in self.nwbfile.all_children() if isinstance(item, ElectricalSeries)]
+        else:
+            backend = "zarr" if self.reading_method == "use_zarr" else "hdf5"
+            electrical_series = _find_neurodata_type_from_backend(
+                self.file, neurodata_type="ElectricalSeries", backend=backend
+            )
+        file_has_electrical_series = len(electrical_series) > 0
+        return file_has_electrical_series
 
     def fetch_unit_properties(self):
         # Return the unit-table columns as a name -> per-unit values mapping in a backend-independent
@@ -1174,10 +1179,13 @@ class NwbSortingExtractor(BaseSorting):
     file_path : str or Path
         Path to NWB file.
     electrical_series_path : str or None, default: None
-        The name of the ElectricalSeries (if multiple ElectricalSeries are present).
+        Path of the ElectricalSeries to read the time base (`sampling_frequency` and `t_start`) from.
+        When given, it is the source of the time base. When omitted, the time base must be provided
+        directly (see `t_start` / `sampling_frequency`); no ElectricalSeries is ever auto-selected.
+        See Notes.
     sampling_frequency : float or None, default: None
-        The sampling frequency in Hz. If None, it is taken from the Units table ``resolution``
-        attribute, or from an ElectricalSeries. See Notes for the full resolution order.
+        The sampling frequency in Hz. If None, it is read from the named ElectricalSeries, or (when no
+        ElectricalSeries is named) from the Units table ``resolution`` attribute. See Notes.
     unit_table_path : str or None, default: "units"
         The path of the unit table in the NWB file.
     samples_for_rate_estimation : int, default: 100000
@@ -1192,8 +1200,10 @@ class NwbSortingExtractor(BaseSorting):
     t_start : float or None, default: None
         Time (in seconds, on the NWB session clock) of the recording's first sample. NWB stores spikes
         as times; frames are computed as ``frames = (times - t_start) * sampling_frequency``. The first
-        frame is always the start of the recording, independent of `t_start`. If None, it is taken from
-        an ElectricalSeries, or defaults to 0 when the file has no ElectricalSeries. See Notes.
+        frame is always the start of the recording, independent of `t_start`. If None: it is read from
+        the named ElectricalSeries; else, when the file contains an ElectricalSeries that was not named,
+        it must be provided (an error is raised otherwise); else, when the file has no ElectricalSeries,
+        it defaults to 0. See Notes.
     cache : bool, default: False
         If True, the file is cached in the file passed to stream_cache_path
         if False, the file is not cached.
@@ -1212,32 +1222,32 @@ class NwbSortingExtractor(BaseSorting):
     Notes
     -----
     A `Units` table stores spikes as times in seconds, so the sorting needs a time base
-    (`sampling_frequency` and `t_start`) to convert them to samples. An explicit `sampling_frequency`
-    or `t_start` argument always takes precedence; otherwise the time base is resolved from the file
-    contents as follows::
+    (`sampling_frequency` and `t_start`) to convert them to samples. There are two ways to supply it:
+    name an ElectricalSeries with `electrical_series_path`, or provide it directly. No ElectricalSeries
+    is consulted unless it is named. Explicit `sampling_frequency` / `t_start` arguments always take
+    precedence. The time base is resolved as follows::
 
-        File / arguments                    sampling_frequency            t_start
-        ----------------------------------  ----------------------------  ----------------------------
-        electrical_series_path given        from named ElectricalSeries   from named ElectricalSeries
-        ElectricalSeries present, unnamed   Units.resolution else raises  required (see below)
-        no ElectricalSeries in the file     Units.resolution else raises  defaults to 0
-
-    When an ElectricalSeries is present but not named, the current release auto-selects it (emitting a
-    FutureWarning); from version 0.107.0 this will raise an error, and the time base must be set
-    explicitly by passing `electrical_series_path`, or `t_start` together with `sampling_frequency`.
+        You provide                                   sampling_frequency            t_start
+        --------------------------------------------  ----------------------------  --------------------------
+        electrical_series_path                        from that ElectricalSeries    from that ElectricalSeries
+        t_start (no electrical_series_path)           argument or Units.resolution  argument
+                                                      (raises if neither)
+        no t_start, file HAS an ElectricalSeries      n/a                           raises (name it or pass
+          (and no electrical_series_path)                                             t_start)
+        no t_start, file has NO ElectricalSeries      argument or Units.resolution  defaults to 0
+                                                      (raises if neither)
 
     Justification:
 
-    - `Units.resolution` (the `1 / sampling_rate` precision of the spike times) is preferred over the
-      ElectricalSeries rate because it is spike-native: the ElectricalSeries present in a file is not
-      necessarily the one the sorting was computed from (for example an LFP series next to a full-band
-      sorting).
-    - `t_start` only anchors the frame grid; the spike times in seconds are preserved regardless. So
-      when there is no recording to align to, it safely defaults to 0. When a recording is present but
-      not named, defaulting would silently mis-anchor spikes against a real recording, so an explicit
-      choice is required instead.
-    - `sampling_frequency` has no safe default (a wrong rate is a scale error that corrupts every
-      frame), so it is required when available from none of the three sources.
+    - No ElectricalSeries is auto-selected: the one present in a file is not necessarily the one the
+      sorting was computed from (for example an LFP series next to a full-band sorting), so it is used
+      only when named.
+    - `t_start` only anchors the frame grid; the spike times in seconds are preserved regardless. When
+      the file has no recording to align to, it defaults to 0. When a recording is present but not
+      named, defaulting would silently mis-anchor spikes against a real recording, so it must be given.
+    - `sampling_frequency` may be omitted when the Units table has a `resolution` attribute (read as
+      1 / resolution, which is spike-native). It has no other safe default (a wrong rate is a scale
+      error that corrupts every frame), so it is required otherwise.
 
     """
 
@@ -1291,50 +1301,44 @@ class NwbSortingExtractor(BaseSorting):
         self.units_table = self._reader.units_table
 
         # Resolve the time base (sampling_frequency, t_start). See the class docstring for the full
-        # contract. sampling_frequency: the provided argument, then the spike-native Units.resolution
-        # attribute, then an ElectricalSeries. Units.resolution is preferred over the ElectricalSeries
-        # because the ElectricalSeries in the file is not necessarily the one the sorting came from.
+        # contract. There are two ways to supply it: name an ElectricalSeries via electrical_series_path
+        # (which yields both values), or provide it directly. No ElectricalSeries is ever consulted
+        # unless it is named, because the ElectricalSeries in a file is not necessarily the one the
+        # sorting was computed from.
         sampling_frequency = self.provided_sampling_frequency
-        if sampling_frequency is None:
-            sampling_frequency = self._reader.sampling_frequency_from_units_metadata()
 
-        if sampling_frequency is None or self.t_start is None:
-            file_has_electrical_series = self._reader.has_electrical_series()
+        if electrical_series_path is not None:
+            # Read both the rate and t_start from the named ElectricalSeries.
+            series_sampling_frequency, series_t_start = self._reader.rate_and_t_start_from_electrical_series(
+                samples_for_rate_estimation
+            )
+            if sampling_frequency is None:
+                sampling_frequency = series_sampling_frequency
+            if self.t_start is None:
+                self.t_start = series_t_start
+        else:
+            # No ElectricalSeries named: the user supplies the time base. sampling_frequency may be
+            # omitted when the Units table carries a 'resolution' attribute (read as 1 / resolution).
+            if sampling_frequency is None:
+                sampling_frequency = self._reader.sampling_frequency_from_units_metadata()
 
-            # Auto-selecting an unnamed ElectricalSeries is deprecated: from version 0.107.0 it must be
-            # requested with electrical_series_path, or the time base provided via sampling_frequency
-            # and t_start.
-            if electrical_series_path is None and file_has_electrical_series:
-                warnings.warn(
-                    "Determining the sorting's sampling_frequency / t_start by auto-selecting an "
-                    "ElectricalSeries is deprecated and will raise an error in version 0.107.0. "
-                    "Set the time base explicitly, in one of two ways: "
-                    "(1) pass 'electrical_series_path' to name the ElectricalSeries to read it from, or "
-                    "(2) pass 't_start' together with 'sampling_frequency' (you may omit "
-                    "'sampling_frequency' if the Units table has a 'resolution' attribute, which is read "
-                    "as 1 / resolution).",
-                    FutureWarning,
-                    stacklevel=2,
-                )
-
-            if electrical_series_path is not None or file_has_electrical_series:
-                # An ElectricalSeries provides both the rate (if still missing) and t_start.
-                series_sampling_frequency, series_t_start = self._reader.rate_and_t_start_from_electrical_series(
-                    samples_for_rate_estimation
-                )
-                if sampling_frequency is None:
-                    sampling_frequency = series_sampling_frequency
-                if self.t_start is None:
-                    self.t_start = series_t_start
-            elif self.t_start is None:
-                # No recording in the file: t_start has no origin to align to, so anchor the frame grid
-                # at 0 (the spike times in seconds are preserved regardless of this choice).
+            # t_start has no origin to derive from. If a recording exists in the file but was not named,
+            # refuse to guess (defaulting to 0 would mis-anchor spikes against a real recording) and
+            # require it explicitly. If there is no recording at all, anchor the frame grid at 0.
+            if self.t_start is None:
+                if self._reader.has_electrical_series():
+                    raise ValueError(
+                        "The file contains an ElectricalSeries but 't_start' was not provided. Pass "
+                        "'electrical_series_path' to read the time base from it, or pass 't_start' "
+                        "explicitly."
+                    )
                 self.t_start = 0.0
 
-        assert sampling_frequency is not None, (
-            "Couldn't determine the sampling frequency. Provide it with the 'sampling_frequency' "
-            "argument, set the Units table 'resolution' attribute, or pass 'electrical_series_path'."
-        )
+        if sampling_frequency is None:
+            raise ValueError(
+                "Couldn't determine the sampling frequency. Provide it with the 'sampling_frequency' "
+                "argument, set the Units table 'resolution' attribute, or pass 'electrical_series_path'."
+            )
 
         unit_ids = self._reader.unit_ids()
         spike_times_data = self._reader.spike_times()

--- a/src/spikeinterface/extractors/tests/test_nwbextractors.py
+++ b/src/spikeinterface/extractors/tests/test_nwbextractors.py
@@ -739,6 +739,48 @@ def test_sorting_electrical_series_path_provides_time_base(tmp_path, use_pynwb):
     np.testing.assert_allclose(extracted_frames, expected_frames)
 
 
+@pytest.mark.parametrize("provided", ["sampling_frequency", "t_start"])
+@pytest.mark.parametrize("use_pynwb", [True, False])
+def test_sorting_electrical_series_path_and_time_base_are_mutually_exclusive(tmp_path, use_pynwb, provided):
+    """Passing electrical_series_path together with an explicit sampling_frequency or t_start raises;
+    the two ways of supplying the time base are mutually exclusive."""
+    from pynwb import NWBHDF5IO
+    from pynwb.testing.mock.file import mock_NWBFile
+    from pynwb.ecephys import ElectricalSeries
+    from pynwb.testing.mock.ecephys import mock_electrodes
+
+    nwbfile = mock_NWBFile()
+    electrical_series_name = "ElectricalSeries"
+    electrodes = mock_electrodes(n_electrodes=5, nwbfile=nwbfile)
+    electrical_series = ElectricalSeries(
+        name=electrical_series_name,
+        starting_time=10.0,
+        rate=30_000.0,
+        data=np.ones((10, 5)),
+        electrodes=electrodes,
+    )
+    nwbfile.add_acquisition(electrical_series)
+    nwbfile.add_unit(spike_times=np.array([10.0, 11.0, 12.0]))
+
+    file_path = tmp_path / "test.nwb"
+    with NWBHDF5IO(path=file_path, mode="w") as io:
+        io.write(nwbfile)
+
+    extra_kwarg = {provided: 30_000.0 if provided == "sampling_frequency" else 0.0}
+    with pytest.raises(ValueError) as exc_info:
+        NwbSortingExtractor(
+            file_path=file_path,
+            electrical_series_path=f"acquisition/{electrical_series_name}",
+            use_pynwb=use_pynwb,
+            **extra_kwarg,
+        )
+    expected_error = (
+        "Provide either 'electrical_series_path' or the time base ('sampling_frequency' and "
+        "'t_start'), not both."
+    )
+    assert str(exc_info.value) == expected_error
+
+
 @pytest.mark.parametrize("use_pynwb", [True, False])
 def test_sorting_sampling_frequency_missing_raises(tmp_path, use_pynwb):
     """With no sampling_frequency argument, no Units.resolution, and no ElectricalSeries, extraction

--- a/src/spikeinterface/extractors/tests/test_nwbextractors.py
+++ b/src/spikeinterface/extractors/tests/test_nwbextractors.py
@@ -582,6 +582,135 @@ def test_sorting_extraction_start_time_from_series(tmp_path, use_pynwb):
 
 
 @pytest.mark.parametrize("use_pynwb", [True, False])
+def test_sorting_sampling_frequency_from_units_resolution(tmp_path, use_pynwb):
+    """sampling_frequency is inferred from Units.resolution when it is not provided and there is no
+    ElectricalSeries (a units-only file)."""
+    from pynwb import NWBHDF5IO
+    from pynwb.testing.mock.file import mock_NWBFile
+
+    nwbfile = mock_NWBFile()
+
+    t_start = 10.0
+    sampling_frequency = 30_000.0
+    spike_times = np.array([0.0, 1.0, 2.0]) + t_start
+    nwbfile.add_unit(spike_times=spike_times)
+    # resolution documents the precision of the spike times, typically 1 / sampling_rate
+    nwbfile.units.resolution = 1.0 / sampling_frequency
+
+    file_path = tmp_path / "test.nwb"
+    with NWBHDF5IO(path=file_path, mode="w") as io:
+        io.write(nwbfile)
+
+    # sampling_frequency is not passed; t_start is, since resolution carries no time origin
+    sorting_extractor = NwbSortingExtractor(
+        file_path=file_path,
+        t_start=t_start,
+        use_pynwb=use_pynwb,
+    )
+
+    assert sorting_extractor.sampling_frequency == sampling_frequency
+
+    extracted_frames = sorting_extractor.get_unit_spike_train(unit_id=0, return_times=False)
+    expected_frames = ((spike_times - t_start) * sampling_frequency).astype("int64")
+    np.testing.assert_allclose(extracted_frames, expected_frames)
+
+
+@pytest.mark.parametrize("use_pynwb", [True, False])
+def test_sorting_sampling_frequency_explicit_argument_wins_over_resolution(tmp_path, use_pynwb):
+    """An explicit sampling_frequency argument takes precedence over Units.resolution."""
+    from pynwb import NWBHDF5IO
+    from pynwb.testing.mock.file import mock_NWBFile
+
+    nwbfile = mock_NWBFile()
+
+    provided_sampling_frequency = 25_000.0
+    resolution_sampling_frequency = 30_000.0
+    nwbfile.add_unit(spike_times=np.array([10.0, 11.0, 12.0]))
+    nwbfile.units.resolution = 1.0 / resolution_sampling_frequency
+
+    file_path = tmp_path / "test.nwb"
+    with NWBHDF5IO(path=file_path, mode="w") as io:
+        io.write(nwbfile)
+
+    sorting_extractor = NwbSortingExtractor(
+        file_path=file_path,
+        sampling_frequency=provided_sampling_frequency,
+        t_start=0.0,
+        use_pynwb=use_pynwb,
+    )
+
+    assert sorting_extractor.sampling_frequency == provided_sampling_frequency
+
+
+@pytest.mark.parametrize("use_pynwb", [True, False])
+def test_sorting_sampling_frequency_resolution_wins_over_electrical_series(tmp_path, use_pynwb):
+    """Units.resolution is spike-native and takes precedence over the ElectricalSeries rate, while
+    t_start still comes from the ElectricalSeries."""
+    from pynwb import NWBHDF5IO
+    from pynwb.testing.mock.file import mock_NWBFile
+    from pynwb.ecephys import ElectricalSeries
+    from pynwb.testing.mock.ecephys import mock_electrodes
+
+    nwbfile = mock_NWBFile()
+    electrical_series_name = "ElectricalSeries"
+    t_start = 10.0
+    series_sampling_frequency = 25_000.0  # a different (e.g. LFP) series rate
+    resolution_sampling_frequency = 30_000.0  # the true sorting rate
+    electrodes = mock_electrodes(n_electrodes=5, nwbfile=nwbfile)
+    electrical_series = ElectricalSeries(
+        name=electrical_series_name,
+        starting_time=t_start,
+        rate=series_sampling_frequency,
+        data=np.ones((10, 5)),
+        electrodes=electrodes,
+    )
+    nwbfile.add_acquisition(electrical_series)
+
+    spike_times = np.array([0.0, 1.0, 2.0]) + t_start
+    nwbfile.add_unit(spike_times=spike_times)
+    nwbfile.units.resolution = 1.0 / resolution_sampling_frequency
+
+    file_path = tmp_path / "test.nwb"
+    with NWBHDF5IO(path=file_path, mode="w") as io:
+        io.write(nwbfile)
+
+    sorting_extractor = NwbSortingExtractor(
+        file_path=file_path,
+        electrical_series_path=f"acquisition/{electrical_series_name}",
+        use_pynwb=use_pynwb,
+    )
+
+    # rate comes from resolution, not from the ElectricalSeries
+    assert sorting_extractor.sampling_frequency == resolution_sampling_frequency
+    # t_start still comes from the ElectricalSeries
+    extracted_frames = sorting_extractor.get_unit_spike_train(unit_id=0, return_times=False)
+    expected_frames = ((spike_times - t_start) * resolution_sampling_frequency).astype("int64")
+    np.testing.assert_allclose(extracted_frames, expected_frames)
+
+
+@pytest.mark.parametrize("use_pynwb", [True, False])
+def test_sorting_sampling_frequency_missing_raises(tmp_path, use_pynwb):
+    """With no sampling_frequency argument, no Units.resolution, and no ElectricalSeries, extraction
+    raises rather than guessing a rate."""
+    from pynwb import NWBHDF5IO
+    from pynwb.testing.mock.file import mock_NWBFile
+
+    nwbfile = mock_NWBFile()
+    nwbfile.add_unit(spike_times=np.array([10.0, 11.0, 12.0]))
+
+    file_path = tmp_path / "test.nwb"
+    with NWBHDF5IO(path=file_path, mode="w") as io:
+        io.write(nwbfile)
+
+    with pytest.raises(ValueError):
+        NwbSortingExtractor(
+            file_path=file_path,
+            t_start=0.0,
+            use_pynwb=use_pynwb,
+        )
+
+
+@pytest.mark.parametrize("use_pynwb", [True, False])
 def test_get_unit_spike_train_in_seconds(tmp_path, use_pynwb):
     """Test that get_unit_spike_train_in_seconds returns accurate timestamps without double conversion."""
     from pynwb import NWBHDF5IO

--- a/src/spikeinterface/extractors/tests/test_nwbextractors.py
+++ b/src/spikeinterface/extractors/tests/test_nwbextractors.py
@@ -775,8 +775,7 @@ def test_sorting_electrical_series_path_and_time_base_are_mutually_exclusive(tmp
             **extra_kwarg,
         )
     expected_error = (
-        "Provide either 'electrical_series_path' or the time base ('sampling_frequency' and "
-        "'t_start'), not both."
+        "Provide either 'electrical_series_path' or the time base ('sampling_frequency' and " "'t_start'), not both."
     )
     assert str(exc_info.value) == expected_error
 

--- a/src/spikeinterface/extractors/tests/test_nwbextractors.py
+++ b/src/spikeinterface/extractors/tests/test_nwbextractors.py
@@ -702,12 +702,39 @@ def test_sorting_sampling_frequency_missing_raises(tmp_path, use_pynwb):
     with NWBHDF5IO(path=file_path, mode="w") as io:
         io.write(nwbfile)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         NwbSortingExtractor(
             file_path=file_path,
             t_start=0.0,
             use_pynwb=use_pynwb,
         )
+
+
+@pytest.mark.parametrize("use_pynwb", [True, False])
+def test_sorting_t_start_defaults_to_zero_without_electrical_series(tmp_path, use_pynwb):
+    """A units-only file with no ElectricalSeries needs no t_start: it defaults to 0, and the
+    sampling_frequency comes from Units.resolution."""
+    from pynwb import NWBHDF5IO
+    from pynwb.testing.mock.file import mock_NWBFile
+
+    nwbfile = mock_NWBFile()
+    sampling_frequency = 30_000.0
+    spike_times = np.array([1.0, 2.0, 3.0])
+    nwbfile.add_unit(spike_times=spike_times)
+    nwbfile.units.resolution = 1.0 / sampling_frequency
+
+    file_path = tmp_path / "test.nwb"
+    with NWBHDF5IO(path=file_path, mode="w") as io:
+        io.write(nwbfile)
+
+    # neither sampling_frequency nor t_start provided, and there is no ElectricalSeries
+    sorting_extractor = NwbSortingExtractor(file_path=file_path, use_pynwb=use_pynwb)
+
+    assert sorting_extractor.sampling_frequency == sampling_frequency
+    # t_start defaulted to 0, so frames are the session-relative sample indices
+    extracted_frames = sorting_extractor.get_unit_spike_train(unit_id=0, return_times=False)
+    expected_frames = (spike_times * sampling_frequency).astype("int64")
+    np.testing.assert_allclose(extracted_frames, expected_frames)
 
 
 @pytest.mark.parametrize("use_pynwb", [True, False])

--- a/src/spikeinterface/extractors/tests/test_nwbextractors.py
+++ b/src/spikeinterface/extractors/tests/test_nwbextractors.py
@@ -695,9 +695,9 @@ def test_sorting_sampling_frequency_explicit_argument_wins_over_resolution(tmp_p
 
 
 @pytest.mark.parametrize("use_pynwb", [True, False])
-def test_sorting_sampling_frequency_resolution_wins_over_electrical_series(tmp_path, use_pynwb):
-    """Units.resolution is spike-native and takes precedence over the ElectricalSeries rate, while
-    t_start still comes from the ElectricalSeries."""
+def test_sorting_electrical_series_path_provides_time_base(tmp_path, use_pynwb):
+    """When electrical_series_path is named, both sampling_frequency and t_start come from that
+    ElectricalSeries; Units.resolution is not consulted on this path."""
     from pynwb import NWBHDF5IO
     from pynwb.testing.mock.file import mock_NWBFile
     from pynwb.ecephys import ElectricalSeries
@@ -706,8 +706,8 @@ def test_sorting_sampling_frequency_resolution_wins_over_electrical_series(tmp_p
     nwbfile = mock_NWBFile()
     electrical_series_name = "ElectricalSeries"
     t_start = 10.0
-    series_sampling_frequency = 25_000.0  # a different (e.g. LFP) series rate
-    resolution_sampling_frequency = 30_000.0  # the true sorting rate
+    series_sampling_frequency = 25_000.0
+    resolution_sampling_frequency = 30_000.0  # present but ignored when the series is named
     electrodes = mock_electrodes(n_electrodes=5, nwbfile=nwbfile)
     electrical_series = ElectricalSeries(
         name=electrical_series_name,
@@ -732,11 +732,10 @@ def test_sorting_sampling_frequency_resolution_wins_over_electrical_series(tmp_p
         use_pynwb=use_pynwb,
     )
 
-    # rate comes from resolution, not from the ElectricalSeries
-    assert sorting_extractor.sampling_frequency == resolution_sampling_frequency
-    # t_start still comes from the ElectricalSeries
+    # both rate and t_start come from the named ElectricalSeries
+    assert sorting_extractor.sampling_frequency == series_sampling_frequency
     extracted_frames = sorting_extractor.get_unit_spike_train(unit_id=0, return_times=False)
-    expected_frames = ((spike_times - t_start) * resolution_sampling_frequency).astype("int64")
+    expected_frames = ((spike_times - t_start) * series_sampling_frequency).astype("int64")
     np.testing.assert_allclose(extracted_frames, expected_frames)
 
 
@@ -754,12 +753,53 @@ def test_sorting_sampling_frequency_missing_raises(tmp_path, use_pynwb):
     with NWBHDF5IO(path=file_path, mode="w") as io:
         io.write(nwbfile)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError) as exc_info:
         NwbSortingExtractor(
             file_path=file_path,
             t_start=0.0,
             use_pynwb=use_pynwb,
         )
+    expected_error = (
+        "Couldn't determine the sampling frequency. Provide it with the 'sampling_frequency' "
+        "argument, set the Units table 'resolution' attribute, or pass 'electrical_series_path'."
+    )
+    assert str(exc_info.value) == expected_error
+
+
+@pytest.mark.parametrize("use_pynwb", [True, False])
+def test_sorting_unnamed_electrical_series_requires_t_start(tmp_path, use_pynwb):
+    """When the file contains an ElectricalSeries that is not named, t_start must be provided
+    explicitly; the series is never auto-selected."""
+    from pynwb import NWBHDF5IO
+    from pynwb.testing.mock.file import mock_NWBFile
+    from pynwb.ecephys import ElectricalSeries
+    from pynwb.testing.mock.ecephys import mock_electrodes
+
+    nwbfile = mock_NWBFile()
+    electrodes = mock_electrodes(n_electrodes=5, nwbfile=nwbfile)
+    electrical_series = ElectricalSeries(
+        name="ElectricalSeries",
+        starting_time=10.0,
+        rate=30_000.0,
+        data=np.ones((10, 5)),
+        electrodes=electrodes,
+    )
+    nwbfile.add_acquisition(electrical_series)
+    nwbfile.add_unit(spike_times=np.array([10.0, 11.0, 12.0]))
+    # resolution is set so sampling_frequency is available; the missing t_start is what must raise
+    nwbfile.units.resolution = 1.0 / 30_000.0
+
+    file_path = tmp_path / "test.nwb"
+    with NWBHDF5IO(path=file_path, mode="w") as io:
+        io.write(nwbfile)
+
+    with pytest.raises(ValueError) as exc_info:
+        NwbSortingExtractor(file_path=file_path, use_pynwb=use_pynwb)
+    expected_error = (
+        "The file contains an ElectricalSeries but 't_start' was not provided. Pass "
+        "'electrical_series_path' to read the time base from it, or pass 't_start' explicitly."
+    )
+    assert str(exc_info.value) == expected_error
 
 
 @pytest.mark.parametrize("use_pynwb", [True, False])


### PR DESCRIPTION
An NWB `Units` table stores spike times in seconds, so the extractor needs a `sampling_frequency` to convert them to frames. Until now it came only from an explicit argument or an `ElectricalSeries`, so a units-only file (common on DANDI) failed unless the user passed the rate by hand, even though such files usually carry it in `Units.resolution` (`1 / sampling_rate`). This reads that attribute, ranked above the `ElectricalSeries` because it is spike-native and cannot be misled by a series the sorting was not computed from (an LFP series next to a full-band sorting); `t_start` is unchanged.
