### PR TITLE
fix: preserve caller-owned inputs

### DIFF
--- a/src/spikeinterface/core/channelsaggregationrecording.py
+++ b/src/spikeinterface/core/channelsaggregationrecording.py
@@ -36,9 +36,12 @@ class ChannelsAggregationRecording(BaseRecording):
             )
 
         self._recordings = recording_list
-
-        for group_id, recording in zip(recording_ids, recording_list):
-            recording.set_property("aggregation_key", [group_id] * recording.get_num_channels())
+        aggregation_key = np.concatenate(
+            [
+                np.asarray([recording_id] * recording.get_num_channels())
+                for recording_id, recording in zip(recording_ids, recording_list)
+            ]
+        )
 
         self._perform_consistency_checks()
         sampling_frequency = recording_list[0].get_sampling_frequency()
@@ -90,6 +93,7 @@ class ChannelsAggregationRecording(BaseRecording):
                             del property_dict[prop_name]
                             break
 
+        property_dict["aggregation_key"] = aggregation_key
         for prop_name, prop_values in property_dict.items():
             self.set_property(key=prop_name, values=prop_values)
 

--- a/src/spikeinterface/core/tests/test_channelsaggregationrecording.py
+++ b/src/spikeinterface/core/tests/test_channelsaggregationrecording.py
@@ -231,6 +231,17 @@ def test_aggretion_labeling_for_dicts():
     assert np.all(user_group_property == [6, 6, 7, 7])
 
 
+def test_aggregate_channels_does_not_change_inputs():
+    recording1 = generate_recording(num_channels=4, durations=[1.0], set_probe=False)
+    recording2 = generate_recording(num_channels=2, durations=[1.0], set_probe=False)
+
+    aggregate_channels([recording1, recording2])
+    aggregate_channels({"X": recording1, "Y": recording2})
+
+    assert "aggregation_key" not in recording1.get_property_keys()
+    assert "aggregation_key" not in recording2.get_property_keys()
+
+
 def test_channel_aggregation_does_not_preserve_ids_if_not_unique():
 
     recording1 = generate_recording(num_channels=3, durations=[10], set_probe=False)  # To avoid location check


### PR DESCRIPTION
A constructor writes derived metadata into caller-owned input objects. This caused the failure reported in [issue 4550](https://github.com/SpikeInterface/spikeinterface/issues/4550).

This change keeps channel aggregation input recordings unchanged.

Closes #4550.
