### PR TITLE
Clean up code around create_sorting_analyzer and create/load_* functions in sortinganalyzer.py

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -19,6 +19,7 @@ from .core_tools import (
     clean_zarr_folder_name,
     is_dict_extractor,
     SIJsonEncoder,
+    is_path_remote,
     make_paths_relative,
     make_paths_absolute,
     check_paths_relative,
@@ -643,7 +644,7 @@ class BaseExtractor:
             extractor.load_metadata_from_folder(folder_metadata)
         return extractor
 
-    def load_metadata_from_folder(self, folder_metadata):
+    def load_metadata_from_folder(self, folder_metadata: str | Path):
         # hack to load probe for recording
         folder_metadata = Path(folder_metadata)
 
@@ -658,11 +659,11 @@ class BaseExtractor:
 
         self._extra_metadata_from_folder(folder_metadata)
 
-    def save_metadata_to_folder(self, folder_metadata):
+    def save_metadata_to_folder(self, folder_metadata: str | Path):
         self._extra_metadata_to_folder(folder_metadata)
 
         # save properties
-        prop_folder = folder_metadata / "properties"
+        prop_folder = Path(folder_metadata) / "properties"
         prop_folder.mkdir(parents=True, exist_ok=False)
         for key in self.get_property_keys():
             values = self.get_property(key)
@@ -1084,24 +1085,17 @@ class BaseExtractor:
             cache_folder = get_global_tmp_folder()
             if name is None:
                 name = "".join(random.choices(string.ascii_uppercase + string.digits, k=8))
-                zarr_path = cache_folder / f"{name}.zarr"
-                if verbose:
-                    print(f"Use zarr_path={zarr_path}")
-            else:
-                zarr_path = cache_folder / f"{name}.zarr"
-                if not is_set_global_tmp_folder():
-                    if verbose:
-                        print(f"Use zarr_path={zarr_path}")
+            zarr_path = (cache_folder / name).with_suffix(".zarr")
+            if verbose:
+                print(f"Saving to zarr_path={zarr_path}")
         else:
-            if storage_options is None:
+            if storage_options is None:  # save locally (not cloud storage)
                 folder = clean_zarr_folder_name(folder)
                 if folder.is_dir() and overwrite:
                     shutil.rmtree(folder)
-                zarr_path = folder
-            else:
-                zarr_path = folder
+            zarr_path = folder
 
-        if isinstance(zarr_path, Path):
+        if not is_path_remote(zarr_path):
             assert not zarr_path.exists(), f"Path {zarr_path} already exists, choose another name"
         save_kwargs["zarr_path"] = zarr_path
         save_kwargs["storage_options"] = storage_options

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -548,7 +548,7 @@ class BaseSorting(BaseExtractor):
         # Re-register the recording if saving to disk (not memory)
         if self.has_recording() and format != "memory":
             warnings.warn(
-                "The recording registered to this sorting object will not be saved to disk"
+                "The recording registered to this sorting object will not be saved to disk. "
                 "Reloading the sorting later will not include the recording"
             )
             cached.register_recording(self._recording)

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -344,7 +344,7 @@ class BaseSorting(BaseExtractor):
                 warnings.warn(
                     "Some spikes exceed the recording's duration! "
                     "Removing these excess spikes with `spikeinterface.curation.remove_excess_spikes()` "
-                    "Might be necessary for further postprocessing."
+                    "might be necessary for further postprocessing."
                 )
         self._recording = recording
         # Copy the recording's start times into the sorting segments. This way,
@@ -500,14 +500,16 @@ class BaseSorting(BaseExtractor):
         else:
             return None
 
-    def _save(self, format="numpy_folder", **save_kwargs):
-        """
-        This function replaces the old CachesortingExtractor, but enables more engines
+    def _save(self, format: str = "numpy_folder", **save_kwargs):
+        """ Save a sorting object to disk in a specified format.
+
+        Note
+        ----
+        This function replaces the old CacheSortingExtractor, but enables more engines
         for caching a results.
 
         Since v0.98.0 "numpy_folder" is used by defult.
         From v0.96.0 to 0.97.0 "npz_folder" was the default.
-
         """
         if format == "numpy_folder":
             from .sortingfolder import NumpyFolderSorting
@@ -515,10 +517,6 @@ class BaseSorting(BaseExtractor):
             folder = save_kwargs.pop("folder")
             NumpyFolderSorting.write_sorting(self, folder)
             cached = NumpyFolderSorting(folder)
-
-            if self.has_recording():
-                warnings.warn("The registered recording will not be persistent on disk, but only available in memory")
-                cached.register_recording(self._recording)
 
         elif format == "zarr":
             from .zarrextractors import ZarrSortingExtractor
@@ -528,20 +526,12 @@ class BaseSorting(BaseExtractor):
             ZarrSortingExtractor.write_sorting(self, zarr_path, storage_options, **save_kwargs)
             cached = ZarrSortingExtractor(zarr_path, storage_options)
 
-            if self.has_recording():
-                warnings.warn("The registered recording will not be persistent on disk, but only available in memory")
-                cached.register_recording(self._recording)
-
         elif format == "npz_folder":
             from .sortingfolder import NpzFolderSorting
 
             folder = save_kwargs.pop("folder")
             NpzFolderSorting.write_sorting(self, folder)
             cached = NpzFolderSorting(folder_path=folder)
-
-            if self.has_recording():
-                warnings.warn("The registered recording will not be persistent on disk, but only available in memory")
-                cached.register_recording(self._recording)
 
         elif format == "memory":
             if save_kwargs.get("sharedmem", True):
@@ -553,7 +543,14 @@ class BaseSorting(BaseExtractor):
 
                 cached = NumpySorting.from_sorting(self)
         else:
-            raise ValueError(f"format {format} not supported")
+            raise ValueError(f"Format {format} not supported")
+
+        # Re-register the recording if saving to disk (not memory)
+        if self.has_recording() and format != "memory":
+            warnings.warn("The recording registered to this sorting object will not be saved to disk" 
+                          "Reloading the sorting later will not include the recording")
+            cached.register_recording(self._recording)
+
         return cached
 
     def get_unit_property(self, unit_id, key):

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -501,7 +501,7 @@ class BaseSorting(BaseExtractor):
             return None
 
     def _save(self, format: str = "numpy_folder", **save_kwargs):
-        """ Save a sorting object to disk in a specified format.
+        """Save a sorting object to disk in a specified format.
 
         Note
         ----
@@ -547,8 +547,10 @@ class BaseSorting(BaseExtractor):
 
         # Re-register the recording if saving to disk (not memory)
         if self.has_recording() and format != "memory":
-            warnings.warn("The recording registered to this sorting object will not be saved to disk" 
-                          "Reloading the sorting later will not include the recording")
+            warnings.warn(
+                "The recording registered to this sorting object will not be saved to disk"
+                "Reloading the sorting later will not include the recording"
+            )
             cached.register_recording(self._recording)
 
         return cached

--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -207,11 +207,9 @@ def check_json(dictionary: dict) -> dict:
     return json.loads(json_string)
 
 
-def clean_zarr_folder_name(folder):
+def clean_zarr_folder_name(folder: str | Path) -> Path:
     folder = Path(folder)
-    if folder.suffix != ".zarr":
-        folder = folder.parent / f"{folder.stem}.zarr"
-    return folder
+    return folder if folder.suffix == ".zarr" else folder.with_suffix(".zarr")
 
 
 def add_suffix(file_path, possible_suffix):
@@ -772,7 +770,7 @@ def is_path_remote(path: str | Path) -> bool:
 
     Returns
     -------
-    bool
+    is_remote: bool
         Whether the path is a remote path.
     """
     return "s3://" in str(path) or "gcs://" in str(path)

--- a/src/spikeinterface/core/globals.py
+++ b/src/spikeinterface/core/globals.py
@@ -17,7 +17,7 @@ base = Path(tempfile.gettempdir()) / "spikeinterface_cache"
 temp_folder_set = False
 
 
-def get_global_tmp_folder():
+def get_global_tmp_folder() -> Path:
     """
     Get the global path temporary folder.
     """
@@ -30,7 +30,7 @@ def get_global_tmp_folder():
     return temp_folder
 
 
-def set_global_tmp_folder(folder):
+def set_global_tmp_folder(folder: str | Path):
     """
     Set the global path temporary folder.
     """

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -196,6 +196,7 @@ def create_sorting_analyzer(
         if sparsity_kwargs is None:
             sparsity_kwargs = {}
 
+    # Aggregate split recordings and sortings if they are provided as dicts
     if isinstance(sorting, dict) and isinstance(recording, dict):
 
         if sorting.keys() != recording.keys():
@@ -207,55 +208,54 @@ def create_sorting_analyzer(
         aggregated_sorting = aggregate_units(sorting)
 
         if sparsity is None:
-            if sparsity_kwargs.get("method", "") != "by_property" and not set_sparsity_by_dict_key:
+            if set_sparsity_by_dict_key:
+                # In this case we estimate and construct sparsity by property
+                sparsity_kwargs = {"method": "by_property", "by_property": "aggregation_key"}
+            elif sparsity_kwargs.get("method") != "by_property":
                 # In this case, we estimate the sparsity on different splitted groups and then we
                 # aggregate the sparsity_masks and main_channel_indices
                 from .template_tools import estimate_main_channel_from_recording
 
-                # In this case we estimate and construct sparsity by property
-                sparsity_mask = np.zeros(
-                    (aggregated_sorting.get_num_units(), aggregated_recording.get_num_channels()), dtype=bool
-                )
-                main_channel_indices = np.zeros(aggregated_sorting.get_num_units(), dtype=int)
-                i_unit = 0
-                i_channel = 0
-                for key in sorting.keys():
-                    recording_single = recording[key]
-                    sorting_single = sorting[key]
-                    num_units = sorting_single.get_num_units()
-                    num_channels = recording_single.get_num_channels()
+                num_total_units = aggregated_sorting.get_num_units()
+                num_total_channels = aggregated_recording.get_num_channels()
+                sparsity_mask = np.zeros((num_total_units, num_total_channels), dtype=bool)
+                main_channel_indices = np.full(num_total_units, -1, dtype=int)
+                unit_offset = 0
+                channel_offset = 0
+                for key, one_sorting in sorting.items():
+                    one_recording = recording[key]
+                    num_units = one_sorting.get_num_units()
+                    num_channels = one_recording.get_num_channels()
+                    unit_slice = slice(unit_offset, unit_offset + num_units)
+                    channel_slice = slice(channel_offset, channel_offset + num_channels)
 
-                    main_channel_indices_single = estimate_main_channel_from_recording(
-                        recording_single,
-                        sorting_single,
+                    one_main_channel_indices = estimate_main_channel_from_recording(
+                        one_recording,
+                        one_sorting,
                         peak_sign=peak_sign,
                         peak_mode=peak_mode,
                         num_spikes_for_main_channel=num_spikes_for_main_channel,
                         seed=seed,
                         **job_kwargs,
                     )
-                    sparsity_partial = estimate_sparsity(
-                        sorting_single,
-                        recording_single,
-                        main_channel_indices=main_channel_indices_single,
+                    main_channel_indices[unit_slice] = one_main_channel_indices + channel_offset
+                    one_sparsity = estimate_sparsity(
+                        one_sorting,
+                        one_recording,
+                        main_channel_indices=one_main_channel_indices,
                         peak_sign=peak_sign,
                         amplitude_mode=peak_mode,
                         **sparsity_kwargs,
                     )
-                    sparsity_mask[i_unit : i_unit + num_units, i_channel : i_channel + num_channels] = (
-                        sparsity_partial.mask
-                    )
-                    main_channel_indices[i_unit : i_unit + num_units] = main_channel_indices_single + i_channel
-                    i_unit += num_units
-                    i_channel += num_channels
-                sparsity = ChannelSparsity(
-                    unit_ids=aggregated_sorting.unit_ids,
-                    channel_ids=aggregated_recording.channel_ids,
-                    mask=sparsity_mask,
-                )
+                    sparsity_mask[unit_slice, channel_slice] = one_sparsity.mask
+
+                    unit_offset += num_units
+                    channel_offset += num_channels
+
+                sparsity = ChannelSparsity(unit_ids=aggregated_sorting.unit_ids,
+                                           channel_ids=aggregated_recording.channel_ids,
+                                           mask=sparsity_mask)
                 sparsity_kwargs = {}
-            elif set_sparsity_by_dict_key:
-                sparsity_kwargs = {"method": "by_property", "by_property": "aggregation_key"}
 
         return create_sorting_analyzer(
             sorting=aggregated_sorting,

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -170,7 +170,7 @@ def create_sorting_analyzer(
     """
     assert format in ["memory", "binary_folder", "zarr"], "Format must be 'memory', 'binary_folder' or 'zarr'."
 
-    # Remove folder if overwrite is True        
+    # Remove folder if overwrite is True
     if format != "memory":
         assert folder is not None, "For format='binary_folder'|'zarr', folder name must be provided"
         if not is_path_remote(folder):

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -168,7 +168,9 @@ def create_sorting_analyzer(
     In some situation, sparsity is not needed, so to make it fast creation, you need to turn
     sparsity off (or give external sparsity) like this.
     """
-    # Remove folder if overwrite is True
+    assert format in ["memory", "binary_folder", "zarr"], "Format must be 'memory', 'binary_folder' or 'zarr'."
+
+    # Remove folder if overwrite is True        
     if format != "memory":
         assert folder is not None, "For format='binary_folder'|'zarr', folder name must be provided"
         if not is_path_remote(folder):

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -40,7 +40,6 @@ from .sparsity import ChannelSparsity, estimate_sparsity
 from .sortingfolder import NumpyFolderSorting
 from .zarrextractors import get_default_zarr_compressor, ZarrSortingExtractor, super_zarr_open, _write_object_array
 from .node_pipeline import run_node_pipeline
-from .globals import get_global_job_kwargs
 
 # Typing hints
 PeakSignType = Literal["both", "neg", "pos"]
@@ -187,7 +186,7 @@ def create_sorting_analyzer(
         warnings.warn(
             "Passing sparsity and job arguments via keyword arguments will be deprecated in 0.106.0. "
             "Please pass them as a `sparsity_kwargs` or `job_kwargs` dictionary instead.",
-            FutureWarning,
+            category=FutureWarning,
             stacklevel=2,
         )
     else:
@@ -495,7 +494,7 @@ class SortingAnalyzer:
         if return_scaled is not None:
             warnings.warn(
                 "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
-                category=DeprecationWarning,
+                category=FutureWarning,
                 stacklevel=2,
             )
             return_in_uV = return_scaled if return_in_uV is None else return_in_uV
@@ -922,7 +921,7 @@ class SortingAnalyzer:
             # See https://github.com/SpikeInterface/spikeinterface/issues/2788
             warnings.warn(
                 "settings.json not found in this analyzer folder. Creating one with default settings.",
-                category=DeprecationWarning(),
+                category=FutureWarning,
                 stacklevel=2,
             )
             with open(settings_file, "w") as f:

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -20,7 +20,7 @@ import spikeinterface
 from spikeinterface.core import BaseRecording, BaseSorting, aggregate_channels, aggregate_units
 from spikeinterface.core.waveform_tools import has_exceeding_spikes
 
-from .recording_tools import get_rec_attributes, do_recording_attributes_match, check_probe_do_not_overlap
+from .recording_tools import get_rec_attributes, do_recording_attributes_match
 from .core_tools import (
     check_json,
     retrieve_importing_provenance,
@@ -42,27 +42,30 @@ from .zarrextractors import get_default_zarr_compressor, ZarrSortingExtractor, s
 from .node_pipeline import run_node_pipeline
 from .globals import get_global_job_kwargs
 
+# Typing hints
+PeakSignType = Literal["both", "neg", "pos"]
+PeakModeType = Literal["extremum", "at_index", "peak_to_peak"]
 
 # high level function
 def create_sorting_analyzer(
-    sorting,
-    recording,
-    format="memory",
-    folder=None,
-    main_channel_indices=None,
-    peak_sign="both",
-    peak_mode="extremum",
-    num_spikes_for_main_channel=100,
-    sparse=True,
-    sparsity=None,
-    set_sparsity_by_dict_key=False,
-    return_scaled=None,
-    return_in_uV=True,
-    overwrite=False,
-    backend_options=None,
-    seed=None,
-    sparsity_kwargs=None,
-    job_kwargs=None,
+    sorting: BaseSorting | dict[Any, BaseSorting],
+    recording: BaseRecording | dict[Any, BaseRecording],
+    format: Literal["memory", "binary_folder", "zarr"] = "memory",
+    folder: str | Path | None = None,
+    main_channel_indices: np.ndarray | None = None,
+    peak_sign: PeakSignType = "both",
+    peak_mode: PeakModeType = "extremum",
+    num_spikes_for_main_channel: int = 100,
+    seed: int | None = None,
+    sparse: bool = True,
+    sparsity: ChannelSparsity | None = None,
+    set_sparsity_by_dict_key: bool = False,
+    return_scaled: bool | None = None,
+    return_in_uV: bool = True,
+    overwrite: bool = False,
+    backend_options: dict[str, Any] | None = None,
+    sparsity_kwargs: dict[str, Any] | None = None,
+    job_kwargs: dict[str, Any] | None = None,
     **extra_kwargs,
 ) -> "SortingAnalyzer":
     """
@@ -85,7 +88,7 @@ def create_sorting_analyzer(
         The sorting object, or a dict of them
     recording : Recording | dict
         The recording object, or a dict of them
-    folder : str or Path or None, default: None
+    folder : str or Path
         The folder where analyzer is cached
     format : "memory | "binary_folder" | "zarr", default: "memory"
         The mode to store analyzer. If "folder", the analyzer is stored on disk in the specified folder.
@@ -102,6 +105,8 @@ def create_sorting_analyzer(
         * "peak_to_peak" : take the peak-to-peak amplitude
     num_spikes_for_main_channel : int, default: 100
         How many spikes per units to compute the main channel.
+    seed : int | None, default: None
+        Random seed for reproducibility when estimating main channel indices. None means no seed is set.
     sparse : bool, default: True
         If True, then a sparsity mask is computed using the `estimate_sparsity()` function using
         a few spikes to get an estimate of dense templates to create a ChannelSparsity object.
@@ -256,44 +261,31 @@ def create_sorting_analyzer(
             **job_kwargs,
         )
 
-    if format != "memory" and not is_path_remote(folder):
-        folder = clean_zarr_folder_name(folder) if format == "zarr" else folder
-        if Path(folder).is_dir():
-            if overwrite:
-                shutil.rmtree(folder)
-            else:
-                raise ValueError(f"Folder {folder} already exists! Use overwrite=True to overwrite it.")
-
-    if main_channel_indices is not None:
-        if len(main_channel_indices) != sorting.get_num_units():
-            raise ValueError("len(main_channel_indices) must equal the number of units in the `sorting`")
-
-    if main_channel_indices is not None and sparsity is None and sparsity_kwargs.get("method") != "radius":
-        raise ValueError(
-            'You can either pass `main_channel_indices` or a sparsity method not equal to "radius", but not both.'
-        )
-
-    # retrieve or compute the main channel index per unit id
-    if main_channel_indices is None:
+    # Handle main_channel_indices
+    if main_channel_indices is None:  # retrieve or compute it
         if "main_channel_id" in sorting.get_property_keys():
-            main_channel_ids = sorting.get_property("main_channel_id")
-            main_channel_indices = recording.ids_to_indices(main_channel_ids)
+            main_channel_indices = recording.ids_to_indices(sorting.get_property("main_channel_id"))
+        else:
+            # this is weird but due to the cyclic import
+            from .template_tools import estimate_main_channel_from_recording
 
-    if main_channel_indices is None:
-        # this is weird but due to the cyclic import
-        from .template_tools import estimate_main_channel_from_recording
+            main_channel_indices = estimate_main_channel_from_recording(
+                recording,
+                sorting,
+                peak_sign=peak_sign,
+                peak_mode=peak_mode,
+                num_spikes_for_main_channel=num_spikes_for_main_channel,
+                seed=seed,
+                **job_kwargs,
+            )
+    else:  # main_channel_indices provided as argument
+        assert len(main_channel_indices) == sorting.get_num_units(
+        ), "len(main_channel_indices) must equal the number of units in the `sorting`"
+        if sparsity is None and sparse:  # sparsity needs to be calculated
+            sparsity_method = sparsity_kwargs.get("method", "radius")  # default method is radius
+            assert sparsity_method == "radius", 'If you pass `main_channel_indices`, you need to use sparsity method "radius"'
 
-        main_channel_indices = estimate_main_channel_from_recording(
-            recording,
-            sorting,
-            peak_sign=peak_sign,
-            peak_mode=peak_mode,
-            num_spikes_for_main_channel=num_spikes_for_main_channel,
-            seed=seed,
-            **job_kwargs,
-        )
-
-    # handle sparsity
+    # Handle sparsity
     if sparsity is not None:
         # some checks
         assert isinstance(sparsity, ChannelSparsity), "'sparsity' must be a ChannelSparsity object"
@@ -325,11 +317,25 @@ def create_sorting_analyzer(
             category=FutureWarning,
             stacklevel=2,
         )
-        return_in_uV = return_scaled
+        return_in_uV = return_scaled if return_in_uV is None else return_in_uV
 
+    # Handle return_in_uV parameter for recordings without scaling
     if return_in_uV and not recording.has_scaleable_traces() and recording.get_dtype().kind == "i":
-        print("create_sorting_analyzer: recording does not have scaling to uV, forcing return_in_uV=False")
+        warnings.warn(
+            "create_sorting_analyzer: recording does not have scaling to uV, forcing return_in_uV=False"
+        )
         return_in_uV = False
+
+    # Remove folder if overwrite is True
+    if format != "memory":
+        assert folder is not None, "For format='binary_folder'|'zarr', folder name must be provided"
+        if not is_path_remote(folder):
+            folder = clean_zarr_folder_name(folder) if format == "zarr" else Path(folder)
+            if folder.exists():
+                if overwrite:
+                    shutil.rmtree(folder)
+                else:
+                    raise ValueError(f"Folder {folder} already exists! Use overwrite=True to overwrite it.")
 
     sorting_analyzer = SortingAnalyzer.create(
         sorting,
@@ -383,12 +389,12 @@ class SortingAnalyzer:
     Class to make a pair of Recording-Sorting which will be used used for all post postprocessing,
     visualization and quality metric computation.
 
-    This internally maintains a list of computed ResultExtention (waveform, pca, unit position, spike position, ...).
+    This internally maintains a list of computed Extension (waveform, pca, unit position, spike position, ...).
 
     This can live in memory and/or can be be persistent to disk in 2 internal formats (folder/json/npz or zarr).
     A SortingAnalyzer can be transfer to another format using `save_as()`
 
-    This handle unit sparsity that can be propagated to ResultExtention.
+    This handle unit sparsity that can be propagated to Extension.
 
     This handle spike sampling that can be propagated to ResultExtention : works on only a subset of spikes.
 
@@ -396,7 +402,7 @@ class SortingAnalyzer:
     the SortingAnalyzer object can be reloaded even if references to the original sorting and/or to the original recording
     are lost.
 
-    SortingAnalyzer() should not never be used directly for creating: use instead create_sorting_analyzer(sorting, resording, ...)
+    SortingAnalyzer() should never be used directly for creating: use instead create_sorting_analyzer(sorting, resording, ...)
     or eventually SortingAnalyzer.create(...)
     """
 
@@ -408,8 +414,8 @@ class SortingAnalyzer:
         format: str | None = None,
         sparsity: ChannelSparsity | None = None,
         return_in_uV: bool = True,
-        peak_sign: Literal["both", "neg", "pos"] = "both",
-        peak_mode: Literal["extremum", "at_index", "peak_to_peak"] = "extremum",
+        peak_sign: PeakSignType = "both",
+        peak_mode: PeakModeType = "extremum",
         backend_options: dict | None = None,
     ):
         # very fast init because checks are done in load and create
@@ -448,9 +454,8 @@ class SortingAnalyzer:
         nchan = self.get_num_channels()
         nunits = self.get_num_units()
         txt = f"{clsname}: {nchan} channels - {nunits} units - {nseg} segments - {self.format}"
-        if self.format != "memory":
-            if is_path_remote(str(self.folder)):
-                txt += f" (remote)"
+        if self.format != "memory" and is_path_remote(self.folder):
+            txt += " (remote)"
         if self.is_sparse():
             txt += " - sparse"
         if self.has_recording():
@@ -470,24 +475,25 @@ class SortingAnalyzer:
         cls,
         sorting: BaseSorting,
         recording: BaseRecording,
-        format: Literal[
-            "memory",
-            "binary_folder",
-            "zarr",
-        ] = "memory",
-        folder=None,
-        main_channel_indices=None,
-        sparsity=None,
-        return_scaled=None,
-        return_in_uV=True,
-        peak_sign="both",
-        peak_mode="extremum",
-        backend_options=None,
+        main_channel_indices: np.ndarray,
+        format: Literal["memory", "binary_folder", "zarr"] = "memory",
+        folder: str | Path | None = None,
+        sparsity: ChannelSparsity | None = None,
+        return_scaled: bool | None = None,
+        return_in_uV: bool = True,
+        peak_sign: PeakSignType = "both",
+        peak_mode: PeakModeType = "extremum",
+        backend_options: dict[str, Any] | None = None,
     ):
         assert recording is not None, "To create a SortingAnalyzer you need to specify the recording"
-        assert (
-            main_channel_indices is not None
-        ), "To create a SortingAnalyzer you need to specify the main_channel_indices"
+        assert main_channel_indices is not None, "To create a SortingAnalyzer you need to specify the main_channel_indices"
+        if return_scaled is not None:
+            warnings.warn(
+                "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            return_in_uV = return_scaled if return_in_uV is None else return_in_uV
 
         # some checks
         if sorting.sampling_frequency != recording.sampling_frequency:
@@ -505,8 +511,6 @@ class SortingAnalyzer:
                     f"recording: {recording.sampling_frequency} - sorting: {sorting.sampling_frequency}. "
                     "Ensure that you are associating the correct Recording and Sorting when creating a SortingAnalyzer."
                 )
-        # check that multiple probes are non-overlapping
-        all_probes = recording.get_probegroup().probes
 
         if has_exceeding_spikes(sorting=sorting, recording=recording):
             warnings.warn(
@@ -517,6 +521,7 @@ class SortingAnalyzer:
 
             sorting = RemoveExcessSpikesSorting(sorting=sorting, recording=recording)
 
+        # Create the sorting analyzer based on the specified format
         if format == "memory":
             sorting_analyzer = cls.create_memory(
                 sorting,
@@ -528,6 +533,7 @@ class SortingAnalyzer:
                 rec_attributes=None,
             )
         elif format == "binary_folder":
+            assert folder is not None, "For format='binary_folder' folder must be provided"
             sorting_analyzer = cls.create_binary_folder(
                 folder,
                 sorting,
@@ -541,8 +547,6 @@ class SortingAnalyzer:
             )
         elif format == "zarr":
             assert folder is not None, "For format='zarr' folder must be provided"
-            if not is_path_remote(folder):
-                folder = clean_zarr_folder_name(folder)
             sorting_analyzer = cls.create_zarr(
                 folder,
                 sorting,
@@ -555,15 +559,23 @@ class SortingAnalyzer:
                 backend_options=backend_options,
             )
         else:
-            raise ValueError("SortingAnalyzer.create: wrong format")
+            raise ValueError(f"SortingAnalyzer.create: wrong format {format}")
 
+        # Store main_channel_ids in analyzer
         main_channel_ids = sorting_analyzer.channel_ids[main_channel_indices]
         sorting_analyzer.set_sorting_property("main_channel_id", main_channel_ids, save=True)
 
         return sorting_analyzer
 
     @classmethod
-    def load(cls, folder, recording=None, load_extensions=True, format="auto", backend_options=None):
+    def load(
+        cls,
+        folder: str | Path,
+        recording: BaseRecording | None = None,
+        load_extensions: bool = True,
+        format: Literal["auto", "binary_folder", "zarr"] = "auto",
+        backend_options: dict | None = None,
+    ):
         """
         Load folder or zarr.
         The recording can be given if the recording location has changed.
@@ -571,10 +583,8 @@ class SortingAnalyzer:
         """
         if format == "auto":
             # make better assumption and check for auto guess format
-            if Path(folder).suffix == ".zarr" or is_path_remote(folder):
-                format = "zarr"
-            else:
-                format = "binary_folder"
+            is_zarr = Path(folder).suffix == ".zarr" or is_path_remote(folder)
+            format = "zarr" if is_zarr else "binary_folder"
 
         if format == "binary_folder":
             sorting_analyzer = SortingAnalyzer.load_from_binary_folder(
@@ -584,16 +594,25 @@ class SortingAnalyzer:
             sorting_analyzer = SortingAnalyzer.load_from_zarr(
                 folder, recording=recording, backend_options=backend_options
             )
+        else:
+            raise ValueError(f"SortingAnalyzer.load: wrong format {format}")
 
-        if not is_path_remote(str(folder)):
-            if load_extensions:
-                sorting_analyzer.load_all_saved_extension()
+        if load_extensions and not is_path_remote(folder):
+            sorting_analyzer.load_all_saved_extension()
 
         return sorting_analyzer
 
     @classmethod
     def create_memory(
-        cls, sorting, recording, sparsity, return_in_uV, peak_sign, peak_mode, rec_attributes, copy_sorting=True
+        cls,
+        sorting: BaseSorting,
+        recording: BaseRecording,
+        sparsity: ChannelSparsity | None,
+        return_in_uV: bool,
+        peak_sign: PeakSignType,
+        peak_mode: PeakModeType,
+        rec_attributes: dict | None,
+        copy_sorting: bool = True,
     ):
         # used by create and save_as
 
@@ -629,89 +648,98 @@ class SortingAnalyzer:
     @classmethod
     def create_binary_folder(
         cls,
-        folder,
-        sorting,
-        recording,
-        sparsity,
-        return_in_uV,
-        peak_sign,
-        peak_mode,
-        rec_attributes,
-        backend_options,
+        folder: str | Path,
+        sorting: BaseSorting,
+        recording: BaseRecording,
+        sparsity: ChannelSparsity | None,
+        return_in_uV: bool,
+        peak_sign: PeakSignType,
+        peak_mode: PeakModeType,
+        rec_attributes: dict | None,
+        backend_options: dict | None,
     ):
         # used by create and save_as
-
         folder = Path(folder)
+        if is_path_remote(folder):
+            raise ValueError(f"Folder {folder} is a remote path. Use format='zarr' for remote paths.")
         if folder.is_dir():
             raise ValueError(f"Folder already exists {folder}")
-        folder.mkdir(parents=True)
 
-        info_file = folder / f"spikeinterface_info.json"
-        info = dict(
-            version=spikeinterface.__version__,
-            dev_mode=spikeinterface.DEV_MODE,
-            object="SortingAnalyzer",
-        )
+        # Create main analyzer folder (and recording info folder)
+        folder.mkdir(parents=True)
+        recording_info_folder = folder / "recording_info"  # to save rec_attributes and probe group
+        recording_info_folder.mkdir()
+
+        # Set names for output files
+        info_file = folder / "spikeinterface_info.json"
+        settings_file = folder / "settings.json"
+        sorting_folder = folder / "sorting"
+        sorting_provenance_file = folder / "sorting_provenance.json"
+        sparsity_file = folder / "sparsity_mask.npy"
+        recording_provenance_file = folder / "recording.json"
+        rec_attributes_file = recording_info_folder / "recording_attributes.json"
+        probegroup_file = recording_info_folder / "probegroup.json"
+
+        # Save general info
+        info = {
+            "version": spikeinterface.__version__, "dev_mode": spikeinterface.DEV_MODE,
+            "object": "SortingAnalyzer"}
         with open(info_file, mode="w") as f:
             json.dump(check_json(info), f, indent=4)
 
-        # save a copy of the sorting
-        sorting.save(folder=folder / "sorting")
+        # Save settings
+        settings = {'return_in_uV': return_in_uV, 'peak_sign': peak_sign, 'peak_mode': peak_mode}
+        with open(settings_file, mode="w") as f:
+            json.dump(check_json(settings), f, indent=4)
 
+        # Save the sorting output
+        sorting.save(folder=sorting_folder)
+
+        # Dump sorting provenance
+        if sorting.check_serializability("json"):
+            sorting.dump(sorting_provenance_file, relative_to=folder)
+        elif sorting.check_serializability("pickle"):
+            sorting.dump(sorting_provenance_file.with_suffix(".pickle"), relative_to=folder)
+        else:
+            warnings.warn(
+                "The sorting provenance is not serializable! The sorting provenance link will be lost for future load"
+            )
+
+        # Save sparsity
+        if sparsity is not None:
+            np.save(sparsity_file, sparsity.mask)
+
+        # Dump recording provenance
         if recording is not None:
             # save recording and sorting provenance
             if recording.check_serializability("json"):
-                recording.dump(folder / "recording.json", relative_to=folder)
+                recording.dump(recording_provenance_file, relative_to=folder)
             elif recording.check_serializability("pickle"):
-                recording.dump(folder / "recording.pickle", relative_to=folder)
+                recording.dump(recording_provenance_file.with_suffix(".pickle"), relative_to=folder)
             else:
                 warnings.warn("The Recording is not serializable! The recording link will be lost for future load")
         else:
             assert rec_attributes is not None, "recording or rec_attributes must be provided"
             warnings.warn("Recording not provided, instantiating SortingAnalyzer in recordingless mode.")
 
-        if sorting.check_serializability("json"):
-            sorting.dump(folder / "sorting_provenance.json", relative_to=folder)
-        elif sorting.check_serializability("pickle"):
-            sorting.dump(folder / "sorting_provenance.pickle", relative_to=folder)
+        # Save recording attributes
+        has_rec_attributes = rec_attributes is not None
+        if has_rec_attributes:
+            rec_attributes_to_save = rec_attributes.copy()
+            rec_attributes_to_save.pop("probegroup")
         else:
-            warnings.warn(
-                "The sorting provenance is not serializable! The sorting provenance link will be lost for future load"
-            )
+            rec_attributes_to_save = get_rec_attributes(recording)
+        rec_attributes_file.write_text(json.dumps(check_json(rec_attributes_to_save), indent=4), encoding="utf8")
 
-        # dump recording attributes
-        probegroup = None
-        rec_attributes_file = folder / "recording_info" / "recording_attributes.json"
-        rec_attributes_file.parent.mkdir()
-        if rec_attributes is None:
-            rec_attributes = get_rec_attributes(recording)
-            rec_attributes_file.write_text(json.dumps(check_json(rec_attributes), indent=4), encoding="utf8")
-            probegroup = recording.get_probegroup()
-        else:
-            rec_attributes_copy = rec_attributes.copy()
-            probegroup = rec_attributes_copy.pop("probegroup")
-            rec_attributes_file.write_text(json.dumps(check_json(rec_attributes_copy), indent=4), encoding="utf8")
-
+        # Save probegroup
+        probegroup = rec_attributes["probegroup"] if has_rec_attributes else recording.get_probegroup()
         if probegroup is not None:
-            probegroup_file = folder / "recording_info" / "probegroup.json"
             probeinterface.write_probeinterface(probegroup_file, probegroup)
-
-        if sparsity is not None:
-            np.save(folder / "sparsity_mask.npy", sparsity.mask)
-
-        settings_file = folder / f"settings.json"
-        settings = dict(
-            return_in_uV=return_in_uV,
-            peak_sign=peak_sign,
-            peak_mode=peak_mode,
-        )
-        with open(settings_file, mode="w") as f:
-            json.dump(check_json(settings), f, indent=4)
 
         return cls.load_from_binary_folder(folder, recording=recording, backend_options=backend_options)
 
     @classmethod
-    def _handle_backward_compatibility_settings_pre_init(cls, settings, sorting, sparsity):
+    def _handle_backward_compatibility_settings_pre_init(cls, settings : dict[str, Any]):
         """
         backward compatibility before the __init__ to handle the settings:
           * return_scaled > return_in_uV
@@ -720,21 +748,18 @@ class SortingAnalyzer:
 
         Note :
          * see also _handle_backward_compatibility_settings_post_init
-         * there is also something at extension level to handle changes in parameters with deferents mechanism
+         * there is also something at extension level to handle changes in paramaters with different mechanisms
         """
 
-        new_settings = dict()
-        new_settings.update(settings)
-        if "return_scaled" in settings:
-            new_settings["return_in_uV"] = new_settings.pop("return_scaled")
-        elif "return_in_uV" in settings:
-            pass
+        new_settings = settings.copy()
+        if "return_in_uV" not in new_settings:
+            # use return_scaled if available, else set to True (for older versions without settings)
+            new_settings["return_in_uV"] = new_settings.pop("return_scaled", True)
         else:
-            # old version did not have settings at all
-            new_settings["return_in_uV"] = True
+            new_settings.pop("return_scaled", None)
 
-        if "peak_sign" not in settings:
-            # before 0.104.0 peak_sign was not in settings.
+        if "peak_sign" not in new_settings:
+            # before 0.104.1 peak_sign was not in settings.
             # TODO make something more fancy that explore the previous params of extension
             # We decided to not do something fancy, as the `peak_sign`s in different
             # extensions may not match the `peak_sign` that was used to create the analyzer.
@@ -782,7 +807,7 @@ class SortingAnalyzer:
         """
 
         warnings.warn(
-            "This sorting analyzer is from an an older version of spikeinterface. "
+            "This sorting analyzer is from an an older version of spikeinterface (<0.105.0). "
             "For future compatibility we will compute the `main_channel_indices`. "
             "To keep this information on disk, please save your analyzer using `analyzer.save_as()`."
         )
@@ -851,21 +876,61 @@ class SortingAnalyzer:
         )
 
     @classmethod
-    def load_from_binary_folder(cls, folder, recording=None, backend_options=None):
+    def load_from_binary_folder(
+        cls,
+        folder: str | Path,
+        recording: BaseRecording | None = None,
+        backend_options: dict | None = None,
+    ):
         from .loading import load
 
         folder = Path(folder)
-        assert folder.is_dir(), f"This folder does not exists {folder}"
+        assert folder.is_dir(), f"Folder {folder} does not exist"
+        assert not is_path_remote(folder), f"Folder {folder} is a remote path. Use load_from_zarr for remote paths."
 
-        # load internal sorting copy in memory
-        sorting = NumpySorting.from_sorting(
-            NumpyFolderSorting(folder / "sorting"), with_metadata=True, copy_spike_vector=True
-        )
+        # Expected file names (as saved in create_binary_folder)
+        settings_file = folder / "settings.json"
+        sorting_folder = folder / "sorting"
+        sparsity_file = folder / "sparsity_mask.npy"
+        recording_provenance_file = folder / "recording.json"
+        rec_attributes_file = folder / "recording_info" / "recording_attributes.json"
+        probegroup_file = folder / "recording_info" / "probegroup.json"
 
-        # Try to load the recording if not provided
+        # Check that rec_attributes_file exists, otherwise this is not a valid SortingAnalyzer folder
+        if not rec_attributes_file.exists():
+            raise ValueError("This folder is not a SortingAnalyzer with format='binary_folder'")
+
+        # Load settings file
+        analyzer_has_settings_file = settings_file.exists()
+        if analyzer_has_settings_file:
+            with open(settings_file, "r") as f:
+                settings = json.load(f)
+        else:
+            # TODO: Remove support for analyzers that have no settings.json (throw an error instead)
+
+            settings = dict()
+        settings = cls._handle_backward_compatibility_settings_pre_init(settings)
+
+        # Create settings file (if not originally in the analyzer)
+        if not analyzer_has_settings_file:
+            # PATCH: Because SortingAnalyzer added settings.json during the development of 0.101.0 we need to save
+            # this as a bridge for early adopters. The else branch can be removed in version 0.102.0/0.103.0
+            # so that this can be simplified in the future
+            # See https://github.com/SpikeInterface/spikeinterface/issues/2788
+            warnings.warn(
+                "settings.json not found in this analyzer folder. Creating one with default settings.",
+                category=DeprecationWarning(), stacklevel=2)
+            with open(settings_file, "w") as f:
+                json.dump(check_json(settings), f, indent=4)
+
+        # Load sorting (in memory)
+        sorting = NumpySorting.from_sorting(NumpyFolderSorting(sorting_folder), with_metadata=True,
+                                            copy_spike_vector=True)
+
+        # Load recording (if available)
         if recording is None:
-            for file_ext in ("json", "pickle"):
-                filename = folder / f"recording.{file_ext}"
+            for file_ext in (".json", ".pickle"):
+                filename = recording_provenance_file.with_suffix(file_ext)
                 if filename.exists():
                     try:
                         recording = load(filename, base_folder=folder)
@@ -873,48 +938,20 @@ class SortingAnalyzer:
                     except:
                         pass
 
-        # recording attributes
-        rec_attributes_file = folder / "recording_info" / "recording_attributes.json"
-        if not rec_attributes_file.exists():
-            raise ValueError("This folder is not a SortingAnalyzer with format='binary_folder'")
+        # Load recording attributes
         with open(rec_attributes_file, "r") as f:
             rec_attributes = json.load(f)
-        # the probe is handle ouside the main json
-        probegroup_file = folder / "recording_info" / "probegroup.json"
 
-        if probegroup_file.is_file():
-            rec_attributes["probegroup"] = probeinterface.read_probeinterface(probegroup_file)
-        else:
-            rec_attributes["probegroup"] = None
+        # Load probe group
+        rec_attributes["probegroup"] = (probeinterface.read_probeinterface(probegroup_file)
+                                        if probegroup_file.exists() else None)
 
-        # sparsity
-        sparsity_file = folder / "sparsity_mask.npy"
-        if sparsity_file.is_file():
+        # Load sparsity
+        if sparsity_file.exists():
             sparsity_mask = np.load(sparsity_file)
             sparsity = ChannelSparsity(sparsity_mask, sorting.unit_ids, rec_attributes["channel_ids"])
         else:
             sparsity = None
-
-        # PATCH: Because SortingAnalyzer added this json during the development of 0.101.0 we need to save
-        # this as a bridge for early adopters. The else branch can be removed in version 0.102.0/0.103.0
-        # so that this can be simplified in the future
-        # See https://github.com/SpikeInterface/spikeinterface/issues/2788
-
-        settings_file = folder / f"settings.json"
-        if settings_file.exists():
-            with open(settings_file, "r") as f:
-                settings = json.load(f)
-            need_to_create = False
-        else:
-            need_to_create = True
-            settings = dict()
-
-        settings = cls._handle_backward_compatibility_settings_pre_init(settings, sorting, sparsity)
-
-        if need_to_create:
-            warnings.warn("settings.json not found for this folder writing one with return_in_uV=True")
-            with open(settings_file, "w") as f:
-                json.dump(check_json(settings), f, indent=4)
 
         sorting_analyzer = SortingAnalyzer(
             sorting=sorting,
@@ -941,47 +978,70 @@ class SortingAnalyzer:
     @classmethod
     def create_zarr(
         cls,
-        folder,
-        sorting,
-        recording,
-        sparsity,
-        return_in_uV,
-        peak_sign,
-        peak_mode,
-        rec_attributes,
-        backend_options,
+        folder : str | Path,
+        sorting : BaseSorting,
+        recording : BaseRecording,
+        sparsity : ChannelSparsity | None,
+        return_in_uV : bool,
+        peak_sign : PeakSignType,
+        peak_mode : PeakModeType,
+        rec_attributes : dict | None,
+        backend_options: dict | None,
     ):
         # used by create and save_as
         import zarr
         from .zarrextractors import add_sorting_to_zarr_group
 
-        if is_path_remote(folder):
-            remote = True
-        else:
-            remote = False
-        if not remote:
+        is_remote = is_path_remote(folder)
+        if not is_remote:
             folder = clean_zarr_folder_name(folder)
-            if folder.is_dir():
+            if folder.exists():
                 raise ValueError(f"Folder already exists {folder}")
 
+        # Read backend options
         backend_options = {} if backend_options is None else backend_options
         storage_options = backend_options.get("storage_options", {})
         saving_options = backend_options.get("saving_options", {})
 
+        # Create zarr root group (and subgroups)
         zarr_root = zarr.open(folder, mode="w", storage_options=storage_options)
+        sorting_group = zarr_root.create_group("sorting")  # for sorting output
+        recording_info_group = zarr_root.create_group("recording_info")  # rec_attributes and probe group
+        zarr_root.create_group("extensions")  # used later
 
-        info = dict(version=spikeinterface.__version__, dev_mode=spikeinterface.DEV_MODE, object="SortingAnalyzer")
+        # Save general info
+        info = {
+            "version": spikeinterface.__version__, "dev_mode": spikeinterface.DEV_MODE,
+            "object": "SortingAnalyzer"}
         zarr_root.attrs["spikeinterface_info"] = check_json(info)
 
-        settings = dict(
-            return_in_uV=return_in_uV,
-            peak_sign=peak_sign,
-            peak_mode=peak_mode,
-        )
+        # Save settings
+        settings = {"return_in_uV": return_in_uV, "peak_sign": peak_sign, "peak_mode": peak_mode}
         zarr_root.attrs["settings"] = check_json(settings)
 
-        # the recording
-        relative_to = folder if not remote else None
+        # Save the sorting output
+        add_sorting_to_zarr_group(sorting, sorting_group, **saving_options)
+
+        # Dump sorting provenance
+        relative_to = None if is_remote else folder
+        sort_dict = sorting.to_dict(relative_to=relative_to, recursive=True)
+        if sorting.check_serializability("json"):
+            _write_object_array(zarr_root, "sorting_provenance", check_json(sort_dict), codec="json")
+        elif sorting.check_serializability("pickle"):
+            try:
+                _write_object_array(zarr_root, "sorting_provenance", sort_dict, codec="pickle")
+            except:
+                warnings.warn("Failed to serialize sorting provenance with Pickle Codec! "
+                              "The sorting provenance link will be lost for future load")
+        else:
+            warnings.warn("The sorting provenance is not serializable! "
+                          "The sorting provenance link will be lost for future load")
+
+        # Save sparsity
+        if sparsity is not None:
+            zarr_root.create_dataset("sparsity_mask", data=sparsity.mask, **saving_options)
+
+        # Dump recording provenance
         if recording is not None:
             rec_dict = recording.to_dict(relative_to=relative_to, recursive=True)
             if recording.check_serializability("json"):
@@ -994,81 +1054,64 @@ class SortingAnalyzer:
             assert rec_attributes is not None, "recording or rec_attributes must be provided"
             warnings.warn("Recording not provided, instntiating SortingAnalyzer in recordingless mode.")
 
-        # sorting provenance
-        sort_dict = sorting.to_dict(relative_to=relative_to, recursive=True)
-        if sorting.check_serializability("json"):
-            _write_object_array(zarr_root, "sorting_provenance", check_json(sort_dict), codec="json")
-        elif sorting.check_serializability("pickle"):
-            try:
-                _write_object_array(zarr_root, "sorting_provenance", sort_dict, codec="pickle")
-            except Exception as e:
-                warnings.warn(
-                    "Failed to serialize sorting provenance with Pickle Codec! "
-                    "The sorting provenance link will be lost for future load"
-                )
+        # Save recording attributes
+        has_rec_attributes = rec_attributes is not None
+        if has_rec_attributes:
+            rec_attributes_to_save = rec_attributes.copy()
+            rec_attributes_to_save.pop("probegroup")
         else:
-            warnings.warn(
-                "The sorting provenance is not serializable! "
-                "The sorting provenance link will be lost for future load"
-            )
+            rec_attributes_to_save = get_rec_attributes(recording)
+        recording_info_group.attrs["recording_attributes"] = check_json(rec_attributes_to_save)
 
-        recording_info = zarr_root.create_group("recording_info")
-
-        if rec_attributes is None:
-            rec_attributes = get_rec_attributes(recording)
-            probegroup = recording.get_probegroup()
-        else:
-            rec_attributes = rec_attributes.copy()
-            probegroup = rec_attributes.pop("probegroup")
-
-        recording_info.attrs["recording_attributes"] = check_json(rec_attributes)
-
+        # Save probegroup
+        probegroup = rec_attributes["probegroup"] if has_rec_attributes else recording.get_probegroup()
         if probegroup is not None:
-            recording_info.attrs["probegroup"] = check_json(probegroup.to_dict())
+            recording_info_group.attrs["probegroup"] = check_json(probegroup.to_dict())
 
-        if sparsity is not None:
-            zarr_root.create_dataset("sparsity_mask", data=sparsity.mask, **saving_options)
-
-        add_sorting_to_zarr_group(sorting, zarr_root.create_group("sorting"), **saving_options)
-
-        recording_info = zarr_root.create_group("extensions")
-
+        # Consolidate metadata (for faster reads)
         zarr.consolidate_metadata(zarr_root.store)
 
         return cls.load_from_zarr(folder, recording=recording, backend_options=backend_options)
 
     @classmethod
-    def load_from_zarr(cls, folder, recording=None, backend_options=None):
+    def load_from_zarr(
+        cls,
+        folder: str | Path,
+        recording: BaseRecording | None = None,
+        backend_options: dict | None = None,
+    ):
         import zarr
         from .loading import load
 
         backend_options = {} if backend_options is None else backend_options
         storage_options = backend_options.get("storage_options", {})
 
+        # Open root group
         zarr_root = super_zarr_open(str(folder), mode="r", storage_options=storage_options)
 
+        # Consolidate metadata (if needed)
+        # v0.101.0 did not have a consolidate metadata step after computing extensions.
+        # Here we try to consolidate the metadata and throw a warning if it fails.
         si_info = zarr_root.attrs["spikeinterface_info"]
         if parse(si_info["version"]) < parse("0.101.1"):
-            # v0.101.0 did not have a consolidate metadata step after computing extensions.
-            # Here we try to consolidate the metadata and throw a warning if it fails.
             try:
                 zarr_root_a = zarr.open(str(folder), mode="a", storage_options=storage_options)
                 zarr.consolidate_metadata(zarr_root_a.store)
-            except Exception as e:
-                warnings.warn(
-                    "The zarr store was not properly consolidated prior to v0.101.1. "
-                    "This may lead to unexpected behavior in loading extensions. "
-                    "Please consider re-generating the SortingAnalyzer object."
-                )
+            except:
+                warnings.warn("The zarr store was not consolidated prior to v0.101.1. "
+                              "This may lead to unexpected behavior in loading extensions. "
+                              "Consider re-generating the SortingAnalyzer object.")
 
-        # load internal sorting in memory
+        # Load settings
+        settings = zarr_root.attrs["settings"]
+        settings = cls._handle_backward_compatibility_settings_pre_init(settings)
+
+        # Load sorting (in memory)
         sorting = NumpySorting.from_sorting(
             ZarrSortingExtractor(folder, zarr_group="sorting", storage_options=storage_options),
-            with_metadata=True,
-            copy_spike_vector=True,
-        )
+            with_metadata=True, copy_spike_vector=True)
 
-        # load recording if possible
+        # Load recording (if available)
         if recording is None:
             rec_field = zarr_root.get("recording")
             if rec_field is not None:
@@ -1076,30 +1119,23 @@ class SortingAnalyzer:
                 try:
                     recording = load(rec_dict, base_folder=folder)
                 except:
-                    recording = None
-        else:
-            # TODO maybe maybe not??? : do we need to check  attributes match internal rec_attributes
-            # Note this will make the loading too slow
-            pass
+                    pass
 
-        # recording attributes
+        # Load recording attributes
         rec_attributes = zarr_root["recording_info"].attrs["recording_attributes"]
-        if "probegroup" in zarr_root["recording_info"].attrs:
-            probegroup_dict = zarr_root["recording_info"].attrs["probegroup"]
-            rec_attributes["probegroup"] = probeinterface.ProbeGroup.from_dict(probegroup_dict)
-        else:
-            rec_attributes["probegroup"] = None
 
-        # sparsity
+        # Load probegroup
+        probegroup_dict = zarr_root["recording_info"].attrs.get("probegroup")
+        rec_attributes["probegroup"] = (probeinterface.ProbeGroup.from_dict(probegroup_dict)
+                                        if probegroup_dict is not None else None)
+
+        # Load sparsity
         if "sparsity_mask" in zarr_root:
             sparsity = ChannelSparsity(
                 np.array(zarr_root["sparsity_mask"]), sorting.unit_ids, rec_attributes["channel_ids"]
             )
         else:
             sparsity = None
-
-        settings = zarr_root.attrs["settings"]
-        settings = cls._handle_backward_compatibility_settings_pre_init(settings, sorting, sparsity)
 
         sorting_analyzer = SortingAnalyzer(
             sorting=sorting,
@@ -1971,7 +2007,7 @@ class SortingAnalyzer:
         elif self.format == "binary_folder":
             return not os.access(self.folder, os.W_OK)
         else:
-            if not is_path_remote(str(self.folder)):
+            if not is_path_remote(self.folder):
                 return not os.access(self.folder, os.W_OK)
             else:
                 # in this case we don't know if the file is read only so an error

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -666,8 +666,8 @@ class SortingAnalyzer:
         folder = Path(folder)
         if is_path_remote(folder):
             raise ValueError(f"Folder {folder} is a remote path. Use format='zarr' for remote paths.")
-        if folder.is_dir():
-            raise ValueError(f"Folder already exists {folder}")
+        if folder.exists():
+            raise ValueError(f"Folder {folder} already exists")
 
         # Create main analyzer folder (and recording info folder)
         folder.mkdir(parents=True)
@@ -899,7 +899,7 @@ class SortingAnalyzer:
         probegroup_file = folder / "recording_info" / "probegroup.json"
 
         # Check that rec_attributes_file exists, otherwise this is not a valid SortingAnalyzer folder
-        if not rec_attributes_file.exists():
+        if not rec_attributes_file.is_file():
             raise ValueError("This folder is not a SortingAnalyzer with format='binary_folder'")
 
         # Load settings file
@@ -936,7 +936,7 @@ class SortingAnalyzer:
         if recording is None:
             for file_ext in (".json", ".pickle"):
                 filename = recording_provenance_file.with_suffix(file_ext)
-                if filename.exists():
+                if filename.is_file():
                     try:
                         recording = load(filename, base_folder=folder)
                         break
@@ -949,11 +949,11 @@ class SortingAnalyzer:
 
         # Load probe group
         rec_attributes["probegroup"] = (
-            probeinterface.read_probeinterface(probegroup_file) if probegroup_file.exists() else None
+            probeinterface.read_probeinterface(probegroup_file) if probegroup_file.is_file() else None
         )
 
         # Load sparsity
-        if sparsity_file.exists():
+        if sparsity_file.is_file():
             sparsity_mask = np.load(sparsity_file)
             sparsity = ChannelSparsity(sparsity_mask, sorting.unit_ids, rec_attributes["channel_ids"])
         else:
@@ -1002,7 +1002,7 @@ class SortingAnalyzer:
         if not is_remote:
             folder = clean_zarr_folder_name(folder)
             if folder.exists():
-                raise ValueError(f"Folder already exists {folder}")
+                raise ValueError(f"Folder {folder} already exists")
 
         # Read backend options
         backend_options = {} if backend_options is None else backend_options
@@ -1060,7 +1060,7 @@ class SortingAnalyzer:
                 warnings.warn("The Recording is not serializable! The recording link will be lost for future load")
         else:
             assert rec_attributes is not None, "recording or rec_attributes must be provided"
-            warnings.warn("Recording not provided, instntiating SortingAnalyzer in recordingless mode.")
+            warnings.warn("Recording not provided, instantiating SortingAnalyzer in recordingless mode.")
 
         # Save recording attributes
         has_rec_attributes = rec_attributes is not None
@@ -2073,7 +2073,7 @@ class SortingAnalyzer:
             for type in ("json", "pickle"):
                 filename = self.folder / f"sorting_provenance.{type}"
                 sorting_provenance = None
-                if filename.exists():
+                if filename.is_file():
                     # try-except here is because it's not required to be able
                     # to load the sorting provenance, as the user might have deleted
                     # the original sorting folder
@@ -3292,7 +3292,7 @@ class AnalyzerExtension:
                         json.dump(ext_data_, f)
                 elif isinstance(ext_data, np.ndarray):
                     data_file = extension_folder / f"{ext_data_name}.npy"
-                    if isinstance(ext_data, np.memmap) and data_file.exists():
+                    if isinstance(ext_data, np.memmap) and data_file.is_file():
                         # important some SortingAnalyzer like ComputeWaveforms already run the computation with memmap
                         # so no need to save theses array
                         pass
@@ -3367,7 +3367,7 @@ class AnalyzerExtension:
         """
         if self.format == "binary_folder":
             extension_folder = self._get_binary_extension_folder()
-            if extension_folder.is_dir():
+            if extension_folder.exists():
                 shutil.rmtree(extension_folder)
 
         elif self.format == "zarr":

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -680,7 +680,7 @@ class SortingAnalyzer:
         sorting_folder = folder / "sorting"
         sorting_provenance_file = folder / "sorting_provenance.json"
         sparsity_file = folder / "sparsity_mask.npy"
-        recording_provenance_file = folder / "recording.json"
+        recording_provenance_file = folder / "recording"  # .json (default) or .pickle (if not json-serializable)
         rec_attributes_file = recording_info_folder / "recording_attributes.json"
         probegroup_file = recording_info_folder / "probegroup.json"
 
@@ -715,7 +715,7 @@ class SortingAnalyzer:
         if recording is not None:
             # save recording and sorting provenance
             if recording.check_serializability("json"):
-                recording.dump(recording_provenance_file, relative_to=folder)
+                recording.dump(recording_provenance_file.with_suffix(".json"), relative_to=folder)
             elif recording.check_serializability("pickle"):
                 recording.dump(recording_provenance_file.with_suffix(".pickle"), relative_to=folder)
             else:
@@ -894,7 +894,7 @@ class SortingAnalyzer:
         settings_file = folder / "settings.json"
         sorting_folder = folder / "sorting"
         sparsity_file = folder / "sparsity_mask.npy"
-        recording_provenance_file = folder / "recording.json"
+        recording_provenance_file = folder / "recording"  # .json (default) or .pickle (if not json-serializable)
         rec_attributes_file = folder / "recording_info" / "recording_attributes.json"
         probegroup_file = folder / "recording_info" / "probegroup.json"
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -661,7 +661,7 @@ class SortingAnalyzer:
         peak_mode: PeakModeType,
         rec_attributes: dict | None,
         backend_options: dict | None,
-    ):
+    ) -> "SortingAnalyzer":
         # used by create and save_as
         folder = Path(folder)
         if is_path_remote(folder):
@@ -883,7 +883,7 @@ class SortingAnalyzer:
         folder: str | Path,
         recording: BaseRecording | None = None,
         backend_options: dict | None = None,
-    ):
+    ) -> "SortingAnalyzer":
         from .loading import load
 
         folder = Path(folder)
@@ -993,7 +993,7 @@ class SortingAnalyzer:
         peak_mode: PeakModeType,
         rec_attributes: dict | None,
         backend_options: dict | None,
-    ):
+    ) -> "SortingAnalyzer":
         # used by create and save_as
         import zarr
         from .zarrextractors import add_sorting_to_zarr_group
@@ -1087,7 +1087,7 @@ class SortingAnalyzer:
         folder: str | Path,
         recording: BaseRecording | None = None,
         backend_options: dict | None = None,
-    ):
+    ) -> "SortingAnalyzer":
         import zarr
         from .loading import load
 

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -46,6 +46,7 @@ from .globals import get_global_job_kwargs
 PeakSignType = Literal["both", "neg", "pos"]
 PeakModeType = Literal["extremum", "at_index", "peak_to_peak"]
 
+
 # high level function
 def create_sorting_analyzer(
     sorting: BaseSorting | dict[Any, BaseSorting],
@@ -279,11 +280,14 @@ def create_sorting_analyzer(
                 **job_kwargs,
             )
     else:  # main_channel_indices provided as argument
-        assert len(main_channel_indices) == sorting.get_num_units(
+        assert (
+            len(main_channel_indices) == sorting.get_num_units()
         ), "len(main_channel_indices) must equal the number of units in the `sorting`"
         if sparsity is None and sparse:  # sparsity needs to be calculated
             sparsity_method = sparsity_kwargs.get("method", "radius")  # default method is radius
-            assert sparsity_method == "radius", 'If you pass `main_channel_indices`, you need to use sparsity method "radius"'
+            assert (
+                sparsity_method == "radius"
+            ), 'If you pass `main_channel_indices`, you need to use sparsity method "radius"'
 
     # Handle sparsity
     if sparsity is not None:
@@ -321,9 +325,7 @@ def create_sorting_analyzer(
 
     # Handle return_in_uV parameter for recordings without scaling
     if return_in_uV and not recording.has_scaleable_traces() and recording.get_dtype().kind == "i":
-        warnings.warn(
-            "create_sorting_analyzer: recording does not have scaling to uV, forcing return_in_uV=False"
-        )
+        warnings.warn("create_sorting_analyzer: recording does not have scaling to uV, forcing return_in_uV=False")
         return_in_uV = False
 
     # Remove folder if overwrite is True
@@ -486,7 +488,9 @@ class SortingAnalyzer:
         backend_options: dict[str, Any] | None = None,
     ):
         assert recording is not None, "To create a SortingAnalyzer you need to specify the recording"
-        assert main_channel_indices is not None, "To create a SortingAnalyzer you need to specify the main_channel_indices"
+        assert (
+            main_channel_indices is not None
+        ), "To create a SortingAnalyzer you need to specify the main_channel_indices"
         if return_scaled is not None:
             warnings.warn(
                 "`return_scaled` is deprecated and will be removed in version 0.105.0. Use `return_in_uV` instead.",
@@ -681,14 +685,12 @@ class SortingAnalyzer:
         probegroup_file = recording_info_folder / "probegroup.json"
 
         # Save general info
-        info = {
-            "version": spikeinterface.__version__, "dev_mode": spikeinterface.DEV_MODE,
-            "object": "SortingAnalyzer"}
+        info = {"version": spikeinterface.__version__, "dev_mode": spikeinterface.DEV_MODE, "object": "SortingAnalyzer"}
         with open(info_file, mode="w") as f:
             json.dump(check_json(info), f, indent=4)
 
         # Save settings
-        settings = {'return_in_uV': return_in_uV, 'peak_sign': peak_sign, 'peak_mode': peak_mode}
+        settings = {"return_in_uV": return_in_uV, "peak_sign": peak_sign, "peak_mode": peak_mode}
         with open(settings_file, mode="w") as f:
             json.dump(check_json(settings), f, indent=4)
 
@@ -739,7 +741,7 @@ class SortingAnalyzer:
         return cls.load_from_binary_folder(folder, recording=recording, backend_options=backend_options)
 
     @classmethod
-    def _handle_backward_compatibility_settings_pre_init(cls, settings : dict[str, Any]):
+    def _handle_backward_compatibility_settings_pre_init(cls, settings: dict[str, Any]):
         """
         backward compatibility before the __init__ to handle the settings:
           * return_scaled > return_in_uV
@@ -919,13 +921,16 @@ class SortingAnalyzer:
             # See https://github.com/SpikeInterface/spikeinterface/issues/2788
             warnings.warn(
                 "settings.json not found in this analyzer folder. Creating one with default settings.",
-                category=DeprecationWarning(), stacklevel=2)
+                category=DeprecationWarning(),
+                stacklevel=2,
+            )
             with open(settings_file, "w") as f:
                 json.dump(check_json(settings), f, indent=4)
 
         # Load sorting (in memory)
-        sorting = NumpySorting.from_sorting(NumpyFolderSorting(sorting_folder), with_metadata=True,
-                                            copy_spike_vector=True)
+        sorting = NumpySorting.from_sorting(
+            NumpyFolderSorting(sorting_folder), with_metadata=True, copy_spike_vector=True
+        )
 
         # Load recording (if available)
         if recording is None:
@@ -943,8 +948,9 @@ class SortingAnalyzer:
             rec_attributes = json.load(f)
 
         # Load probe group
-        rec_attributes["probegroup"] = (probeinterface.read_probeinterface(probegroup_file)
-                                        if probegroup_file.exists() else None)
+        rec_attributes["probegroup"] = (
+            probeinterface.read_probeinterface(probegroup_file) if probegroup_file.exists() else None
+        )
 
         # Load sparsity
         if sparsity_file.exists():
@@ -978,14 +984,14 @@ class SortingAnalyzer:
     @classmethod
     def create_zarr(
         cls,
-        folder : str | Path,
-        sorting : BaseSorting,
-        recording : BaseRecording,
-        sparsity : ChannelSparsity | None,
-        return_in_uV : bool,
-        peak_sign : PeakSignType,
-        peak_mode : PeakModeType,
-        rec_attributes : dict | None,
+        folder: str | Path,
+        sorting: BaseSorting,
+        recording: BaseRecording,
+        sparsity: ChannelSparsity | None,
+        return_in_uV: bool,
+        peak_sign: PeakSignType,
+        peak_mode: PeakModeType,
+        rec_attributes: dict | None,
         backend_options: dict | None,
     ):
         # used by create and save_as
@@ -1010,9 +1016,7 @@ class SortingAnalyzer:
         zarr_root.create_group("extensions")  # used later
 
         # Save general info
-        info = {
-            "version": spikeinterface.__version__, "dev_mode": spikeinterface.DEV_MODE,
-            "object": "SortingAnalyzer"}
+        info = {"version": spikeinterface.__version__, "dev_mode": spikeinterface.DEV_MODE, "object": "SortingAnalyzer"}
         zarr_root.attrs["spikeinterface_info"] = check_json(info)
 
         # Save settings
@@ -1031,11 +1035,15 @@ class SortingAnalyzer:
             try:
                 _write_object_array(zarr_root, "sorting_provenance", sort_dict, codec="pickle")
             except:
-                warnings.warn("Failed to serialize sorting provenance with Pickle Codec! "
-                              "The sorting provenance link will be lost for future load")
+                warnings.warn(
+                    "Failed to serialize sorting provenance with Pickle Codec! "
+                    "The sorting provenance link will be lost for future load"
+                )
         else:
-            warnings.warn("The sorting provenance is not serializable! "
-                          "The sorting provenance link will be lost for future load")
+            warnings.warn(
+                "The sorting provenance is not serializable! "
+                "The sorting provenance link will be lost for future load"
+            )
 
         # Save sparsity
         if sparsity is not None:
@@ -1098,9 +1106,11 @@ class SortingAnalyzer:
                 zarr_root_a = zarr.open(str(folder), mode="a", storage_options=storage_options)
                 zarr.consolidate_metadata(zarr_root_a.store)
             except:
-                warnings.warn("The zarr store was not consolidated prior to v0.101.1. "
-                              "This may lead to unexpected behavior in loading extensions. "
-                              "Consider re-generating the SortingAnalyzer object.")
+                warnings.warn(
+                    "The zarr store was not consolidated prior to v0.101.1. "
+                    "This may lead to unexpected behavior in loading extensions. "
+                    "Consider re-generating the SortingAnalyzer object."
+                )
 
         # Load settings
         settings = zarr_root.attrs["settings"]
@@ -1109,7 +1119,9 @@ class SortingAnalyzer:
         # Load sorting (in memory)
         sorting = NumpySorting.from_sorting(
             ZarrSortingExtractor(folder, zarr_group="sorting", storage_options=storage_options),
-            with_metadata=True, copy_spike_vector=True)
+            with_metadata=True,
+            copy_spike_vector=True,
+        )
 
         # Load recording (if available)
         if recording is None:
@@ -1126,8 +1138,9 @@ class SortingAnalyzer:
 
         # Load probegroup
         probegroup_dict = zarr_root["recording_info"].attrs.get("probegroup")
-        rec_attributes["probegroup"] = (probeinterface.ProbeGroup.from_dict(probegroup_dict)
-                                        if probegroup_dict is not None else None)
+        rec_attributes["probegroup"] = (
+            probeinterface.ProbeGroup.from_dict(probegroup_dict) if probegroup_dict is not None else None
+        )
 
         # Load sparsity
         if "sparsity_mask" in zarr_root:

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -89,7 +89,7 @@ def create_sorting_analyzer(
         The sorting object, or a dict of them
     recording : Recording | dict
         The recording object, or a dict of them
-    folder : str or Path
+    folder : str or Path or None, default: None
         The folder where analyzer is cached
     format : "memory | "binary_folder" | "zarr", default: "memory"
         The mode to store analyzer. If "folder", the analyzer is stored on disk in the specified folder.
@@ -169,6 +169,17 @@ def create_sorting_analyzer(
     In some situation, sparsity is not needed, so to make it fast creation, you need to turn
     sparsity off (or give external sparsity) like this.
     """
+    # Remove folder if overwrite is True
+    if format != "memory":
+        assert folder is not None, "For format='binary_folder'|'zarr', folder name must be provided"
+        if not is_path_remote(folder):
+            folder = clean_zarr_folder_name(folder) if format == "zarr" else Path(folder)
+            if folder.exists():
+                if overwrite:
+                    shutil.rmtree(folder)
+                else:
+                    raise ValueError(
+                        f"Folder {folder} already exists! Use overwrite=True to overwrite it.")
 
     # We used to allow users to pass sparsity kwargs directly to create_sorting_analyzer.
     # This is for backwards compatibility
@@ -327,17 +338,6 @@ def create_sorting_analyzer(
     if return_in_uV and not recording.has_scaleable_traces() and recording.get_dtype().kind == "i":
         warnings.warn("create_sorting_analyzer: recording does not have scaling to uV, forcing return_in_uV=False")
         return_in_uV = False
-
-    # Remove folder if overwrite is True
-    if format != "memory":
-        assert folder is not None, "For format='binary_folder'|'zarr', folder name must be provided"
-        if not is_path_remote(folder):
-            folder = clean_zarr_folder_name(folder) if format == "zarr" else Path(folder)
-            if folder.exists():
-                if overwrite:
-                    shutil.rmtree(folder)
-                else:
-                    raise ValueError(f"Folder {folder} already exists! Use overwrite=True to overwrite it.")
 
     sorting_analyzer = SortingAnalyzer.create(
         sorting,
@@ -750,7 +750,7 @@ class SortingAnalyzer:
 
         Note :
          * see also _handle_backward_compatibility_settings_post_init
-         * there is also something at extension level to handle changes in paramaters with different mechanisms
+         * there is also something at extension level to handle changes in parameters with different mechanisms
         """
 
         new_settings = settings.copy()
@@ -761,7 +761,7 @@ class SortingAnalyzer:
             new_settings.pop("return_scaled", None)
 
         if "peak_sign" not in new_settings:
-            # before 0.104.1 peak_sign was not in settings.
+            # before 0.105.0 peak_sign was not in settings.
             # TODO make something more fancy that explore the previous params of extension
             # We decided to not do something fancy, as the `peak_sign`s in different
             # extensions may not match the `peak_sign` that was used to create the analyzer.

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -178,8 +178,7 @@ def create_sorting_analyzer(
                 if overwrite:
                     shutil.rmtree(folder)
                 else:
-                    raise ValueError(
-                        f"Folder {folder} already exists! Use overwrite=True to overwrite it.")
+                    raise ValueError(f"Folder {folder} already exists! Use overwrite=True to overwrite it.")
 
     # We used to allow users to pass sparsity kwargs directly to create_sorting_analyzer.
     # This is for backwards compatibility
@@ -252,9 +251,11 @@ def create_sorting_analyzer(
                     unit_offset += num_units
                     channel_offset += num_channels
 
-                sparsity = ChannelSparsity(unit_ids=aggregated_sorting.unit_ids,
-                                           channel_ids=aggregated_recording.channel_ids,
-                                           mask=sparsity_mask)
+                sparsity = ChannelSparsity(
+                    unit_ids=aggregated_sorting.unit_ids,
+                    channel_ids=aggregated_recording.channel_ids,
+                    mask=sparsity_mask,
+                )
                 sparsity_kwargs = {}
 
         return create_sorting_analyzer(

--- a/src/spikeinterface/core/sortinganalyzer.py
+++ b/src/spikeinterface/core/sortinganalyzer.py
@@ -909,7 +909,6 @@ class SortingAnalyzer:
                 settings = json.load(f)
         else:
             # TODO: Remove support for analyzers that have no settings.json (throw an error instead)
-
             settings = dict()
         settings = cls._handle_backward_compatibility_settings_pre_init(settings)
 

--- a/src/spikeinterface/core/sortingfolder.py
+++ b/src/spikeinterface/core/sortingfolder.py
@@ -13,7 +13,7 @@ class NumpyFolderSorting(BaseSorting):
     NumpyFolderSorting is the new internal format used in spikeinterface (>=0.99.0) for caching sorting objects.
 
     It is a simple folder that contains:
-      * a file "spike.npy" (numpy format) with all flatten spikes (using sorting.to_spike_vector())
+      * a file "spikes.npy" (numpy format) with all flatten spikes (using sorting.to_spike_vector())
       * a "numpysorting_info.json" containing sampling_frequency, unit_ids and num_segments
       * a metadata folder for units properties.
 
@@ -24,30 +24,31 @@ class NumpyFolderSorting(BaseSorting):
     mode = "folder"
     name = "NumpyFolder"
 
-    def __init__(self, folder_path):
+    def __init__(self, folder_path: str | Path):
         folder_path = Path(folder_path)
 
+        # Load general info
         with open(folder_path / "numpysorting_info.json", "r") as f:
             info = json.load(f)
-
         sampling_frequency = info["sampling_frequency"]
         unit_ids = np.array(info["unit_ids"])
         num_segments = info["num_segments"]
 
-        BaseSorting.__init__(self, sampling_frequency, unit_ids)
+        # Init superclass
+        super().__init__(sampling_frequency, unit_ids)
 
+        # Load spikes vector
         self.spikes = np.load(folder_path / "spikes.npy")
-
         for segment_index in range(num_segments):
             self.add_sorting_segment(SpikeVectorSortingSegment(self.spikes, segment_index, unit_ids))
-
         # important trick : the cache is already spikes vector
         self._cached_spike_vector = self.spikes
 
-        folder_metadata = folder_path
-        self.load_metadata_from_folder(folder_metadata)
+        # Load metadata
+        self.load_metadata_from_folder(folder_path)
 
-        self._kwargs = dict(folder_path=str(folder_path.absolute()))
+        # Save folder_path as kwargs for serialization
+        self._kwargs = {"folder_path": str(folder_path.absolute())}
 
     @staticmethod
     def write_sorting(sorting, save_path):

--- a/src/spikeinterface/core/testing_tools.py
+++ b/src/spikeinterface/core/testing_tools.py
@@ -2,7 +2,7 @@ import warnings
 
 warnings.warn(
     "The 'testing_tools' submodule is deprecated. " "Use spikeinterface.core.generate instead",
-    DeprecationWarning,
+    FutureWarning,
     stacklevel=2,
 )
 

--- a/src/spikeinterface/core/zarrextractors.py
+++ b/src/spikeinterface/core/zarrextractors.py
@@ -63,7 +63,7 @@ def super_zarr_open(folder_path: str | Path, mode: str = "r", storage_options: d
 
     root = None
     exception = None
-    if is_path_remote(str(folder_path)):
+    if is_path_remote(folder_path):
         for open_func in open_funcs:
             if root is not None:
                 break


### PR DESCRIPTION
This PR does not functionally change much. It is mainly for code refactoring and to improve legibility.

The only two functional changes are:
* fix small bug when calling save_to_zarr("test.zarr") would add an extra .zarr to the filename (https://github.com/SpikeInterface/spikeinterface/blob/39dfac40e630ff996be410aa62a54f5ff6b7eb11/src/spikeinterface/core/base.py#L1087)
* when return_scaled and return_in_uV are provided, prioritize return_in_uV. Currently, it prefers return_scaled over return_in_uV

Code quality improvements:
* type hinting
* Collect code into logical blocks (e..g, everything that has to do wit main indices together); add comment headers (e.g., Saving main indices) and reorder this blocks (e.g., expected stuff like sorting should be saved and loaded before any of the optional things like sparsity)
* Make create_binary_folder parallel create_zarr (you can now see how they are both doing exactly the same). 
* Make load_binary_folder parallel load_zarr.
* Preserve the same order of operations when loading and saving. If sorting was saved first, then load first and so on.
* Tighten code when possible