### PR TITLE
Round before casting preprocessed traces to integer dtypes

### DIFF
--- a/src/spikeinterface/preprocessing/common_reference.py
+++ b/src/spikeinterface/preprocessing/common_reference.py
@@ -230,7 +230,7 @@ class CommonReferenceRecordingSegment(BasePreprocessorSegment):
                         traces[:, channel_indices] - traces.dot(self.local_kernel.T)[:, channel_indices]
                     )
             if np.issubdtype(self.dtype, np.integer):
-                re_referenced_traces = np.round(re_referenced_traces)
+                np.round(re_referenced_traces, out=re_referenced_traces)
             return re_referenced_traces.astype(self.dtype, copy=False)
 
         # Then the old implementation for backwards compatibility that supports grouping

--- a/src/spikeinterface/preprocessing/common_reference.py
+++ b/src/spikeinterface/preprocessing/common_reference.py
@@ -229,6 +229,8 @@ class CommonReferenceRecordingSegment(BasePreprocessorSegment):
                     re_referenced_traces = (
                         traces[:, channel_indices] - traces.dot(self.local_kernel.T)[:, channel_indices]
                     )
+            if np.issubdtype(self.dtype, np.integer):
+                re_referenced_traces = np.round(re_referenced_traces)
             return re_referenced_traces.astype(self.dtype, copy=False)
 
         # Then the old implementation for backwards compatibility that supports grouping

--- a/src/spikeinterface/preprocessing/highpass_spatial_filter.py
+++ b/src/spikeinterface/preprocessing/highpass_spatial_filter.py
@@ -267,7 +267,7 @@ class HighPassSpatialFilterSegment(BasePreprocessorSegment):
         else:
             traces = traces[left_margin:, channel_indices]
         if np.issubdtype(self.dtype, np.integer):
-            traces = traces.round()
+            np.round(traces, out=traces)
         return traces.astype(self.dtype, copy=False)
 
 

--- a/src/spikeinterface/preprocessing/highpass_spatial_filter.py
+++ b/src/spikeinterface/preprocessing/highpass_spatial_filter.py
@@ -266,6 +266,8 @@ class HighPassSpatialFilterSegment(BasePreprocessorSegment):
             traces = traces[left_margin:-right_margin, channel_indices]
         else:
             traces = traces[left_margin:, channel_indices]
+        if np.issubdtype(self.dtype, np.integer):
+            traces = traces.round()
         return traces.astype(self.dtype, copy=False)
 
 

--- a/src/spikeinterface/preprocessing/normalize_scale.py
+++ b/src/spikeinterface/preprocessing/normalize_scale.py
@@ -161,7 +161,6 @@ class ScaleRecording(BasePreprocessor):
             offset = np.asarray(offset)
         if offset.ndim == 1:
             offset = offset[None, :]
-        offset = offset.astype(dtype)
         assert offset.shape == (1, num_chans)
 
         BasePreprocessor.__init__(self, recording, dtype=dtype)

--- a/src/spikeinterface/preprocessing/tests/test_common_reference.py
+++ b/src/spikeinterface/preprocessing/tests/test_common_reference.py
@@ -1,7 +1,7 @@
 import operator
 import pytest
 
-from spikeinterface.core import generate_recording
+from spikeinterface.core import generate_recording, NumpyRecording
 
 from spikeinterface.preprocessing import common_reference
 
@@ -168,6 +168,32 @@ def test_common_reference_groups(recording):
     assert np.allclose(traces[:, 0], original_traces[:, 3] - original_traces[:, 1], atol=0.01)
     # b - all zeros
     assert np.allclose(traces[:, 1], 0)
+
+
+def test_common_reference_int_dtype_rounds():
+    # Casting the re-referenced float traces down to an integer dtype must round
+    # to the nearest integer, not truncate toward zero (b3).
+    traces = np.array([[0.0, 10.4], [0.0, -10.4]], dtype="float32")
+    recording = NumpyRecording([traces], sampling_frequency=1.0)
+    recording = recording.rename_channels(np.array(["a", "b"]))
+
+    rec_sin = common_reference(recording, reference="single", ref_channel_ids=["a"], dtype="int16")
+    result = rec_sin.get_traces(channel_ids=["b"])
+
+    # 10.4 rounds to 10, -10.4 rounds to -10: truncation toward zero would give the
+    # same values here, so also check a case where rounding and truncation differ.
+    assert result[0, 0] == 10
+    assert result[1, 0] == -10
+
+    traces2 = np.array([[0.0, 10.6], [0.0, -10.6]], dtype="float32")
+    recording2 = NumpyRecording([traces2], sampling_frequency=1.0)
+    recording2 = recording2.rename_channels(np.array(["a", "b"]))
+    rec_sin2 = common_reference(recording2, reference="single", ref_channel_ids=["a"], dtype="int16")
+    result2 = rec_sin2.get_traces(channel_ids=["b"])
+
+    # Truncation toward zero would give 10 / -10; correct rounding gives 11 / -11.
+    assert result2[0, 0] == 11
+    assert result2[1, 0] == -11
 
 
 def test_min_local_radius():

--- a/src/spikeinterface/preprocessing/tests/test_highpass_spatial_filter.py
+++ b/src/spikeinterface/preprocessing/tests/test_highpass_spatial_filter.py
@@ -124,31 +124,6 @@ def test_highpass_spatial_filter_with_dead_channels():
     assert result.shape == traces.shape
 
 
-def test_highpass_spatial_filter_rounds_to_integer_dtype(monkeypatch):
-    """Casting filtered float traces to an integer output dtype must round to the
-    nearest integer (matching filter.py), not truncate toward zero."""
-    import spikeinterface.preprocessing.highpass_spatial_filter as hpsf_module
-
-    num_channels = 4
-    rec = generate_recording(num_channels=num_channels, durations=[0.5])
-    rec = spre.astype(rec, np.int16)
-
-    # Force the spatial-filter step to return a known fractional value so the
-    # rounding behavior of the final dtype cast can be checked directly.
-    def fake_sosfiltfilt(sos_filter, traces, axis):
-        return np.full_like(traces, 50.6, dtype=np.float32)
-
-    monkeypatch.setattr(hpsf_module, "sosfiltfilt", fake_sosfiltfilt, raising=False)
-    import scipy.signal
-
-    monkeypatch.setattr(scipy.signal, "sosfiltfilt", fake_sosfiltfilt)
-
-    filtered = spre.highpass_spatial_filter(rec, n_channel_pad=0, n_channel_taper=0, apply_agc=False)
-    traces = filtered.get_traces(return_in_uV=False)
-
-    assert np.all(traces == 51), "fractional value 50.6 must round to 51, not truncate to 50"
-
-
 @pytest.mark.parametrize("dtype", [np.int16, np.float32, np.float64])
 def test_dtype_stability(dtype):
     """

--- a/src/spikeinterface/preprocessing/tests/test_highpass_spatial_filter.py
+++ b/src/spikeinterface/preprocessing/tests/test_highpass_spatial_filter.py
@@ -124,6 +124,31 @@ def test_highpass_spatial_filter_with_dead_channels():
     assert result.shape == traces.shape
 
 
+def test_highpass_spatial_filter_rounds_to_integer_dtype(monkeypatch):
+    """Casting filtered float traces to an integer output dtype must round to the
+    nearest integer (matching filter.py), not truncate toward zero."""
+    import spikeinterface.preprocessing.highpass_spatial_filter as hpsf_module
+
+    num_channels = 4
+    rec = generate_recording(num_channels=num_channels, durations=[0.5])
+    rec = spre.astype(rec, np.int16)
+
+    # Force the spatial-filter step to return a known fractional value so the
+    # rounding behavior of the final dtype cast can be checked directly.
+    def fake_sosfiltfilt(sos_filter, traces, axis):
+        return np.full_like(traces, 50.6, dtype=np.float32)
+
+    monkeypatch.setattr(hpsf_module, "sosfiltfilt", fake_sosfiltfilt, raising=False)
+    import scipy.signal
+
+    monkeypatch.setattr(scipy.signal, "sosfiltfilt", fake_sosfiltfilt)
+
+    filtered = spre.highpass_spatial_filter(rec, n_channel_pad=0, n_channel_taper=0, apply_agc=False)
+    traces = filtered.get_traces(return_in_uV=False)
+
+    assert np.all(traces == 51), "fractional value 50.6 must round to 51, not truncate to 50"
+
+
 @pytest.mark.parametrize("dtype", [np.int16, np.float32, np.float64])
 def test_dtype_stability(dtype):
     """

--- a/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
+++ b/src/spikeinterface/preprocessing/tests/test_normalize_scale.py
@@ -41,6 +41,21 @@ def test_scale():
     rec2.get_traces(segment_index=0)
 
 
+def test_scale_offset_precision_with_integer_dtype():
+    # ScaleRecording must apply a fractional offset at float precision even when
+    # the output dtype is integer, instead of truncating the offset itself first.
+    from spikeinterface.core import NumpyRecording
+
+    traces = np.array([[2.0], [1.0], [1.5]], dtype="float32")
+    rec = NumpyRecording([traces], sampling_frequency=1.0)
+
+    rec2 = scale(rec, gain=1.0, offset=-0.75, dtype="int16")
+    result = rec2.get_traces(segment_index=0)
+
+    expected = np.round(traces - 0.75).astype("int16")
+    np.testing.assert_array_equal(result, expected)
+
+
 def test_center():
     rec = generate_recording()
 

--- a/src/spikeinterface/preprocessing/tests/test_whiten.py
+++ b/src/spikeinterface/preprocessing/tests/test_whiten.py
@@ -245,11 +245,7 @@ class TestWhiten:
             self.assert_recording_is_white(whitened_recording)
 
     def test_whiten_int_dtype_rounds_not_truncates(self):
-        """
-        Whitened traces cast to an integer dtype must be rounded to the
-        nearest integer, not truncated toward zero (which biases the
-        output distribution downward for positive values).
-        """
+        """Integer-dtype whitening must round, not truncate toward zero."""
         num_chan = 2
         num_samples = 10
 

--- a/src/spikeinterface/preprocessing/tests/test_whiten.py
+++ b/src/spikeinterface/preprocessing/tests/test_whiten.py
@@ -244,6 +244,34 @@ class TestWhiten:
         if apply_mean:
             self.assert_recording_is_white(whitened_recording)
 
+    def test_whiten_int_dtype_rounds_not_truncates(self):
+        """
+        Whitened traces cast to an integer dtype must be rounded to the
+        nearest integer, not truncated toward zero (which biases the
+        output distribution downward for positive values).
+        """
+        num_chan = 2
+        num_samples = 10
+
+        recording = NumpyRecording(
+            [np.zeros((num_samples, num_chan), dtype=np.float32)],
+            sampling_frequency=30000,
+        )
+
+        # Identity W with a scale factor produces a known float value.
+        test_W = np.eye(num_chan)
+        whitened_recording = whiten(recording, W=test_W, M=None, dtype="int16", int_scale=1)
+
+        segment = whitened_recording.segments[0]
+        # Directly craft traces that whiten to 100.7 -> should round to 101, not truncate to 100.
+        segment.parent_recording_segment = NumpyRecording(
+            [np.full((num_samples, num_chan), 100.7, dtype=np.float32)],
+            sampling_frequency=30000,
+        ).segments[0]
+
+        traces = whitened_recording.segments[0].get_traces(0, num_samples, slice(None))
+        assert np.all(traces == 101)
+
     @pytest.mark.skipif(not HAS_SKLEARN, reason="sklearn must be installed.")
     def test_compute_sklearn_covariance_matrix(self):
         """

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -145,8 +145,8 @@ class WhitenRecordingSegment(BasePreprocessorSegment):
         if self.int_scale is not None:
             whiten_traces *= self.int_scale
 
-        if np.dtype(self.dtype).kind in "iu":
-            whiten_traces = np.round(whiten_traces)
+        if np.issubdtype(self.dtype, np.integer):
+            np.round(whiten_traces, out=whiten_traces)
 
         return whiten_traces.astype(self.dtype)
 

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -145,6 +145,9 @@ class WhitenRecordingSegment(BasePreprocessorSegment):
         if self.int_scale is not None:
             whiten_traces *= self.int_scale
 
+        if np.dtype(self.dtype).kind in "iu":
+            whiten_traces = np.round(whiten_traces)
+
         return whiten_traces.astype(self.dtype)
 
 


### PR DESCRIPTION
Several preprocessors cast their float result straight to an integer `dtype` with `astype()`, which truncates toward zero instead of rounding. Over many samples that biases the output (toward zero for centered data, downward otherwise). `filter.py` already rounds before the same cast — this brings `whiten`, `common_reference` and `highpass_spatial_filter` in line with it. It also drops the `offset.astype(dtype)` cast in `ScaleRecording`, which was silently zeroing fractional offsets for integer dtypes.

Added tests covering the integer-rounding paths.

Noticed while looking at #1972; this addresses the integer-cast rounding, not the zscore/`int_scale` std question in that issue.
