### PR TITLE
Fixes a couple of minor warnings

### DIFF
--- a/src/spikeinterface/core/binaryrecordingextractor.py
+++ b/src/spikeinterface/core/binaryrecordingextractor.py
@@ -156,17 +156,6 @@ class BinaryRecordingExtractor(BaseRecording):
         )
         return d
 
-    def __del__(self):
-        """
-        Ensures that all segment resources are properly cleaned up when this recording extractor is deleted.
-        Closes any open file handles in the recording segments.
-        """
-        # Close all recording segments
-        for segment in self.segments:
-            # This will trigger the __del__ method of the BinaryRecordingSegment
-            # which will close the file handle
-            del segment
-
 
 BinaryRecordingExtractor.write_recording.__doc__ = BinaryRecordingExtractor.write_recording.__doc__.format(
     _shared_job_kwargs_doc

--- a/src/spikeinterface/postprocessing/template_similarity.py
+++ b/src/spikeinterface/postprocessing/template_similarity.py
@@ -341,9 +341,10 @@ if HAVE_NUMBA:
             tgt_sliced = other_templates_array[:, num_shifts + shift : num_samples - num_shifts + shift]
 
             for i in prange(num_templates):
-                src_template = src_sliced[i]
-                overlapping_ids = overlapping_j_list[i]
-                overlapping_chs = active_channels_list[i]
+                i_ = np.int64(i)
+                src_template = src_sliced[i_]
+                overlapping_ids = overlapping_j_list[i_]
+                overlapping_chs = active_channels_list[i_]
 
                 for pair_idx in range(len(overlapping_ids)):
                     j = np.uint16(overlapping_ids[pair_idx])


### PR DESCRIPTION
numba casting warning
```
NumbaTypeSafetyWarning: unsafe cast from uint64 to int64. Precision may be lost.
    overlapping_ids = overlapping_j_list[i]
```



`__del__` called before object is fully instantiated
```
Exception ignored in: <function BinaryRecordingExtractor.__del__ at 0x7006e81db6a0>
Traceback (most recent call last):
  File "/home/alessio/Documents/codes/spike_sorting/spikeinterface/spikeinterface/src/spikeinterface/core/binaryrecordingextractor.py", line 165, in __del__
    for segment in self.segments:
  File "/home/alessio/Documents/codes/spike_sorting/spikeinterface/spikeinterface/src/spikeinterface/core/baserecording.py", line 172, in segments
    return self._segments
AttributeError: 'BinaryFolderRecording' object has no attribute '_segments'
```

Would close  #4528