### PR TITLE
Propagate shared annotations in aggregate_channels

### DIFF
--- a/src/spikeinterface/core/channelsaggregationrecording.py
+++ b/src/spikeinterface/core/channelsaggregationrecording.py
@@ -10,6 +10,9 @@ class ChannelsAggregationRecording(BaseRecording):
     """
     Class that handles aggregating channels from different recordings, e.g. from different channel groups.
 
+    Annotations shared by all the recordings, meaning present in every recording and with the same value
+    everywhere, are propagated to the aggregated recording. All other annotations are dropped.
+
     Do not use this class directly but use `si.aggregate_channels(...)`
 
     """
@@ -96,6 +99,23 @@ class ChannelsAggregationRecording(BaseRecording):
         property_dict["aggregation_key"] = aggregation_key
         for prop_name, prop_values in property_dict.items():
             self.set_property(key=prop_name, values=prop_values)
+
+        # Propagate the annotations that are shared by the recordings. An annotation is shared when every
+        # recording carries it and all of them agree on its value. Anything else is dropped, which is the
+        # same rule used by `UnitsAggregationSorting` in unitsaggregationsorting.py.
+        for annotation_name in recording_list[0].get_annotation_keys():
+            if not all(annotation_name in rec.get_annotation_keys() for rec in recording_list):
+                continue
+            values = [rec.get_annotation(annotation_name, copy=False) for rec in recording_list]
+            try:
+                # `np.array_equal` gives a single bool for scalars, strings and arrays alike. Values it
+                # cannot compare (e.g. ragged object arrays) raise, and are then treated as not shared.
+                all_values_are_equal = all(np.array_equal(value, values[0]) for value in values[1:])
+            except Exception:
+                all_values_are_equal = False
+            if all_values_are_equal:
+                # take a copy so the aggregate does not share mutable state with its first child
+                self.set_annotation(annotation_name, recording_list[0].get_annotation(annotation_name), overwrite=True)
 
         # Aggregate probe information
         all_probegroups = [rec.get_probegroup() for rec in recording_list if rec.has_probe()]
@@ -254,6 +274,12 @@ def aggregate_channels(
     -------
     aggregate_recording: ChannelsAggregationRecording
         The aggregated recording object
+
+    Notes
+    -----
+    Annotations are propagated only when they are shared by all the recordings, meaning present in every
+    recording and with the same value everywhere. Annotations missing from one recording, or with differing
+    values, are dropped.
     """
 
     return ChannelsAggregationRecording(recording_list_or_dict, renamed_channel_ids, recording_list)

--- a/src/spikeinterface/core/tests/test_channelsaggregationrecording.py
+++ b/src/spikeinterface/core/tests/test_channelsaggregationrecording.py
@@ -332,5 +332,111 @@ def test_aggregate_channels_split_by_round_trip():
     assert recovered_names == {"probe_A", "probe_B"}
 
 
+def test_aggregate_channels_propagates_shared_annotations():
+    """Annotations present in every recording with the same value are propagated (issue #3983)."""
+    recording1 = generate_recording(num_channels=3, durations=[1.0], set_probe=False)
+    recording2 = generate_recording(num_channels=2, durations=[1.0], set_probe=False)
+
+    recording1.annotate(experimenter="alice", session_id=7)
+    recording2.annotate(experimenter="alice", session_id=7)
+
+    aggregated_recording = aggregate_channels([recording1, recording2])
+
+    assert aggregated_recording.get_annotation("experimenter") == "alice"
+    assert aggregated_recording.get_annotation("session_id") == 7
+
+    # `is_filtered` is set by all recordings and agrees, so it must be propagated rather than
+    # falling back to the `BaseRecording.__init__` default of False
+    assert recording1.get_annotation("is_filtered") == recording2.get_annotation("is_filtered")
+    assert aggregated_recording.get_annotation("is_filtered") == recording1.get_annotation("is_filtered")
+
+
+def test_aggregate_channels_drops_conflicting_annotations():
+    """Annotations present everywhere but with different values are not propagated (issue #3983)."""
+    recording1 = generate_recording(num_channels=3, durations=[1.0], set_probe=False)
+    recording2 = generate_recording(num_channels=2, durations=[1.0], set_probe=False)
+
+    recording1.annotate(experimenter="alice")
+    recording2.annotate(experimenter="bob")
+
+    aggregated_recording = aggregate_channels([recording1, recording2])
+
+    assert "experimenter" not in aggregated_recording.get_annotation_keys()
+
+
+def test_aggregate_channels_drops_partial_annotations():
+    """Annotations present in only some recordings are not propagated (issue #3983)."""
+    recording1 = generate_recording(num_channels=3, durations=[1.0], set_probe=False)
+    recording2 = generate_recording(num_channels=2, durations=[1.0], set_probe=False)
+
+    recording1.annotate(experimenter="alice")
+
+    aggregated_recording = aggregate_channels([recording1, recording2])
+
+    assert "experimenter" not in aggregated_recording.get_annotation_keys()
+
+    # also check the other direction, the loop is seeded from the first recording's keys
+    aggregated_recording_reversed = aggregate_channels([recording2, recording1])
+    assert "experimenter" not in aggregated_recording_reversed.get_annotation_keys()
+
+
+def test_aggregate_channels_with_array_valued_annotations():
+    """Array-valued and ragged annotations must never raise during aggregation (issue #3983)."""
+    recording1 = generate_recording(num_channels=3, durations=[1.0], set_probe=False)
+    recording2 = generate_recording(num_channels=2, durations=[1.0], set_probe=False)
+
+    # equal arrays: shared, so propagated
+    recording1.annotate(reference_waveform=np.arange(5))
+    recording2.annotate(reference_waveform=np.arange(5))
+
+    # arrays of different shape: not shared, so dropped, and must not raise
+    recording1.annotate(coverage=np.zeros((2, 3)))
+    recording2.annotate(coverage=np.zeros((4, 7)))
+
+    # ragged object values: not provably equal, so dropped, and must not raise
+    recording1.annotate(ragged=[np.arange(2), np.arange(3)])
+    recording2.annotate(ragged=[np.arange(2), np.arange(3)])
+
+    aggregated_recording = aggregate_channels([recording1, recording2])
+
+    assert np.array_equal(aggregated_recording.get_annotation("reference_waveform"), np.arange(5))
+    assert "coverage" not in aggregated_recording.get_annotation_keys()
+    # the ragged annotation may be propagated or dropped, the contract is only that we did not crash
+    assert aggregated_recording.get_num_channels() == 5
+
+
+def test_aggregate_channels_annotations_do_not_leak_to_inputs():
+    """The aggregated recording must not share mutable annotation values with its children."""
+    recording1 = generate_recording(num_channels=3, durations=[1.0], set_probe=False)
+    recording2 = generate_recording(num_channels=2, durations=[1.0], set_probe=False)
+
+    recording1.annotate(shared_list=[1, 2, 3])
+    recording2.annotate(shared_list=[1, 2, 3])
+
+    aggregated_recording = aggregate_channels([recording1, recording2])
+    aggregated_recording.get_annotation("shared_list", copy=False).append(4)
+
+    assert recording1.get_annotation("shared_list") == [1, 2, 3]
+    assert recording2.get_annotation("shared_list") == [1, 2, 3]
+
+
+def test_aggregate_channels_annotations_preserve_probe_information():
+    """Propagating annotations must not disturb the probe metadata of the aggregated recording."""
+    rec_A = _make_rec_with_named_probe("probe_A", "vendor_X", 0.0)
+    rec_B = _make_rec_with_named_probe("probe_B", "vendor_Y", 1000.0)
+
+    contours = [np.asarray(rec.get_probe().probe_planar_contour) for rec in (rec_A, rec_B)]
+    assert all(contour is not None and contour.size > 0 for contour in contours)
+
+    combined = aggregate_channels([rec_A, rec_B])
+
+    probes = combined.get_probes()
+    assert len(probes) == 2
+    for probe, expected_contour in zip(probes, contours):
+        assert np.array_equal(np.asarray(probe.probe_planar_contour), expected_contour)
+    assert np.array_equal(combined.get_channel_locations()[:8], rec_A.get_channel_locations())
+    assert np.array_equal(combined.get_channel_locations()[8:], rec_B.get_channel_locations())
+
+
 if __name__ == "__main__":
     test_channelsaggregationrecording()


### PR DESCRIPTION
Fixes #3983.

`ChannelsAggregationRecording` propagates properties from its child recordings but propagates no annotations at all, so metadata that every child agrees on is silently lost when you aggregate. The most visible case is `is_filtered`, which `BaseRecording.__init__` sets to `False` on the new aggregate, so aggregating two filtered recordings gave you an aggregate claiming to be unfiltered.

This adds annotation propagation just after the existing property block. The rule implemented is that an annotation is propagated only when it is present in every recording in the list and all of the recordings agree on its value. Anything missing from even one recording, and anything where the values differ, is dropped rather than guessed at. This is the same definition of shared that `UnitsAggregationSorting` in `unitsaggregationsorting.py` already uses for sortings, so the two aggregation paths now behave consistently.

The alternative worth naming is a union rule, where an annotation held by only some recordings is still carried over from whichever ones have it, possibly collected into a per recording list. I did not take that route because the aggregate would then be asserting metadata that is not true of all of its channels, and because it would diverge from the sorting sibling. Happy to switch if you prefer the union semantics.

Two small deliberate differences from the sorting version. First, the equality check uses `np.array_equal` rather than building an array of all the values and comparing with `==`. The sibling idiom is fragile once an annotation value is itself an array, since `np.array` on unequal length values either raises or yields an object array, and `==` on arrays returns an elementwise result instead of a single bool. The comparison is wrapped so that a value which cannot be compared at all, such as a ragged object array, is treated as not shared and skipped rather than crashing the aggregation. Second, the annotation is set with `overwrite=True`, which is required because `BaseRecording.__init__` has already set `is_filtered` by the time this loop runs and `set_annotation` otherwise raises on an existing key. Sortings do not hit this because `BaseSorting.__init__` sets no default annotations. The value stored is a copy, so the aggregate never shares mutable state with its first child.

On `name`, which is a main annotation, I chose to include it rather than special case it out. It is only ever present when someone has explicitly set it, since `BaseExtractor.name` falls back to the class name when the annotation is absent, so this only fires when every child carries the same explicit name. The repr still shows the class alongside it, as in `MyRecording (ChannelsAggregationRecording)`, so the aggregate is not disguised as one of its children, and splitting then re-aggregating now round trips the name instead of dropping it. Excluding it would have been an extra special case that neither the issue nor the sorting sibling asks for, but say the word and I will exclude it.

One note on the issue text. `probe_planar_contour` is no longer a recording annotation on main, it now lives on the `probeinterface.Probe` object, and `set_probegroup` no longer writes any annotation, so there is nothing for this change to clobber there. I placed the new block before the probegroup aggregation anyway, and added a test asserting that per probe planar contours and channel locations are unchanged after aggregating recordings that carry probes.

Tests added to `test_channelsaggregationrecording.py` cover an annotation shared by all children being propagated, one present everywhere with differing values being dropped, one present in only some children being dropped in both list orders, array valued and ragged annotations being handled without raising, the propagated value being a copy rather than a reference into the first child, and the probe metadata regression guard.

Reverting the source to main makes three of the new tests fail. The whole file passes after at 19, `test_unitsaggregationsorting.py` passes at 8, and the entire `core/tests/` suite runs to completion at 329 passed and 5 skipped. `black --line-length 120` reports both files unchanged.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
