### PR TITLE
Remove `load_from_folder` from base

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -882,10 +882,6 @@ class BaseExtractor:
         intialization_args = (self.to_dict(),)
         return (instance_constructor, intialization_args)
 
-    @staticmethod
-    def load_from_folder(folder) -> "BaseExtractor":
-        return BaseExtractor.load(folder)
-
     def _save(self, folder, **save_kwargs):
         # This implemented in BaseRecording or baseSorting
         # this is internally call by cache(...) main function

--- a/src/spikeinterface/core/tests/test_baserecording.py
+++ b/src/spikeinterface/core/tests/test_baserecording.py
@@ -155,7 +155,7 @@ def test_BaseRecording(create_cache_folder):
     # cache to binary
     folder = cache_folder / "simple_recording"
     rec.save(format="binary", folder=folder)
-    rec2 = BaseExtractor.load_from_folder(folder)
+    rec2 = BaseExtractor.load(folder)
     assert "quality" in rec2.get_property_keys()
     values = rec2.get_property("quality")
     assert values[0] == 1.0

--- a/src/spikeinterface/core/tests/test_basesnippets.py
+++ b/src/spikeinterface/core/tests/test_basesnippets.py
@@ -115,7 +115,7 @@ def test_BaseSnippets(create_cache_folder):
     # cache to npy
     folder = cache_folder / "simple_snippets"
     snippets.save(format="npy", folder=folder)
-    snippets2 = BaseExtractor.load_from_folder(folder)
+    snippets2 = BaseExtractor.load(folder)
     assert "quality" in snippets2.get_property_keys()
     values = snippets2.get_property("quality")
     assert values[0] == 1.0

--- a/src/spikeinterface/core/tests/test_basesorting.py
+++ b/src/spikeinterface/core/tests/test_basesorting.py
@@ -72,14 +72,14 @@ def test_BaseSorting(create_cache_folder):
     folder = cache_folder / "simple_sorting_npz_folder"
     sorting.set_property("test", np.ones(len(sorting.unit_ids)))
     sorting.save(folder=folder, format="npz_folder")
-    sorting2 = BaseExtractor.load_from_folder(folder)
+    sorting2 = BaseExtractor.load(folder)
     assert isinstance(sorting2, NpzFolderSorting)
 
     # cache new format : numpy_folder
     folder = cache_folder / "simple_sorting_numpy_folder"
     sorting.set_property("test", np.ones(len(sorting.unit_ids)))
     sorting.save(folder=folder, format="numpy_folder")
-    sorting2 = BaseExtractor.load_from_folder(folder)
+    sorting2 = BaseExtractor.load(folder)
     assert isinstance(sorting2, NumpyFolderSorting)
 
     # but also possible


### PR DESCRIPTION
`load` already handles this and `load_from_folder` is just barely wrapping `load` anyway. We could consider deprecating for a version, but since `load` is there I think any complaints form people are very easily addressed.