### PR TITLE
Skip pruning of macOS uv cache

### DIFF
--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           python-version: '3.11'
           enable-cache: true
+          prune-cache: ${{ runner.os != 'macOS' }} # the pruning fails on macOS all the time test skipping for macOS
       - name: Create the directory to store the data
         run: |
           mkdir -p  ~/spikeinterface_datasets/ephy_testing_data/


### PR DESCRIPTION
Our caching CI when merging into main keeps failing on macOS. This seems to be due to the pruning operation of uv timing out leading to a failure of the action. I've updated the action to skip pruning on macOS. Then we can always change the pruning in the future if decide that we need the macOS cache pruned. 

```
Post job cleanup.
UV_CACHE_DIR is already set to /Users/runner/work/_temp/setup-uv-cache
UV_PYTHON_INSTALL_DIR is already set to /Users/runner/work/_temp/uv-python-dir
Pruning cache...
/Users/runner/hostedtoolcache/uv/0.11.28/aarch64/uv cache prune --ci --force
No cache found at: /Users/runner/work/_temp/setup-uv-cache
Error: Cache path /Users/runner/work/_temp/setup-uv-cache does not exist on disk. This likely indicates that there are no dependencies to cache. Consider disabling the cache input if it is not needed.
```
error from a recent run included here. I think this will prevent it. Otherwise we would need to shut off caching completely on Mac. But we can start by trying to shut off pruning first.

Example: https://github.com/SpikeInterface/spikeinterface/actions/runs/29084757930/job/86335739439