### PR TITLE
Run the kwargs backward compatibility hook regardless of the saved version

### DIFF
--- a/src/spikeinterface/core/base.py
+++ b/src/spikeinterface/core/base.py
@@ -1151,8 +1151,7 @@ def _load_extractor_from_dict(dic) -> "BaseExtractor":
     extractor_class = _get_class_from_string(class_name)
 
     assert extractor_class is not None and class_name is not None, "Could not load spikeinterface class"
-    is_old_version = not _check_same_version(class_name, dic["version"])
-    if is_old_version and hasattr(extractor_class, "_handle_kwargs_backward_compatibility"):
+    if hasattr(extractor_class, "_handle_kwargs_backward_compatibility"):
         new_kwargs = extractor_class._handle_kwargs_backward_compatibility(new_kwargs, dic)
 
     # Initialize the extractor

--- a/src/spikeinterface/core/tests/test_binaryrecordingextractor.py
+++ b/src/spikeinterface/core/tests/test_binaryrecordingextractor.py
@@ -2,7 +2,9 @@ import pytest
 import numpy as np
 from pathlib import Path
 
+import spikeinterface
 from spikeinterface.core import BinaryRecordingExtractor, MockRecording
+from spikeinterface.core.base import BaseExtractor
 from spikeinterface.core.numpyextractors import NumpyRecording
 from spikeinterface.core.core_tools import measure_memory_allocation
 
@@ -121,6 +123,32 @@ def test_sequential_reading_of_small_traces(folder_with_binary_files):
     small_traces = recording.get_traces(start_frame=start_frame, end_frame=end_frame)
     expected_traces = full_traces[start_frame:end_frame, :]
     assert np.allclose(small_traces, expected_traces)
+
+
+def test_num_chan_backward_compatibility_within_same_version(tmp_path):
+    # A dict written by the same major.minor can still carry a kwarg that the current
+    # constructor no longer accepts, so the repair hook must run whatever version it records.
+    num_channels = 3
+    num_samples = 30
+    sampling_frequency = 10_000.0
+    dtype = "int16"
+
+    file_path = tmp_path / "test_num_chan_backward_compatibility.raw"
+    np.memmap(file_path, dtype=dtype, mode="w+", shape=(num_samples, num_channels))
+
+    recording = BinaryRecordingExtractor(
+        file_paths=file_path,
+        sampling_frequency=sampling_frequency,
+        num_channels=num_channels,
+        dtype=dtype,
+    )
+
+    dictionary = recording.to_dict()
+    assert dictionary["version"] == spikeinterface.__version__
+    dictionary["kwargs"]["num_chan"] = dictionary["kwargs"].pop("num_channels")
+
+    loaded_recording = BaseExtractor.from_dict(dictionary)
+    assert loaded_recording.get_num_channels() == num_channels
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@ecobost found in #4629 that a recording saved before `load_sync_channel` was dropped still fails to load, as `_handle_kwargs_backward_compatibility` only runs when the saved version differs in major or minor:
https://github.com/SpikeInterface/spikeinterface/issues/4629#issuecomment-5486773828

> is_old_version can be False (because it only checks for major&minor version so for instance if you saved something with 0.104.x and reload it with 0.104.x but the new neo, then the backward compatibility check won't happen)

I thought about improving the version check to also consider the patch number but that seems unnecessary. I think it is better to remove the version check entirely. If an extractor has tooling to reload old kwargs let it operate regardless. This removes some machinery and improves the functionality. 

