### PR TITLE
Fix Llobet expected-violations formula in sliding RP metric

### DIFF
--- a/src/spikeinterface/metrics/quality/misc_metrics.py
+++ b/src/spikeinterface/metrics/quality/misc_metrics.py
@@ -552,7 +552,7 @@ def compute_sliding_rp_violations(
     max_ref_period_ms : float, default: 10
         Maximum refractory period to test in ms.
     contamination_values : 1d array or None, default: None
-        The contamination values to test, If None, it is set to np.arange(0.5, 35, 0.5).
+        The contamination values to test, If None, it is set to np.arange(0.5, 35.5, 0.5).
 
     Returns
     -------
@@ -1688,7 +1688,7 @@ def slidingRP_violations(
     max_ref_period_ms : float, default: 10
         Maximum refractory period to test in ms.
     contamination_values : 1d array or None, default: None
-        The contamination values to test, if None it is set to np.arange(0.5, 35, 0.5) / 100.
+        The contamination values to test, if None it is set to np.arange(0.5, 35.5, 0.5) / 100.
     return_conf_matrix : bool, default: False
         If True, the confidence matrix (n_contaminations, n_ref_periods) is returned.
 
@@ -1701,7 +1701,9 @@ def slidingRP_violations(
         The minimum contamination with confidence > 90%.
     """
     if contamination_values is None:
-        contamination_values = np.arange(0.5, 35, 0.5) / 100  # vector of contamination values to test
+        # 0.5, 1, ..., 35 % (upper bound inclusive), matching the reference
+        # slidingRefractory implementation (previously stopped at 34.5 %).
+        contamination_values = np.arange(0.5, 35.5, 0.5) / 100  # vector of contamination values to test
     rp_bin_size = bin_size_ms / 1000
     rp_edges = np.arange(0, max_ref_period_ms / 1000, rp_bin_size)  # in s
     rp_centers = rp_edges + ((rp_edges[1] - rp_edges[0]) / 2)  # vector of refractory period durations to test
@@ -1793,8 +1795,16 @@ def _compute_rp_contamination_one_unit(
 
 
 def _compute_violations(obs_viol, firing_rate, spike_count, ref_period_dur, contamination_prop):
-    contamination_rate = firing_rate * contamination_prop
-    expected_viol = contamination_rate * ref_period_dur * 2 * spike_count
+    # Expected violations follow the Llobet et al. (2022) formulation, in which
+    # contaminating spikes produce violations both with base-neuron spikes and
+    # among themselves:
+    #   Ve = 2 * ref_period_dur / duration * Nc * (Nb + (Nc - 1) / 2)
+    # with Nc = C * N, Nb = (1 - C) * N and duration = N / firing_rate. The
+    # previous expression used Nc * N (i.e. Nb + Nc), overestimating Ve.
+    n_c = spike_count * contamination_prop
+    n_b = spike_count * (1 - contamination_prop)
+    duration = spike_count / firing_rate
+    expected_viol = 2 * ref_period_dur / duration * n_c * (n_b + (n_c - 1) / 2)
 
     from scipy.stats import poisson
 

--- a/src/spikeinterface/metrics/quality/tests/test_metrics_functions.py
+++ b/src/spikeinterface/metrics/quality/tests/test_metrics_functions.py
@@ -30,6 +30,7 @@ from spikeinterface.metrics.quality.misc_metrics import (
     compute_sd_ratio,
     _noise_cutoff,
     _get_synchrony_counts,
+    _compute_violations,
     amplitude_cutoff,
 )
 from spikeinterface.metrics.quality.pca_metrics import (
@@ -433,6 +434,30 @@ def test_calculate_sliding_rp_violations(sorting_analyzer_violations, periods_vi
     # testing method accuracy with magic number is not a good pratcice, I remove this.
     # contaminations_gt = {0: 0.03, 1: 0.185, 2: 0.325}
     # assert np.allclose(list(contaminations_gt.values()), list(contaminations.values()), rtol=0.05)
+
+
+def test_compute_violations_llobet():
+    # Expected violations must follow the Llobet et al. (2022) formulation, where
+    # contaminating spikes produce violations both with base spikes and among
+    # themselves: Ve = 2 * ref_dur / D * Nc * (Nb + (Nc - 1) / 2), with
+    # Nc = C * N, Nb = (1 - C) * N and duration D = N / firing_rate.
+    # See https://github.com/SteinmetzLab/slidingRefractory (metrics.computeViol).
+    from scipy.stats import poisson
+
+    spike_count = 1000
+    firing_rate = 10.0  # Hz  -> duration D = 100 s
+    ref_period_dur = 0.002  # s
+    contamination_prop = 0.1
+    obs_viol = 5
+
+    duration = spike_count / firing_rate
+    n_c = spike_count * contamination_prop
+    n_b = spike_count * (1 - contamination_prop)
+    expected_viol = 2 * ref_period_dur / duration * n_c * (n_b + (n_c - 1) / 2)
+    expected_confidence = 1 - poisson.cdf(obs_viol, expected_viol)
+
+    confidence = _compute_violations(obs_viol, firing_rate, spike_count, ref_period_dur, contamination_prop)
+    assert np.isclose(confidence, expected_confidence)
 
 
 def test_calculate_rp_violations(sorting_analyzer_violations, periods_violations):


### PR DESCRIPTION
## Fix Llobet expected-violations formula in the sliding RP metric

`_compute_violations` computed expected violations as `Ve = 2·τ/D · Nc·N` (i.e. `Nc·(Nb + Nc)`), which overestimates `Ve` and inflates the contamination confidence. Corrected to the Llobet et al. (2022) form used by the reference implementation:

```
Ve = 2·τ/D · Nc·(Nb + (Nc − 1)/2)     Nc = C·N,  Nb = (1 − C)·N,  D = N / firing_rate
```

Also extends the default contamination grid to include 35 % (`np.arange(0.5, 35.5, 0.5)`, previously stopped at 34.5 %) and adds a unit test for `_compute_violations` against the analytical formula.

Reference: https://github.com/SteinmetzLab/slidingRefractory (`metrics.computeViol`).

### Known non-equivalences (out of scope)
The metric definition now matches the reference, but results are not bit-identical because SI (by existing design) uses a coarser ACG bin size (`bin_size_ms=0.25` vs sample-resolution) and a different correlogram engine (`_compute_correlograms_*` vs the reference `histdiff`-equivalent). Full numerical parity would be a separate change.
