### PR TITLE
Add `SortingAnalyzer.select_channels()` function

### DIFF
--- a/src/spikeinterface/core/analyzer_extension_core.py
+++ b/src/spikeinterface/core/analyzer_extension_core.py
@@ -564,7 +564,7 @@ class ComputeTemplates(AnalyzerExtension):
     def _select_channels_extension_data(self, channel_ids):
         keep_channel_indices = np.flatnonzero(np.isin(self.sorting_analyzer.channel_ids, channel_ids))
 
-        new_data = dict()
+        new_data = {}
         for key, arr in self.data.items():
             new_data[key] = arr[:, :, keep_channel_indices]
 

--- a/src/spikeinterface/core/analyzer_extension_core.py
+++ b/src/spikeinterface/core/analyzer_extension_core.py
@@ -809,7 +809,7 @@ class ComputeNoiseLevels(AnalyzerExtension):
     def _select_channels_extension_data(self, channel_ids):
         # this does not depend on channels
         channel_indices = self.sorting_analyzer.channel_ids_to_indices(channel_ids)
-        return self.data["noise_levels"][channel_indices]
+        return dict(noise_levels=self.data["noise_levels"][channel_indices])
 
     def _merge_extension_data(
         self, merge_unit_groups, new_unit_ids, new_sorting_analyzer, keep_mask=None, verbose=False, **job_kwargs

--- a/src/spikeinterface/core/analyzer_extension_core.py
+++ b/src/spikeinterface/core/analyzer_extension_core.py
@@ -75,7 +75,7 @@ class ComputeRandomSpikes(AnalyzerExtension):
         params = dict(method=method, max_spikes_per_unit=max_spikes_per_unit, margin_size=margin_size, seed=seed)
         return params
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         random_spikes_indices = self.data["random_spikes_indices"]
 
         spikes = self.sorting_analyzer.sorting.to_spike_vector()
@@ -243,7 +243,7 @@ class ComputeWaveforms(AnalyzerExtension):
         )
         return params
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         # random_spikes_indices = self.sorting_analyzer.get_extension("random_spikes").get_data()
         some_spikes = self.sorting_analyzer.get_extension("random_spikes").get_random_spikes()
 
@@ -552,12 +552,21 @@ class ComputeTemplates(AnalyzerExtension):
         nafter = ms_to_samples(self.params["ms_after"], self.sorting_analyzer.sampling_frequency)
         return nafter
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         keep_unit_indices = np.flatnonzero(np.isin(self.sorting_analyzer.unit_ids, unit_ids))
 
         new_data = dict()
         for key, arr in self.data.items():
             new_data[key] = arr[keep_unit_indices, :, :]
+
+        return new_data
+
+    def _select_channels_extension_data(self, channel_ids):
+        keep_channel_indices = np.flatnonzero(np.isin(self.sorting_analyzer.channel_ids, channel_ids))
+
+        new_data = dict()
+        for key, arr in self.data.items():
+            new_data[key] = arr[:, :, keep_channel_indices]
 
         return new_data
 
@@ -793,9 +802,14 @@ class ComputeNoiseLevels(AnalyzerExtension):
         params = noise_level_params.copy()
         return params
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         # this does not depend on units
         return self.data
+
+    def _select_channels_extension_data(self, channel_ids):
+        # this does not depend on channels
+        channel_indices = self.sorting_analyzer.channel_ids_to_indices(channel_ids)
+        return self.data["noise_levels"][channel_indices]
 
     def _merge_extension_data(
         self, merge_unit_groups, new_unit_ids, new_sorting_analyzer, keep_mask=None, verbose=False, **job_kwargs
@@ -1350,7 +1364,7 @@ class BaseMetricExtension(AnalyzerExtension):
         # convert to correct dtype
         return self.data["metrics"]
 
-    def _select_extension_data(self, unit_ids: list[int | str]):
+    def _select_units_extension_data(self, unit_ids: list[int | str]):
         """
         Select data for a subset of unit ids.
 
@@ -1636,7 +1650,7 @@ class BaseSpikeVectorExtension(AnalyzerExtension):
         else:
             raise ValueError(f"Wrong .get_data(outputs={outputs}); possibilities are `numpy` or `by_unit`")
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         keep_unit_indices = np.flatnonzero(np.isin(self.sorting_analyzer.unit_ids, unit_ids))
 
         spikes = self.sorting_analyzer.sorting.to_spike_vector()

--- a/src/spikeinterface/core/channelsaggregationrecording.py
+++ b/src/spikeinterface/core/channelsaggregationrecording.py
@@ -101,9 +101,9 @@ class ChannelsAggregationRecording(BaseRecording):
             for probegroup in all_probegroups:
                 for probe in probegroup.probes:
                     all_positions.extend(probe.contact_positions)
-            # assert len(np.unique(np.array(all_positions), axis=0)) == len(
-            #     all_positions
-            # ), "Contact positions are not unique! Cannot aggregate recordings."
+            assert len(np.unique(np.array(all_positions), axis=0)) == len(
+                all_positions
+            ), "Contact positions are not unique! Cannot aggregate recordings."
 
             # Now make a new probegroup with all probes and set global device channel indices
             probegroup_agg = ProbeGroup()

--- a/src/spikeinterface/core/channelsaggregationrecording.py
+++ b/src/spikeinterface/core/channelsaggregationrecording.py
@@ -101,9 +101,9 @@ class ChannelsAggregationRecording(BaseRecording):
             for probegroup in all_probegroups:
                 for probe in probegroup.probes:
                     all_positions.extend(probe.contact_positions)
-            assert len(np.unique(np.array(all_positions), axis=0)) == len(
-                all_positions
-            ), "Contact positions are not unique! Cannot aggregate recordings."
+            # assert len(np.unique(np.array(all_positions), axis=0)) == len(
+            #     all_positions
+            # ), "Contact positions are not unique! Cannot aggregate recordings."
 
             # Now make a new probegroup with all probes and set global device channel indices
             probegroup_agg = ProbeGroup()

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -3020,17 +3020,36 @@ class AnalyzerExtension:
             warnings.warn(f"Found no data for {self.extension_name}, extension should be re-computed.")
 
     def copy(self, new_sorting_analyzer, unit_ids=None, channel_ids=None):
-        # alessio : please note that this also replace the old select_units!!!
+        """
+        Copy the extension to a new sorting analyzer, optionally selecting a subset of units and channels.
+        Only unit_ids or channel_ids can be specified, not both.
+
+        Parameters
+        ----------
+        new_sorting_analyzer : SortingAnalyzer
+            The new sorting analyzer to copy the extension to.
+        unit_ids : list, optional
+            List of unit IDs to sub-select data for. If None, all units are copied.
+        channel_ids : list, optional
+            List of channel IDs to sub-select data for. If None, all channels are copied.
+
+        Returns
+        -------
+        new_extension : Extension
+            The copied extension.
+        """
+        if unit_ids is not None and channel_ids is not None:
+            raise ValueError("Cannot select both unit_ids and channel_ids when copying an extension.")
         new_extension = self.__class__(new_sorting_analyzer)
         new_extension.params = self.params.copy()
         if unit_ids is None:
             new_extension.data = self.data
         else:
             new_extension.data = self._select_units_extension_data(unit_ids)
-        if channel_ids is not None:
-            new_extension.data = new_extension._select_channels_extension_data(channel_ids)
+        if channel_ids is None:
+            new_extension.data = self.data
         else:
-            new_extension.data = new_extension.data
+            new_extension.data = self._select_channels_extension_data(channel_ids)
         new_extension.run_info = copy(self.run_info)
         new_extension.save()
         return new_extension

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1589,6 +1589,10 @@ class SortingAnalyzer:
         analyzer :  SortingAnalyzer
             The newly create sorting_analyzer with the selected channels
         """
+        # Check that all channel_ids are in the current channel_ids
+        if not np.all(np.isin(channel_ids, self.channel_ids)):
+            wrong_channel_ids = [ch for ch in channel_ids if ch not in self.channel_ids]
+            raise ValueError(f"Some channel_ids are not in the current channel_ids: {wrong_channel_ids}")
         if self.has_recording() or self.has_temporary_recording():
             new_recording = self.recording.select_channels(channel_ids)
             new_rec_attributes = None
@@ -1600,12 +1604,13 @@ class SortingAnalyzer:
             if "properties" in new_rec_attributes:
                 new_properties = {}
                 for key, values in new_rec_attributes["properties"].items():
-                    if len(values) == len(self.channel_ids):
+                    values_arr = np.array(values)
+                    if len(values_arr) == len(self.channel_ids):
                         # only slice properties that have the same length as channel_ids
                         channel_indices = [np.where(self.channel_ids == id)[0][0] for id in channel_ids]
-                        new_properties[key] = values[channel_indices]
+                        new_properties[key] = values_arr[channel_indices]
                     else:
-                        new_properties[key] = values
+                        new_properties[key] = values_arr
                 new_rec_attributes["properties"] = new_properties
             if new_rec_attributes.get("probegroup") is not None:
                 slice_indices = self.channel_ids_to_indices(channel_ids)

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -3042,14 +3042,12 @@ class AnalyzerExtension:
             raise ValueError("Cannot select both unit_ids and channel_ids when copying an extension.")
         new_extension = self.__class__(new_sorting_analyzer)
         new_extension.params = self.params.copy()
-        if unit_ids is None:
-            new_extension.data = self.data
-        else:
+        if unit_ids is not None:
             new_extension.data = self._select_units_extension_data(unit_ids)
-        if channel_ids is None:
-            new_extension.data = self.data
-        else:
+        elif channel_ids is not None:
             new_extension.data = self._select_channels_extension_data(channel_ids)
+        else:
+            new_extension.data = self.data
         new_extension.run_info = copy(self.run_info)
         new_extension.save()
         return new_extension

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -178,55 +178,8 @@ def create_sorting_analyzer(
         aggregated_recording = aggregate_channels(recording)
         aggregated_sorting = aggregate_units(sorting)
 
-        if sparsity is None:
-            if sparsity_kwargs.get("method", "") != "by_property" and not set_sparsity_by_dict_key:
-                # this is weird but due to the cyclic import
-                from .template_tools import estimate_main_channel_from_recording
-
-                # In this case we estimate and construct sparsity by property
-                sparsity_mask = np.zeros(
-                    (aggregated_sorting.get_num_units(), aggregated_recording.get_num_channels()), dtype=bool
-                )
-                main_channel_indices = np.zeros(aggregated_sorting.get_num_units(), dtype=int)
-                i_unit = 0
-                i_channel = 0
-                for key in sorting.keys():
-                    recording_single = recording[key]
-                    sorting_single = sorting[key]
-                    num_units = sorting_single.get_num_units()
-                    num_channels = recording_single.get_num_channels()
-
-                    main_channel_indices_single = estimate_main_channel_from_recording(
-                        recording_single,
-                        sorting_single,
-                        peak_sign=peak_sign,
-                        peak_mode=peak_mode,
-                        num_spikes_for_main_channel=num_spikes_for_main_channel,
-                        seed=seed,
-                        **job_kwargs,
-                    )
-                    sparsity_partial = estimate_sparsity(
-                        sorting_single,
-                        recording_single,
-                        main_channel_indices=main_channel_indices_single,
-                        peak_sign=peak_sign,
-                        amplitude_mode=peak_mode,
-                        **sparsity_kwargs,
-                    )
-                    sparsity_mask[i_unit : i_unit + num_units, i_channel : i_channel + num_channels] = (
-                        sparsity_partial.mask
-                    )
-                    main_channel_indices[i_unit : i_unit + num_units] = main_channel_indices_single + i_channel
-                    i_unit += num_units
-                    i_channel += num_channels
-                sparsity = ChannelSparsity(
-                    unit_ids=aggregated_sorting.unit_ids,
-                    channel_ids=aggregated_recording.channel_ids,
-                    mask=sparsity_mask,
-                )
-                sparsity_kwargs = {}
-            elif set_sparsity_by_dict_key:
-                sparsity_kwargs = {"method": "by_property", "by_property": "aggregation_key"}
+        if set_sparsity_by_dict_key:
+            sparsity_kwargs = {"method": "by_property", "by_property": "aggregation_key"}
 
         return create_sorting_analyzer(
             sorting=aggregated_sorting,
@@ -1266,37 +1219,6 @@ class SortingAnalyzer:
             return dict(zip(self.unit_ids, main_chans))
         else:
             return main_chans
-
-    def is_aggregated(self):
-        """
-        Returns True if the SortingAnalyzer is aggregated, False otherwise.
-        """
-        return (
-            "aggregation_key" in self.get_sorting_property_keys()
-            and "aggregation_key" in self.get_recording_property_keys()
-        )
-
-    def split(self):
-        """
-        Returns a dictionary of SortingAnalyzer objects, split by the aggregation_key.
-        The keys of the dictionary are the unique values of the aggregation_key, and the values
-        are the SortingAnalyzer objects corresponding to each unique value.
-        """
-        if not self.is_aggregated():
-            raise ValueError("SortingAnalyzer is not aggregated")
-
-        units_aggregation_key = self.get_sorting_property("aggregation_key")
-        channel_aggregation_key = self.get_recording_property("aggregation_key")
-        unique_keys = np.unique(units_aggregation_key)
-        split_analyzers = {}
-        for key in unique_keys:
-            unit_ids = self.unit_ids[units_aggregation_key == key]
-            channel_ids = self.channel_ids[channel_aggregation_key == key]
-            analyzer_units = self.select_units(unit_ids)
-            analyzer_split = analyzer_units.select_channels(channel_ids)
-            split_analyzers[key] = analyzer_split
-
-        return split_analyzers
 
     def are_units_mergeable(
         self,

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -178,8 +178,55 @@ def create_sorting_analyzer(
         aggregated_recording = aggregate_channels(recording)
         aggregated_sorting = aggregate_units(sorting)
 
-        if set_sparsity_by_dict_key:
-            sparsity_kwargs = {"method": "by_property", "by_property": "aggregation_key"}
+        if sparsity is None:
+            if sparsity_kwargs.get("method", "") != "by_property" and not set_sparsity_by_dict_key:
+                # this is weird but due to the cyclic import
+                from .template_tools import estimate_main_channel_from_recording
+
+                # In this case we estimate and construct sparsity by property
+                sparsity_mask = np.zeros(
+                    (aggregated_sorting.get_num_units(), aggregated_recording.get_num_channels()), dtype=bool
+                )
+                main_channel_indices = np.zeros(aggregated_sorting.get_num_units(), dtype=int)
+                i_unit = 0
+                i_channel = 0
+                for key in sorting.keys():
+                    recording_single = recording[key]
+                    sorting_single = sorting[key]
+                    num_units = sorting_single.get_num_units()
+                    num_channels = recording_single.get_num_channels()
+
+                    main_channel_indices_single = estimate_main_channel_from_recording(
+                        recording_single,
+                        sorting_single,
+                        peak_sign=peak_sign,
+                        peak_mode=peak_mode,
+                        num_spikes_for_main_channel=num_spikes_for_main_channel,
+                        seed=seed,
+                        **job_kwargs,
+                    )
+                    sparsity_partial = estimate_sparsity(
+                        sorting_single,
+                        recording_single,
+                        main_channel_indices=main_channel_indices_single,
+                        peak_sign=peak_sign,
+                        amplitude_mode=peak_mode,
+                        **sparsity_kwargs,
+                    )
+                    sparsity_mask[i_unit : i_unit + num_units, i_channel : i_channel + num_channels] = (
+                        sparsity_partial.mask
+                    )
+                    main_channel_indices[i_unit : i_unit + num_units] = main_channel_indices_single + i_channel
+                    i_unit += num_units
+                    i_channel += num_channels
+                sparsity = ChannelSparsity(
+                    unit_ids=aggregated_sorting.unit_ids,
+                    channel_ids=aggregated_recording.channel_ids,
+                    mask=sparsity_mask,
+                )
+                sparsity_kwargs = {}
+            elif set_sparsity_by_dict_key:
+                sparsity_kwargs = {"method": "by_property", "by_property": "aggregation_key"}
 
         return create_sorting_analyzer(
             sorting=aggregated_sorting,
@@ -188,6 +235,7 @@ def create_sorting_analyzer(
             folder=folder,
             sparse=sparse,
             sparsity=sparsity,
+            main_channel_indices=main_channel_indices,
             return_scaled=return_scaled,
             return_in_uV=return_in_uV,
             overwrite=overwrite,
@@ -208,7 +256,7 @@ def create_sorting_analyzer(
         if len(main_channel_indices) != sorting.get_num_units():
             raise ValueError("len(main_channel_indices) must equal the number of units in the `sorting`")
 
-    if main_channel_indices is not None and sparsity_kwargs.get("method") != "radius":
+    if main_channel_indices is not None and sparsity is None and sparsity_kwargs.get("method") != "radius":
         raise ValueError(
             'You can either pass `main_channel_indices` or a sparsity method not equal to "radius", but not both.'
         )
@@ -1143,6 +1191,57 @@ class SortingAnalyzer:
         """
         return self.sorting.get_property(key, ids=ids)
 
+    def get_sorting_property_keys(self) -> list[str]:
+        """
+        Get the list of property keys for the sorting object.
+
+        Returns
+        -------
+        keys : list[str]
+            List of property keys
+        """
+        return self.sorting.get_property_keys()
+
+    def get_recording_property(self, key: str, ids: Optional[Iterable] = None) -> np.ndarray:
+        """
+        Get property vector for channel ids.
+
+        Parameters
+        ----------
+        key : str
+            The property name
+        ids : list/np.array, default: None
+            List of subset of ids to get the values.
+            if None all the ids are returned
+        """
+        if self.has_recording() or self.has_temporary_recording():
+            return self.recording.get_property(key, ids=ids)
+        else:
+            properties = self.rec_attributes.get("properties", {})
+            if key not in properties:
+                raise ValueError(f"Property {key} not found in recording attributes")
+            values = properties[key]
+            if ids is not None:
+                channel_ids = self.channel_ids
+                indices = [np.where(channel_ids == id)[0][0] for id in ids]
+                values = values[indices]
+            return values
+
+    def get_recording_property_keys(self) -> list[str]:
+        """
+        Get the list of property keys for the recording object.
+
+        Returns
+        -------
+        keys : list[str]
+            List of property keys
+        """
+        if self.has_recording() or self.has_temporary_recording():
+            return self.recording.get_property_keys()
+        else:
+            properties = self.rec_attributes.get("properties", {})
+            return list(properties.keys())
+
     def get_main_channels(self, outputs: Literal["index", "id"] = "index", with_dict: bool = False):
         """
         Returns the main_channels of the analyzer.
@@ -1167,6 +1266,37 @@ class SortingAnalyzer:
             return dict(zip(self.unit_ids, main_chans))
         else:
             return main_chans
+
+    def is_aggregated(self):
+        """
+        Returns True if the SortingAnalyzer is aggregated, False otherwise.
+        """
+        return (
+            "aggregation_key" in self.get_sorting_property_keys()
+            and "aggregation_key" in self.get_recording_property_keys()
+        )
+
+    def split(self):
+        """
+        Returns a dictionary of SortingAnalyzer objects, split by the aggregation_key.
+        The keys of the dictionary are the unique values of the aggregation_key, and the values
+        are the SortingAnalyzer objects corresponding to each unique value.
+        """
+        if not self.is_aggregated():
+            raise ValueError("SortingAnalyzer is not aggregated")
+
+        units_aggregation_key = self.get_sorting_property("aggregation_key")
+        channel_aggregation_key = self.get_recording_property("aggregation_key")
+        unique_keys = np.unique(units_aggregation_key)
+        split_analyzers = {}
+        for key in unique_keys:
+            unit_ids = self.unit_ids[units_aggregation_key == key]
+            channel_ids = self.channel_ids[channel_aggregation_key == key]
+            analyzer_units = self.select_units(unit_ids)
+            analyzer_split = analyzer_units.select_channels(channel_ids)
+            split_analyzers[key] = analyzer_split
+
+        return split_analyzers
 
     def are_units_mergeable(
         self,
@@ -1520,6 +1650,62 @@ class SortingAnalyzer:
         if format == "zarr":
             folder = clean_zarr_folder_name(folder)
         return self._save_or_select_or_merge_or_split(format=format, folder=folder, unit_ids=unit_ids)
+
+    def select_channels(self, channel_ids) -> "SortingAnalyzer":
+        """
+        This method is equivalent to `save_as()` but with a subset of channels.
+        Filters channels by creating a new sorting analyzer object in a new folder.
+
+        Extensions are also updated to filter the selected channel ids.
+
+        Parameters
+        ----------
+        channel_ids : list or array
+            The channel ids to keep in the new SortingAnalyzer object
+
+        Returns
+        -------
+        analyzer :  SortingAnalyzer
+            The newly create sorting_analyzer with the selected channels
+        """
+        if self.has_recording() or self.has_temporary_recording():
+            recording = self.recording
+            new_recording = recording.select_channels(channel_ids)
+            new_rec_attributes = get_rec_attributes(new_recording)
+        else:
+            new_recording = None
+            new_rec_attributes = self.rec_attributes.copy()
+            new_rec_attributes["channel_ids"] = np.array(channel_ids)
+            # slice properties according to channel_ids
+            if "properties" in new_rec_attributes:
+                new_properties = {}
+                for key, values in new_rec_attributes["properties"].items():
+                    if len(values) == len(self.channel_ids):
+                        # only slice properties that have the same length as channel_ids
+                        channel_indices = [np.where(self.channel_ids == id)[0][0] for id in channel_ids]
+                        new_properties[key] = values[channel_indices]
+                    else:
+                        new_properties[key] = values
+                new_rec_attributes["properties"] = new_properties
+        if self.sparsity is not None:
+            sparsity_mask = self.sparsity.mask[:, np.isin(self.channel_ids, channel_ids)]
+            new_sparsity = ChannelSparsity(sparsity_mask, self.unit_ids, np.array(channel_ids))
+        else:
+            new_sparsity = None
+        new_sorting_analyzer = SortingAnalyzer.create_memory(
+            sorting=self.sorting,
+            recording=new_recording,
+            sparsity=new_sparsity,
+            return_in_uV=self.return_in_uV,
+            peak_sign=self.peak_sign,
+            peak_mode=self.peak_mode,
+            rec_attributes=new_rec_attributes,
+        )
+        for extension_name, extension in self.extensions.items():
+            new_sorting_analyzer.extensions[extension_name] = extension.copy(
+                new_sorting_analyzer, channel_ids=channel_ids
+            )
+        return new_sorting_analyzer
 
     def remove_units(self, remove_unit_ids, format="memory", folder=None) -> "SortingAnalyzer":
         """
@@ -2576,7 +2762,7 @@ class AnalyzerExtension:
       * need_job_kwargs
       * _set_params()
       * _run()
-      * _select_extension_data()
+      * _select_units_extension_data()
       * _merge_extension_data()
       * _split_extension_data()
       * _get_data()
@@ -2622,7 +2808,7 @@ class AnalyzerExtension:
         # must return a cleaned version of params dict
         raise NotImplementedError
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         # must be implemented in subclass
         raise NotImplementedError
 
@@ -2635,6 +2821,9 @@ class AnalyzerExtension:
     def _split_extension_data(self, split_units, new_unit_ids, new_sorting_analyzer, verbose=False, **job_kwargs):
         # must be implemented in subclass
         raise NotImplementedError
+
+    def _select_channels_extension_data(self, channel_ids):
+        return self.data
 
     def _get_pipeline_nodes(self):
         # must be implemented in subclass only if use_nodepipeline=True
@@ -2900,14 +3089,18 @@ class AnalyzerExtension:
         if len(self.data) == 0:
             warnings.warn(f"Found no data for {self.extension_name}, extension should be re-computed.")
 
-    def copy(self, new_sorting_analyzer, unit_ids=None):
+    def copy(self, new_sorting_analyzer, unit_ids=None, channel_ids=None):
         # alessio : please note that this also replace the old select_units!!!
         new_extension = self.__class__(new_sorting_analyzer)
         new_extension.params = self.params.copy()
         if unit_ids is None:
             new_extension.data = self.data
         else:
-            new_extension.data = self._select_extension_data(unit_ids)
+            new_extension.data = self._select_units_extension_data(unit_ids)
+        if channel_ids is not None:
+            new_extension.data = new_extension._select_channels_extension_data(channel_ids)
+        else:
+            new_extension.data = new_extension.data
         new_extension.run_info = copy(self.run_info)
         new_extension.save()
         return new_extension

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -2685,6 +2685,7 @@ class AnalyzerExtension:
       * _set_params()
       * _run()
       * _select_units_extension_data()
+      * _select_channels_extension_data()
       * _merge_extension_data()
       * _split_extension_data()
       * _get_data()

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -1591,9 +1591,8 @@ class SortingAnalyzer:
             The newly create sorting_analyzer with the selected channels
         """
         if self.has_recording() or self.has_temporary_recording():
-            recording = self.recording
-            new_recording = recording.select_channels(channel_ids)
-            new_rec_attributes = get_rec_attributes(new_recording)
+            new_recording = self.recording.select_channels(channel_ids)
+            new_rec_attributes = None
         else:
             new_recording = None
             new_rec_attributes = self.rec_attributes.copy()
@@ -1609,6 +1608,10 @@ class SortingAnalyzer:
                     else:
                         new_properties[key] = values
                 new_rec_attributes["properties"] = new_properties
+            if new_rec_attributes.get("probegroup") is not None:
+                slice_indices = self.channel_ids_to_indices(channel_ids)
+                new_probegroup = new_rec_attributes["probegroup"].get_slice(slice_indices)
+                new_rec_attributes["probegroup"] = new_probegroup
         if self.sparsity is not None:
             sparsity_mask = self.sparsity.mask[:, np.isin(self.channel_ids, channel_ids)]
             new_sparsity = ChannelSparsity(sparsity_mask, self.unit_ids, np.array(channel_ids))

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -188,7 +188,6 @@ def create_sorting_analyzer(
             folder=folder,
             sparse=sparse,
             sparsity=sparsity,
-            main_channel_indices=main_channel_indices,
             return_scaled=return_scaled,
             return_in_uV=return_in_uV,
             overwrite=overwrite,
@@ -209,7 +208,7 @@ def create_sorting_analyzer(
         if len(main_channel_indices) != sorting.get_num_units():
             raise ValueError("len(main_channel_indices) must equal the number of units in the `sorting`")
 
-    if main_channel_indices is not None and sparsity is None and sparsity_kwargs.get("method") != "radius":
+    if main_channel_indices is not None and sparsity_kwargs.get("method") != "radius":
         raise ValueError(
             'You can either pass `main_channel_indices` or a sparsity method not equal to "radius", but not both.'
         )

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -843,8 +843,9 @@ def estimate_sparsity(
             # standard case
             probe = recording.get_probe()
         else:
-            # if many probe or no probe then we use channel location and create a dummy probe with all channels
-            # note that get_channel_locations() is checking that channel are not spatialy overlapping so the radius method is OK.
+            # if the recording has multiple probes, we use channel locations and create a dummy probe with all channels
+            # to make it compatible with the Templates object. This is a workaround for the fact that the Templates
+            # object expects a probe, but we don't have a single probe in this case.
             chan_locs = recording.get_channel_locations()
             probe = recording.create_dummy_probe_from_locations(chan_locs)
 

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -423,10 +423,6 @@ class ChannelSparsity:
         from .template import Templates
 
         if isinstance(templates_or_sorting_analyzer, Templates):
-            assert peak_sign is not None and peak_mode is not None, (
-                "When using `compute_sparsity` with a Templates object, "
-                "and `peak_sign` and `amplitude_mode` must be specified."
-            )
             main_channel_indices = templates_or_sorting_analyzer.get_main_channels(
                 outputs="index", peak_sign=peak_sign, peak_mode=peak_mode
             )
@@ -705,6 +701,13 @@ def compute_sparsity(
         assert isinstance(
             templates_or_sorting_analyzer, (Templates, SortingAnalyzer)
         ), f"compute_sparsity(method='{method}') need Templates or SortingAnalyzer"
+        if isinstance(templates_or_sorting_analyzer, Templates):
+            assert (
+                peak_sign is not None
+            ), "When using `compute_sparsity` with a Templates object, `peak_sign` must be specified."
+            assert (
+                amplitude_mode is not None
+            ), "When using `compute_sparsity` with a Templates object, `amplitude_mode` must be specified."
     else:
         assert isinstance(
             templates_or_sorting_analyzer, SortingAnalyzer

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -423,6 +423,10 @@ class ChannelSparsity:
         from .template import Templates
 
         if isinstance(templates_or_sorting_analyzer, Templates):
+            assert peak_sign is not None and peak_mode is not None, (
+                "When using `compute_sparsity` with a Templates object, "
+                "and `peak_sign` and `amplitude_mode` must be specified."
+            )
             main_channel_indices = templates_or_sorting_analyzer.get_main_channels(
                 outputs="index", peak_sign=peak_sign, peak_mode=peak_mode
             )
@@ -824,15 +828,6 @@ def estimate_sparsity(
         "Available methods are 'radius', 'best_channels', 'snr', 'amplitude', 'by_property'"
     )
 
-    if recording.get_probes() == 1:
-        # standard case
-        probe = recording.get_probe()
-    else:
-        # if many probe or no probe then we use channel location and create a dummy probe with all channels
-        # note that get_channel_locations() is checking that channel are not spatialy overlapping so the radius method is OK.
-        chan_locs = recording.get_channel_locations()
-        probe = recording.create_dummy_probe_from_locations(chan_locs)
-
     if method == "radius" and main_channel_indices is not None:
         assert len(main_channel_indices) == len(sorting.unit_ids)
         chan_locs = recording.get_channel_locations()
@@ -841,6 +836,14 @@ def estimate_sparsity(
         )
 
     elif method != "by_property":
+        if recording.get_probes() == 1:
+            # standard case
+            probe = recording.get_probe()
+        else:
+            # if many probe or no probe then we use channel location and create a dummy probe with all channels
+            # note that get_channel_locations() is checking that channel are not spatialy overlapping so the radius method is OK.
+            chan_locs = recording.get_channel_locations()
+            probe = recording.create_dummy_probe_from_locations(chan_locs)
 
         templates_array = _get_templates_array_from_recording_and_sorting(
             recording, sorting, ms_before, ms_after, num_spikes_for_sparsity, 2205, **job_kwargs

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -724,6 +724,31 @@ def test_runtime_dependencies(dataset):
     assert not sorting_analyzer.has_extension("dummy_pipeline")
 
 
+def test_select_channels(dataset):
+    recording, sorting = dataset
+    sorting_analyzer = create_sorting_analyzer(sorting, recording, format="memory", sparse=False, sparsity=None)
+    sorting_analyzer.compute(["random_spikes", "templates", "noise_levels"])
+    # select channels
+    keep_channel_ids = recording.channel_ids[::2]
+    sorting_analyzer2 = sorting_analyzer.select_channels(channel_ids=keep_channel_ids)
+
+    assert np.array_equal(sorting_analyzer2.channel_ids, keep_channel_ids)
+    assert np.array_equal(sorting_analyzer2.get_channel_locations(), recording.get_channel_locations(keep_channel_ids))
+    assert sorting_analyzer2.get_extension("templates").data["average"].shape[2] == len(keep_channel_ids)
+    assert len(sorting_analyzer2.get_extension("noise_levels").data["noise_levels"]) == len(keep_channel_ids)
+    for p in sorting_analyzer2.rec_attributes["properties"].values():
+        assert len(p) == len(keep_channel_ids)
+
+    # Now test in recordingless mode
+    sorting_analyzer2._recording = None
+    assert np.array_equal(sorting_analyzer2.channel_ids, keep_channel_ids)
+    assert np.array_equal(sorting_analyzer2.get_channel_locations(), recording.get_channel_locations(keep_channel_ids))
+    assert sorting_analyzer2.get_extension("templates").data["average"].shape[2] == len(keep_channel_ids)
+    assert len(sorting_analyzer2.get_extension("noise_levels").data["noise_levels"]) == len(keep_channel_ids)
+    for p in sorting_analyzer2.rec_attributes["properties"].values():
+        assert len(p) == len(keep_channel_ids)
+
+
 if __name__ == "__main__":
     tmp_path = Path("test_SortingAnalyzer")
     dataset = get_dataset()

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -555,7 +555,7 @@ class DummyAnalyzerExtension(AnalyzerExtension):
         self.data["result_two"] = spikes["unit_index"].copy()
         self.data["result_three"] = np.zeros((len(self.sorting_analyzer.unit_ids), 2))
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         keep_unit_indices = np.flatnonzero(np.isin(self.sorting_analyzer.unit_ids, unit_ids))
 
         spikes = self.sorting_analyzer.sorting.to_spike_vector()

--- a/src/spikeinterface/postprocessing/correlograms.py
+++ b/src/spikeinterface/postprocessing/correlograms.py
@@ -96,7 +96,7 @@ class ComputeCorrelograms(AnalyzerExtension):
 
         return params
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         # filter metrics dataframe
         unit_indices = self.sorting_analyzer.sorting.ids_to_indices(unit_ids)
         new_ccgs = self.data["ccgs"][unit_indices][:, unit_indices]
@@ -271,7 +271,7 @@ class ComputeAutoCorrelograms(AnalyzerExtension):
         params = dict(window_ms=window_ms, bin_ms=bin_ms, method=method, fast_mode=fast_mode)
         return params
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         # filter metrics dataframe
         unit_indices = self.sorting_analyzer.sorting.ids_to_indices(unit_ids)
         new_acgs = self.data["acgs"][unit_indices]
@@ -1209,7 +1209,7 @@ class ComputeACG3D(AnalyzerExtension):
 
         return params
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         # filter metrics dataframe
         unit_indices = self.sorting_analyzer.sorting.ids_to_indices(unit_ids)
         new_acgs_3d = self.data["acgs_3d"][unit_indices]

--- a/src/spikeinterface/postprocessing/isi.py
+++ b/src/spikeinterface/postprocessing/isi.py
@@ -43,7 +43,7 @@ class ComputeISIHistograms(AnalyzerExtension):
 
         return params
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         # filter metrics dataframe
         unit_indices = self.sorting_analyzer.sorting.ids_to_indices(unit_ids)
         new_isi_hists = self.data["isi_histograms"][unit_indices, :]

--- a/src/spikeinterface/postprocessing/principal_component.py
+++ b/src/spikeinterface/postprocessing/principal_component.py
@@ -85,7 +85,7 @@ class ComputePrincipalComponents(AnalyzerExtension):
         )
         return params
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
 
         keep_unit_indices = np.flatnonzero(np.isin(self.sorting_analyzer.unit_ids, unit_ids))
         some_spikes = self.sorting_analyzer.get_extension("random_spikes").get_random_spikes()

--- a/src/spikeinterface/postprocessing/template_similarity.py
+++ b/src/spikeinterface/postprocessing/template_similarity.py
@@ -58,7 +58,7 @@ class ComputeTemplateSimilarity(AnalyzerExtension):
         params = dict(method=method, max_lag_ms=max_lag_ms, support=support)
         return params
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         # filter metrics dataframe
         unit_indices = self.sorting_analyzer.sorting.ids_to_indices(unit_ids)
         new_similarity = self.data["similarity"][unit_indices][:, unit_indices]

--- a/src/spikeinterface/postprocessing/unit_locations.py
+++ b/src/spikeinterface/postprocessing/unit_locations.py
@@ -50,7 +50,7 @@ class ComputeUnitLocations(AnalyzerExtension):
         params.update(method_kwargs)
         return params
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         unit_inds = self.sorting_analyzer.sorting.ids_to_indices(unit_ids)
         new_unit_location = self.data["unit_locations"][unit_inds]
         return dict(unit_locations=new_unit_location)

--- a/src/spikeinterface/postprocessing/valid_unit_periods.py
+++ b/src/spikeinterface/postprocessing/valid_unit_periods.py
@@ -186,7 +186,7 @@ class ComputeValidUnitPeriods(AnalyzerExtension):
 
         return params
 
-    def _select_extension_data(self, unit_ids):
+    def _select_units_extension_data(self, unit_ids):
         new_extension_data = {}
         new_valid_periods, _ = remap_unit_indices_in_vector(
             self.data["valid_unit_periods"], self.sorting_analyzer.unit_ids, unit_ids


### PR DESCRIPTION
This PR adds a `select_channels` function to the `SortingAnalyzer` that returns a new analyzer in memory with sliced recording (or attirbutes), probegroup, and properties, and extensions (with a new `_select_channels_extension_data`)

Only a few extensions are affected: `noise_levels` - `templates`

`_select_extension_data` is now renamed to `_select_units_extension_data`