### PR TITLE
Read the ragged index before the data when loading NWB table properties

### DIFF
--- a/src/spikeinterface/extractors/nwbextractors.py
+++ b/src/spikeinterface/extractors/nwbextractors.py
@@ -441,6 +441,38 @@ class _NWBReader:
             values = np.array([v.decode("utf-8") if isinstance(v, bytes) else v for v in values])
         return values
 
+    def _read_table_property(self, table, name, columns, indices=None):
+        # Load one DynamicTable column as a per-row property, or return None if it cannot be one.
+        # Scalar columns are read directly (and optionally reordered to `indices`). Ragged columns
+        # (those with a `<name>_index`) are decided from their index alone.
+        #
+        # Performance, read the (tiny) index before the (potentially huge) data. Whether a ragged
+        # column can be a per-row property is fully determined by its index: unequal per-row lengths
+        # cannot stack into a per-row array, and a ragged column cannot be reordered to a channel
+        # subset. So we inspect the index first and, when the column is unusable, return None WITHOUT
+        # ever reading its data. This matters because ragged columns are frequently per-spike, e.g. a
+        # Units table's spike amplitudes or spike depths, which are as long as the whole spike vector
+        # (tens of millions of values, hundreds of MB), while the index is only `num_rows` values. The
+        # old code read the full data and then discarded it after finding the shapes unequal. On local
+        # disk that waste is nearly invisible; over a network file (remfile / streaming from DANDI) it
+        # is severe, because each of those columns becomes many range requests for bytes we throw away.
+        # For a typical IBL session this avoided reading ~330 MB (two ~20M-long per-spike columns) that
+        # were only ever skipped. Do not reorder this to read `data` before checking the index.
+        index_name = f"{name}_index"
+        if index_name not in columns:
+            return self._read_column(table, name, indices)
+
+        index = table[index_name]
+        index = index.data[:] if hasattr(index, "data") else index[:]
+        if indices is not None or np.unique(np.diff(index, prepend=0)).size != 1:
+            return None
+        data = table[name]
+        if hasattr(data, "data"):  # pynwb resolves the ragged structure when sliced
+            return data[:]
+        data = np.asarray(data[:])
+        starts = np.concatenate([[0], index[:-1]])
+        return [data[start:end] for start, end in zip(starts, index)]
+
     def close(self):
         # Release the open handle (raw hdf5 / zarr store, or the pynwb read IO).
         if self.file is not None:
@@ -607,7 +639,8 @@ class _NWBReader:
     def _fetch_unit_properties(self):
         # Return the unit-table columns as a name -> per-unit values mapping in a backend-independent
         # format. Skips id / spike-time columns, index columns, nested ragged arrays, and ragged
-        # columns whose per-unit shapes are unequal.
+        # columns whose per-unit shapes are unequal. The last are detected from the (small) index
+        # alone, so their (potentially large, e.g. per-spike) data is never read.
         columns = self.units_column_names
 
         properties_to_skip = ["spike_times", "spike_times_index", "unit_name", "id"]
@@ -618,36 +651,13 @@ class _NWBReader:
 
         properties = dict()
         for property_name in properties_to_add:
-            corresponding_index_name = f"{property_name}_index"
-            not_ragged_array = corresponding_index_name not in columns
-            if not_ragged_array:
-                # _read_column materializes a plain, decoded, DynamicTableRegion-safe per-unit array
-                values = self._read_column(self.units_table, property_name)
-            else:  # TODO if we want we could make this recursive to handle nested ragged arrays
-                data = self.units_table[property_name][:]
-                data_index = self.units_table[corresponding_index_name]
-                if hasattr(data_index, "data"):
-                    # for pynwb we need to get the data from the data attribute
-                    data_index = data_index.data[:]
-                else:
-                    data_index = data_index[:]
-                index_spacing = np.diff(data_index, prepend=0)
-                all_index_spacing_are_the_same = np.unique(index_spacing).size == 1
-                if all_index_spacing_are_the_same:
-                    if hasattr(self.units_table[corresponding_index_name], "data"):
-                        # ragged array indexing is handled by pynwb
-                        values = data
-                    else:
-                        # ravel array based on data_index
-                        start_indices = [0] + list(data_index[:-1])
-                        end_indices = list(data_index)
-                        values = [
-                            data[start_index:end_index] for start_index, end_index in zip(start_indices, end_indices)
-                        ]
-                else:
-                    warnings.warn(f"Skipping {property_name} because of unequal shapes across units")
-                    continue
-            properties[property_name] = values
+            values = self._read_table_property(self.units_table, property_name, columns)
+            # A None result is a ragged column with a variable length per unit (typically per-spike
+            # data such as spike amplitudes): not a per-unit property, so it is skipped and its data is
+            # never read. No warning is emitted, this is expected for normal files and there is nothing
+            # for the user to act on.
+            if values is not None:
+                properties[property_name] = values
 
         return properties
 
@@ -751,7 +761,9 @@ class _NWBReader:
 
     def read_electrode_property(self, name):
         # An electrode property is one electrodes-table column, reordered to this series' channels.
-        return self._read_column(self.electrodes_table, name, self.electrodes_indices)
+        # Ragged electrode columns cannot be per-channel scalars, so they are skipped (None returned)
+        # without their data being read.
+        return self._read_table_property(self.electrodes_table, name, self.column_names, self.electrodes_indices)
 
     def _read_ids(self):
         if self.reading_method == "use_pynwb":
@@ -1048,8 +1060,11 @@ class NwbRecordingExtractor(BaseRecording):
             for column in self._reader.column_names:
                 if column in columns_mapped_to_core_fields:
                     continue
+                values = self._reader.read_electrode_property(column)
+                if values is None:  # ragged electrode column, not a per-channel property
+                    continue
                 property_name = "brain_area" if column == "location" else column
-                self.set_property(property_name, self._reader.read_electrode_property(column))
+                self.set_property(property_name, values)
 
         if stream_mode is None and file_path is not None:
             file_path = str(Path(file_path).resolve())


### PR DESCRIPTION
When `NwbSortingExtractor` builds a sorting it loads every Units-table column as a per-unit property, and for a ragged column it read the whole column and only then checked whether the per-unit lengths were equal, discarding the data when they were not. Ragged columns are frequently per-spike (spike amplitudes, spike depths), as long as the entire spike vector, so on a real session this meant streaming hundreds of megabytes only to throw them away. The waste is nearly invisible on local disk but severe over a network file, where each discarded column becomes many range requests; for a typical IBL session this was about 330 MB of pointless reads (two roughly 20-million-long per-spike columns that were always skipped). Whether a ragged column can even be a per-row property is fully determined by its index, which is only `num_rows` values, so this reads the small index first and returns early without ever materializing the data of a column it is going to skip. I folded this into a single `_read_table_property` helper shared by both the Units (sorting) and electrodes (recording) property paths, so the electrodes side is also hardened against a ragged column rather than reading it wholesale.

While here I removed the per-column "unequal shapes" warning. It fired on essentially every real sorting file, because per-spike columns are universal, reported correct and expected behavior, and offered the user nothing to act on, so it was noise rather than a warning; skipping a ragged non-per-unit column is now silent and documented in the code. There is no behavior change to what gets loaded: the same columns become properties and the same ones are skipped, only the skipped ones are no longer read first. The existing `test_sorting_extraction_of_ragged_arrays` already covers that a non-uniform ragged column is skipped and a uniform one is loaded on both the pynwb and hdf5 paths.
