### PR TITLE
Update checking for editable mode of spikeinterface

### DIFF
--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -655,11 +655,20 @@ def convert_string_to_bytes(memory_string: str) -> int:
 def is_editable_mode() -> bool:
     """
     Check if spikeinterface is installed in editable mode
-    pip install -e .
+    pip install -e or UV editable install.
+    Idea modified from here:
+    https://stackoverflow.com/questions/43348746/how-to-detect-if-module-is-installed-in-editable-mode
     """
-    import spikeinterface
+    import importlib.metadata
+    import json
 
-    return (Path(spikeinterface.__file__).parents[2] / "README.md").exists()
+    spikeinterface_dist = importlib.metadata.Distribution.from_name("spikeinterface").read_text("direct_url.json")
+    # if this is None it is not a local build
+    if spikeinterface_dist is None:
+        return False
+    # if there is not an editable field then it is not editable
+    package_is_editable = json.loads(spikeinterface_dist).get("dir_info").get("editable", False)
+    return package_is_editable
 
 
 def normal_pdf(x, mu: float = 0.0, sigma: float = 1.0):

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -77,7 +77,6 @@ def read_python(path):
         dictionary containing parsed file
 
     """
-    from six import exec_
     import re
 
     path = Path(path).absolute()
@@ -659,7 +658,6 @@ def is_editable_mode() -> bool:
     Idea modified from here:
     https://stackoverflow.com/questions/43348746/how-to-detect-if-module-is-installed-in-editable-mode
     """
-    import importlib.metadata
     import json
 
     spikeinterface_dist = importlib.metadata.Distribution.from_name("spikeinterface").read_text("direct_url.json")


### PR DESCRIPTION
Moving on with. my change to imports we don't need to import spikeinterface to see if it is an editable install. 

Instead we check the metadata of the file and see that it was a 
1) a local build (ie from your git repo
2) that the install was in editable mode

if either condition fails then it is not in editable mode.