### PR TITLE
Let `get_streams` work from the path alone on Neuralynx, Biocam and Blackrock

### DIFF
--- a/src/spikeinterface/extractors/neoextractors/biocam.py
+++ b/src/spikeinterface/extractors/neoextractors/biocam.py
@@ -85,7 +85,7 @@ class BiocamRecordingExtractor(NeoBaseRecordingExtractor):
         )
 
     @classmethod
-    def map_to_neo_kwargs(cls, file_path, fill_gaps_strategy):
+    def map_to_neo_kwargs(cls, file_path, fill_gaps_strategy=None):
         neo_kwargs = {
             "filename": str(file_path),
             "fill_gaps_strategy": fill_gaps_strategy,

--- a/src/spikeinterface/extractors/neoextractors/blackrock.py
+++ b/src/spikeinterface/extractors/neoextractors/blackrock.py
@@ -43,9 +43,7 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
         use_names_as_ids: bool = False,
         gap_tolerance_ms: float | None = None,
     ):
-        neo_kwargs = self.map_to_neo_kwargs(file_path)
-        if gap_tolerance_ms is not None:
-            neo_kwargs["gap_tolerance_ms"] = gap_tolerance_ms
+        neo_kwargs = self.map_to_neo_kwargs(file_path, gap_tolerance_ms=gap_tolerance_ms)
         neo_kwargs["load_nev"] = False  # Avoid loading spikes release in neo 0.12.0
 
         # trick to avoid to select automatically the correct stream_id
@@ -63,8 +61,10 @@ class BlackrockRecordingExtractor(NeoBaseRecordingExtractor):
         self._kwargs.update({"file_path": str(Path(file_path).absolute()), "gap_tolerance_ms": gap_tolerance_ms})
 
     @classmethod
-    def map_to_neo_kwargs(cls, file_path):
+    def map_to_neo_kwargs(cls, file_path, gap_tolerance_ms=None):
         neo_kwargs = {"filename": str(file_path)}
+        if gap_tolerance_ms is not None:
+            neo_kwargs["gap_tolerance_ms"] = gap_tolerance_ms
         return neo_kwargs
 
 
@@ -109,9 +109,7 @@ class BlackrockSortingExtractor(NeoBaseSortingExtractor):
         nsx_to_load: int | list | str | None = None,
         gap_tolerance_ms: float | None = None,
     ):
-        neo_kwargs = self.map_to_neo_kwargs(file_path)
-        if gap_tolerance_ms is not None:
-            neo_kwargs["gap_tolerance_ms"] = gap_tolerance_ms
+        neo_kwargs = self.map_to_neo_kwargs(file_path, gap_tolerance_ms=gap_tolerance_ms)
         NeoBaseSortingExtractor.__init__(
             self,
             stream_id=stream_id,
@@ -130,8 +128,10 @@ class BlackrockSortingExtractor(NeoBaseSortingExtractor):
         }
 
     @classmethod
-    def map_to_neo_kwargs(cls, file_path):
+    def map_to_neo_kwargs(cls, file_path, gap_tolerance_ms=None):
         neo_kwargs = {"filename": str(file_path)}
+        if gap_tolerance_ms is not None:
+            neo_kwargs["gap_tolerance_ms"] = gap_tolerance_ms
         return neo_kwargs
 
 

--- a/src/spikeinterface/extractors/neoextractors/neuralynx.py
+++ b/src/spikeinterface/extractors/neoextractors/neuralynx.py
@@ -67,7 +67,7 @@ class NeuralynxRecordingExtractor(NeoBaseRecordingExtractor):
         )
 
     @classmethod
-    def map_to_neo_kwargs(cls, folder_path, exclude_filename, strict_gap_mode):
+    def map_to_neo_kwargs(cls, folder_path, exclude_filename=None, strict_gap_mode=False):
         neo_kwargs = {"dirname": str(folder_path), "exclude_filename": exclude_filename}
         if version("neo") >= "0.13.1":
             neo_kwargs["strict_gap_mode"] = strict_gap_mode
@@ -92,6 +92,9 @@ class NeuralynxSortingExtractor(NeoBaseSortingExtractor):
         Used to extract information about the sampling frequency and t_start from the analog signal if provided.
     stream_name : str, default: None
         Used to extract information about the sampling frequency and t_start from the analog signal if provided.
+    exclude_filename : list[str], default: None
+        List of filename to exclude from the loading.
+        For example, use `exclude_filename=["events.nev"]` to skip loading the event file.
     """
 
     NeoRawIOClass = "NeuralynxRawIO"
@@ -104,8 +107,9 @@ class NeuralynxSortingExtractor(NeoBaseSortingExtractor):
         sampling_frequency: float | None = None,
         stream_id: str | None = None,
         stream_name: str | None = None,
+        exclude_filename: list[str] | None = None,
     ):
-        neo_kwargs = self.map_to_neo_kwargs(folder_path)
+        neo_kwargs = self.map_to_neo_kwargs(folder_path, exclude_filename)
         NeoBaseSortingExtractor.__init__(
             self,
             sampling_frequency=sampling_frequency,
@@ -119,11 +123,12 @@ class NeuralynxSortingExtractor(NeoBaseSortingExtractor):
             "sampling_frequency": sampling_frequency,
             "stream_id": stream_id,
             "stream_name": stream_name,
+            "exclude_filename": exclude_filename,
         }
 
     @classmethod
-    def map_to_neo_kwargs(cls, folder_path):
-        neo_kwargs = {"dirname": str(folder_path)}
+    def map_to_neo_kwargs(cls, folder_path, exclude_filename=None):
+        neo_kwargs = {"dirname": str(folder_path), "exclude_filename": exclude_filename}
         return neo_kwargs
 
 

--- a/src/spikeinterface/extractors/tests/common_tests.py
+++ b/src/spikeinterface/extractors/tests/common_tests.py
@@ -1,4 +1,5 @@
 import pickle
+import inspect
 
 import numpy as np
 
@@ -74,6 +75,24 @@ class RecordingCommonTestSuite(CommonTestSuite):
             if rec.get_property("gain_to_uV") is not None and rec.get_property("offset_to_uV") is not None:
                 trace_scaled = rec.get_traces(segment_index=segment_index, return_in_uV=True, end_frame=2)
                 assert trace_scaled.dtype == "float32"
+
+    def test_get_streams(self):
+        for entity in self.entities:
+            if isinstance(entity, tuple):
+                path, kwargs = entity
+            elif isinstance(entity, str):
+                path = entity
+                kwargs = {}
+
+            if not hasattr(self.ExtractorClass, "NeoRawIOClass"):
+                continue
+
+            # get_streams is called before the extractor exists, with the path and whatever neo needs to open it
+            neo_parameters = inspect.signature(self.ExtractorClass.map_to_neo_kwargs).parameters
+            neo_kwargs = {key: value for key, value in kwargs.items() if key in neo_parameters}
+
+            stream_names, stream_ids = self.ExtractorClass.get_streams(self.get_full_path(path), **neo_kwargs)
+            assert len(stream_names) == len(stream_ids)
 
     def test_neo_annotations(self):
         for entity in self.entities:


### PR DESCRIPTION
When adding `exclude_filename` to `NeuralynxSortingExtractor` (the recording extractor already had it and both go through the same `NeuralynxRawIO`) I realized that `get_neo_streams("neuralynx", folder_path)` throws a `TypeError`. The extra arguments in `map_to_neo_kwargs` have no defaults so the call fails on our own signature before neo is reached. Biocam is the same and blackrock never passed `gap_tolerance_ms` through there at all.

I added the defaults that the constructors already pass. All these errors have the same shape so I think it is good to add a general check instead of a test for the three formats that I found. I am adding it to `RecordingCommonTestSuite` to avoid this problem in the future.
