### PR TITLE
Fix double setting of `operator` in `self`

### DIFF
--- a/src/spikeinterface/preprocessing/common_reference.py
+++ b/src/spikeinterface/preprocessing/common_reference.py
@@ -198,7 +198,6 @@ class CommonReferenceRecordingSegment(BasePreprocessorSegment):
         self.local_kernel = local_kernel
         self.temp = None
         self.dtype = dtype
-        self.operator = operator
         self.operator_func = np.mean if self.operator == "average" else np.median
 
     def get_traces(self, start_frame, end_frame, channel_indices):


### PR DESCRIPTION
While reviewing #4653, I noticed that we set `self.operator` twice. We don't need to do that :) 