### PR TITLE
Deepcopy of metric params

### DIFF
--- a/src/spikeinterface/core/analyzer_extension_core.py
+++ b/src/spikeinterface/core/analyzer_extension_core.py
@@ -9,7 +9,7 @@ It also implements:
   * ComputeNoiseLevels which is very convenient to have
 """
 
-from copy import copy
+from copy import copy, deepcopy
 import warnings
 import numpy as np
 from collections import namedtuple
@@ -958,7 +958,7 @@ class BaseMetricExtension(AnalyzerExtension):
         default_metric_params : dict
             Dictionary of default metric parameters for each metric.
         """
-        default_metric_params = {m.metric_name: m.metric_params for m in cls.metric_list}
+        default_metric_params = {m.metric_name: deepcopy(m.metric_params) for m in cls.metric_list}
         return default_metric_params
 
     @classmethod

--- a/src/spikeinterface/metrics/quality/tests/test_pca_metrics.py
+++ b/src/spikeinterface/metrics/quality/tests/test_pca_metrics.py
@@ -31,7 +31,12 @@ def test_compute_pc_metrics_multi_processing(small_sorting_analyzer, tmp_path):
     with warnings.catch_warnings():
         warnings.filterwarnings("error", message="Falling back to n_jobs=1.")
         res2 = compute_quality_metrics(
-            sorting_analyzer_saved, metric_names=metric_names, n_jobs=2, progress_bar=True, seed=1205
+            sorting_analyzer_saved,
+            metric_names=metric_names,
+            n_jobs=2,
+            progress_bar=True,
+            seed=1205,
+            metric_params=metric_params,
         )
 
     for metric_name in res1.columns:


### PR DESCRIPTION
Fixes full tests failing: https://github.com/SpikeInterface/spikeinterface/actions/runs/29258168630/job/86843964751

Basically, curation tests were mutating `BaseMetric.metric_params`, since we were not deep copying them. The fix is just to add a `deepcopy`