### PR TITLE
Deprecation -> Future

### DIFF
--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -285,7 +285,7 @@ class BaseRecording(BaseRecordingSnippets, TimeSeries):
         if return_scaled is not None:
             warnings.warn(
                 "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-                category=DeprecationWarning,
+                category=FutureWarning,
                 stacklevel=2,
             )
             return_in_uV = return_scaled

--- a/src/spikeinterface/core/baserecordingsnippets.py
+++ b/src/spikeinterface/core/baserecordingsnippets.py
@@ -459,7 +459,7 @@ class BaseRecordingSnippets(BaseExtractor):
                 "set_channel_locations() is deprecated and will be removed in version 0.106.0. "
                 "If you want to set probe information, use `set_dummy_probe_from_locations()`."
             ),
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         self.set_dummy_probe_from_locations(locations, axes="xy")
@@ -486,7 +486,7 @@ class BaseRecordingSnippets(BaseExtractor):
                 "clear_channel_locations() is deprecated and will be removed in version 0.106.0. "
                 "If you want to remove probe information, use `remove_probe()`."
             ),
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         self.remove_probe()

--- a/src/spikeinterface/core/basesnippets.py
+++ b/src/spikeinterface/core/basesnippets.py
@@ -120,7 +120,7 @@ class BaseSnippets(BaseRecordingSnippets):
         if return_scaled is not None:
             warn(
                 "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-                category=DeprecationWarning,
+                category=FutureWarning,
                 stacklevel=2,
             )
             return_in_uV = return_scaled
@@ -181,7 +181,7 @@ class BaseSnippets(BaseRecordingSnippets):
         if return_scaled is not None:
             warn(
                 "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-                category=DeprecationWarning,
+                category=FutureWarning,
                 stacklevel=2,
             )
             return_in_uV = return_scaled

--- a/src/spikeinterface/core/channelsaggregationrecording.py
+++ b/src/spikeinterface/core/channelsaggregationrecording.py
@@ -19,7 +19,7 @@ class ChannelsAggregationRecording(BaseRecording):
         if recording_list is not None:
             warnings.warn(
                 "`recording_list` is deprecated and will be removed in 0.105.0. Please use `recording_list_or_dict` instead.",
-                category=DeprecationWarning,
+                category=FutureWarning,
                 stacklevel=2,
             )
             recording_list_or_dict = recording_list

--- a/src/spikeinterface/core/recording_tools.py
+++ b/src/spikeinterface/core/recording_tools.py
@@ -344,7 +344,7 @@ def write_to_h5_dataset_format(
         if return_scaled is not None:
             warnings.warn(
                 "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-                category=DeprecationWarning,
+                category=FutureWarning,
             )
             return_in_uV = return_scaled
 
@@ -430,7 +430,7 @@ def get_random_data_chunks(
     if return_scaled is not None:
         warnings.warn(
             "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
         return_in_uV = return_scaled
@@ -572,7 +572,7 @@ def get_noise_levels(
     if return_scaled is not None:
         warnings.warn(
             "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-            category=DeprecationWarning,
+            category=FutureWarning,
         )
         return_in_uV = return_scaled
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -308,7 +308,7 @@ def create_sorting_analyzer(
     if return_scaled is not None:
         warnings.warn(
             "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
         return_in_uV = return_scaled

--- a/src/spikeinterface/core/testing.py
+++ b/src/spikeinterface/core/testing.py
@@ -45,7 +45,7 @@ def check_recordings_equal(
     if return_scaled is not None:
         warnings.warn(
             "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
         return_in_uV = return_scaled

--- a/src/spikeinterface/core/tests/test_baserecording.py
+++ b/src/spikeinterface/core/tests/test_baserecording.py
@@ -297,7 +297,7 @@ def test_BaseRecording(create_cache_folder):
     rec_int16.set_property("offset_to_uV", [0.0] * 5)
 
     # Test deprecated return_scaled parameter
-    with pytest.warns(DeprecationWarning, match="`return_scaled` is deprecated"):
+    with pytest.warns(FutureWarning, match="`return_scaled` is deprecated"):
         traces_float32_old = rec_int16.get_traces(return_scaled=True)  # Keep this for testing the deprecation warning
         assert traces_float32_old.dtype == "float32"
 

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -93,7 +93,7 @@ def extract_waveforms_to_buffers(
     if return_scaled is not None:
         warnings.warn(
             "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
         return_in_uV = return_scaled
@@ -502,7 +502,7 @@ def extract_waveforms_to_single_buffer(
     if return_scaled is not None:
         warnings.warn(
             "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
         return_in_uV = return_scaled
@@ -796,7 +796,7 @@ def estimate_templates(
     if return_scaled is not None:
         warnings.warn(
             "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
         return_in_uV = return_scaled
@@ -902,7 +902,7 @@ def estimate_templates_with_accumulator(
     if return_scaled is not None:
         warnings.warn(
             "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-            category=DeprecationWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
         return_in_uV = return_scaled

--- a/src/spikeinterface/curation/auto_merge.py
+++ b/src/spikeinterface/curation/auto_merge.py
@@ -672,7 +672,7 @@ def get_potential_auto_merge(
     # deprecation moved to 0.105.0 for @zm711
     warnings.warn(
         "get_potential_auto_merge() is deprecated and will be removed in version 0.105.0. Use compute_merge_unit_groups() instead",
-        DeprecationWarning,
+        FutureWarning,
         stacklevel=2,
     )
 

--- a/src/spikeinterface/curation/curation_model.py
+++ b/src/spikeinterface/curation/curation_model.py
@@ -482,7 +482,7 @@ class Curation(BaseModel):
 def CurationModel(*args, **kwargs):
     warnings.warn(
         "`CurationModel` is deprecated and will be removed in 0.105.0. Use `Curation` instead",
-        DeprecationWarning,
+        FutureWarning,
         stacklevel=2,
     )
     return Curation(*args, **kwargs)

--- a/src/spikeinterface/curation/model_based_curation.py
+++ b/src/spikeinterface/curation/model_based_curation.py
@@ -324,7 +324,7 @@ def auto_label_units(*args, **kwargs):
     warnings.warn(
         "`auto_label_units` is deprecated and will be removed in v0.105.0. "
         "Please use `model_based_label_units` instead.",
-        DeprecationWarning,
+        FutureWarning,
         stacklevel=2,
     )
     return model_based_label_units(*args, **kwargs)

--- a/src/spikeinterface/curation/sortingview_curation.py
+++ b/src/spikeinterface/curation/sortingview_curation.py
@@ -20,7 +20,7 @@ def get_kachery():
     elif importlib.util.find_spec("kachery_cloud") is not None:
         import kachery_cloud as kcl
 
-        warnings.warn("kachery-cloud is deprecated, use kachery instead", DeprecationWarning, stacklevel=2)
+        warnings.warn("kachery-cloud is deprecated, use kachery instead", FutureWarning, stacklevel=2)
         return kcl
     else:
         raise ImportError(

--- a/src/spikeinterface/metrics/quality/misc_metrics.py
+++ b/src/spikeinterface/metrics/quality/misc_metrics.py
@@ -657,7 +657,7 @@ def compute_synchrony_metrics(sorting_analyzer, unit_ids=None, periods=None, syn
 
     if synchrony_sizes is not None:
         warning_message = "Custom `synchrony_sizes` is deprecated; the `synchrony_metrics` will be computed using `synchrony_sizes = [2,4,8]`"
-        warnings.warn(warning_message, DeprecationWarning, stacklevel=2)
+        warnings.warn(warning_message, FutureWarning, stacklevel=2)
 
     synchrony_sizes = np.array([2, 4, 8])
 

--- a/src/spikeinterface/widgets/isi_distribution.py
+++ b/src/spikeinterface/widgets/isi_distribution.py
@@ -38,7 +38,7 @@ class ISIDistributionWidget(BaseWidget):
         if sorting is not None:
             # When removed, make `sorting_analyzer_or_sorting` a required argument rather than None.
             deprecation_msg = "`sorting` argument is deprecated and will be removed in version 0.105.0. Please use `sorting_analyzer_or_sorting` instead"
-            warn(deprecation_msg, category=DeprecationWarning, stacklevel=2)
+            warn(deprecation_msg, category=FutureWarning, stacklevel=2)
             sorting_analyzer_or_sorting = sorting
 
         sorting = self.ensure_sorting(sorting_analyzer_or_sorting)

--- a/src/spikeinterface/widgets/rasters.py
+++ b/src/spikeinterface/widgets/rasters.py
@@ -422,11 +422,11 @@ class RasterWidget(BaseRasterWidget):
         if sorting is not None:
             # When removed, make `sorting_analyzer_or_sorting` a required argument rather than None.
             deprecation_msg = "`sorting` argument is deprecated and will be removed in version 0.105.0. Please use `sorting_analyzer_or_sorting` instead"
-            warn(deprecation_msg, category=DeprecationWarning, stacklevel=2)
+            warn(deprecation_msg, category=FutureWarning, stacklevel=2)
             sorting_analyzer_or_sorting = sorting
         if sorting_analyzer is not None:
             deprecation_msg = "`sorting_analyzer` argument is deprecated and will be removed in version 0.105.0. Please use `sorting_analyzer_or_sorting` instead"
-            warn(deprecation_msg, category=DeprecationWarning, stacklevel=2)
+            warn(deprecation_msg, category=FutureWarning, stacklevel=2)
             sorting_analyzer_or_sorting = sorting_analyzer
 
         sorting = self.ensure_sorting(sorting_analyzer_or_sorting)

--- a/src/spikeinterface/widgets/spikes_on_traces.py
+++ b/src/spikeinterface/widgets/spikes_on_traces.py
@@ -95,7 +95,7 @@ class SpikesOnTracesWidget(BaseWidget):
         if return_scaled is not None:
             warnings.warn(
                 "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-                category=DeprecationWarning,
+                category=FurtureWarning,
                 stacklevel=2,
             )
             return_in_uV = return_scaled

--- a/src/spikeinterface/widgets/traces.py
+++ b/src/spikeinterface/widgets/traces.py
@@ -97,7 +97,7 @@ class TracesWidget(BaseWidget):
         if return_scaled is not None:
             warnings.warn(
                 "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-                category=DeprecationWarning,
+                category=FutureWarning,
                 stacklevel=2,
             )
             return_in_uV = return_scaled

--- a/src/spikeinterface/widgets/unit_presence.py
+++ b/src/spikeinterface/widgets/unit_presence.py
@@ -40,7 +40,7 @@ class UnitPresenceWidget(BaseWidget):
         if sorting is not None:
             # When removed, make `sorting_analyzer_or_sorting` a required argument rather than None.
             deprecation_msg = "`sorting` argument is deprecated and will be removed in version 0.105.0. Please use `sorting_analyzer_or_sorting` instead"
-            warn(deprecation_msg, category=DeprecationWarning, stacklevel=2)
+            warn(deprecation_msg, category=FutureWarning, stacklevel=2)
             sorting_analyzer_or_sorting = sorting
 
         sorting = self.ensure_sorting(sorting_analyzer_or_sorting)


### PR DESCRIPTION
For @chrishalcrow 

For future readers:

`DeprecationWarnings` are for other developers which means that the warnings are filtered out in REPLs and notebooks. Most of our warnings are meant for end-users which per the Python docs should be `FutureWarnings` as of Python 3.7+. This updates our warnings to be in-line with this.