### PR TITLE
Cleanup Serializability checking in `base.py`

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -809,7 +809,7 @@ class BaseExtractor:
         folder_metadata: str, Path, or None
             Folder with files containing additional information (e.g. probe in BaseRecording) and properties.
         """
-        assert self.check_if_pickle_serializable(), "The extractor is not serializable to file with pickle"
+        assert self.check_serializability("pickle"), "The extractor is not serializable to file with pickle"
 
         # Writing paths as relative_to requires recursively expanding the dict
         if relative_to:

--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -694,34 +694,6 @@ class BaseExtractor:
                         return False
         return self._serializability[type]
 
-    def check_if_memory_serializable(self) -> bool:
-        """
-        Check if the object is serializable to memory with pickle, including nested objects.
-
-        Returns
-        -------
-        bool
-            True if the object is memory serializable, False otherwise.
-        """
-        return self.check_serializability("memory")
-
-    def check_if_json_serializable(self) -> bool:
-        """
-        Check if the object is json serializable, including nested objects.
-
-        Returns
-        -------
-        bool
-            True if the object is json serializable, False otherwise.
-        """
-        # we keep this for backward compatilibity or not ????
-        # is this needed ??? I think no.
-        return self.check_serializability("json")
-
-    def check_if_pickle_serializable(self) -> bool:
-        # is this needed ??? I think no.
-        return self.check_serializability("pickle")
-
     @staticmethod
     def _get_file_path(file_path: str | Path, extensions: Sequence) -> Path:
         """

--- a/src/spikeinterface/core/job_tools.py
+++ b/src/spikeinterface/core/job_tools.py
@@ -232,7 +232,7 @@ def ensure_n_jobs(extractor, n_jobs=1):
         print(f"Python {sys.version} does not support parallel processing")
         n_jobs = 1
 
-    if not extractor.check_if_memory_serializable():
+    if not extractor.check_serializability("memory"):
         if n_jobs != 1:
             raise RuntimeError(
                 "Extractor is not serializable to memory and can't be processed in parallel. "

--- a/src/spikeinterface/core/tests/test_base.py
+++ b/src/spikeinterface/core/tests/test_base.py
@@ -46,13 +46,13 @@ def test_check_if_memory_serializable():
     # make a list of memory serializable objects
     extractors_mem_serializable = make_nested_extractors(test_extractor)
     for extractor in extractors_mem_serializable:
-        assert extractor.check_if_memory_serializable()
+        assert extractor.check_serializability("memory")
 
     # make not not memory serilizable
     test_extractor._serializability["memory"] = False
     extractors_not_mem_serializable = make_nested_extractors(test_extractor)
     for extractor in extractors_not_mem_serializable:
-        assert not extractor.check_if_memory_serializable()
+        assert not extractor.check_serializability("memory")
 
 
 def test_check_if_serializable():

--- a/src/spikeinterface/core/zarrextractors.py
+++ b/src/spikeinterface/core/zarrextractors.py
@@ -545,7 +545,7 @@ def add_recording_to_zarr_group(
 ):
     zarr_kwargs, job_kwargs = split_job_kwargs(kwargs)
 
-    if recording.check_if_json_serializable():
+    if recording.check_serializability("json"):
         zarr_group.attrs["provenance"] = check_json(recording.to_dict(recursive=True))
     else:
         zarr_group.attrs["provenance"] = None


### PR DESCRIPTION
We currently have 4 functions for assessing serializability.
1) check_serializability is the core function
then 3+ functions that are just wrappers of check_serializability.

this PR deletes the wrappers and keeps the core function.