### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ With SpikeInterface, users can:
 - pre-process extracellular recordings.
 - run many popular, semi-automatic spike sorters (kilosort1-4, mountainsort4-5, spykingcircus,
   tridesclous, ironclust, herdingspikes, yass, waveclus)
-- run sorters developed in house (lupin, spkykingcicus2, tridesclous2, simple) that compete with kilosort4
-- run theses polar sorters without installation using containers (Docker/Singularity).
-- post-process sorted datasets using th SortingAnalyzer
+- run sorters developed in house (lupin, spykingcircus2, tridesclous2, simple) that compete with kilosort4
+- run these popular sorters without installation using containers (Docker/Singularity).
+- post-process sorted datasets using the SortingAnalyzer
 - compare and benchmark spike sorting outputs.
 - compute quality metrics to validate and curate spike sorting outputs.
 - visualize recordings and spike sorting outputs in several ways (matplotlib, sortingview, jupyter, ephyviewer)

--- a/src/spikeinterface/benchmark/benchmark_base.py
+++ b/src/spikeinterface/benchmark/benchmark_base.py
@@ -173,7 +173,7 @@ class BenchmarkStudy:
                     )
 
             else:
-                # new case : analzyer
+                # new case : analyzer
                 assert isinstance(data, SortingAnalyzer)
                 analyzer = data
                 if data.format == "memory":
@@ -359,7 +359,7 @@ class BenchmarkStudy:
         """
         Set colors for the study cases or for a given levels_to_group_by.
 
-        Parmeters
+        Parameters
         ---------
         colors : dict | None, default: None
             A user-defined dictionary with the case keys as keys and the colors as values.
@@ -424,7 +424,7 @@ class BenchmarkStudy:
         levels_to_group_by : list
             A list of levels to group by.
         case_keys : list
-            Optionaly a sub list of case_keys to consider
+            Optionally a sub list of case_keys to consider
 
         Returns
         -------
@@ -563,7 +563,7 @@ class BenchmarkStudy:
 
     def get_all_metrics(self, case_keys=None):
         """
-        Return a DataFrame with concatented metrics for multiple cases.
+        Return a DataFrame with concatenated metrics for multiple cases.
         """
         import pandas as pd
 
@@ -592,7 +592,7 @@ class BenchmarkStudy:
 
     def get_pairs_by_level(self, level):
         """
-        usefull for function like plot_performance_losses() where you need to plot one pair of results
+        useful for function like plot_performance_losses() where you need to plot one pair of results
         This generate list of pairs for a given level.
         """
 

--- a/src/spikeinterface/benchmark/benchmark_matching.py
+++ b/src/spikeinterface/benchmark/benchmark_matching.py
@@ -61,7 +61,7 @@ class MatchingBenchmark(Benchmark):
 
 class MatchingStudy(BenchmarkStudy, MixinStudyUnitCount):
     """
-    Benchmark study to compare template matchong methods.
+    Benchmark study to compare template matching methods.
 
     The ground truth sorting objects must be given and method outputs
     will be compared to them.

--- a/src/spikeinterface/benchmark/benchmark_motion_estimation.py
+++ b/src/spikeinterface/benchmark/benchmark_motion_estimation.py
@@ -154,7 +154,7 @@ class MotionEstimationStudy(BenchmarkStudy):
     """
     Benchmark study to compare motion estimation methods.
 
-    The ground truth displaements of all units must be known and method outputs
+    The ground truth displacements of all units must be known and method outputs
     will be compared to them.
 
     See also :py:func:`~spikeinterface.generation.generate_drifting_recording`,

--- a/src/spikeinterface/benchmark/benchmark_plot_tools.py
+++ b/src/spikeinterface/benchmark/benchmark_plot_tools.py
@@ -69,7 +69,7 @@ def aggregate_dataframe_by_levels(df, study, case_keys=None, levels_to_group_by=
     case_keys : list | None, default: None
         A list of case keys to use. If None, then all cases are used.
     levels_to_group_by : list | None, default: None
-        A list of levels to keep. If None, the original dataframe, keys, labels and colros are returned.
+        A list of levels to keep. If None, the original dataframe, keys, labels and colors are returned.
     map_name : str | None, default: None
         The name of the map to use for colors.
 
@@ -243,7 +243,7 @@ def plot_unit_counts(
     colors : dict | None, default: None
         A dictionary of colors to use for each class ("Well Detected", "False Positive", "Redundant", "Overmerged").
     columns : None | list
-        Optionaly select which columns to display
+        Optionally select which columns to display
     with_rectangle : bool
         Add or not a grouping colored rectangle for each case.
     revert_bad : bool
@@ -351,7 +351,7 @@ def plot_unit_counts(
 
 def plot_agreement_matrix(study, ordered=True, case_keys=None, axs=None):
     """
-    Plot agreement matri ces for cases in a study.
+    Plot agreement matrices for cases in a study.
 
     Parameters
     ----------

--- a/src/spikeinterface/benchmark/benchmark_sorter.py
+++ b/src/spikeinterface/benchmark/benchmark_sorter.py
@@ -26,7 +26,7 @@ class SorterBenchmark(Benchmark):
         self.result = {"sorting": sorting}
 
     def compute_result(self, match_score=0.5, exhaustive_gt=True, with_analyzer=False, **job_kwargs):
-        # run becnhmark result
+        # run benchmark result
         sorting = self.result["sorting"]
         comp = compare_sorter_to_ground_truth(
             self.gt_sorting, sorting, exhaustive_gt=exhaustive_gt, match_score=match_score

--- a/src/spikeinterface/benchmark/residual_analysis.py
+++ b/src/spikeinterface/benchmark/residual_analysis.py
@@ -13,19 +13,19 @@ def analyse_residual(
     """
     This create the residual by removing each spike from the recording.
     This take in account the spike amplitude scaling, analyzer need "amplitude_scalings" extensions.
-    Then a peak detector is run on this residual tarces and then number of peaks can be analyzed (the less the better).
+    Then a peak detector is run on this residual traces and then number of peaks can be analyzed (the less the better).
 
-    This residual is not perfect at the moement because it do not take in the account the jitter per spikes
+    This residual is not perfect at the moment because it do not take in the account the jitter per spikes
     and so the residual can be high for high amplitude when there is a inherent jitter per spike.
 
-    Paramters
+    Parameters
     ----------
     analyzer : SortingAnalyzer
 
     Returns
     -------
     residual : Recording
-        The resdiual
+        The residual
     peaks : np.array
         The peaks vector detected on the residual.
 
@@ -41,16 +41,16 @@ def analyse_residual(
 
 def make_residual_recording(analyzer):
     """
-    This make a lazy recording residual from an anlyzer.
+    This make a lazy recording residual from an analyzer.
 
-    Paramters
+    Parameters
     ----------
     analyzer : SortingAnalyzer
 
     Returns
     -------
     residual : Recording
-        The resdiual
+        The residual
     """
 
     templates = analyzer.get_extension("templates").get_templates(outputs="Templates")

--- a/src/spikeinterface/comparison/basecomparison.py
+++ b/src/spikeinterface/comparison/basecomparison.py
@@ -234,7 +234,7 @@ class BasePairComparison(BaseComparison):
     """
     Base class for pair comparisons.
 
-    It handles the matching procedurs.
+    It handles the matching procedures.
 
     Agreement scores must be computed in inherited classes by overriding the
     "_do_agreement(self)" function

--- a/src/spikeinterface/comparison/comparisontools.py
+++ b/src/spikeinterface/comparison/comparisontools.py
@@ -459,7 +459,7 @@ def make_possible_match(agreement_scores, min_score):
 
 
 def _empty_match_series(unit1_ids, unit2_ids):
-    # construct empty series of match with the correct dtype for best match and hugarian match
+    # construct empty series of match with the correct dtype for best match and hungarian match
     import pandas as pd
 
     match_12 = pd.Series(data=np.zeros(unit1_ids.size, dtype=unit2_ids.dtype), index=unit1_ids)
@@ -470,7 +470,7 @@ def _empty_match_series(unit1_ids, unit2_ids):
     elif unit2_ids.dtype.kind == "O":
         match_12[:] = ""
     else:
-        raise ValueError("make_best_match or make_hungarian_match has unit_ids dtype wich are not  'i' or 'U'")
+        raise ValueError("make_best_match or make_hungarian_match has unit_ids dtype which are not  'i' or 'U'")
     return match_12
 
 

--- a/src/spikeinterface/core/analyzer_extension_core.py
+++ b/src/spikeinterface/core/analyzer_extension_core.py
@@ -26,7 +26,7 @@ from .core_tools import ms_to_samples
 
 class ComputeRandomSpikes(AnalyzerExtension):
     """
-    AnalyzerExtension that select somes random spikes.
+    AnalyzerExtension that select some random spikes.
     This allows for a subsampling of spikes for further calculations and is important
     for managing that amount of memory and speed of computation in the analyzer.
 

--- a/src/spikeinterface/core/baserecording.py
+++ b/src/spikeinterface/core/baserecording.py
@@ -293,7 +293,7 @@ class BaseRecording(BaseRecordingSnippets, TimeSeries):
         if return_in_uV:
             if not self.has_scaleable_traces():
                 if self._dtype.kind == "f":
-                    # here we do not truely have scale but we assume this is scaled
+                    # here we do not truly have scale but we assume this is scaled
                     # this helps a lot for simulated data
                     pass
                 else:

--- a/src/spikeinterface/core/baserecordingsnippets.py
+++ b/src/spikeinterface/core/baserecordingsnippets.py
@@ -346,7 +346,7 @@ class BaseRecordingSnippets(BaseExtractor):
             write_probeinterface(folder / "probegroup.json", probegroup)
 
     def _extra_metadata_from_dict(self, dump_dict):
-        # load probe and hanlde backward-compatibility with legacy "contact_vector"/"location" property
+        # load probe and handle backward-compatibility with legacy "contact_vector"/"location" property
         if "probegroup" in dump_dict:
             # this is for SI>=0.105.0
             probegroup = dump_dict["probegroup"]

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -952,8 +952,8 @@ class BaseSorting(BaseExtractor):
         extremum_channel_inds : None or dict, default: None
             This is deprecated. Used main_channel_indices instead.
         main_channel_indices: None or array
-            Give optionaly the main_channel_indices vector to add an extra field "channel_index".
-            This can be convinient for computing spikes postion after sorter.
+            Give optionally the main_channel_indices vector to add an extra field "channel_index".
+            This can be convenient for computing spikes position after sorter.
             This dict can be given by analyzer.get_main_channels(outputs="index", with_dict=False)
         use_cache : bool, default: True
             When True the spikes vector is cached as an attribute of the object (`_cached_spike_vector`).
@@ -1184,7 +1184,7 @@ class BaseSorting(BaseExtractor):
     def to_shared_memory_sorting(self):
         """
         Turn any sorting in a SharedMemorySorting.
-        Usefull to have it in memory with a unique vector representation and sharable across processes.
+        Useful to have it in memory with a unique vector representation and sharable across processes.
         """
         from .numpyextractors import SharedMemorySorting
 

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -412,7 +412,7 @@ def check_paths_relative(input_dict, relative_folder) -> bool:
     Parameters
     ----------
     input_dict: dict
-        A dict describing an extactor obtained by BaseExtractor.to_dict()
+        A dict describing an extractor obtained by BaseExtractor.to_dict()
     relative_folder: str or Path
         The folder to be relative to.
 
@@ -464,7 +464,7 @@ def make_paths_relative(input_dict: dict, relative_folder: str | Path) -> dict:
     Parameters
     ----------
     input_dict: dict
-        A dict describing an extactor obtained by BaseExtractor.to_dict()
+        A dict describing an extractor obtained by BaseExtractor.to_dict()
     relative_folder: str or Path
         The folder to be relative to.
 
@@ -499,7 +499,7 @@ def make_paths_absolute(input_dict, base_folder) -> dict:
     Parameters
     ----------
     input_dict: dict
-        A dict describing an extactor obtained by BaseExtractor.to_dict()
+        A dict describing an extractor obtained by BaseExtractor.to_dict()
     base_folder: str or Path
         The folder to be relative to.
 
@@ -738,7 +738,7 @@ def measure_memory_allocation(measure_in_process: bool = True) -> float:
     Parameters
     ----------
     measure_in_process : bool, True by default
-        Mesure memory allocation in the current process only, if false then measures at the system
+        Measure memory allocation in the current process only, if false then measures at the system
         level.
     """
     import psutil

--- a/src/spikeinterface/core/generate.py
+++ b/src/spikeinterface/core/generate.py
@@ -469,7 +469,7 @@ class TransformSorting(BaseSorting):
         common_ids = sorting2.unit_ids[mask1]
         exclusive_ids = sorting2.unit_ids[~mask1]
 
-        # We detect the indicies in the spike_vectors
+        # We detect the indices in the spike_vectors
         idx1 = sorting1.ids_to_indices(common_ids)
         idx2 = sorting2.ids_to_indices(common_ids)
 
@@ -801,7 +801,7 @@ def synthesize_poisson_spike_vector(
     spike_frames[:num_correct_frames] = spike_frames[mask]  # Avoids a malloc
     unit_indices = unit_indices[mask]
 
-    # Sort globaly
+    # Sort globally
     spike_frames = spike_frames[:num_correct_frames]
     # the `stable` is important because this guarantees result is equivalent to
     # np.lexsort((unit_indices, spike_frames, ))
@@ -1732,8 +1732,8 @@ def generate_templates(
         Templates dtype
     upsample_factor : int | None, default: None
         If not None then template are generated upsampled by this factor.
-        Then a new dimention (axis=3) is added to the template with intermediate inter sample representation.
-        This allow easy random jitter by choising a template this new dim
+        Then a new dimension (axis=3) is added to the template with intermediate inter sample representation.
+        This allow easy random jitter by choosing a template this new dim
     unit_params : dict[np.array] | dict[float] | dict[tuple] | None, default: None
         An optional dict containing parameters per units.
         Keys are parameter names:
@@ -1933,7 +1933,7 @@ class InjectTemplatesRecording(BaseRecording):
         check_borders: bool = False,
     ) -> None:
         templates = np.asarray(templates)
-        # TODO: this should be external to this class. It is not the responsability of this class to check the templates
+        # TODO: this should be external to this class. It is not the responsibility of this class to check the templates
         if check_borders:
             self._check_templates(templates)
             # lets test this only once so force check_borders=False for kwargs
@@ -2352,7 +2352,7 @@ def generate_ground_truth_recording(
     probe : Probe | None
         An external Probe object. If not provided a probe is generated using generate_probe_kwargs.
     generate_probe_kwargs : dict
-        A dict to constuct the Probe using :py:func:`probeinterface.generate_multi_columns_probe()`.
+        A dict to construct the Probe using :py:func:`probeinterface.generate_multi_columns_probe()`.
     templates : np.ndarray | None
         The templates of units.
         If None they are generated.
@@ -2380,8 +2380,8 @@ def generate_ground_truth_recording(
         The dtype of the recording.
     seed : int | None
         Seed for random initialization.
-        If None a diffrent Recording is generated at every call.
-        Note: even with None a generated recording keep internaly a seed to regenerate the same signal after dump/load.
+        If None a different Recording is generated at every call.
+        Note: even with None a generated recording keep internally a seed to regenerate the same signal after dump/load.
 
     Returns
     -------

--- a/src/spikeinterface/core/node_pipeline.py
+++ b/src/spikeinterface/core/node_pipeline.py
@@ -54,7 +54,7 @@ class PipelineNode:
         self._kwargs = dict()
 
     def get_margin(self):
-        # can optionaly be overwritten
+        # can optionally be overwritten
         return 0
 
     def get_dtype(self):
@@ -507,7 +507,7 @@ def find_parents_of_type(list_of_parents, parent_type):
 
 def check_graph(nodes, check_for_peak_source=True):
     """
-    Check that node list is orderd in a good (parents are before children)
+    Check that node list is ordered in a good (parents are before children)
     """
 
     node0 = nodes[0]
@@ -596,7 +596,7 @@ def run_node_pipeline(
         Skip the computation after n_peaks.
         This is not an exact because internally this skip is done per worker in average.
     slices : None | list[tuple]
-        Optionaly give a list of slices to run the pipeline only on some chunks of the recording.
+        Optionally give a list of slices to run the pipeline only on some chunks of the recording.
         It must be a list of (segment_index, frame_start, frame_stop).
         If None (default), the function iterates over the entire duration of the recording.
     check_for_peak_source : bool, default False

--- a/src/spikeinterface/core/numpyextractors.py
+++ b/src/spikeinterface/core/numpyextractors.py
@@ -119,7 +119,7 @@ class NumpyRecordingSegment(BaseRecordingSegment):
 
 class SharedMemoryRecording(BaseRecording):
     """
-    In memory recording with shared memmory buffer.
+    In memory recording with shared memory buffer.
 
     Parameters
     ----------

--- a/src/spikeinterface/core/sorting_tools.py
+++ b/src/spikeinterface/core/sorting_tools.py
@@ -57,7 +57,7 @@ def spike_vector_to_indices(spike_vector: list[np.array], unit_ids: np.array, ab
     Similar to spike_vector_to_spike_trains but instead having the spike_trains (aka spike times) return
     spike indices by segment and units.
 
-    This is usefull to split back other unique vector like "spike_amplitudes", "spike_locations" into dict of dict
+    This is useful to split back other unique vector like "spike_amplitudes", "spike_locations" into dict of dict
     Internally calls numba if numba is installed.
 
     Parameters
@@ -188,7 +188,7 @@ def random_spikes_selection(
     Returns
     -------
     random_spikes_indices: np.array
-        Selected spike indices coresponding to the sorting spike vector.
+        Selected spike indices corresponding to the sorting spike vector.
     """
     rng_methods = ("uniform", "percentage", "maximum_rate")
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -698,7 +698,7 @@ class SortingAnalyzer:
 
         Note :
          * see also _handle_backward_compatibility_settings_post_init
-         * there is also something at extension level to handle changes in paramaters with deferents mechanism
+         * there is also something at extension level to handle changes in parameters with deferents mechanism
         """
 
         new_settings = dict()
@@ -1364,7 +1364,7 @@ class SortingAnalyzer:
             A dictionary with the keys being the unit ids to split and the values being the split indices.
         splitting_mode : "soft" | "hard", default: "soft"
             How splits are performed. In the "soft" mode, splits will be approximated, with no smart splitting.
-            If `splitting_mode` is "hard", the extensons for split units willbe recomputed.
+            If `splitting_mode` is "hard", the extensions for split units will be recomputed.
         split_new_unit_ids : list or None, default: None
             The new unit ids for split units. Required if `split_units` is not None.
         verbose : bool, default: False
@@ -1443,7 +1443,7 @@ class SortingAnalyzer:
         else:
             sparsity = None
 
-        # Note that the sorting is a copy we need to go back to the orginal sorting (if available)
+        # Note that the sorting is a copy we need to go back to the original sorting (if available)
         sorting_provenance = self.get_sorting_provenance()
         if sorting_provenance is None:
             # if the original sorting object is not available anymore (kilosort folder deleted, ....), take the copy
@@ -1604,7 +1604,7 @@ class SortingAnalyzer:
             The unit ids to keep in the new SortingAnalyzer object
         format : "memory" | "binary_folder" | "zarr" , default: "memory"
             The format of the returned SortingAnalyzer.
-        folder : Path | None, deafult: None
+        folder : Path | None, default: None
             The new folder where the analyzer with selected units is copied if `format` is
             "binary_folder" or "zarr"
 
@@ -1963,7 +1963,7 @@ class SortingAnalyzer:
         from .loading import load
 
         if self.format == "memory":
-            # the orginal sorting provenance is not keps in that case
+            # the original sorting provenance is not kept in that case
             sorting_provenance = None
 
         elif self.format == "binary_folder":
@@ -3058,7 +3058,7 @@ class AnalyzerExtension:
                 elif "object" in ext_data_.attrs:
                     ext_data = ext_data_[0]
                 else:
-                    # this load in memmory
+                    # this load in memory
                     ext_data = np.array(ext_data_)
                 self.set_data(ext_data_name, ext_data)
 

--- a/src/spikeinterface/core/sparsity.py
+++ b/src/spikeinterface/core/sparsity.py
@@ -205,7 +205,7 @@ class ChannelSparsity:
         if not self.are_waveforms_sparse(waveforms=waveforms, unit_id=unit_id):
             error_message = (
                 "Waveforms do not seem to be in the sparsity shape for this unit_id. The number of active channels is "
-                f"{num_active_channels}, but the waveform has non-zero values outsies of those active channels: \n"
+                f"{num_active_channels}, but the waveform has non-zero values outside of those active channels: \n"
                 f"{waveforms[..., num_active_channels:]}"
             )
             raise ValueError(error_message)
@@ -291,7 +291,7 @@ class ChannelSparsity:
 
         return cls.from_unit_id_to_channel_ids(**dictionary)
 
-    ## Some convinient function to compute sparsity from several strategy
+    ## Some convenient function to compute sparsity from several strategy
     @classmethod
     def from_best_channels(cls, templates_or_sorting_analyzer, num_channels, peak_sign=None, amplitude_mode="extremum"):
         """
@@ -328,7 +328,7 @@ class ChannelSparsity:
             mask[unit_ind, chan_inds] = True
         return cls(mask, templates_or_sorting_analyzer.unit_ids, templates_or_sorting_analyzer.channel_ids)
 
-    ## Some convinient function to compute sparsity from several strategy
+    ## Some convenient function to compute sparsity from several strategy
     @classmethod
     def from_closest_channels(cls, templates_or_sorting_analyzer, num_channels, peak_sign=None, peak_mode=None):
         """
@@ -814,7 +814,7 @@ def estimate_sparsity(
         Noise levels required for the "snr" and "energy" methods. You can use the
         `get_noise_levels()` function to compute them.
     main_channel_indices : np.array | None, default: None
-        Main channel indicies for the case of method="radius"
+        Main channel indices for the case of method="radius"
     {}
 
     Returns

--- a/src/spikeinterface/core/template.py
+++ b/src/spikeinterface/core/template.py
@@ -191,7 +191,7 @@ class Templates:
 
     def to_sparse(self, sparsity):
         # Turn a dense representation of templates into a sparse one, given some sparsity.
-        # Note that nothing prevent Templates tobe empty after sparsification if the sparse mask have no channels for some units
+        # Note that nothing prevent Templates to be empty after sparsification if the sparse mask have no channels for some units
         if isinstance(sparsity, np.ndarray):
             sparsity = ChannelSparsity(
                 mask=sparsity,

--- a/src/spikeinterface/core/tests/test_binaryrecordingextractor.py
+++ b/src/spikeinterface/core/tests/test_binaryrecordingextractor.py
@@ -85,7 +85,7 @@ def folder_with_binary_files(tmpdir_factory):
 
 
 def test_sequential_reading_of_small_traces(folder_with_binary_files):
-    # Test that memmap is readed correctly when pointing to specific frames
+    # Test that memmap is read correctly when pointing to specific frames
     folder = folder_with_binary_files
     num_channels = 32
     sampling_frequency = 30_000.0

--- a/src/spikeinterface/core/tests/test_generate.py
+++ b/src/spikeinterface/core/tests/test_generate.py
@@ -82,7 +82,7 @@ def measure_memory_allocation(measure_in_process: bool = True) -> float:
     Parameters
     ----------
     measure_in_process : bool, True by default
-        Mesure memory allocation in the current process only, if false then measures at the system
+        Measure memory allocation in the current process only, if false then measures at the system
         level.
     """
 

--- a/src/spikeinterface/core/tests/test_node_pipeline.py
+++ b/src/spikeinterface/core/tests/test_node_pipeline.py
@@ -100,7 +100,7 @@ def test_run_node_pipeline(cache_folder_creation):
         peak_sign="neg",
     )
 
-    # test with 3 differents first nodes
+    # test with 3 different first nodes
     for loop, peak_source in enumerate((peak_retriever, peak_retriever_few, spike_retriever_T, spike_retriever_S)):
         # one step only : squeeze output
         nodes = [

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -43,9 +43,9 @@ def extract_waveforms_to_buffers(
     Same as calling allocate_waveforms_buffers() and then distribute_waveforms_to_buffers().
 
     Important note: for the "shared_memory" mode arrays_info contains reference to
-    the shared memmory buffer, this variable must be reference as long as arrays as used.
+    the shared memory buffer, this variable must be reference as long as arrays as used.
     And this variable is also returned.
-    To avoid this a copy to non shared memmory can be perform at the end.
+    To avoid this a copy to non shared memory can be perform at the end.
 
     Parameters
     ----------
@@ -150,7 +150,7 @@ def allocate_waveforms_buffers(
     Allocate memmap or shared memory buffers before snippet extraction.
 
     Important note: for the shared memory mode arrays_info contains reference to
-    the shared memmory buffer, this variable must be reference as long as arrays as used.
+    the shared memory buffer, this variable must be reference as long as arrays as used.
 
     Parameters
     ----------
@@ -242,7 +242,7 @@ def distribute_waveforms_to_buffers(
     Buffers must be pre-allocated with the `allocate_waveforms_buffers()` function.
 
     Important note, for "shared_memory" mode arrays_info contain reference to
-    the shared memmory buffer, this variable must be reference as long as arrays as used.
+    the shared memory buffer, this variable must be reference as long as arrays as used.
 
     Parameters
     ----------
@@ -446,9 +446,9 @@ def extract_waveforms_to_single_buffer(
     This ensures that spikes.shape[0] == all_waveforms.shape[0].
 
     Important note: for the "shared_memory" mode wf_array_info contains reference to
-    the shared memmory buffer, this variable must be referenced as long as arrays is used.
+    the shared memory buffer, this variable must be referenced as long as arrays is used.
     This variable must also unlink() when the array is de-referenced.
-    To avoid this complicated behavior, default: (copy=True) the shared memmory buffer is copied into a standard
+    To avoid this complicated behavior, default: (copy=True) the shared memory buffer is copied into a standard
     numpy array.
 
 

--- a/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
+++ b/src/spikeinterface/core/waveforms_extractor_backwards_compatibility.py
@@ -374,10 +374,10 @@ def load_waveforms(
     output="MockWaveformExtractor",
 ) -> MockWaveformExtractor | SortingAnalyzer:
     """
-    This read an old WaveformsExtactor folder (folder or zarr) and convert it into a SortingAnalyzer or MockWaveformExtractor.
+    This read an old WaveformsExtractor folder (folder or zarr) and convert it into a SortingAnalyzer or MockWaveformExtractor.
 
     It also mimic the old load_waveforms by opening a Sortingresult folder and return a MockWaveformExtractor.
-    This later behavior is usefull to no break old code like this in versio >=0.101
+    This later behavior is useful to no break old code like this in version >=0.101
 
     >>> # In this example we is a MockWaveformExtractor that behave the same as before
     >>> we = extract_waveforms(..., folder="/my_we")

--- a/src/spikeinterface/curation/curationsorting.py
+++ b/src/spikeinterface/curation/curationsorting.py
@@ -74,7 +74,7 @@ class CurationSorting:
             Each array can contain more than 2 indices (e.g. for splitting in 3 or more units) and it should
             be the same length as the spike train (for each segment).
             If the sorting has only one segment, indices_list can be a single array
-        new_unit_ids : list[str|int] ot None
+        new_unit_ids : list[str|int] or None
             List of new unit ids. If None, a new unit id is automatically selected
         """
         current_sorting = self._sorting_stages[self._sorting_stages_i]
@@ -161,7 +161,7 @@ class CurationSorting:
 
         Parameters
         ----------
-        unit_id : int ot str
+        unit_id : int or str
             The unit id to remove
         """
         self.remove_units([unit_id])

--- a/src/spikeinterface/curation/model_based_curation.py
+++ b/src/spikeinterface/curation/model_based_curation.py
@@ -336,7 +336,7 @@ def load_model(model_folder=None, repo_id=None, model_name=None, trust_model=Fal
 
     Parameters
     ----------
-    model_folder : str or Path, defualt: None
+    model_folder : str or Path, default: None
         The path to the folder containing the model
     repo_id : str, default: None
         Hugging face repo id which contains the model e.g. 'username/model'

--- a/src/spikeinterface/exporters/report.py
+++ b/src/spikeinterface/exporters/report.py
@@ -36,7 +36,7 @@ def export_report(
     show_figures : bool, default: False
         If True, figures are shown. If False, figures are closed after saving
     force_computation :  bool, default: False
-        Force or not some heavy computaion before exporting
+        Force or not some heavy computation before exporting
     {}
     """
     import pandas as pd
@@ -78,7 +78,7 @@ def export_report(
     else:
         correlograms = None
         warnings.warn(
-            "export_report(): correlograms will not be exported. Use sorting_anlyzer.compute('correlograms') if you want to include them."
+            "export_report(): correlograms will not be exported. Use sorting_analyzer.compute('correlograms') if you want to include them."
         )
 
     # pre-compute unit locations if not done
@@ -96,7 +96,7 @@ def export_report(
     # unit list
     units = pd.DataFrame(index=unit_ids)  #  , columns=['max_on_channel_id', 'amplitude'])
     units.index.name = "unit_id"
-    # max_on_channel_id is kept (oold name)
+    # max_on_channel_id is kept (old name)
     units["max_on_channel_id"] = sorting_analyzer.get_main_channels(outputs="id", with_dict=False)
     units["main_channel_id"] = sorting_analyzer.get_main_channels(outputs="id", with_dict=False)
 

--- a/src/spikeinterface/exporters/to_phy.py
+++ b/src/spikeinterface/exporters/to_phy.py
@@ -87,7 +87,7 @@ def export_to_phy(
     if (num_chans > 64) and (sparsity is None and not sorting_analyzer.is_sparse()):
         warnings.warn(
             "Exporting to Phy with many channels and without sparsity might result in a heavy and less "
-            "informative visualization. You can use use a sparse SortingAnalyzer or you can use the 'sparsity' "
+            "informative visualization. You can use a sparse SortingAnalyzer or you can use the 'sparsity' "
             "argument to enforce sparsity (see compute_sparsity())"
         )
 
@@ -101,7 +101,7 @@ def export_to_phy(
     else:
         used_sparsity = ChannelSparsity.create_dense(sorting_analyzer)
         save_sparse = False
-    # convenient sparsity dict for the 3 cases to retrieve channl_inds
+    # convenient sparsity dict for the 3 cases to retrieve channel_inds
     sparse_dict = used_sparsity.unit_id_to_channel_indices
 
     empty_flag = False

--- a/src/spikeinterface/extractors/extractor_classes.py
+++ b/src/spikeinterface/extractors/extractor_classes.py
@@ -159,7 +159,7 @@ _snippets_extractor_full_dict = {
 # Organize the possible extractors into a user facing format with keys being extractor names
 # (e.g. 'intan' , 'kilosort') and values being the appropriate Extractor class returned as its wrapper
 # (e.g. IntanRecordingExtractor, KiloSortSortingExtractor)
-# An important note is the the formats are returned after performing `.lower()` so a format like
+# An important note is that the formats are returned after performing `.lower()` so a format like
 # SpikeGLX will have a key of 'spikeglx'
 # for example if we wanted to create a recording from an intan file we could do the following:
 # >>> recording = se.recording_extractor_full_dict['intan'](file_path='path/to/data.rhd')

--- a/src/spikeinterface/extractors/herdingspikesextractors.py
+++ b/src/spikeinterface/extractors/herdingspikesextractors.py
@@ -53,7 +53,7 @@ class HerdingspikesSortingExtractor(BaseSorting):
         self.extra_requirements.append("h5py")
 
 
-# alias for backward compatiblity
+# alias for backward compatibility
 HS2SortingExtractor = HerdingspikesSortingExtractor
 
 

--- a/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
+++ b/src/spikeinterface/extractors/neoextractors/neobaseextractor.py
@@ -304,7 +304,7 @@ class NeoBaseRecordingExtractor(_NeoBaseExtractor, BaseRecording):
             scalar_annotations = {name: value for name, value in sig_ann.items() if not name.startswith("__")}
 
             # name in neo corresponds to stream name
-            # We don't propagate the name as an annotation because that has a differnt meaning on spikeinterface
+            # We don't propagate the name as an annotation because that has a different meaning on spikeinterface
             stream_name = scalar_annotations.pop("name", None)
             if stream_name:
                 self.set_annotation(annotation_key="stream_name", value=stream_name)
@@ -379,7 +379,7 @@ class NeoBaseSortingExtractor(_NeoBaseExtractor, BaseSorting):
     neo_returns_frames = True
     # `neo_returns_frames` is a class attribute indicating whether
     # `neo_reader.get_spike_timestamps` returns frames instead of timestamps (!),
-    # If False, then the segments need to transform timestamps to to frames.
+    # If False, then the segments need to transform timestamps to frames.
     # For formats that return timestamps (e.g. Mearec, Blackrock, Neuralynx) this should be set to
     # False in the format class that inherits from this.
 
@@ -599,7 +599,7 @@ class NeoBaseSortingExtractor(_NeoBaseExtractor, BaseSorting):
             t_start = None
             warning_message = (
                 "Multiple streams ids with corresponding sampling frequency found \n "
-                "Each stream has the correspoding t_start: \n"
+                "Each stream has the corresponding t_start: \n"
                 f"{stream_id_to_t_start} \n"
                 f"Setting t_start to None. \n"
             )

--- a/src/spikeinterface/extractors/neoextractors/neuralynx.py
+++ b/src/spikeinterface/extractors/neoextractors/neuralynx.py
@@ -32,7 +32,7 @@ class NeuralynxRecordingExtractor(NeoBaseRecordingExtractor):
     strict_gap_mode : bool, default: False
         See neo documentation.
         Detect gaps using strict mode or not.
-        * strict_gap_mode = True then a gap is consider when timstamp difference between
+        * strict_gap_mode = True then a gap is consider when timestamp difference between
         two consecutive data packets is more than one sample interval.
         * strict_gap_mode = False then a gap has an increased tolerance. Some new systems
         with different clocks need this option otherwise, too many gaps are detected

--- a/src/spikeinterface/extractors/phykilosortextractors.py
+++ b/src/spikeinterface/extractors/phykilosortextractors.py
@@ -156,7 +156,7 @@ class BasePhyKilosortSortingExtractor(BaseSorting):
         # update spike clusters and times values
         bad_clusters = [clust for clust in unique_unit_ids if clust not in cluster_info["cluster_id"].values]
         if len(bad_clusters) > 0:
-            # if no bad cluster we avoid this data reduction wich cost a lot for long dataset
+            # if no bad cluster we avoid this data reduction which cost a lot for long dataset
             spike_clusters_clean_idxs = ~np.isin(spike_clusters, bad_clusters)
             spike_clusters_clean = spike_clusters[spike_clusters_clean_idxs]
             spike_times_clean = spike_times[spike_clusters_clean_idxs]

--- a/src/spikeinterface/generation/drift_tools.py
+++ b/src/spikeinterface/generation/drift_tools.py
@@ -29,7 +29,7 @@ def interpolate_templates(
         The channel source location corresponding to templates_array.
         shape = (num_channels, 2)
     dest_locations : np.array
-        The new channel position, if ndim == 3, then the interpolation is broadcated with last dim.
+        The new channel position, if ndim == 3, then the interpolation is broadcasted with last dim.
         shape = (num_channels, 2) or (num_motions, num_channels, 2)
     interpolation_method : str, default "cubic"
         The interpolation method.
@@ -138,7 +138,7 @@ class DriftingTemplates(Templates):
 
     This class supports 2 different strategies:
       * move every templates on-the-fly, this lead to one interpolation per spike
-      * precompute some displacements for all templates and use a discreate interpolation, for instance by step of 1um
+      * precompute some displacements for all templates and use a discrete interpolation, for instance by step of 1um
         This is the same strategy used by MEArec.
 
     Parameters
@@ -323,7 +323,7 @@ class InjectDriftingTemplatesRecording(BaseRecording):
     drifting_templates : DriftingTemplates
         The drifting template object
     displacement_vectors : list of numpy array
-        The lenght of the list is the number of segment.
+        The length of the list is the number of segment.
         Per segment, the drift vector is a numpy array with shape (num_times, 2, num_motions)
         num_motions is generally = 1 but can be > 1 in case of combining several drift vectors
     displacement_sampling_frequency : float
@@ -446,7 +446,7 @@ class InjectDriftingTemplatesRecording(BaseRecording):
             ), "drifting_templates must have precomputed displacements"
             displacements = drifting_templates.displacements
 
-            # compute the displacement indicies
+            # compute the displacement indices
             segment_slices = []
             displacement_indices = np.zeros(self.spike_vector.size, dtype="int64")
             for segment_index in range(sorting.get_num_segments()):

--- a/src/spikeinterface/generation/drifting_generator.py
+++ b/src/spikeinterface/generation/drifting_generator.py
@@ -1,5 +1,5 @@
 """
-This module implements generation of more realistics signal than `spikeinterface.core.generate`
+This module implements generation of more realistic signal than `spikeinterface.core.generate`
 
   * drift
   * correlated noise
@@ -72,7 +72,7 @@ def _make_probe_by_name(probe_name: str):
         manufacturer, probe_name_ = probe_name.split("#")
         probe = get_probe(manufacturer, probe_name_)
     else:
-        raise ValueError("wring probe_name")
+        raise ValueError("wrong probe_name")
 
     return probe
 
@@ -90,8 +90,8 @@ def make_one_displacement_vector(
     seed=None,
 ):
     """
-    Generates a toy displacement vector with ziagzag or bumps patterns.
-    This displacement vector has no amplitde, this generate only the shape
+    Generates a toy displacement vector with zigzag or bumps patterns.
+    This displacement vector has no amplitude, this generate only the shape
     in the range [-0.5, 0.5]
 
     Parameters
@@ -118,7 +118,7 @@ def make_one_displacement_vector(
     Returns
     -------
     displacement_vector: np.array
-        The discplacement vector in micrometers
+        The displacement vector in micrometers
     """
     from scipy.signal import sawtooth
 
@@ -292,7 +292,7 @@ def generate_displacement_vector(
 
     displacement_vectors = np.concatenate(displacement_vectors, axis=2)
 
-    # unit_displacements is the sum of all discplacements (times, units, direction_x_y)
+    # unit_displacements is the sum of all displacements (times, units, direction_x_y)
     unit_displacements = np.zeros((displacement_vectors.shape[0], num_units, 2))
     for direction in (0, 1):
         # x and y
@@ -382,7 +382,7 @@ def generate_drifting_recording(
         Number of units.
     duration : float, default: 600.
         The duration in seconds.
-    sampling_frequency : float, dfault: 30000.
+    sampling_frequency : float, default: 30000.
         The sampling frequency.
     probe: Probe object, default None
         If provided, the Probe geometry to consider
@@ -414,8 +414,8 @@ def generate_drifting_recording(
     amplitude_factor: np.ndarray, optional
         Optional fixed per-spike amplitude modulation
     extra_outputs : bool, default False
-        Return optionaly a dict with more variables.
-    seed : None ot int
+        Return optionally a dict with more variables.
+    seed : None or int
         A unique seed for all steps.
 
     Returns
@@ -425,7 +425,7 @@ def generate_drifting_recording(
     drifting_recording : Recording
         A generated recording with motion.
     sorting : Sorting
-        The ground trith soring object.
+        The ground truth sorting object.
         Same for both recordings.
     extra_infos:
         If extra_outputs=True, then return also a dict that contain various information like:
@@ -436,7 +436,7 @@ def generate_drifting_recording(
             * displacement_unit_factor
             * unit_displacements
 
-        This can be helpfull for motion benchmark.
+        This can be helpful for motion benchmark.
     """
 
     seed = _ensure_seed(seed)
@@ -548,7 +548,7 @@ def generate_drifting_recording(
     sorting.set_property("max_channel_index", max_channel_index)
 
     ## Important precompute displacement do not work on border and so do not work for tetrode
-    # here we bypass the interpolation and regenrate templates at severals positions.
+    # here we bypass the interpolation and regenerate templates at several positions.
     ## drifting_templates.precompute_displacements(displacements_steps)
     # shape (num_displacement, num_templates, num_samples, num_channels)
     drifting_templates.templates_array_moved = templates_array_moved

--- a/src/spikeinterface/generation/hybrid_tools.py
+++ b/src/spikeinterface/generation/hybrid_tools.py
@@ -40,7 +40,7 @@ def estimate_templates_from_recording(
     Parameters
     ----------
     recording : BaseRecording
-        The recording to get temaples from.
+        The recording to get templates from.
     ms_before : float
         The time before peaks of templates.
     ms_after : float
@@ -50,7 +50,7 @@ def estimate_templates_from_recording(
     run_sorter_kwargs : dict
         The parameters to provide to the run_sorter function of spikeinterface.
     job_kwargs : dict
-        The jobe keyword arguments to be used in the estimation of the templates.
+        The job keyword arguments to be used in the estimation of the templates.
 
     Returns
     -------
@@ -245,7 +245,7 @@ def relocate_templates(
         If greater than 0, the templates are allowed to go beyond the borders of the probe.
     favor_borders : bool, default: True
         If True, the templates are always moved to the borders of the probe if this is
-        possoble based on the min_displacement and max_displacement constraints.
+        possible based on the min_displacement and max_displacement constraints.
         This avoids a bias in moving templates towards the center of the probe.
     depth_direction : "x" | "y", default: "y"
         The direction in which to move the templates. Can be "x" or "y"
@@ -375,8 +375,8 @@ def generate_hybrid_recording(
         Dict used to generated template when template not provided.
     seed : int or None
         Seed for random initialization.
-        If None a diffrent Recording is generated at every call.
-        Note: even with None a generated recording keep internaly a seed to regenerate the same signal after dump/load.
+        If None a different Recording is generated at every call.
+        Note: even with None a generated recording keep internally a seed to regenerate the same signal after dump/load.
 
     Returns
     -------

--- a/src/spikeinterface/generation/noise_tools.py
+++ b/src/spikeinterface/generation/noise_tools.py
@@ -37,9 +37,9 @@ class NoiseGeneratorRecording(BaseRecording):
     strategy : "tile_pregenerated" | "on_the_fly", default: "tile_pregenerated"
         The strategy of generating noise chunk:
           * "tile_pregenerated": pregenerate a noise chunk of noise_block_size sample and repeat it
-                                 very fast and cusume only one noise block.
+                                 very fast and consume only one noise block.
           * "on_the_fly": generate on the fly a new noise block by combining seed + noise block index
-                          no memory preallocation but a bit more computaion (random)
+                          no memory preallocation but a bit more computation (random)
     noise_block_size : int, default: 30000
         Size in sample of noise block.
 

--- a/src/spikeinterface/generation/splitting_tools.py
+++ b/src/spikeinterface/generation/splitting_tools.py
@@ -7,7 +7,7 @@ def split_sorting_by_times(
     sorting_analyzer, splitting_probability=0.5, partial_split_prob=0.95, unit_ids=None, min_snr=None, seed=None
 ):
     """
-    Fonction used to split a sorting based on the times of the units. This
+    Function used to split a sorting based on the times of the units. This
     might be used for benchmarking meta merging step (see components)
 
     Parameters
@@ -79,7 +79,7 @@ def split_sorting_by_amplitudes(
     sorting_analyzer, splitting_probability=0.5, partial_split_prob=0.95, unit_ids=None, min_snr=None, seed=None
 ):
     """
-    Fonction used to split a sorting based on the amplitudes of the units. This
+    Function used to split a sorting based on the amplitudes of the units. This
     might be used for benchmarking meta merging step (see components)
 
     Parameters

--- a/src/spikeinterface/generation/template_database.py
+++ b/src/spikeinterface/generation/template_database.py
@@ -94,7 +94,7 @@ def query_templates_from_database(template_df: "pandas.DataFrame", verbose: bool
     for dataset in requested_datasets:
         templates = fetch_template_object_from_database(dataset)
 
-        # check consisency across datasets
+        # check consistency across datasets
         if nbefore is None:
             nbefore = templates.nbefore
         if channel_locations is None:

--- a/src/spikeinterface/generation/tests/test_drift_tools.py
+++ b/src/spikeinterface/generation/tests/test_drift_tools.py
@@ -165,7 +165,7 @@ def test_InjectDriftingTemplatesRecording(create_cache_folder):
 
     num_motion = 29
 
-    # 2 drifts signal with diffarents factor for units
+    # 2 drifts signal with different factor for units
     start = np.array([0, -15.0])
     stop = np.array([0, 12])
     mid = (start + stop) / 2
@@ -179,7 +179,7 @@ def test_InjectDriftingTemplatesRecording(create_cache_folder):
     displacement_unit_factor[:, 0] = np.linspace(0.7, 0.9, num_units)
     displacement_unit_factor[:, 1] = 0.1
 
-    # precompute discplacements
+    # precompute displacements
     displacements = make_linear_displacement(start, stop, num_step=num_motion)
     drifting_templates.precompute_displacements(displacements)
 
@@ -203,7 +203,7 @@ def test_InjectDriftingTemplatesRecording(create_cache_folder):
         amplitude_factor=None,
     )
 
-    # check serialibility
+    # check serializability
     rec = BaseRecording.from_dict(rec.to_dict())
     print(rec)
 

--- a/src/spikeinterface/metrics/quality/misc_metrics.py
+++ b/src/spikeinterface/metrics/quality/misc_metrics.py
@@ -1649,7 +1649,7 @@ def amplitude_cutoff(
 
         # Find number of missed spikes
         cutoff_point = pdf[0]  # >> pdf[-1] if spikes were cutoff (at lower amplitudes)
-        G = np.where(pdf >= cutoff_point)[0][-1]  # last occurence where pdf was greater than cutoff
+        G = np.where(pdf >= cutoff_point)[0][-1]  # last occurrence where pdf was greater than cutoff
         num_missed_spikes = np.sum(pdf[G + 1 :])  # theoretically missing spikes on the left side
 
         # Compute fraction of missed spikes

--- a/src/spikeinterface/metrics/utils.py
+++ b/src/spikeinterface/metrics/utils.py
@@ -17,7 +17,7 @@ def compute_bin_edges_per_unit(sorting, segment_samples, bin_duration_s=1.0, per
     periods : array of unit_period_dtype, default: None
         Periods to consider for each unit
     concatenated : bool, default: True
-        Wheter the bins are concatenated across segments or not.
+        Whether the bins are concatenated across segments or not.
         If False, the bin edges are computed per segment and the first index of each segment is 0.
         If True, the bin edges are computed on the concatenated segments, with the correct offsets.
 
@@ -138,7 +138,7 @@ def create_regular_periods(sorting_analyzer, num_periods, bin_size_s=None):
         The sorting analyzer containing the units and recording information.
     num_periods : int
         The number of periods to divide the total duration into (used if bin_size_s is None).
-    bin_size_s : float, defaut: None
+    bin_size_s : float, default: None
         If given, periods will be multiple of this size in seconds.
 
     Returns

--- a/src/spikeinterface/postprocessing/amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/amplitude_scalings.py
@@ -522,7 +522,7 @@ def fit_collision(
         full_template = np.zeros_like(local_waveform)
 
         # For the collision spike, take its unit template and insert
-        # it into `full_template` at the time the collision spike occured.
+        # it into `full_template` at the time the collision spike occurred.
         sample_centered = spike["sample_index"] - local_waveform_start
         template = all_templates[spike["unit_index"]][:, sparse_indices]
         template_cut = template[nbefore - cut_out_before : nbefore + cut_out_after]

--- a/src/spikeinterface/postprocessing/correlograms.py
+++ b/src/spikeinterface/postprocessing/correlograms.py
@@ -1417,8 +1417,8 @@ def _compute_3d_acg_one_unit(
         num_firing_rate_quantiles = len(firing_rate_quantiles)
     spike_counts = np.zeros(
         (num_firing_rate_quantiles, len(bin_times_ms))
-    )  # Counts number of occurences of spikes in a given bin in time axis
-    firing_rate_bin_occurence = np.zeros(num_firing_rate_quantiles, dtype=np.int64)  # total occurence
+    )  # Counts number of occurrences of spikes in a given bin in time axis
+    firing_rate_bin_occurence = np.zeros(num_firing_rate_quantiles, dtype=np.int64)  # total occurrence
 
     # Samples per bin
     samples_per_bin = int(np.ceil(fs / (1000 / bin_size)))

--- a/src/spikeinterface/postprocessing/principal_component.py
+++ b/src/spikeinterface/postprocessing/principal_component.py
@@ -468,7 +468,7 @@ class ComputePrincipalComponents(AnalyzerExtension):
         p = self.params
         unit_ids = self.sorting_analyzer.unit_ids
 
-        # there is one unique PCA accross channels
+        # there is one unique PCA across channels
         from sklearn.decomposition import IncrementalPCA
 
         pca_model = IncrementalPCA(n_components=p["n_components"], whiten=p["whiten"])
@@ -497,7 +497,7 @@ class ComputePrincipalComponents(AnalyzerExtension):
 
         assert self.sorting_analyzer.sparsity is None, "For mode 'concatenated' waveforms need to be dense"
 
-        # there is one unique PCA accross channels
+        # there is one unique PCA across channels
         from sklearn.decomposition import IncrementalPCA
 
         pca_model = IncrementalPCA(n_components=p["n_components"], whiten=p["whiten"])
@@ -619,7 +619,7 @@ def _all_pc_extractor_chunk(segment_index, start_frame, end_frame, worker_ctx):
 
     if i0 != i1:
         # protect from spikes on border :  spike_time<0 or spike_time>seg_size
-        # usefull only when max_spikes_per_unit is not None
+        # useful only when max_spikes_per_unit is not None
         # waveform will not be extracted and a zeros will be left in the memmap file
         while (spike_times[i0] - nbefore) < 0 and (i0 != i1):
             i0 = i0 + 1

--- a/src/spikeinterface/postprocessing/tests/common_extension_tests.py
+++ b/src/spikeinterface/postprocessing/tests/common_extension_tests.py
@@ -65,7 +65,7 @@ class AnalyzerExtensionCommonTestSuite:
     def setUpClass(self, create_cache_folder):
         """
         This method sets up the class once at the start of testing. It is
-        in scope for the lifetime of te class and is reused across all
+        in scope for the lifetime of the class and is reused across all
         tests that inherit from this base class to save processing time and
         force a small radius.
 

--- a/src/spikeinterface/preprocessing/normalize_scale.py
+++ b/src/spikeinterface/preprocessing/normalize_scale.py
@@ -235,7 +235,7 @@ class ZScoreRecording(BasePreprocessor):
     mode : "median+mad" | "mean+std", default: "median+mad"
         The mode to compute the zscore
     dtype : None or dtype
-        If None the the parent dtype is kept.
+        If None the parent dtype is kept.
         For integer dtype a int_scale must be also given.
     gain : None or np.array
         Pre-computed gain.

--- a/src/spikeinterface/preprocessing/remove_artifacts.py
+++ b/src/spikeinterface/preprocessing/remove_artifacts.py
@@ -40,10 +40,10 @@ class RemoveArtifactsRecording(BasePreprocessor):
         - "zeros": Artifacts are replaced by zeros.
 
         - "median": The median over all artifacts is computed and subtracted for
-            each occurence of an artifact
+            each occurrence of an artifact
 
         - "average": The mean over all artifacts is computed and subtracted for each
-            occurence of an artifact
+            occurrence of an artifact
 
         - "linear": Replacement are obtained through Linear interpolation between
            the trace before and after the artifact.
@@ -76,7 +76,7 @@ class RemoveArtifactsRecording(BasePreprocessor):
         the channels where the artifacts should be considered (for subtraction/scaling)
     scale_amplitude : False, default: False
         If true, then for mode "median" or "average" the amplitude of the template
-        will be scaled in amplitude at each time occurence to minimize residuals
+        will be scaled in amplitude at each time occurrence to minimize residuals
     time_jitter : float, default: 0
         If non 0, then for mode "median" or "average", a time jitter in ms
         can be allowed to minimize the residuals

--- a/src/spikeinterface/preprocessing/tests/test_detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/tests/test_detect_bad_channels.py
@@ -94,7 +94,7 @@ def test_detect_bad_channels_std_mad():
     # Check that the size of the segments os maintained after preprocessor
     assert np.array_equal(
         *([r.get_num_frames(x) for x in range(rec.get_num_segments())] for r in [rec, rec2])
-    ), "wrong lenght of resulting segments."
+    ), "wrong length of resulting segments."
     # Check that locations are mantained
     assert np.array_equal(
         rec.get_channel_locations()[[0, 2, 3]], rec2.get_channel_locations()
@@ -250,7 +250,7 @@ def add_noisy_and_dead_channels(recording, is_dead, is_noisy, not_noisy):
     psd_cutoff = reduce_high_freq_power_in_non_noisy_channels(recording, is_noisy, not_noisy)
     recording = add_dead_channels(recording, is_dead)
     # Note this will reduce the PSD for these channels but
-    # as noisy have higher freq > 80% nyqist this does not matter
+    # as noisy have higher freq > 80% nyquist this does not matter
 
     return psd_cutoff
 

--- a/src/spikeinterface/preprocessing/tests/test_filter.py
+++ b/src/spikeinterface/preprocessing/tests/test_filter.py
@@ -105,7 +105,7 @@ class TestCausalFilter:
     def test_causal_kwarg_error_raised(self, recording_and_data):
         """
         Test that passing the "forward-backward" direction results in
-        an error. It is is critical this error is raised,
+        an error. It is critical this error is raised,
         otherwise the filter will no longer be causal.
         """
         recording, raw_data = recording_and_data

--- a/src/spikeinterface/preprocessing/tests/test_interpolate_bad_channels.py
+++ b/src/spikeinterface/preprocessing/tests/test_interpolate_bad_channels.py
@@ -156,7 +156,7 @@ def test_output_values():
     """
     Quick sanity check that the outputs are as expected. Settings all
     channels equally apart, the interpolated channel should be a linear
-    combination of the non-bad channels, using arbitary sigma_um and p.
+    combination of the non-bad channels, using arbitrary sigma_um and p.
 
     Then, set the final channel to twice as far away as the rest of the
     other channels. Calculate the expected weights and check they

--- a/src/spikeinterface/preprocessing/tests/test_resample.py
+++ b/src/spikeinterface/preprocessing/tests/test_resample.py
@@ -47,7 +47,7 @@ def create_sinusoidal_traces(sampling_frequency=3e4, duration=30, freqs_n=10, ma
         pahse_shifts : Phase shifts of the frequencies, this one is an overkill.
 
     """
-    # Will return a signal with many frequencies some of wich, must be lost
+    # Will return a signal with many frequencies some of which, must be lost
     # on the resampling without breaking the lower bands
     x = np.arange(0, duration, step=1 / sampling_frequency)
     # Sample log spaced freqs from 10-10k
@@ -121,7 +121,7 @@ def test_resample_freq_domain():
             for resamp_fs, resamp_rec in zip(resamp_fss, resamp_recs)
         ]
     ), msg3
-    # Test that traces and times are the same lenght
+    # Test that traces and times are the same length
     msg4 = "The time and traces vectors must be of equal length. Non integer resampling rates can lead to this."
     assert np.all([rec.get_traces().shape[0] == rec.get_times().shape[0] for rec in resamp_recs]), msg4
     # One can see that they are quite alike, the signals but also their freq domains

--- a/src/spikeinterface/preprocessing/tests/test_whiten.py
+++ b/src/spikeinterface/preprocessing/tests/test_whiten.py
@@ -348,7 +348,7 @@ class TestWhiten:
     def test_passed_W_and_M(self):
         """
         Check that passing W (whitening matrix) and M (means) is
-        sucessfully propagated to the relevant segments and stored
+        successfully propagated to the relevant segments and stored
         on the kwargs. It is assumed if this is true, they will
         be used for the actual whitening computation.
         """

--- a/src/spikeinterface/preprocessing/tests/test_zero_padding.py
+++ b/src/spikeinterface/preprocessing/tests/test_zero_padding.py
@@ -161,7 +161,7 @@ def test_trace_padded_recording_retrieve_start_padding_and_partial_original_trac
     end_frame = padding_start + end_frame_original_traces
     padded_traces = padded_recording.get_traces(start_frame=start_frame, end_frame=end_frame)
 
-    # Check the the beginning of the trace is is padded with zeros
+    # Check the beginning of the trace is padded with zeros
     start_padding = padded_traces[:start_padding_to_retrieve, :]
     expected_padding = np.zeros((start_padding_to_retrieve, num_channels))
     assert np.allclose(start_padding, expected_padding)

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -18,7 +18,7 @@ class WhitenRecording(BasePreprocessor):
     dtype : None or dtype, default: None
         Datatype of the output recording (covariance matrix estimation
         and whitening are performed in float32).
-        If None the the parent dtype is kept.
+        If None the parent dtype is kept.
         For integer dtype a int_scale must be also given.
     mode : "global" | "local", default: "global"
         "global" use the entire covariance matrix to compute the W matrix
@@ -26,7 +26,7 @@ class WhitenRecording(BasePreprocessor):
     radius_um : None or float, default: None
         Used for mode = "local" to get the neighborhood
     apply_mean : bool, default: False
-        Substract or not the mean matrix M before the dot product with W.
+        Subtract or not the mean matrix M before the dot product with W.
     int_scale : None or float, default: None
         Apply a scaling factor to fit the integer range.
         This is used when the dtype is an integer, so that the output is scaled.

--- a/src/spikeinterface/sorters/external/kilosort.py
+++ b/src/spikeinterface/sorters/external/kilosort.py
@@ -213,7 +213,7 @@ class KilosortSorter(KilosortBase, BaseSorter):
             # Kilosort's default behavior if nNeighPC is None in params (from _default_params)
             ops["nNeighPC"] = min(
                 12.0, ops["Nchan"]
-            )  # visualization only (Phy): number of channnels to mask the PCs, leave empty to skip (12)
+            )  # visualization only (Phy): number of channels to mask the PCs, leave empty to skip (12)
 
         ops["nNeigh"] = params[
             "nNeigh"
@@ -270,7 +270,7 @@ class KilosortSorter(KilosortBase, BaseSorter):
         ops["loc_range"] = params["loc_range"]  # ranges to detect peaks; plus/minus in time and channel ([3 1])
         ops["long_range"] = params["long_range"]  # ranges to detect isolated peaks ([30 6])
         ops["maskMaxChannels"] = params["maskMaxChannels"]  # how many channels to mask up/down ([5])
-        ops["crit"] = params["crit"]  # upper criterion for discarding spike repeates (0.65)
+        ops["crit"] = params["crit"]  # upper criterion for discarding spike repeats (0.65)
         ops["nFiltMax"] = params["nFiltMax"]  # maximum "unique" spikes to consider (10000)
 
         # options for posthoc merges (under construction)

--- a/src/spikeinterface/sorters/internal/lupin.py
+++ b/src/spikeinterface/sorters/internal/lupin.py
@@ -339,7 +339,7 @@ class LupinSorter(ComponentsBasedSorter):
         if verbose:
             print(f"find_clusters_from_peaks(): {unit_ids.size} cluster found")
 
-        # preestimate the sparsity unsing peaks channel
+        # preestimate the sparsity using peaks channel
         spike_vector = sorting_pre_peeler.to_spike_vector(concatenated=True)
         sparsity, unit_locations = compute_sparsity_from_peaks_and_label(
             kept_peaks, spike_vector["unit_index"], sorting_pre_peeler.unit_ids, recording, params["template_radius_um"]

--- a/src/spikeinterface/sorters/internal/simplesorter.py
+++ b/src/spikeinterface/sorters/internal/simplesorter.py
@@ -10,7 +10,7 @@ import numpy as np
 
 class SimpleSorter(ComponentsBasedSorter):
     """
-    Implementation of a very simple sorter usefull for teaching.
+    Implementation of a very simple sorter useful for teaching.
     The idea is quite old school:
       * detect peaks
       * project waveforms with SVD or PCA
@@ -18,7 +18,7 @@ class SimpleSorter(ComponentsBasedSorter):
 
       No template matching. No auto cleaning.
 
-      Mainly usefull for few channels (1 to 8), teaching and testing.
+      Mainly useful for few channels (1 to 8), teaching and testing.
     """
 
     sorter_name = "simple"
@@ -159,7 +159,7 @@ class SimpleSorter(ComponentsBasedSorter):
             peak_labels = GaussianMixture(**clusterer_kwargs).fit_predict(features_flat)
 
         else:
-            raise ValueError(f"simple_sorter : unkown clustering method {clusterer}")
+            raise ValueError(f"simple_sorter : unknown clustering method {clusterer}")
 
         # keep positive labels
         keep = peak_labels >= 0

--- a/src/spikeinterface/sorters/internal/spyking_circus2.py
+++ b/src/spikeinterface/sorters/internal/spyking_circus2.py
@@ -113,7 +113,7 @@ class Spykingcircus2Sorter(ComponentsBasedSorter):
             HAVE_TORCH = False
             print("spykingcircus2 could benefit from using torch. Consider installing it")
 
-        # this is importanted only on demand because numba import are too heavy
+        # this is imported only on demand because numba import are too heavy
         from spikeinterface.sortingcomponents.peak_detection import detect_peaks
         from spikeinterface.sortingcomponents.peak_selection import select_peaks
         from spikeinterface.sortingcomponents.clustering import find_clusters_from_peaks

--- a/src/spikeinterface/sorters/internal/tridesclous2.py
+++ b/src/spikeinterface/sorters/internal/tridesclous2.py
@@ -291,13 +291,13 @@ class Tridesclous2Sorter(ComponentsBasedSorter):
             print(f"find_clusters_from_peaks(): {unit_ids.size} cluster found")
 
         # here the idea was to be able to use other preprocessing for peeler
-        # but at teh moment it is the same for clustering and peeling
+        # but at the moment it is the same for clustering and peeling
         recording_for_peeler = recording
         noise_levels = get_noise_levels(
             recording_for_peeler, return_in_uV=False, random_slices_kwargs=dict(seed=seed), **job_kwargs
         )
 
-        # preestimate the sparsity unsing peaks channel
+        # preestimate the sparsity using peaks channel
         spike_vector = sorting_pre_peeler.to_spike_vector(concatenated=True)
         sparsity, unit_locations = compute_sparsity_from_peaks_and_label(
             kept_peaks, spike_vector["unit_index"], sorting_pre_peeler.unit_ids, recording, params["template_radius_um"]

--- a/src/spikeinterface/sorters/runsorter.py
+++ b/src/spikeinterface/sorters/runsorter.py
@@ -706,7 +706,7 @@ def read_sorter_folder(folder, register_recording=True, sorting_info=True, raise
         Attach recording (when json or pickle) to the sorting
     sorting_info : bool, default: True
         Attach sorting info to the sorting
-    raise_error : bool, detault: True
+    raise_error : bool, default: True
         Raise an error if the spike sorting failed
     """
     folder = Path(folder)

--- a/src/spikeinterface/sorters/sorterlist.py
+++ b/src/spikeinterface/sorters/sorterlist.py
@@ -18,7 +18,7 @@ from .external.waveclus import WaveClusSorter
 from .external.waveclus_snippets import WaveClusSnippetsSorter
 from .external.yass import YassSorter
 
-# based on spikeinertface.sortingcomponents
+# based on spikeinterface.sortingcomponents
 from .internal.spyking_circus2 import Spykingcircus2Sorter
 from .internal.tridesclous2 import Tridesclous2Sorter
 from .internal.simplesorter import SimpleSorter
@@ -56,7 +56,7 @@ archived_sorter_list = [KlustaSorter, YassSorter]
 
 try:
     # if the spikeinterface_kilosort_components source are installed on the machine
-    # then an extra sorter is added, this is expermimental at the moment.
+    # then an extra sorter is added, this is experimental at the moment.
     from spikeinterface_kilosort_components.kilosort_like_sorter import Kilosort4LikeSorter
 
     sorter_full_list.append(Kilosort4LikeSorter)

--- a/src/spikeinterface/sorters/tests/test_launcher.py
+++ b/src/spikeinterface/sorters/tests/test_launcher.py
@@ -55,7 +55,7 @@ def test_run_sorter_jobs_loop(job_list):
     print(sortings)
 
 
-@pytest.mark.skipif(True, reason="tridesclous is already multiprocessing, joblib cannot run it in parralel")
+@pytest.mark.skipif(True, reason="tridesclous is already multiprocessing, joblib cannot run it in parallel")
 def test_run_sorter_jobs_joblib(job_list):
     sortings = run_sorter_jobs(
         job_list, engine="joblib", engine_kwargs=dict(n_jobs=2, backend="loky"), return_output=True
@@ -64,7 +64,7 @@ def test_run_sorter_jobs_joblib(job_list):
 
 
 @pytest.mark.skipif(
-    True, reason="tridesclous is already multiprocessing, processpoolexecutor cannot run it in parralel"
+    True, reason="tridesclous is already multiprocessing, processpoolexecutor cannot run it in parallel"
 )
 def test_run_sorter_jobs_processpoolexecutor(job_list, create_cache_folder):
     cache_folder = create_cache_folder
@@ -171,7 +171,7 @@ def test_run_sorter_jobs_slurm_kwargs(mocker, tmp_path, job_list):
     ]
     mock_subprocess_run.assert_called_with(expected_command, capture_output=True, text=True)
 
-    # Next, check the fisrt call (which sets up `si_script_0.py`)
+    # Next, check the first call (which sets up `si_script_0.py`)
     # also has the expected arguments.
     expected_command[9] = script_0_path
     assert mock_subprocess_run.call_args_list[0].args[0] == expected_command

--- a/src/spikeinterface/sortingcomponents/clustering/cleaning_tools.py
+++ b/src/spikeinterface/sortingcomponents/clustering/cleaning_tools.py
@@ -1,5 +1,5 @@
 """
-This gather some function usefull for some clusetring algos.
+This gather some function useful for some clustering algos.
 """
 
 import numpy as np
@@ -107,7 +107,7 @@ def _split_waveforms_nested(
 
         (active_ind,) = np.nonzero(local_labels_with_noise == 0)
 
-        # reduce dimention in 2 step
+        # reduce dimension in 2 step
         active_wfs = wfs_and_noise[active_ind, :, :]
         local_feature = np.zeros((active_wfs.shape[0], n_components_by_channel * active_wfs.shape[2]))
         tsvd = sklearn.decomposition.TruncatedSVD(n_components=n_components_by_channel)

--- a/src/spikeinterface/sortingcomponents/clustering/graph_tools.py
+++ b/src/spikeinterface/sortingcomponents/clustering/graph_tools.py
@@ -32,12 +32,12 @@ def create_graph_from_peak_features(
     This done using a binarization along the depth axis.
     Each peaks can connect to peaks of the same bin and neighbour bins.
 
-    The distances are locally computed on a local sparse set of channels that depend on thev detph.
-    So the original features sparsity must be big enougth to cover local channel (actual bin+neighbour).
+    The distances are locally computed on a local sparse set of channels that depend on the depth.
+    So the original features sparsity must be big enough to cover local channel (actual bin+neighbour).
 
     2 possible modes:
       * "full_connected_bin" : compute the distances from all peaks in a bin to all peaks in the same bin + neighbour
-      * "knn" : keep the k neareast neighbour for each peaks in bin + neighbour
+      * "knn" : keep the k nearest neighbour for each peaks in bin + neighbour
 
     Important, peak_locations can be:
       * the peak location from the channel (fast)

--- a/src/spikeinterface/sortingcomponents/clustering/isosplit_isocut.py
+++ b/src/spikeinterface/sortingcomponents/clustering/isosplit_isocut.py
@@ -272,7 +272,7 @@ def isosplit(
     min_cluster_size : int, default 10
         Minimum cluster size. Too small clsuters are merged with neigbors.
     isocut_threshold : float, default 2.0
-        Threhold for the merging test when exploring the cluster pairs.
+        Threshold for the merging test when exploring the cluster pairs.
         Merge is applied when : dipscore < isocut_threshold.
     seed : Int | None
         Eventually a seed for the kmeans initial step.
@@ -631,7 +631,7 @@ if HAVE_NUMBA:
                     (modified_inds1,) = np.nonzero(L12[: inds1.size] == 2)
                     (modified_inds2,) = np.nonzero(L12[inds1.size :] == 1)
 
-                    # protect against pure swaping between label1<>label2
+                    # protect against pure swapping between label1<>label2
                     # pure_swaping = modified_inds1.size == inds1.size and modified_inds2.size == inds2.size
                     pure_swaping = (modified_inds1.size / inds1.size + modified_inds2.size / inds2.size) >= 1.0
 

--- a/src/spikeinterface/sortingcomponents/clustering/itersplit_tools.py
+++ b/src/spikeinterface/sortingcomponents/clustering/itersplit_tools.py
@@ -188,7 +188,7 @@ class LocalFeatureClustering:
        * "herding_split()" in DART/spikepsvae by Charlie Windolf
 
     The idea simple :
-     * agregate features (svd or even waveforms) with sparse channel.
+     * aggregate features (svd or even waveforms) with sparse channel.
      * run a local feature reduction (pca or svd)
      * try a new split (hdscan or isosplit)
     """

--- a/src/spikeinterface/sortingcomponents/matching/base.py
+++ b/src/spikeinterface/sortingcomponents/matching/base.py
@@ -53,5 +53,5 @@ class BaseTemplateMatching(PeakDetector):
         pass
 
     def get_extra_outputs(self):
-        # can be overwritten if need to ouput some variables with a dict
+        # can be overwritten if need to output some variables with a dict
         return None

--- a/src/spikeinterface/sortingcomponents/matching/tdc_peeler.py
+++ b/src/spikeinterface/sortingcomponents/matching/tdc_peeler.py
@@ -970,7 +970,7 @@ if HAVE_NUMBA:
         traces, sparse_template, sample_index, nbefore, possible_shifts, distances_shift, chan_sparsity
     ):
         """
-        numba implementation to compute several sample shift before template substraction
+        numba implementation to compute several sample shift before template subtraction
         """
         width = sparse_template.shape[0]
         total_chans = traces.shape[1]

--- a/src/spikeinterface/sortingcomponents/matching/wobble.py
+++ b/src/spikeinterface/sortingcomponents/matching/wobble.py
@@ -125,7 +125,7 @@ class TemplateMetadata:
     jitter2template_shift : ndarray
         Maps the optimal jitter from the jitter_window to the optimal template shift.
     jitter2spike_time_shift : ndarray
-        Maps the optimal jitter from teh jitter_window to the optimal shift in spike time index.
+        Maps the optimal jitter from the jitter_window to the optimal shift in spike time index.
 
     Notes
     -----

--- a/src/spikeinterface/sortingcomponents/motion/decentralized.py
+++ b/src/spikeinterface/sortingcomponents/motion/decentralized.py
@@ -53,7 +53,7 @@ class DecentralizedRegistration:
     max_displacement_um: float
         Maximum possible displacement in micrometers.
     weight_scale: "linear" or "exp"
-        For parwaise displacement, how to to rescale the associated weight matrix.
+        For pairwise displacement, how to rescale the associated weight matrix.
     error_sigma: float, default: 0.2
         In case weight_scale="exp" this controls the sigma of the exponential.
     conv_engine: "numpy" or "torch" or None, default: None
@@ -66,10 +66,10 @@ class DecentralizedRegistration:
         on GPUs and sometimes on CPU as well.
     corr_threshold: float
         Minimum correlation between pair of time bins in order for these to be
-        considered when optimizing a global displacment vector to align with
+        considered when optimizing a global displacement vector to align with
         the pairwise displacements.
     time_horizon_s: None or float
-        When not None the parwise discplament matrix is computed in a small time horizon.
+        When not None the pairwise displacement matrix is computed in a small time horizon.
         In short only pair of bins close in time.
         So the pariwaise matrix is super sparse and have values only the diagonal.
     convergence_method: "lsmr" | "lsqr_robust" | "gradient_descent", default: "lsmr"

--- a/src/spikeinterface/sortingcomponents/motion/motion_cleaner.py
+++ b/src/spikeinterface/sortingcomponents/motion/motion_cleaner.py
@@ -18,7 +18,7 @@ def clean_motion_vector(motion, temporal_bins, bin_duration_s, speed_threshold=3
     bin_duration_s : float
         bin duration in second
     speed_threshold : float (units um/s)
-        Maximum speed treshold between 2 bins allowed.
+        Maximum speed threshold between 2 bins allowed.
         Expressed in um/s
     sigma_smooth_s : None or float
         Optional smooting gaussian kernel.

--- a/src/spikeinterface/sortingcomponents/motion/motion_estimation.py
+++ b/src/spikeinterface/sortingcomponents/motion/motion_estimation.py
@@ -84,7 +84,7 @@ def estimate_motion(
         The motion object.
     extra: dict
         Optional output if `extra_outputs=True`
-        This dict contain histogram, pairwise_displacement usefull for ploting.
+        This dict contain histogram, pairwise_displacement useful for plotting.
     """
 
     if margin_um is not None:

--- a/src/spikeinterface/sortingcomponents/motion/motion_interpolation.py
+++ b/src/spikeinterface/sortingcomponents/motion/motion_interpolation.py
@@ -299,7 +299,7 @@ class InterpolateMotionRecording(BasePreprocessor):
 
             * "kriging" : the same one used in kilosort
             * "idw" : inverse  distance weighted
-            * "nearest" : use neareast channel
+            * "nearest" : use nearest channel
 
     sigma_um : float, default: 20.0
         Used in the "kriging" formula.

--- a/src/spikeinterface/sortingcomponents/peak_detection/iterative.py
+++ b/src/spikeinterface/sortingcomponents/peak_detection/iterative.py
@@ -153,7 +153,7 @@ class IterativePeakDetector(PeakDetector):
         waveforms: np.ndarray,
     ):
         """
-        Substract inplace the cleaned waveforms from the traces_chunk.
+        Subtract inplace the cleaned waveforms from the traces_chunk.
 
         Parameters
         ----------

--- a/src/spikeinterface/sortingcomponents/waveforms/peak_svd.py
+++ b/src/spikeinterface/sortingcomponents/waveforms/peak_svd.py
@@ -36,7 +36,7 @@ def extract_peaks_svd(
 
     This is done in 2 steps:
       * fit a TruncatedSVD model on a few peaks on max channel
-      * tranform each peaks in parralel on a sparse channel set with this model
+      * transform each peaks in parallel on a sparse channel set with this model
 
     The recording have a drift, hen, optionally, the motion object can be given.
     In that case all the svd features are moved back using cubi interpolation.

--- a/src/spikeinterface/widgets/base.py
+++ b/src/spikeinterface/widgets/base.py
@@ -8,7 +8,7 @@ from spikeinterface.core.waveforms_extractor_backwards_compatibility import Mock
 def get_default_plotter_backend():
     """Return the default backend for spikeinterface widgets.
     The default backend is "matplotlib" at init.
-    It can be be globally set with `set_default_plotter_backend(backend)`
+    It can be globally set with `set_default_plotter_backend(backend)`
     """
 
     global default_backend_

--- a/src/spikeinterface/widgets/bombcell_curation.py
+++ b/src/spikeinterface/widgets/bombcell_curation.py
@@ -24,7 +24,7 @@ class BombcellUpsetPlotWidget(BaseWidget):
     sorting_analyzer : SortingAnalyzer
         The sorting analyzer object with computed metrics extensions.
     unit_labels : np.ndarray
-        Array of unit labels as strings, includeing bombcell labels like "noise", "mua",
+        Array of unit labels as strings, including bombcell labels like "noise", "mua",
         "non_soma", "non_soma_good", "non_soma_mua".
     thresholds : dict, optional
         Threshold dictionary with structure "noise", "mua", "non-somatic" as sections. Each section contains

--- a/src/spikeinterface/widgets/collision.py
+++ b/src/spikeinterface/widgets/collision.py
@@ -5,7 +5,7 @@ from .base import BaseWidget, to_attr
 
 class ComparisonCollisionBySimilarityWidget(BaseWidget):
     """
-    Plots CollisionGTComparison pair by pair orderer by cosine_similarity
+    Plots CollisionGTComparison pair by pair ordered by cosine_similarity
 
     Parameters
     ----------
@@ -184,7 +184,7 @@ class ComparisonCollisionBySimilarityWidget(BaseWidget):
 
 class StudyComparisonCollisionBySimilarityWidget(BaseWidget):
     """
-    Plots CollisionGTComparison pair by pair orderer by cosine_similarity for all
+    Plots CollisionGTComparison pair by pair ordered by cosine_similarity for all
     cases in a study.
 
     Parameters

--- a/src/spikeinterface/widgets/gtstudy.py
+++ b/src/spikeinterface/widgets/gtstudy.py
@@ -1,8 +1,8 @@
 """
 This module will be deprecated and will be removed in 0.102.0
 
-All ploting for the previous GTStudy is now centralized in spikeinterface.benchmark.benchmark_plot_tools
-Please not that GTStudy is replaced by SorterStudy wich is based more generic BenchmarkStudy.
+All plotting for the previous GTStudy is now centralized in spikeinterface.benchmark.benchmark_plot_tools
+Please note that GTStudy is replaced by SorterStudy which is based more generic BenchmarkStudy.
 """
 
 from .base import BaseWidget

--- a/src/spikeinterface/widgets/isi_distribution.py
+++ b/src/spikeinterface/widgets/isi_distribution.py
@@ -84,7 +84,7 @@ class ISIDistributionWidget(BaseWidget):
                     bin_counts = bin_counts_
                 else:
                     bin_counts += bin_counts_
-                    # TODO handle sensity when several segments
+                    # TODO handle density when several segments
 
             ax.bar(x=bin_edges[:-1], height=bin_counts, width=dp.bin_ms, color="gray", align="edge")
 

--- a/src/spikeinterface/widgets/metrics.py
+++ b/src/spikeinterface/widgets/metrics.py
@@ -293,7 +293,7 @@ class MetricsBaseWidget(BaseWidget):
             values = check_json(metrics.loc[unit_id].to_dict())
             values_skip_nans = {}
             for k, v in values.items():
-                # convert_dypes returns NaN as None or np.nan (for float)
+                # convert_dtypes returns NaN as None or np.nan (for float)
                 if v is None:
                     continue
                 if np.isnan(v):

--- a/src/spikeinterface/widgets/motion.py
+++ b/src/spikeinterface/widgets/motion.py
@@ -288,9 +288,9 @@ class DriftRasterMapWidget(BaseRasterWidget):
 
 class MotionInfoWidget(BaseWidget):
     """
-    Plot motion information from the motion_info dictionary returned by the `correct_motion()` funciton.
+    Plot motion information from the motion_info dictionary returned by the `correct_motion()` function.
     This widget plots:
-        * the motion iself
+        * the motion itself
         * the drift raster map (peak depth vs time) before correction
         * the drift raster map (peak depth vs time) after correction
 

--- a/src/spikeinterface/widgets/peaks_on_probe.py
+++ b/src/spikeinterface/widgets/peaks_on_probe.py
@@ -131,7 +131,7 @@ class PeaksOnProbeWidget(BaseWidget):
             )
 
             if dp.ylim is None:
-                padding = 25  # arbitary padding just to give some space around highests and lowest peaks on the plot
+                padding = 25  # arbitrary padding just to give some space around highest and lowest peaks on the plot
                 ylim = (np.min(peak_locs_to_plot["y"]) - padding, np.max(peak_locs_to_plot["y"]) + padding)
             else:
                 ylim = dp.ylim
@@ -188,7 +188,7 @@ class PeaksOnProbeWidget(BaseWidget):
 
     def _check_and_format_inputs(self, peaks, peak_locations):
         """
-        Check that the inpust are in expected form. Corresponding peaks
+        Check that the inputs are in expected form. Corresponding peaks
         and peak_locations of same size and format must be provided.
         """
         types_are_list = [isinstance(peaks, list), isinstance(peak_locations, list)]

--- a/src/spikeinterface/widgets/sorting_summary.py
+++ b/src/spikeinterface/widgets/sorting_summary.py
@@ -51,12 +51,12 @@ class SortingSummaryWidget(BaseWidget):
         A dict with extra units properties to display.
         The key is the property name and the value must be a numpy.array.
     curation_dict : dict or None, default: None
-        When curation is True, optionaly the viewer can get a previous 'curation_dict'
+        When curation is True, optionally the viewer can get a previous 'curation_dict'
         to continue/check  previous curations on this analyzer.
-        In this case label_definitions must be None beacuse it is already included in the curation_dict.
+        In this case label_definitions must be None because it is already included in the curation_dict.
         (spikeinterface_gui backend)
     label_definitions : dict or None, default: None
-        When curation is True, optionaly the user can provide a label_definitions dict.
+        When curation is True, optionally the user can provide a label_definitions dict.
         This replaces the label_choices in the curation_format.
         (spikeinterface_gui backend)
     """
@@ -87,7 +87,7 @@ class SortingSummaryWidget(BaseWidget):
             unit_ids = sorting.get_unit_ids()
 
         if curation_dict is not None and label_definitions is not None:
-            raise ValueError("curation_dict and label_definitions are mutualy exclusive, they cannot be not None both")
+            raise ValueError("curation_dict and label_definitions are mutually exclusive, they cannot be not None both")
 
         if displayed_unit_properties is None:
             displayed_unit_properties = list(_default_displayed_unit_properties)

--- a/src/spikeinterface/widgets/traces.py
+++ b/src/spikeinterface/widgets/traces.py
@@ -250,7 +250,7 @@ class TracesWidget(BaseWidget):
         else:
             evensts_w_dtype = None
 
-        # keep aglobal ref of colorbar
+        # keep a global ref of colorbar
         self.cb = None
 
         plot_data = dict(

--- a/src/spikeinterface/widgets/unit_summary.py
+++ b/src/spikeinterface/widgets/unit_summary.py
@@ -18,7 +18,7 @@ class UnitSummaryWidget(BaseWidget):
     """
     Plot a unit summary.
 
-    If amplitudes are alreday computed, they are displayed.
+    If amplitudes are already computed, they are displayed.
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ class UnitSummaryWidget(BaseWidget):
 
         self.figure, self.axes, self.ax = make_mpl_figure(**backend_kwargs)
 
-        # and use custum grid spec
+        # and use custom grid spec
         fig = self.figure
         nrows = 2
         ncols = 2

--- a/src/spikeinterface/widgets/unit_waveforms.py
+++ b/src/spikeinterface/widgets/unit_waveforms.py
@@ -40,7 +40,7 @@ class UnitWaveformsWidget(BaseWidget):
     scale : float, default: 1
         Scale factor for the waveforms/templates (matplotlib backend)
     abs_y_scale : None | float, default None
-        Absolut y_scale that override the auto y scale mechanism
+        Absolute y_scale that override the auto y scale mechanism
     widen_narrow_scale : float, default: 1
         Scale factor for the x-axis of the waveforms/templates (matplotlib backend)
     axis_equal : bool, default: False
@@ -76,7 +76,7 @@ class UnitWaveformsWidget(BaseWidget):
         If True, waveforms and templates are displayed on the same axis (matplotlib backend)
     x_offset_units : bool, default: False
         In case same_axis is True, this parameter allow to x-offset the waveforms for different units
-        (recommended for a few units) (matlotlib backend)
+        (recommended for a few units) (matplotlib backend)
     plot_legend : bool, default: True
         Display legend (matplotlib backend)
     """
@@ -183,7 +183,7 @@ class UnitWaveformsWidget(BaseWidget):
             ):
                 warn(
                     "templates_percentile_shading can only be used if the 'waveforms' extension is available. "
-                    "Settimg templates_percentile_shading to None."
+                    "Setting templates_percentile_shading to None."
                 )
                 templates_percentile_shading = None
             templates_shading = self._get_template_shadings(unit_ids, templates_percentile_shading)

--- a/src/spikeinterface/widgets/utils.py
+++ b/src/spikeinterface/widgets/utils.py
@@ -234,7 +234,7 @@ def array_to_image(
             image = Image.fromarray(output_image)
             image_editable = ImageDraw.Draw(image)
 
-            # bar should be around 1/5 of row and ultiple of 5ms
+            # bar should be around 1/5 of row and multiple of 5ms
             if row_ms / 5 > 5:
                 bar_ms = int(np.ceil((row_ms / 5) // 5 * 5))
                 text_offset = 0.3


### PR DESCRIPTION
Fixes typos in src/ and in the README. 

I left alone some historical comments with typos e.g. at top of `core/__init__.py`. Also left personal comments like `"Fot me (sam) this is not necessary unless someone realy really want to use"` alone.