### PR TITLE
Fix mismatch in vairable name in mergeunitssorting.py

### DIFF
--- a/src/spikeinterface/curation/mergeunitssorting.py
+++ b/src/spikeinterface/curation/mergeunitssorting.py
@@ -161,7 +161,7 @@ class MergeUnitsSortingSegment(BaseSortingSegment):
             else:
                 start_i = 0
             if end_frame is not None:
-                end_i = np.searchsorted(spike_times, start_frame, side="right")
+                end_i = np.searchsorted(spike_times, end_frame, side="right")
             else:
                 end_i = len(spike_times)
             return spike_times[start_i:end_i]


### PR DESCRIPTION
Fix issue: #4735 
This PR changed the variable name in line 164 in spikeinterface\src\spikeinterface\curation\mergeunitssorting.py. Now the variable name matches in line 163-164
 