### PR TITLE
Improve sparsity estimation for aggregated analyzers

### DIFF
--- a/src/spikeinterface/core/channelsaggregationrecording.py
+++ b/src/spikeinterface/core/channelsaggregationrecording.py
@@ -96,15 +96,6 @@ class ChannelsAggregationRecording(BaseRecording):
         # Aggregate probe information
         all_probegroups = [rec.get_probegroup() for rec in recording_list if rec.has_probe()]
         if len(all_probegroups) == len(recording_list):
-            # check that contact positions are unique across all recordings
-            all_positions = []
-            for probegroup in all_probegroups:
-                for probe in probegroup.probes:
-                    all_positions.extend(probe.contact_positions)
-            assert len(np.unique(np.array(all_positions), axis=0)) == len(
-                all_positions
-            ), "Contact positions are not unique! Cannot aggregate recordings."
-
             # Now make a new probegroup with all probes and set global device channel indices
             probegroup_agg = ProbeGroup()
             for probegroup in all_probegroups:

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -175,8 +175,55 @@ def create_sorting_analyzer(
         aggregated_recording = aggregate_channels(recording)
         aggregated_sorting = aggregate_units(sorting)
 
-        if set_sparsity_by_dict_key:
-            sparsity_kwargs = {"method": "by_property", "by_property": "aggregation_key"}
+        if sparsity is None:
+            if sparsity_kwargs.get("method", "") != "by_property" and not set_sparsity_by_dict_key:
+                # this is weird but due to the cyclic import
+                from .template_tools import estimate_main_channel_from_recording
+
+                # In this case we estimate and construct sparsity by property
+                sparsity_mask = np.zeros(
+                    (aggregated_sorting.get_num_units(), aggregated_recording.get_num_channels()), dtype=bool
+                )
+                main_channel_indices = np.zeros(aggregated_sorting.get_num_units(), dtype=int)
+                i_unit = 0
+                i_channel = 0
+                for key in sorting.keys():
+                    recording_single = recording[key]
+                    sorting_single = sorting[key]
+                    num_units = sorting_single.get_num_units()
+                    num_channels = recording_single.get_num_channels()
+
+                    main_channel_indices_single = estimate_main_channel_from_recording(
+                        recording_single,
+                        sorting_single,
+                        peak_sign=peak_sign,
+                        peak_mode=peak_mode,
+                        num_spikes_for_main_channel=num_spikes_for_main_channel,
+                        seed=seed,
+                        **job_kwargs,
+                    )
+                    sparsity_partial = estimate_sparsity(
+                        sorting_single,
+                        recording_single,
+                        main_channel_indices=main_channel_indices_single,
+                        peak_sign=peak_sign,
+                        amplitude_mode=peak_mode,
+                        **sparsity_kwargs,
+                    )
+                    sparsity_mask[i_unit : i_unit + num_units, i_channel : i_channel + num_channels] = (
+                        sparsity_partial.mask
+                    )
+                    main_channel_indices[i_unit : i_unit + num_units] = main_channel_indices_single + i_channel
+                    i_unit += num_units
+                    i_channel += num_channels
+                sparsity = ChannelSparsity(
+                    unit_ids=aggregated_sorting.unit_ids,
+                    channel_ids=aggregated_recording.channel_ids,
+                    mask=sparsity_mask,
+                )
+                sparsity_kwargs = {}
+            elif set_sparsity_by_dict_key:
+                sparsity_kwargs = {"method": "by_property", "by_property": "aggregation_key"}
 
         return create_sorting_analyzer(
             sorting=aggregated_sorting,
@@ -185,6 +232,7 @@ def create_sorting_analyzer(
             folder=folder,
             sparse=sparse,
             sparsity=sparsity,
+            main_channel_indices=main_channel_indices,
             return_scaled=return_scaled,
             return_in_uV=return_in_uV,
             overwrite=overwrite,
@@ -205,7 +253,7 @@ def create_sorting_analyzer(
         if len(main_channel_indices) != sorting.get_num_units():
             raise ValueError("len(main_channel_indices) must equal the number of units in the `sorting`")
 
-    if main_channel_indices is not None and sparsity_kwargs.get("method") != "radius":
+    if main_channel_indices is not None and sparsity is None and sparsity_kwargs.get("method") != "radius":
         raise ValueError(
             'You can either pass `main_channel_indices` or a sparsity method not equal to "radius", but not both.'
         )

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -177,7 +177,8 @@ def create_sorting_analyzer(
 
         if sparsity is None:
             if sparsity_kwargs.get("method", "") != "by_property" and not set_sparsity_by_dict_key:
-                # this is weird but due to the cyclic import
+                # In this case, we estimate the sparsity on different splitted groups and then we
+                # aggregate the sparsity_masks and main_channel_indices
                 from .template_tools import estimate_main_channel_from_recording
 
                 # In this case we estimate and construct sparsity by property

--- a/src/spikeinterface/core/tests/test_sortinganalyzer.py
+++ b/src/spikeinterface/core/tests/test_sortinganalyzer.py
@@ -262,6 +262,21 @@ def test_create_by_dict():
     combined_analyzer = create_sorting_analyzer(split_sort_different_order, rec.split_by("group"), sparse=False)
     assert np.all(sort.get_unit_spike_train(unit_id="5") == combined_analyzer.sorting.get_unit_spike_train(unit_id="5"))
 
+    # test with sparsity
+    analyzer_with_sparsity = create_sorting_analyzer(split_sort, split_rec, sparse=True)
+    assert analyzer_with_sparsity.sparsity is not None
+    # check that the main channel indices are correct
+    main_channel_indices = analyzer_with_sparsity.get_main_channels(outputs="index")
+    sparsity_mask = analyzer_with_sparsity.sparsity.mask
+    # check that sparsity mask is false on channels from other groups
+    unit_groups = analyzer_with_sparsity.get_sorting_property("aggregation_key")
+    recording_groups = analyzer_with_sparsity.recording.get_property("aggregation_key")
+    for i, main_channel_index in enumerate(main_channel_indices):
+        group = unit_groups[i]
+        other_group_channel_indices = np.flatnonzero(recording_groups != group)
+        assert not np.any(sparsity_mask[i][other_group_channel_indices])
+        assert sparsity_mask[i, main_channel_index]
+
 
 def test_load_without_runtime_info(tmp_path, dataset):
     import zarr


### PR DESCRIPTION
Currently, when constricting a `SortingAnalyzer` via dicts, the only supported option for sparsity was `by_property`. This is ok for tetrodes, but is not the best option for multi shank probes.

This PR extends the logic of sparsity to first split by aggregation key and then apply whatever external sparsity is given (e.g. radius). 