### PR TITLE
Parameter pass through for class -> function wrapper

### DIFF
--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -1,5 +1,6 @@
 from pathlib import Path, WindowsPath
-from collections.abc import Generator
+from collections import namedtuple
+from collections.abc import Generator, Callable
 import os
 import sys
 import datetime
@@ -7,8 +8,8 @@ import json
 from copy import deepcopy
 import importlib
 from math import prod
-from collections import namedtuple
 import inspect
+from typing import TypeVar, ParamSpec
 
 from probeinterface import ProbeGroup
 import numpy as np
@@ -57,7 +58,13 @@ def define_function_handling_dict_from_class(source_class, name):
     return source_class_or_dict_of_sources_classes
 
 
-def define_function_from_class(source_class, name):
+# Generic typing needed to help propagate typing
+# across multiple language servers
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def define_function_from_class(source_class: Callable[P, T], name: str) -> Callable[P, T]:
     "Wrapper to change the name of a class"
 
     return source_class

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -60,6 +60,7 @@ def define_function_handling_dict_from_class(source_class, name):
 
 # Generic typing needed to help propagate typing
 # across multiple language servers
+# see https://github.com/SpikeInterface/spikeinterface/issues/4319
 P = ParamSpec("P")
 T = TypeVar("T")
 


### PR DESCRIPTION
Hey all, I think this option proposed by @grahamfindlay is fine for at least the extractor class -> extractor function. I'm not sure how we will deal with Chris' wrapper, but this is cheap typing magic so low cost to just add if it allows more language servers to understand our code. 

Partially in support of #4319.