### PR TITLE
Release the shared memory accumulator when template estimation fails

### DIFF
--- a/src/spikeinterface/core/tests/test_waveform_tools.py
+++ b/src/spikeinterface/core/tests/test_waveform_tools.py
@@ -5,6 +5,7 @@ import platform
 
 import numpy as np
 
+import spikeinterface.core.waveform_tools as waveform_tools
 from spikeinterface.core import generate_recording, generate_sorting, generate_ground_truth_recording, ms_to_samples
 from spikeinterface.core.waveform_tools import (
     extract_waveforms_to_buffers,
@@ -210,6 +211,106 @@ def test_estimate_templates_with_accumulator():
                 #     ax = axs[1]
                 #     ax.plot((templates - templates_loop)[unit_index, :, :].T.flatten(), color="k", ls="--")
                 # plt.show()
+
+
+class _SharedArrayRecorder:
+    """
+    Drop-in replacement for `make_shared_array` that records every segment it allocates and
+    whether `unlink()` was called on it.
+    """
+
+    def __init__(self):
+        self.segments = []
+
+    def __call__(self, shape, dtype):
+        from spikeinterface.core.core_tools import make_shared_array
+
+        arr, shm = make_shared_array(shape, dtype)
+        record = {"shm": shm, "unlinked": False}
+        self.segments.append(record)
+        real_unlink = shm.unlink
+
+        def tracked_unlink():
+            record["unlinked"] = True
+            real_unlink()
+
+        shm.unlink = tracked_unlink
+        return arr, shm
+
+    def cleanup(self):
+        # do not let a failing test leave real segments behind
+        for record in self.segments:
+            if not record["unlinked"]:
+                record["shm"].unlink()
+                record["unlinked"] = True
+
+
+@pytest.mark.parametrize("return_std", [False, True])
+def test_estimate_templates_with_accumulator_releases_shared_memory_on_error(monkeypatch, return_std):
+    # when the parallel run raises, the shared memory accumulator must still be unlinked.
+    # otherwise the segment survives the failure and python reports
+    # "There appear to be N leaked shared_memory objects to clean up at shutdown". See issue #4566.
+    recording, sorting = get_dataset()
+
+    nbefore = ms_to_samples(1.0, recording.sampling_frequency)
+    nafter = ms_to_samples(1.5, recording.sampling_frequency)
+    spikes = sorting.to_spike_vector()[::10]
+
+    recorder = _SharedArrayRecorder()
+    monkeypatch.setattr(waveform_tools, "make_shared_array", recorder)
+
+    def failing_worker(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(waveform_tools, "_worker_estimate_templates", failing_worker)
+
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            estimate_templates_with_accumulator(
+                recording,
+                spikes,
+                sorting.unit_ids,
+                nbefore,
+                nafter,
+                return_in_uV=True,
+                return_std=return_std,
+                n_jobs=1,
+                chunk_duration="1s",
+                progress_bar=False,
+            )
+
+        assert len(recorder.segments) == (2 if return_std else 1)
+        assert all(record["unlinked"] for record in recorder.segments)
+    finally:
+        recorder.cleanup()
+
+
+def test_estimate_templates_with_accumulator_allocation_error_is_explicit(monkeypatch):
+    # a failed allocation of the shared accumulator is an opaque "OSError: [Errno 28] No space left
+    # on device". It should instead name the sizes that produced it. See issue #4566.
+    recording, sorting = get_dataset()
+
+    nbefore = ms_to_samples(1.0, recording.sampling_frequency)
+    nafter = ms_to_samples(1.5, recording.sampling_frequency)
+    spikes = sorting.to_spike_vector()[::10]
+
+    def no_space(shape, dtype):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(waveform_tools, "make_shared_array", no_space)
+
+    with pytest.raises(MemoryError, match="n_jobs"):
+        estimate_templates_with_accumulator(
+            recording,
+            spikes,
+            sorting.unit_ids,
+            nbefore,
+            nafter,
+            return_in_uV=True,
+            n_jobs=2,
+            chunk_duration="1s",
+            progress_bar=False,
+        )
 
 
 def test_estimate_templates():

--- a/src/spikeinterface/core/waveform_tools.py
+++ b/src/spikeinterface/core/waveform_tools.py
@@ -566,7 +566,16 @@ def extract_waveforms_to_single_buffer(
         processor = TimeSeriesChunkExecutor(
             recording, func, init_func, init_args, job_name=job_name, verbose=verbose, **job_kwargs
         )
-        processor.run()
+        try:
+            processor.run()
+        except Exception:
+            # the buffer is never handed over to the caller when the run fails, so nobody else can
+            # release it. Without this, a failed run leaves a shared memory segment behind.
+            if mode == "shared_memory" and shm is not None:
+                del all_waveforms
+                shm.unlink()
+                shm.close()
+            raise
 
     if mode == "memmap":
         return all_waveforms
@@ -830,21 +839,51 @@ def estimate_templates(
             copy=False,
             **job_kwargs,
         )
-        templates_array = np.zeros(
-            (len(unit_ids), all_waveforms.shape[1], all_waveforms.shape[2]), dtype=all_waveforms.dtype
-        )
-        for unit_index, unit_id in enumerate(unit_ids):
-            wfs = all_waveforms[spikes["unit_index"] == unit_index]
-            templates_array[unit_index, :, :] = np.median(wfs, axis=0)
-        # release shared memory after the median
-        del all_waveforms
-        wf_array_info["shm"].close()
-        wf_array_info["shm"].unlink()
+        try:
+            templates_array = np.zeros(
+                (len(unit_ids), all_waveforms.shape[1], all_waveforms.shape[2]), dtype=all_waveforms.dtype
+            )
+            for unit_index, unit_id in enumerate(unit_ids):
+                wfs = all_waveforms[spikes["unit_index"] == unit_index]
+                templates_array[unit_index, :, :] = np.median(wfs, axis=0)
+        finally:
+            # release shared memory after the median, also when the median raises
+            del all_waveforms
+            shm = wf_array_info["shm"]
+            if shm is not None:
+                # empty arrays have no shared memory
+                shm.unlink()
+                shm.close()
 
     else:
         raise ValueError(f"estimate_templates(..., operator={operator}) wrong operator must be average or median")
 
     return templates_array
+
+
+def _allocate_accumulator_shared_array(shape, dtype):
+    """
+    Allocate one shared memory accumulator for `estimate_templates_with_accumulator()`.
+
+    The accumulator is allocated per worker, so its size scales with n_jobs and the allocation
+    can fail on machines with a small shared memory area (/dev/shm on Linux). The raw failure is
+    an opaque "OSError: [Errno 28] No space left on device", so it is re-raised with the sizes
+    that caused it.
+    """
+    try:
+        return make_shared_array(shape, dtype)
+    except (OSError, MemoryError) as err:
+        dtype = np.dtype(dtype)
+        num_worker, num_units, num_samples, num_chans = shape
+        nbytes = int(np.prod(shape)) * dtype.itemsize
+        size = f"{nbytes / 1e9:.2f} GB" if nbytes >= 1e9 else f"{nbytes / 1e6:.2f} MB"
+        raise MemoryError(
+            f"estimate_templates_with_accumulator() could not allocate its shared memory accumulator of "
+            f"{size}. The accumulator is allocated per worker, so its size is "
+            f"n_jobs * num_units * num_samples * num_channels * itemsize = "
+            f"{num_worker} * {num_units} * {num_samples} * {num_chans} * {dtype.itemsize} bytes. "
+            f"Lower n_jobs, or pass an explicit sparsity so that num_channels is smaller."
+        ) from err
 
 
 def estimate_templates_with_accumulator(
@@ -921,68 +960,86 @@ def estimate_templates_with_accumulator(
     shape = (num_worker, num_units, nbefore + nafter, num_chans)
 
     dtype = np.dtype("float32")
-    waveform_accumulator_per_worker, shm = make_shared_array(shape, dtype)
+    waveform_accumulator_per_worker, shm = _allocate_accumulator_shared_array(shape, dtype)
     shm_name = shm.name
-    if return_std:
-        waveform_squared_accumulator_per_worker, shm_squared = make_shared_array(shape, dtype)
-        shm_squared_name = shm_squared.name
-    else:
-        waveform_squared_accumulator_per_worker = None
-        shm_squared_name = None
+    waveform_squared_accumulator_per_worker = None
+    shm_squared = None
+    shm_squared_name = None
 
-    func = _worker_estimate_templates
-    init_func = _init_worker_estimate_templates
+    # everything below must release the shared memory, including on error. A segment that is not
+    # unlinked outlives the failure, keeps consuming the resource that is already scarce here, and
+    # is reported at interpreter shutdown as "leaked shared_memory objects".
+    try:
+        if return_std:
+            waveform_squared_accumulator_per_worker, shm_squared = _allocate_accumulator_shared_array(shape, dtype)
+            shm_squared_name = shm_squared.name
 
-    init_args = (
-        recording,
-        spikes,
-        shm_name,
-        shm_squared_name,
-        shape,
-        dtype,
-        nbefore,
-        nafter,
-        return_in_uV,
-        sparsity_mask,
-    )
+        func = _worker_estimate_templates
+        init_func = _init_worker_estimate_templates
 
-    if job_name is None:
-        job_name = "estimate_templates_with_accumulator"
-    processor = TimeSeriesChunkExecutor(
-        recording, func, init_func, init_args, job_name=job_name, verbose=verbose, need_worker_index=True, **job_kwargs
-    )
-    processor.run()
+        init_args = (
+            recording,
+            spikes,
+            shm_name,
+            shm_squared_name,
+            shape,
+            dtype,
+            nbefore,
+            nafter,
+            return_in_uV,
+            sparsity_mask,
+        )
 
-    # average
-    waveforms_sum = np.sum(waveform_accumulator_per_worker, axis=0)
-    if return_std:
-        # we need a copy here because we will use the means to compute the stds
-        template_means = waveforms_sum.copy()
-    else:
-        # waveforms_sum will also be changed in this case when acting on template_means
-        template_means = waveforms_sum
+        if job_name is None:
+            job_name = "estimate_templates_with_accumulator"
+        processor = TimeSeriesChunkExecutor(
+            recording,
+            func,
+            init_func,
+            init_args,
+            job_name=job_name,
+            verbose=verbose,
+            need_worker_index=True,
+            **job_kwargs,
+        )
+        processor.run()
 
-    unit_indices, spike_count = np.unique(spikes["unit_index"], return_counts=True)
-    template_means[unit_indices, :, :] /= spike_count[:, np.newaxis, np.newaxis]
+        # average
+        waveforms_sum = np.sum(waveform_accumulator_per_worker, axis=0)
+        if return_std:
+            # we need a copy here because we will use the means to compute the stds
+            template_means = waveforms_sum.copy()
+        else:
+            # waveforms_sum will also be changed in this case when acting on template_means
+            template_means = waveforms_sum
 
-    if return_std:
-        waveforms_squared_sum = np.sum(waveform_squared_accumulator_per_worker, axis=0)
-        # standard deviation
-        template_stds = np.zeros_like(template_means)
-        for unit_index, count in zip(unit_indices, spike_count):
-            residuals = (
-                waveforms_squared_sum[unit_index] - 2 * template_means[unit_index] * waveforms_sum[unit_index]
-            ) + count * template_means[unit_index] ** 2
-            residuals[residuals < 0] = 0
-            template_stds[unit_index] = np.sqrt(residuals / count)
+        unit_indices, spike_count = np.unique(spikes["unit_index"], return_counts=True)
+        template_means[unit_indices, :, :] /= spike_count[:, np.newaxis, np.newaxis]
+
+        if return_std:
+            waveforms_squared_sum = np.sum(waveform_squared_accumulator_per_worker, axis=0)
+            # standard deviation
+            template_stds = np.zeros_like(template_means)
+            for unit_index, count in zip(unit_indices, spike_count):
+                residuals = (
+                    waveforms_squared_sum[unit_index] - 2 * template_means[unit_index] * waveforms_sum[unit_index]
+                ) + count * template_means[unit_index] ** 2
+                residuals[residuals < 0] = 0
+                template_stds[unit_index] = np.sqrt(residuals / count)
+    finally:
+        # important : release the sharedmem.
+        # the numpy views on the buffers must be dropped before closing, otherwise numpy raises
+        # "BufferError: cannot close exported pointers exist". unlink() is what actually frees the
+        # segment so it comes first, a failing close() must not leave the segment behind.
+        del waveform_accumulator_per_worker
         del waveform_squared_accumulator_per_worker
-        shm_squared.unlink()
-        shm_squared.close()
+        shm.unlink()
+        shm.close()
+        if shm_squared is not None:
+            shm_squared.unlink()
+            shm_squared.close()
 
-    # important : release the sharedmem
-    del waveform_accumulator_per_worker
-    shm.unlink()
-    shm.close()
+    # the returned arrays come from np.sum / np.zeros_like, so they do not view the shared buffers
 
     if return_std:
         return template_means, template_stds


### PR DESCRIPTION
Related to #4566.

`estimate_templates_with_accumulator()` allocates a shared memory accumulator, runs the chunk executor over it, and then unlinks it. The unlink and close calls only sit on the success path, so any exception raised inside `processor.run()`, or in the averaging that follows, returns without ever releasing the segment. Python then prints "There appear to be 1 leaked shared_memory objects to clean up at shutdown", which is exactly the message in the report, and the orphaned segment keeps occupying the shared memory area that a retry needs.

This change wraps the whole body in try/finally so the segment is released either way. The numpy views are still dropped before `close()` so numpy does not raise "cannot close exported pointers exist", and `unlink()` now runs before `close()` so a failing close cannot leave the segment behind. The returned arrays come from `np.sum` and `np.zeros_like`, so they do not view the shared buffers and are safe to return after the release.

Two sibling functions in the same module had the same unprotected release and are fixed the same way. `extract_waveforms_to_single_buffer()` leaked its buffer when the run failed, in both copy modes, because the caller never receives the handle when the call raises. The median branch of `estimate_templates()` leaked its buffer if the median computation raised.

I checked the four other `make_shared_array` call sites and deliberately left them alone, since they hand ownership to the caller: `allocate_waveforms_buffers`, `numpyextractors.py:527`, `time_series_tools.py:241`, and the matching components.

The second part of this change is about the error message. The accumulator is allocated per worker, so its size is `n_jobs * num_units * num_samples * num_channels * 4` bytes. When `estimate_sparsity()` is the caller there is no sparsity mask yet, so `num_channels` is the full channel count. For the reporter's numbers, roughly 1500 units on 384 channels with 105 samples, that is about 2.4 GB of shared memory at 10 jobs. On Linux `/dev/shm` defaults to half of RAM, so the allocation fails with a bare `OSError: [Errno 28] No space left on device`, which reads nothing like a job or sparsity problem. That failure is now re-raised as a `MemoryError` that prints the requested size, spells out the four factors that produced it, and points at lowering `n_jobs` or passing an explicit sparsity. No pre-emptive cap is added, so nothing that works today starts refusing to run.

To be clear about what this does not do. It does not change the fact that the accumulator scales with `n_jobs * num_units`, and that scaling is the actual root cause of the crash in #4566. It matches the reporter's own measurements well: 10 cores topped out around 800 units, 6 cores around 1000, and 4 cores handled all 1500, so the product of cores and units is roughly constant, which is what a per worker allocation predicts. Working through the three data points at 30 kHz with the default 1.0 and 2.5 ms window on 384 channels in float32 gives 1.29 GB for 10 by 800 which fails, and 0.97 GB for both 6 by 1000 and 4 by 1500 which work, so there is a fixed ceiling between 1.0 and 1.3 GB.

Reworking the accumulator so it does not scale with the worker count is a much larger design change and I did not want to bundle it into this PR, so I have left that decision to you. What this change does fix is that a failure no longer leaves shared memory behind to make the next attempt worse, and that the failure now says what went wrong.

Tests are added in `src/spikeinterface/core/tests/test_waveform_tools.py`. One records every segment created through `make_shared_array`, forces the per chunk worker to raise, and asserts every recorded segment was unlinked, covering both the `return_std=False` and `return_std=True` shapes. The other asserts the allocation failure surfaces as a `MemoryError` mentioning `n_jobs`. Both fail on current main.

Reverting the source to main makes all three new tests fail. They pass after, and the regression runs complete at 12 passed for waveform_tools plus sparsity, 14 passed adding template_tools, and 41 passed for sortinganalyzer plus analyzer_extension_core. `black` reports both files unchanged.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
