### PR TITLE
Fix amplitude being ignored for static hybrid recordings

### DIFF
--- a/src/spikeinterface/generation/hybrid_tools.py
+++ b/src/spikeinterface/generation/hybrid_tools.py
@@ -564,6 +564,7 @@ def generate_hybrid_recording(
             nbefore=nbefore,
             parent_recording=recording,
             upsample_vector=upsample_vector,
+            amplitude_factor=amplitude_factor,
         )
 
     return hybrid_recording, sorting


### PR DESCRIPTION
generate_hybrid_recording's `amplitude_std` is ignored when generating a static hybrid recording because `amplitude_factor` is not passed to `InjectTemplatesRecording`. 

`amplitude_std` works with drifting hybrid recordings because `amplitude_factor` is passed to `InjectDriftingTemplatesRecording`

Fixed by passing `amplitude_factor`

Repro:

```python
import spikeinterface.generation as sg
import spikeinterface.widgets as sw
import spikeinterface.full as si
from spikeinterface.preprocessing import correct_motion

rec_static, rec_drifting, gt_sorting, extra_infos = si.generate_drifting_recording(num_units=20, duration=90. ,seed=2205, extra_outputs=True)

_, motion_info = correct_motion(rec_drifting, preset="nonrigid_fast_and_accurate", n_jobs=8, progress_bar=True, output_motion_info=True)

def analyse_amplitudes(is_drifting, amplitude_std):
    hybrid_recording, hybrid_sorting = sg.generate_hybrid_recording(recording=rec_drifting, 
                                                                    seed=2308, 
                                                                    motion=motion_info["motion"] if is_drifting else None, 
                                                                    amplitude_std=amplitude_std)

    analyzer = si.create_sorting_analyzer(hybrid_sorting, hybrid_recording, format="memory", sparse=True)
    analyzer.compute(["random_spikes", "waveforms", "templates", "spike_amplitudes"], n_jobs=4)
    sw.plot_amplitudes(analyzer, unit_ids=analyzer.unit_ids[:5], plot_histograms=True)

# Clear difference in amplitude when motion is provided (making it a drifting hybrid recording)
analyse_amplitudes(True, 999)
analyse_amplitudes(True, 0.4)

# Amplitude has no effect for the static recording
analyse_amplitudes(False, 999)
analyse_amplitudes(False, 0.4)
```

