### PR TITLE
Fix NwbSortingExtractor unit-property loading for DynamicTableRegion columns

### DIFF
--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -425,25 +425,21 @@ class _NWBReader:
         column = table[name]
         # A DynamicTableRegion column (e.g. IBL's `max_electrode`) holds a per-row index into another
         # table. On the pynwb path `column[:]` resolves the region into a DataFrame of the referenced
-        # rows; read the raw per-row indices instead so every backend returns the same plain array.
-        if self._column_is_dynamic_table_region(column):
-            column = column.data if self.reading_method == "use_pynwb" else column
+        # rows, so read the raw per-row indices (`column.data`) instead. The raw hdf5/zarr dataset is
+        # already those indices, so nothing is unwrapped there. This keeps every backend returning the
+        # same plain array. The pynwb-only import is safe here: this branch runs only when
+        # reading_method is "use_pynwb", where pynwb (and hdmf) are present.
+        if self.reading_method == "use_pynwb":
+            from hdmf.common import DynamicTableRegion
+
+            if isinstance(column, DynamicTableRegion):
+                column = column.data
         values = np.asarray(column[:])
         if indices is not None:
             values = values[indices]
         if values.dtype.kind in ("S", "O"):
             values = np.array([v.decode("utf-8") if isinstance(v, bytes) else v for v in values])
         return values
-
-    def _column_is_dynamic_table_region(self, column):
-        # A per-row reference into another table, recognized across the pynwb object and the raw
-        # hdf5/zarr dataset representations. The pynwb-only import is safe here without a guard:
-        # this branch runs only when reading_method is "use_pynwb", where pynwb (and hdmf) are present.
-        if self.reading_method == "use_pynwb":
-            from hdmf.common import DynamicTableRegion
-
-            return isinstance(column, DynamicTableRegion)
-        return column.attrs.get("neurodata_type") == "DynamicTableRegion"
 
     def close(self):
         # Release the open handle (raw hdf5 / zarr store, or the pynwb read IO).

--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -422,12 +422,28 @@ class _NWBReader:
     def _read_column(self, table, name, indices=None):
         # Materialize a table column to numpy (h5py only fancy-indexes increasing, GH-4619), optionally
         # reorder to `indices`, and decode HDF5 byte-strings once on behalf of every caller.
-        values = np.asarray(table[name][:])
+        column = table[name]
+        # A DynamicTableRegion column (e.g. IBL's `max_electrode`) holds a per-row index into another
+        # table. On the pynwb path `column[:]` resolves the region into a DataFrame of the referenced
+        # rows; read the raw per-row indices instead so every backend returns the same plain array.
+        if self._column_is_dynamic_table_region(column):
+            column = column.data if self.reading_method == "use_pynwb" else column
+        values = np.asarray(column[:])
         if indices is not None:
             values = values[indices]
         if values.dtype.kind in ("S", "O"):
             values = np.array([v.decode("utf-8") if isinstance(v, bytes) else v for v in values])
         return values
+
+    def _column_is_dynamic_table_region(self, column):
+        # A per-row reference into another table, recognized across the pynwb object and the raw
+        # hdf5/zarr dataset representations. The pynwb-only import is safe here without a guard:
+        # this branch runs only when reading_method is "use_pynwb", where pynwb (and hdmf) are present.
+        if self.reading_method == "use_pynwb":
+            from hdmf.common import DynamicTableRegion
+
+            return isinstance(column, DynamicTableRegion)
+        return column.attrs.get("neurodata_type") == "DynamicTableRegion"
 
     def close(self):
         # Release the open handle (raw hdf5 / zarr store, or the pynwb read IO).
@@ -558,6 +574,53 @@ class _NWBReader:
         if self.reading_method == "use_pynwb":
             return {column.name: column for column in self.units_table.columns}["spike_times_index"].data
         return self.units_table["spike_times_index"]
+
+    def fetch_unit_properties(self):
+        # Return the unit-table columns as a name -> per-unit values mapping in a backend-independent
+        # format. Skips id / spike-time columns, index columns, nested ragged arrays, and ragged
+        # columns whose per-unit shapes are unequal.
+        columns = self.units_column_names
+
+        properties_to_skip = ["spike_times", "spike_times_index", "unit_name", "id"]
+        index_columns = [name for name in columns if name.endswith("_index")]
+        nested_ragged_array_properties = [name for name in columns if f"{name}_index_index" in columns]
+        skip_properties = properties_to_skip + index_columns + nested_ragged_array_properties
+        properties_to_add = [name for name in columns if name not in skip_properties]
+
+        properties = dict()
+        for property_name in properties_to_add:
+            corresponding_index_name = f"{property_name}_index"
+            not_ragged_array = corresponding_index_name not in columns
+            if not_ragged_array:
+                # _read_column materializes a plain, decoded, DynamicTableRegion-safe per-unit array
+                values = self._read_column(self.units_table, property_name)
+            else:  # TODO if we want we could make this recursive to handle nested ragged arrays
+                data = self.units_table[property_name][:]
+                data_index = self.units_table[corresponding_index_name]
+                if hasattr(data_index, "data"):
+                    # for pynwb we need to get the data from the data attribute
+                    data_index = data_index.data[:]
+                else:
+                    data_index = data_index[:]
+                index_spacing = np.diff(data_index, prepend=0)
+                all_index_spacing_are_the_same = np.unique(index_spacing).size == 1
+                if all_index_spacing_are_the_same:
+                    if hasattr(self.units_table[corresponding_index_name], "data"):
+                        # ragged array indexing is handled by pynwb
+                        values = data
+                    else:
+                        # ravel array based on data_index
+                        start_indices = [0] + list(data_index[:-1])
+                        end_indices = list(data_index)
+                        values = [
+                            data[start_index:end_index] for start_index, end_index in zip(start_indices, end_indices)
+                        ]
+                else:
+                    warnings.warn(f"Skipping {property_name} because of unequal shapes across units")
+                    continue
+            properties[property_name] = values
+
+        return properties
 
     def rate_and_t_start_from_electrical_series(self, samples_for_rate_estimation):
         # Locate the ElectricalSeries the sorting came from and read its rate / t_start.
@@ -1215,10 +1278,8 @@ class NwbSortingExtractor(BaseSorting):
 
         # fetch and add sorting properties
         if load_unit_properties:
-            properties = self._fetch_properties(self._reader.units_column_names)
-            for property_name, property_values in properties.items():
-                values = [x.decode("utf-8") if isinstance(x, bytes) else x for x in property_values]
-                self.set_property(property_name, values)
+            for property_name, property_values in self._reader.fetch_unit_properties().items():
+                self.set_property(property_name, property_values)
 
         if reading_method == "use_pynwb":
             self.extra_requirements.append("pynwb")
@@ -1253,51 +1314,6 @@ class NwbSortingExtractor(BaseSorting):
             "load_unit_properties": load_unit_properties,
             "t_start": self.t_start,
         }
-
-    def _fetch_properties(self, columns):
-        units_table = self.units_table
-
-        properties_to_skip = ["spike_times", "spike_times_index", "unit_name", "id"]
-        index_columns = [name for name in columns if name.endswith("_index")]
-        nested_ragged_array_properties = [name for name in columns if f"{name}_index_index" in columns]
-
-        # Filter those properties that are nested ragged arrays
-        skip_properties = properties_to_skip + index_columns + nested_ragged_array_properties
-        properties_to_add = [name for name in columns if name not in skip_properties]
-
-        properties = dict()
-        for property_name in properties_to_add:
-            data = units_table[property_name][:]
-            corresponding_index_name = f"{property_name}_index"
-            not_ragged_array = corresponding_index_name not in columns
-            if not_ragged_array:
-                values = data[:]
-            else:  # TODO if we want we could make this recursive to handle nested ragged arrays
-                data_index = units_table[corresponding_index_name]
-                if hasattr(data_index, "data"):
-                    # for pynwb we need to get the data from the data attribute
-                    data_index = data_index.data[:]
-                else:
-                    data_index = data_index[:]
-                index_spacing = np.diff(data_index, prepend=0)
-                all_index_spacing_are_the_same = np.unique(index_spacing).size == 1
-                if all_index_spacing_are_the_same:
-                    if hasattr(units_table[corresponding_index_name], "data"):
-                        # ragged array indexing is handled by pynwb
-                        values = data
-                    else:
-                        # ravel array based on data_index
-                        start_indices = [0] + list(data_index[:-1])
-                        end_indices = list(data_index)
-                        values = [
-                            data[start_index:end_index] for start_index, end_index in zip(start_indices, end_indices)
-                        ]
-                else:
-                    warnings.warn(f"Skipping {property_name} because of unequal shapes across units")
-                    continue
-            properties[property_name] = values
-
-        return properties
 
     @staticmethod
     def fetch_available_units_tables(

--- a/src/spikeinterface/extractors/tests/test_nwbextractors.py
+++ b/src/spikeinterface/extractors/tests/test_nwbextractors.py
@@ -476,6 +476,58 @@ def test_sorting_extraction_of_ragged_arrays(tmp_path, use_pynwb):
 
 
 @pytest.mark.parametrize("use_pynwb", [True, False])
+def test_sorting_extraction_with_dynamic_table_region_column(tmp_path, use_pynwb):
+    """A non-ragged Units column stored as a DynamicTableRegion (e.g. IBL's ``max_electrode``)
+    must not break unit-property loading. On the pynwb path, indexing the region returns a
+    DataFrame of the referenced rows, which the loader then collapses to the target table's
+    column names, producing the wrong number of values. This guards against that."""
+    from pynwb import NWBHDF5IO
+    from pynwb.testing.mock.file import mock_NWBFile
+    from pynwb.testing.mock.device import mock_Device
+    from pynwb.testing.mock.ecephys import mock_ElectrodeGroup
+
+    nwbfile = mock_NWBFile()
+
+    # electrodes table: the region target
+    device = mock_Device()
+    nwbfile.add_device(device)
+    electrode_group = mock_ElectrodeGroup(device=device)
+    nwbfile.add_electrode_group(electrode_group)
+    for index in range(5):
+        nwbfile.add_electrode(id=index, location="brain", group=electrode_group)
+
+    # per-unit single-index region column, like IBL's `max_electrode`
+    nwbfile.add_unit_column(
+        name="max_electrode",
+        description="peak electrode for the unit, stored as a DynamicTableRegion",
+        table=nwbfile.electrodes,
+    )
+    nwbfile.add_unit(spike_times=np.array([0.0, 1.0, 2.0]), max_electrode=0)
+    nwbfile.add_unit(spike_times=np.array([0.0, 1.0, 2.0, 3.0]), max_electrode=3)
+
+    file_path = tmp_path / "test.nwb"
+    with NWBHDF5IO(path=file_path, mode="w") as io:
+        io.write(nwbfile)
+
+    sorting_extractor = NwbSortingExtractor(
+        file_path=file_path,
+        sampling_frequency=10.0,
+        t_start=0,
+        use_pynwb=use_pynwb,
+    )
+
+    assert sorting_extractor.get_num_units() == 2
+
+    # `max_electrode` must load as the raw per-unit electrode indices, exactly the values written.
+    # Before the fix, the pynwb path resolved the DynamicTableRegion to a DataFrame of the
+    # referenced electrode rows and the loader then iterated it, collapsing it to that table's
+    # column names, so set_property got one value per electrodes-table column (not per unit) and
+    # raised an AssertionError.
+    assert "max_electrode" in sorting_extractor.get_property_keys()
+    np.testing.assert_array_equal(sorting_extractor.get_property("max_electrode"), [0, 3])
+
+
+@pytest.mark.parametrize("use_pynwb", [True, False])
 def test_sorting_extraction_start_time(tmp_path, use_pynwb):
 
     from pynwb import NWBHDF5IO


### PR DESCRIPTION
`NwbSortingExtractor` raised an error when a Units table stored a column as a DynamicTableRegion, for example the `max_electrode` column that the International Brain Laboratory (IBL) writes as a per-unit reference into the electrodes table. On the pynwb read path, indexing such a column resolves the region to a pandas DataFrame of the referenced electrode rows instead of returning the raw per-unit indices, and the property loader then iterated that DataFrame, which yields its column labels, so `set_property` received one value per electrodes-table column rather than one per unit and failed the size check. The default hdf5 (and zarr) path was unaffected, because those backends return the raw index array, so the two read paths disagreed. The fix teaches the reader's shared column materializer to recognize DynamicTableRegion columns and read their raw per-row indices on every backend, so pynwb now matches hdf5 and zarr.

Continuing the mission of the `_NWBReader` refactor (#4630), I moved unit-property fetching off `NwbSortingExtractor` and onto `_NWBReader`, so the reader stays the single place responsible for returning columns in a backend-independent format, the same way the recording extractor already delegates electrode properties through `read_electrode_property`. This was also the natural home for the fix: placing the region handling in the reader's `_read_column` means electrode and unit columns get identical treatment across pynwb, hdf5, and zarr and keeps all backend branching inside the reader. I picked reading the raw indices over skipping region columns so the information (each unit's referenced electrode) survives as a normal per-unit property. The regression test builds a Units table with a `max_electrode` DynamicTableRegion column and asserts the loaded values are the exact per-unit indices, parametrized over both read paths.
