### PR TITLE
Fix remove_artifacts sparsity handling for median/average modes (#3290)

### DIFF
--- a/src/spikeinterface/preprocessing/remove_artifacts.py
+++ b/src/spikeinterface/preprocessing/remove_artifacts.py
@@ -376,7 +376,12 @@ class RemoveArtifactsRecordingSegment(BasePreprocessorSegment):
                     mask = self.sparsity[label]
                 else:
                     mask = None
-                artifact_duration = len(self.artifacts[label])
+                artifact = self.artifacts[label]
+                if mask is not None:
+                    # restrict the template to the sparse channels so that it aligns
+                    # with the sparsified traces (see issue #3290)
+                    artifact = artifact[:, mask]
+                artifact_duration = len(artifact)
                 if self.time_pad > 0:
                     jitters = np.arange(-self.time_pad, self.time_pad, 1)
                 else:
@@ -404,7 +409,7 @@ class RemoveArtifactsRecordingSegment(BasePreprocessorSegment):
                     if mask is not None:
                         trace_slice_values = trace_slice_values[:, mask]
 
-                    artifact_slice_values = self.artifacts[label][artifact_slice]
+                    artifact_slice_values = artifact[artifact_slice]
 
                     norm = np.linalg.norm(trace_slice_values) * np.linalg.norm(artifact_slice_values)
                     best_amplitudes[count] = (
@@ -435,11 +440,9 @@ class RemoveArtifactsRecordingSegment(BasePreprocessorSegment):
                     best_amp = 1
 
                 if mask is not None:
-                    traces[trace_slice][:, mask] -= (best_amp * self.artifacts[label][artifact_slice]).astype(
-                        traces.dtype
-                    )
+                    traces[trace_slice][:, mask] -= (best_amp * artifact[artifact_slice]).astype(traces.dtype)
                 else:
-                    traces[trace_slice] -= (best_amp * self.artifacts[label][artifact_slice]).astype(traces.dtype)
+                    traces[trace_slice] -= (best_amp * artifact[artifact_slice]).astype(traces.dtype)
             traces = traces[:, channel_indices]
 
         return traces

--- a/src/spikeinterface/preprocessing/tests/test_remove_artifacts.py
+++ b/src/spikeinterface/preprocessing/tests/test_remove_artifacts.py
@@ -85,5 +85,47 @@ def test_remove_artifacts():
     )
 
 
+def test_remove_artifacts_sparsity():
+    # non-regression test for issue #3290: "median"/"average" modes with sparsity
+    # used to raise "shapes not aligned" because the template was kept full-channel
+    # while the traces were sparsified before the np.dot / subtraction.
+    rec = generate_recording(num_channels=4, durations=[10.0], seed=0)
+    rec.annotate(is_filtered=True)
+
+    ms = 10
+    ms_frames = int(ms * rec.get_sampling_frequency() / 1000)
+
+    # two artifact labels, each removed on a different subset of channels
+    triggers = [15000, 30000, 45000, 60000]
+    labels = [0, 1, 0, 1]
+    list_triggers = [triggers]
+    list_labels = [labels]
+    sparsity = {
+        0: np.array([True, False, True, False]),
+        1: np.array([False, True, False, True]),
+    }
+
+    for mode in ("median", "average"):
+        rec_rmart = remove_artifacts(
+            rec,
+            list_triggers,
+            ms_before=ms,
+            ms_after=ms,
+            mode=mode,
+            list_labels=list_labels,
+            sparsity=sparsity,
+        )
+        for trig, label in zip(triggers, labels):
+            mask = sparsity[label]
+            traces_clean = rec.get_traces(start_frame=trig - ms_frames, end_frame=trig + ms_frames)
+            # get_traces must not raise (the bug reported in issue #3290)
+            traces = rec_rmart.get_traces(start_frame=trig - ms_frames, end_frame=trig + ms_frames)
+            # channels outside the sparsity mask are left untouched
+            assert np.array_equal(traces[:, ~mask], traces_clean[:, ~mask])
+            # channels inside the sparsity mask have the artifact subtracted
+            assert not np.allclose(traces[:, mask], traces_clean[:, mask])
+
+
 if __name__ == "__main__":
     test_remove_artifacts()
+    test_remove_artifacts_sparsity()


### PR DESCRIPTION
Fixes #3290

## Why

Using `remove_artifacts(..., mode="median"|"average", artifacts=..., sparsity=...)`
and then calling `get_traces()` raises:

```
ValueError: shapes (M,) and (N,) not aligned
```

In `RemoveArtifactsRecordingSegment.get_traces` (median/average branch), when a
`sparsity` mask is given the traces are sparsified to the masked channels:

```python
trace_slice_values = traces[trace_slice]
if mask is not None:
    trace_slice_values = trace_slice_values[:, mask]
```

but the artifact template `self.artifacts[label]` stays **full-channel**. The
subsequent `np.dot(trace_slice_values.flatten(), artifact_slice_values.flatten())`
(and the later subtraction `traces[trace_slice][:, mask] -= ... artifact ...`)
therefore operate on mismatched channel counts. The `sparsity` block in `__init__`
only asserts that every label has a mask; it never restricts the template.

## What

Restrict the template to the sparse channels **at use time**, right where the
traces are sparsified:

```python
artifact = self.artifacts[label]
if mask is not None:
    # restrict the template to the sparse channels so that it aligns
    # with the sparsified traces (see issue #3290)
    artifact = artifact[:, mask]
```

and use this local `artifact` for the duration, the dot product, and the
subtraction.

Design notes:
- **Both artifact-provisioning paths are covered.** `self.artifacts[label]` is
  full-channel whether the template was passed in via `artifacts=` or computed by
  `estimate_templates`, so slicing at use time handles both uniformly.
- **Serialization stays correct.** The stored template and `_kwargs["artifacts"]`
  remain full-channel and `sparsity` remains full masks, so `to_dict()/load()`
  round-trips reproduce identical traces (verified). Storing a *pre-sliced* template
  in `_kwargs` instead would double-slice on reload — `__init__` would try to index
  a full-length mask into an already-1-channel template (`IndexError`) — which is
  why the slice is applied at use time, not stored.
- **No-sparsity path unchanged.** When `mask is None` the template is used as-is.

## Tests

Added `test_remove_artifacts_sparsity` covering `mode="median"` and
`mode="average"` with a `sparsity` mask and two labels (each masking a different
channel subset). It asserts that:
- `get_traces()` no longer raises,
- channels **outside** the mask are byte-identical to the clean traces
  (`np.array_equal`),
- channels **inside** the mask have the artifact subtracted (`not np.allclose`).

Before the fix this test fails at the `np.dot` with
`ValueError: shapes (1200,) and (2400,) not aligned` (600 samples × 2 sparse
channels vs 600 × 4 full channels); after the fix the whole file passes (`2 passed`).

I also verified (manually) the `to_dict()`→`load()` round-trip reproduces identical
traces, and the precomputed-`artifacts` path with sparsity — happy to add either as a
committed test if you'd like it locked in.

## Note (out of scope)

The exact minimal snippet in the issue supplies a 30-sample artifact while the
default `ms_before`/`ms_after` imply a 105-sample window, so it additionally hits a
*duration* mismatch (`105 vs 30`) that is independent of sparsity. This PR fixes the
sparsity/channel-alignment bug (the subject of #3290); after the fix the channel
dimensions match (the error, if a mis-sized template is passed, reduces to the
pre-existing duration check).

---

*Prepared with AI assistance (Claude Code): the reproduction, root-cause analysis,
fix, and test were AI-drafted; the reasoning and verification (including the rejected
store-pre-sliced approach that double-slices on reload) are documented above.*
