### PR TITLE
Fix cache spike vector in base sorting

### DIFF
--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -983,7 +983,9 @@ class BaseSorting(BaseExtractor):
         else:
             spike_dtype = minimum_spike_dtype + [("channel_index", "int64")]
             spikes = np.zeros(self._cached_spike_vector.size, dtype=spike_dtype)
-            spikes[["sample_index", "unit_index", "segment_index"]] = self._cached_spike_vector
+            spikes[["sample_index", "unit_index", "segment_index"]] = self._cached_spike_vector[
+                ["sample_index", "unit_index", "segment_index"]
+            ]
 
             spikes["channel_index"] = main_channel_indices[spikes["unit_index"]]
 

--- a/src/spikeinterface/core/basesorting.py
+++ b/src/spikeinterface/core/basesorting.py
@@ -980,13 +980,12 @@ class BaseSorting(BaseExtractor):
 
         if main_channel_indices is None:
             spikes = self._cached_spike_vector
+        elif "channel_index" in self._cached_spike_vector.dtype.names:
+            spikes = self._cached_spike_vector
         else:
             spike_dtype = minimum_spike_dtype + [("channel_index", "int64")]
             spikes = np.zeros(self._cached_spike_vector.size, dtype=spike_dtype)
-            spikes[["sample_index", "unit_index", "segment_index"]] = self._cached_spike_vector[
-                ["sample_index", "unit_index", "segment_index"]
-            ]
-
+            spikes[["sample_index", "unit_index", "segment_index"]] = self._cached_spike_vector
             spikes["channel_index"] = main_channel_indices[spikes["unit_index"]]
 
         if not concatenated:


### PR DESCRIPTION
When a sorting is loaded from a folder (NumpyFolderSorting), `cached_spike_vector` is read from `spikes.npy` which was saved with 4 fields (including `channel_index)`. The code then tried to assign this 4-field structured array into a 3-field selection and numpy refuses the cast. Fix: explicitly select only the 3 needed fields from the source array.