### PR TITLE
Parallelize coherence-based bad channel detection

### DIFF
--- a/src/spikeinterface/preprocessing/detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/detect_bad_channels.py
@@ -161,11 +161,11 @@ def _get_all_detect_bad_channel_kwargs(detect_bad_channels_kwargs):
     return all_detect_bad_channels_kwargs
 
 
-def _detect_bad_channels_coherence_psd_chunk_init(recording, method_kwargs):
+def _detect_bad_channels_chunk_init(recording, method_kwargs):
     return {"recording": recording, "method_kwargs": method_kwargs}
 
 
-def _detect_bad_channels_coherence_psd_chunk(segment_index, start_frame, end_frame, worker_context):
+def _detect_bad_channels_chunk(segment_index, start_frame, end_frame, worker_context):
     recording = worker_context["recording"]
     method_kwargs = worker_context["method_kwargs"]
 
@@ -263,10 +263,31 @@ def detect_bad_channels(
     else:
         recording_hp = recording
 
+    # Adjust random chunk kwargs based on method
+    if method in ("std", "mad"):
+        random_chunk_kwargs["return_in_uV"] = False
+        random_chunk_kwargs["concatenated"] = True
+    elif method == "neighborhood_r2":
+        random_chunk_kwargs["return_in_uV"] = False
+        random_chunk_kwargs["concatenated"] = False
+
+    if method != "coherence+psd":
+        random_data = get_random_data_chunks(recording_hp, **random_chunk_kwargs)
+
     channel_labels = np.zeros(recording.get_num_channels(), dtype="U5")
     channel_labels[:] = "good"
 
-    if method == "coherence+psd":
+    if method in ("std", "mad"):
+        if method == "std":
+            deviations = np.std(random_data, axis=0)
+        else:
+            deviations = median_abs_deviation(random_data, axis=0)
+        thresh = std_mad_threshold * np.median(deviations)
+        mask = deviations > thresh
+        bad_channel_ids = recording.channel_ids[mask]
+        channel_labels[mask] = "noise"
+
+    elif method == "coherence+psd":
         job_kwargs = {} if job_kwargs is None else job_kwargs
         job_kwargs = fix_job_kwargs(job_kwargs)
 
@@ -304,8 +325,8 @@ def detect_bad_channels(
         random_slices = get_random_sample_slices(recording_hp, **random_chunk_kwargs)
         executor = TimeSeriesChunkExecutor(
             recording_hp,
-            _detect_bad_channels_coherence_psd_chunk,
-            _detect_bad_channels_coherence_psd_chunk_init,
+            _detect_bad_channels_chunk,
+            _detect_bad_channels_chunk_init,
             (recording_hp, method_kwargs),
             handle_returns=True,
             chunk_size=random_chunk_kwargs["chunk_size"],
@@ -350,72 +371,52 @@ def detect_bad_channels(
         filtered_bad_channel_mask = np.isin(channel_labels, list(channel_filters))
         bad_channel_ids = recording.channel_ids[filtered_bad_channel_mask]
 
-    else:
-        if method in ("std", "mad"):
-            random_chunk_kwargs["return_in_uV"] = False
-            random_chunk_kwargs["concatenated"] = True
-        else:  # neighborhood_r2
-            random_chunk_kwargs["return_in_uV"] = False
-            random_chunk_kwargs["concatenated"] = False
+    elif method == "neighborhood_r2":
+        # make neighboring channels structure. this should probably be a function in core.
+        geom = recording.get_channel_locations()
+        num_channels = recording.get_num_channels()
+        chan_distances = np.linalg.norm(geom[:, None, :] - geom[None, :, :], axis=2)
+        np.fill_diagonal(chan_distances, neighborhood_r2_radius_um + 1)
+        neighbors_mask = chan_distances < neighborhood_r2_radius_um
+        if neighbors_mask.sum(axis=1).min() < 1:
+            warnings.warn(
+                f"neighborhood_r2_radius_um={neighborhood_r2_radius_um} led "
+                "to channels with no neighbors for this geometry, which has "
+                f"minimal channel distance {chan_distances.min()}um. These "
+                "channels will not be marked as bad, but you might want to "
+                "check them."
+            )
+        max_neighbors = neighbors_mask.sum(axis=1).max()
+        channel_index = np.full((num_channels, max_neighbors), num_channels)
+        for c in range(num_channels):
+            my_neighbors = np.flatnonzero(neighbors_mask[c])
+            channel_index[c, : my_neighbors.size] = my_neighbors
 
-        random_data = get_random_data_chunks(recording_hp, **random_chunk_kwargs)
+        # get the correlation of each channel with its neighbors' median inside each chunk
+        # note that we did not concatenate the chunks here
+        correlations = []
+        for chunk in random_data:
+            chunk = chunk.astype(np.float32, copy=False)
+            chunk = chunk - np.median(chunk, axis=0, keepdims=True)
+            padded_chunk = np.pad(chunk, [(0, 0), (0, 1)], constant_values=np.nan)
+            # channels with no neighbors will get a pure-nan median trace here
+            neighbmeans = np.nanmedian(
+                padded_chunk[:, channel_index],
+                axis=2,
+            )
+            denom = np.sqrt(np.nanmean(np.square(chunk), axis=0) * np.nanmean(np.square(neighbmeans), axis=0))
+            denom[denom == 0] = 1
+            # channels with no neighbors will get a nan here
+            chunk_correlations = np.nanmean(chunk * neighbmeans, axis=0) / denom
+            correlations.append(chunk_correlations)
 
-        if method in ("std", "mad"):
-            if method == "std":
-                deviations = np.std(random_data, axis=0)
-            else:
-                deviations = median_abs_deviation(random_data, axis=0)
-            thresh = std_mad_threshold * np.median(deviations)
-            mask = deviations > thresh
-            bad_channel_ids = recording.channel_ids[mask]
-            channel_labels[mask] = "noise"
-
-        else:  # neighborhood_r2
-            # make neighboring channels structure. this should probably be a function in core.
-            geom = recording.get_channel_locations()
-            num_channels = recording.get_num_channels()
-            chan_distances = np.linalg.norm(geom[:, None, :] - geom[None, :, :], axis=2)
-            np.fill_diagonal(chan_distances, neighborhood_r2_radius_um + 1)
-            neighbors_mask = chan_distances < neighborhood_r2_radius_um
-            if neighbors_mask.sum(axis=1).min() < 1:
-                warnings.warn(
-                    f"neighborhood_r2_radius_um={neighborhood_r2_radius_um} led "
-                    "to channels with no neighbors for this geometry, which has "
-                    f"minimal channel distance {chan_distances.min()}um. These "
-                    "channels will not be marked as bad, but you might want to "
-                    "check them."
-                )
-            max_neighbors = neighbors_mask.sum(axis=1).max()
-            channel_index = np.full((num_channels, max_neighbors), num_channels)
-            for c in range(num_channels):
-                my_neighbors = np.flatnonzero(neighbors_mask[c])
-                channel_index[c, : my_neighbors.size] = my_neighbors
-
-            # get the correlation of each channel with its neighbors' median inside each chunk
-            # note that we did not concatenate the chunks here
-            correlations = []
-            for chunk in random_data:
-                chunk = chunk.astype(np.float32, copy=False)
-                chunk = chunk - np.median(chunk, axis=0, keepdims=True)
-                padded_chunk = np.pad(chunk, [(0, 0), (0, 1)], constant_values=np.nan)
-                # channels with no neighbors will get a pure-nan median trace here
-                neighbmeans = np.nanmedian(
-                    padded_chunk[:, channel_index],
-                    axis=2,
-                )
-                denom = np.sqrt(np.nanmean(np.square(chunk), axis=0) * np.nanmean(np.square(neighbmeans), axis=0))
-                denom[denom == 0] = 1
-                # channels with no neighbors will get a nan here
-                chunk_correlations = np.nanmean(chunk * neighbmeans, axis=0) / denom
-                correlations.append(chunk_correlations)
-
-            # now take the median over chunks and threshold to finish
-            median_correlations = np.nanmedian(correlations, 0)
-            r2s = median_correlations**2
-            # channels with no neighbors will have r2==nan, and nan<x==False always
-            bad_channel_mask = r2s < neighborhood_r2_threshold
-            bad_channel_ids = recording.channel_ids[bad_channel_mask]
-            channel_labels[bad_channel_mask] = "noise"
+        # now take the median over chunks and threshold to finish
+        median_correlations = np.nanmedian(correlations, 0)
+        r2s = median_correlations**2
+        # channels with no neighbors will have r2==nan, and nan<x==False always
+        bad_channel_mask = r2s < neighborhood_r2_threshold
+        bad_channel_ids = recording.channel_ids[bad_channel_mask]
+        channel_labels[bad_channel_mask] = "noise"
 
     return bad_channel_ids, channel_labels
 

--- a/src/spikeinterface/preprocessing/detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/detect_bad_channels.py
@@ -288,13 +288,8 @@ def detect_bad_channels(
         channel_labels[mask] = "noise"
 
     elif method == "coherence+psd":
-        if job_kwargs is None:
-            job_kwargs = {"progress_bar": False}
+        job_kwargs = {}  if job_kwargs is None else job_kwargs
         job_kwargs = fix_job_kwargs(job_kwargs)
-        executor_job_kwargs = {
-            key: job_kwargs[key]
-            for key in ("pool_engine", "n_jobs", "progress_bar", "mp_context", "max_threads_per_worker")
-        }
 
         # some checks
         assert recording.has_scaleable_traces(), (
@@ -336,7 +331,7 @@ def detect_bad_channels(
             handle_returns=True,
             chunk_size=random_chunk_kwargs["chunk_size"],
             job_name="detect_bad_channels",
-            **executor_job_kwargs,
+            **job_kwargs,
         )
         chunk_channel_labels = np.stack(executor.run(slices=random_slices), axis=1)
 

--- a/src/spikeinterface/preprocessing/detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/detect_bad_channels.py
@@ -161,11 +161,11 @@ def _get_all_detect_bad_channel_kwargs(detect_bad_channels_kwargs):
     return all_detect_bad_channels_kwargs
 
 
-def _detect_bad_channels_chunk_init(recording, method_kwargs):
+def _detect_bad_channels_coherence_psd_chunk_init(recording, method_kwargs):
     return {"recording": recording, "method_kwargs": method_kwargs}
 
 
-def _detect_bad_channels_chunk(segment_index, start_frame, end_frame, worker_context):
+def _detect_bad_channels_coherence_psd_chunk(segment_index, start_frame, end_frame, worker_context):
     recording = worker_context["recording"]
     method_kwargs = worker_context["method_kwargs"]
 
@@ -263,31 +263,10 @@ def detect_bad_channels(
     else:
         recording_hp = recording
 
-    # Adjust random chunk kwargs based on method
-    if method in ("std", "mad"):
-        random_chunk_kwargs["return_in_uV"] = False
-        random_chunk_kwargs["concatenated"] = True
-    elif method == "neighborhood_r2":
-        random_chunk_kwargs["return_in_uV"] = False
-        random_chunk_kwargs["concatenated"] = False
-
-    if method != "coherence+psd":
-        random_data = get_random_data_chunks(recording_hp, **random_chunk_kwargs)
-
     channel_labels = np.zeros(recording.get_num_channels(), dtype="U5")
     channel_labels[:] = "good"
 
-    if method in ("std", "mad"):
-        if method == "std":
-            deviations = np.std(random_data, axis=0)
-        else:
-            deviations = median_abs_deviation(random_data, axis=0)
-        thresh = std_mad_threshold * np.median(deviations)
-        mask = deviations > thresh
-        bad_channel_ids = recording.channel_ids[mask]
-        channel_labels[mask] = "noise"
-
-    elif method == "coherence+psd":
+    if method == "coherence+psd":
         job_kwargs = {} if job_kwargs is None else job_kwargs
         job_kwargs = fix_job_kwargs(job_kwargs)
 
@@ -325,8 +304,8 @@ def detect_bad_channels(
         random_slices = get_random_sample_slices(recording_hp, **random_chunk_kwargs)
         executor = TimeSeriesChunkExecutor(
             recording_hp,
-            _detect_bad_channels_chunk,
-            _detect_bad_channels_chunk_init,
+            _detect_bad_channels_coherence_psd_chunk,
+            _detect_bad_channels_coherence_psd_chunk_init,
             (recording_hp, method_kwargs),
             handle_returns=True,
             chunk_size=random_chunk_kwargs["chunk_size"],
@@ -371,52 +350,72 @@ def detect_bad_channels(
         filtered_bad_channel_mask = np.isin(channel_labels, list(channel_filters))
         bad_channel_ids = recording.channel_ids[filtered_bad_channel_mask]
 
-    elif method == "neighborhood_r2":
-        # make neighboring channels structure. this should probably be a function in core.
-        geom = recording.get_channel_locations()
-        num_channels = recording.get_num_channels()
-        chan_distances = np.linalg.norm(geom[:, None, :] - geom[None, :, :], axis=2)
-        np.fill_diagonal(chan_distances, neighborhood_r2_radius_um + 1)
-        neighbors_mask = chan_distances < neighborhood_r2_radius_um
-        if neighbors_mask.sum(axis=1).min() < 1:
-            warnings.warn(
-                f"neighborhood_r2_radius_um={neighborhood_r2_radius_um} led "
-                "to channels with no neighbors for this geometry, which has "
-                f"minimal channel distance {chan_distances.min()}um. These "
-                "channels will not be marked as bad, but you might want to "
-                "check them."
-            )
-        max_neighbors = neighbors_mask.sum(axis=1).max()
-        channel_index = np.full((num_channels, max_neighbors), num_channels)
-        for c in range(num_channels):
-            my_neighbors = np.flatnonzero(neighbors_mask[c])
-            channel_index[c, : my_neighbors.size] = my_neighbors
+    else:
+        if method in ("std", "mad"):
+            random_chunk_kwargs["return_in_uV"] = False
+            random_chunk_kwargs["concatenated"] = True
+        else:  # neighborhood_r2
+            random_chunk_kwargs["return_in_uV"] = False
+            random_chunk_kwargs["concatenated"] = False
 
-        # get the correlation of each channel with its neighbors' median inside each chunk
-        # note that we did not concatenate the chunks here
-        correlations = []
-        for chunk in random_data:
-            chunk = chunk.astype(np.float32, copy=False)
-            chunk = chunk - np.median(chunk, axis=0, keepdims=True)
-            padded_chunk = np.pad(chunk, [(0, 0), (0, 1)], constant_values=np.nan)
-            # channels with no neighbors will get a pure-nan median trace here
-            neighbmeans = np.nanmedian(
-                padded_chunk[:, channel_index],
-                axis=2,
-            )
-            denom = np.sqrt(np.nanmean(np.square(chunk), axis=0) * np.nanmean(np.square(neighbmeans), axis=0))
-            denom[denom == 0] = 1
-            # channels with no neighbors will get a nan here
-            chunk_correlations = np.nanmean(chunk * neighbmeans, axis=0) / denom
-            correlations.append(chunk_correlations)
+        random_data = get_random_data_chunks(recording_hp, **random_chunk_kwargs)
 
-        # now take the median over chunks and threshold to finish
-        median_correlations = np.nanmedian(correlations, 0)
-        r2s = median_correlations**2
-        # channels with no neighbors will have r2==nan, and nan<x==False always
-        bad_channel_mask = r2s < neighborhood_r2_threshold
-        bad_channel_ids = recording.channel_ids[bad_channel_mask]
-        channel_labels[bad_channel_mask] = "noise"
+        if method in ("std", "mad"):
+            if method == "std":
+                deviations = np.std(random_data, axis=0)
+            else:
+                deviations = median_abs_deviation(random_data, axis=0)
+            thresh = std_mad_threshold * np.median(deviations)
+            mask = deviations > thresh
+            bad_channel_ids = recording.channel_ids[mask]
+            channel_labels[mask] = "noise"
+
+        else:  # neighborhood_r2
+            # make neighboring channels structure. this should probably be a function in core.
+            geom = recording.get_channel_locations()
+            num_channels = recording.get_num_channels()
+            chan_distances = np.linalg.norm(geom[:, None, :] - geom[None, :, :], axis=2)
+            np.fill_diagonal(chan_distances, neighborhood_r2_radius_um + 1)
+            neighbors_mask = chan_distances < neighborhood_r2_radius_um
+            if neighbors_mask.sum(axis=1).min() < 1:
+                warnings.warn(
+                    f"neighborhood_r2_radius_um={neighborhood_r2_radius_um} led "
+                    "to channels with no neighbors for this geometry, which has "
+                    f"minimal channel distance {chan_distances.min()}um. These "
+                    "channels will not be marked as bad, but you might want to "
+                    "check them."
+                )
+            max_neighbors = neighbors_mask.sum(axis=1).max()
+            channel_index = np.full((num_channels, max_neighbors), num_channels)
+            for c in range(num_channels):
+                my_neighbors = np.flatnonzero(neighbors_mask[c])
+                channel_index[c, : my_neighbors.size] = my_neighbors
+
+            # get the correlation of each channel with its neighbors' median inside each chunk
+            # note that we did not concatenate the chunks here
+            correlations = []
+            for chunk in random_data:
+                chunk = chunk.astype(np.float32, copy=False)
+                chunk = chunk - np.median(chunk, axis=0, keepdims=True)
+                padded_chunk = np.pad(chunk, [(0, 0), (0, 1)], constant_values=np.nan)
+                # channels with no neighbors will get a pure-nan median trace here
+                neighbmeans = np.nanmedian(
+                    padded_chunk[:, channel_index],
+                    axis=2,
+                )
+                denom = np.sqrt(np.nanmean(np.square(chunk), axis=0) * np.nanmean(np.square(neighbmeans), axis=0))
+                denom[denom == 0] = 1
+                # channels with no neighbors will get a nan here
+                chunk_correlations = np.nanmean(chunk * neighbmeans, axis=0) / denom
+                correlations.append(chunk_correlations)
+
+            # now take the median over chunks and threshold to finish
+            median_correlations = np.nanmedian(correlations, 0)
+            r2s = median_correlations**2
+            # channels with no neighbors will have r2==nan, and nan<x==False always
+            bad_channel_mask = r2s < neighborhood_r2_threshold
+            bad_channel_ids = recording.channel_ids[bad_channel_mask]
+            channel_labels[bad_channel_mask] = "noise"
 
     return bad_channel_ids, channel_labels
 

--- a/src/spikeinterface/preprocessing/detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/detect_bad_channels.py
@@ -288,7 +288,7 @@ def detect_bad_channels(
         channel_labels[mask] = "noise"
 
     elif method == "coherence+psd":
-        job_kwargs = {}  if job_kwargs is None else job_kwargs
+        job_kwargs = {} if job_kwargs is None else job_kwargs
         job_kwargs = fix_job_kwargs(job_kwargs)
 
         # some checks

--- a/src/spikeinterface/preprocessing/detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/detect_bad_channels.py
@@ -4,6 +4,8 @@ import numpy as np
 from typing import Literal
 
 from spikeinterface.core.core_tools import define_function_handling_dict_from_class
+from spikeinterface.core.job_tools import TimeSeriesChunkExecutor, fix_job_kwargs
+from spikeinterface.core.time_series_tools import get_random_sample_slices
 from .filter import highpass_filter
 from spikeinterface.core import get_random_data_chunks, order_channels_by_depth, BaseRecording
 from spikeinterface.core.channelslice import ChannelSliceRecording
@@ -75,6 +77,12 @@ seed : int | None, default: None
     The random seed to extract chunks
 channel_filters : set | None, default: None
     For coherence+psd - only return `bad_channel_ids` whose labels are in the set `channel_filter`.
+job_kwargs : dict | None, default: None
+    Keyword arguments for parallel processing. Only used for the "coherence+psd" method. Only the
+    execution-related keys (`pool_engine`, `n_jobs`, `progress_bar`, `mp_context`,
+    `max_threads_per_worker`) apply; the chunking size is fixed by `chunk_duration_s` and
+    `num_random_chunks` above, so `chunk_size`, `chunk_memory`, `total_memory` and `chunk_duration`
+    are not used here.
 """
 
 
@@ -153,6 +161,39 @@ def _get_all_detect_bad_channel_kwargs(detect_bad_channels_kwargs):
     return all_detect_bad_channels_kwargs
 
 
+def _detect_bad_channels_chunk_init(recording, method_kwargs):
+    return {"recording": recording, "method_kwargs": method_kwargs}
+
+
+def _detect_bad_channels_chunk(segment_index, start_frame, end_frame, worker_context):
+    recording = worker_context["recording"]
+    method_kwargs = worker_context["method_kwargs"]
+
+    random_chunk = recording.get_traces(
+        start_frame=start_frame,
+        end_frame=end_frame,
+        segment_index=segment_index,
+        return_in_uV=True,
+    )
+
+    order_f = method_kwargs["order_f"]
+    order_r = method_kwargs["order_r"]
+    random_chunk_sorted = random_chunk[:, order_f] if order_f is not None else random_chunk
+    chunk_labels = detect_bad_channels_ibl(
+        raw=random_chunk_sorted,
+        fs=recording.sampling_frequency,
+        psd_hf_threshold=method_kwargs["psd_hf_threshold"],
+        dead_channel_thr=method_kwargs["dead_channel_threshold"],
+        noisy_channel_thr=method_kwargs["noisy_channel_threshold"],
+        outside_channel_thr=method_kwargs["outside_channel_threshold"],
+        n_neighbors=method_kwargs["n_neighbors"],
+        nyquist_threshold=method_kwargs["nyquist_threshold"],
+        welch_window_ms=method_kwargs["welch_window_ms"],
+        outside_channels_location=method_kwargs["outside_channels_location"],
+    )
+    return chunk_labels[order_r] if order_r is not None else chunk_labels
+
+
 def detect_bad_channels(
     recording: BaseRecording,
     method: str = "coherence+psd",
@@ -173,6 +214,7 @@ def detect_bad_channels(
     neighborhood_r2_radius_um: float = 30.0,
     seed: int | None = None,
     channel_filters: set | None = None,
+    job_kwargs: dict | None = None,
 ):
     """
     Perform bad channel detection.
@@ -225,14 +267,12 @@ def detect_bad_channels(
     if method in ("std", "mad"):
         random_chunk_kwargs["return_in_uV"] = False
         random_chunk_kwargs["concatenated"] = True
-    elif method == "coherence+psd":
-        random_chunk_kwargs["return_in_uV"] = True
-        random_chunk_kwargs["concatenated"] = False
     elif method == "neighborhood_r2":
         random_chunk_kwargs["return_in_uV"] = False
         random_chunk_kwargs["concatenated"] = False
 
-    random_data = get_random_data_chunks(recording_hp, **random_chunk_kwargs)
+    if method != "coherence+psd":
+        random_data = get_random_data_chunks(recording_hp, **random_chunk_kwargs)
 
     channel_labels = np.zeros(recording.get_num_channels(), dtype="U5")
     channel_labels[:] = "good"
@@ -248,6 +288,14 @@ def detect_bad_channels(
         channel_labels[mask] = "noise"
 
     elif method == "coherence+psd":
+        if job_kwargs is None:
+            job_kwargs = {"progress_bar": False}
+        job_kwargs = fix_job_kwargs(job_kwargs)
+        executor_job_kwargs = {
+            key: job_kwargs[key]
+            for key in ("pool_engine", "n_jobs", "progress_bar", "mp_context", "max_threads_per_worker")
+        }
+
         # some checks
         assert recording.has_scaleable_traces(), (
             "The 'coherence+psd' method uses thresholds assuming the traces are in uV, "
@@ -267,24 +315,30 @@ def detect_bad_channels(
             order_f = None
             order_r = None
 
-        # Create empty channel labels and fill with bad-channel detection estimate for each chunk
-        chunk_channel_labels = np.zeros((recording.get_num_channels(), len(random_data)), dtype=np.int8)
-
-        for i, random_chunk in enumerate(random_data):
-            random_chunk_sorted = random_chunk[:, order_f] if order_f is not None else random_chunk
-            chunk_labels = detect_bad_channels_ibl(
-                raw=random_chunk_sorted,
-                fs=recording.sampling_frequency,
-                psd_hf_threshold=psd_hf_threshold,
-                dead_channel_thr=dead_channel_threshold,
-                noisy_channel_thr=noisy_channel_threshold,
-                outside_channel_thr=outside_channel_threshold,
-                n_neighbors=n_neighbors,
-                nyquist_threshold=nyquist_threshold,
-                welch_window_ms=welch_window_ms,
-                outside_channels_location=outside_channels_location,
-            )
-            chunk_channel_labels[:, i] = chunk_labels[order_r] if order_r is not None else chunk_labels
+        method_kwargs = dict(
+            order_f=order_f,
+            order_r=order_r,
+            psd_hf_threshold=psd_hf_threshold,
+            dead_channel_threshold=dead_channel_threshold,
+            noisy_channel_threshold=noisy_channel_threshold,
+            outside_channel_threshold=outside_channel_threshold,
+            n_neighbors=n_neighbors,
+            nyquist_threshold=nyquist_threshold,
+            welch_window_ms=welch_window_ms,
+            outside_channels_location=outside_channels_location,
+        )
+        random_slices = get_random_sample_slices(recording_hp, **random_chunk_kwargs)
+        executor = TimeSeriesChunkExecutor(
+            recording_hp,
+            _detect_bad_channels_chunk,
+            _detect_bad_channels_chunk_init,
+            (recording_hp, method_kwargs),
+            handle_returns=True,
+            chunk_size=random_chunk_kwargs["chunk_size"],
+            job_name="detect_bad_channels",
+            **executor_job_kwargs,
+        )
+        chunk_channel_labels = np.stack(executor.run(slices=random_slices), axis=1)
 
         # Take the mode of the chunk estimates as final result. Convert to binary good / bad channel output.
         mode_channel_labels, _ = mode(chunk_channel_labels, axis=1, keepdims=False)

--- a/src/spikeinterface/preprocessing/detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/detect_bad_channels.py
@@ -78,11 +78,7 @@ seed : int | None, default: None
 channel_filters : set | None, default: None
     For coherence+psd - only return `bad_channel_ids` whose labels are in the set `channel_filter`.
 job_kwargs : dict | None, default: None
-    Keyword arguments for parallel processing. Only used for the "coherence+psd" method. Only the
-    execution-related keys (`pool_engine`, `n_jobs`, `progress_bar`, `mp_context`,
-    `max_threads_per_worker`) apply; the chunking size is fixed by `chunk_duration_s` and
-    `num_random_chunks` above, so `chunk_size`, `chunk_memory`, `total_memory` and `chunk_duration`
-    are not used here.
+    Keyword arguments for parallel processing (only used for the "coherence+psd" method).
 """
 
 

--- a/src/spikeinterface/preprocessing/tests/test_detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/tests/test_detect_bad_channels.py
@@ -103,9 +103,24 @@ def test_detect_bad_channels_std_mad():
 
 @pytest.mark.parametrize("pool_engine", ["thread", "process"])
 def test_detect_bad_channels_parallel(pool_engine):
-    recording = generate_recording(num_channels=16, durations=[1, 1], seed=0)
+    num_channels = 16
+    sampling_frequency = 30000.0
+    rng = np.random.default_rng(0)
+    traces_list = [rng.standard_normal((int(sampling_frequency), num_channels)).astype("float32") for _ in range(2)]
+
+    # Inject dead channels: near-zero amplitude makes xcorr_neighbors << dead_channel_threshold (-0.5)
+    dead_channel_indices = [2, 7]
+    for traces in traces_list:
+        traces[:, dead_channel_indices] *= 1e-4
+
+    recording = NumpyRecording(traces_list, sampling_frequency)
     recording.set_channel_gains(1)
     recording.set_channel_offsets(0)
+    probe = generate_linear_probe(num_elec=num_channels)
+    probe.set_device_channel_indices(np.arange(num_channels))
+    recording.set_probe(probe)
+    recording.annotate(is_filtered=True)
+
     method_kwargs = dict(
         method="coherence+psd",
         num_random_chunks=4,
@@ -114,6 +129,8 @@ def test_detect_bad_channels_parallel(pool_engine):
     )
 
     expected_bad_channel_ids, expected_channel_labels = detect_bad_channels(recording, **method_kwargs)
+    assert np.any(expected_channel_labels != "good"), "Injected dead channels were not detected; test is not meaningful"
+
     job_kwargs = dict(n_jobs=2, pool_engine=pool_engine, max_threads_per_worker=1)
     if pool_engine == "process":
         job_kwargs["mp_context"] = "spawn"
@@ -134,11 +151,19 @@ def test_detect_bad_channels_parallel_unfiltered_spawn():
     exercises the highpass_filter() wrapper that detect_bad_channels builds internally for an
     unfiltered recording. Use a plain NumpyRecording (is_filtered() defaults to False) with a
     spawned process pool, so that wrapper has to survive cross-process serialization.
+    Dead channels are injected (near-zero amplitude) so that the test exercises non-good-channel
+    paths, not just an all-good result.
     """
     num_channels = 16
     sampling_frequency = 30000.0
     rng = np.random.default_rng(0)
     traces_list = [rng.standard_normal((int(sampling_frequency), num_channels)).astype("float32") for _ in range(2)]
+
+    # Inject dead channels: near-zero amplitude makes xcorr_neighbors << dead_channel_threshold (-0.5)
+    dead_channel_indices = [3, 10]
+    for traces in traces_list:
+        traces[:, dead_channel_indices] *= 1e-4
+
     recording = NumpyRecording(traces_list, sampling_frequency)
     recording.set_channel_gains(1)
     recording.set_channel_offsets(0)
@@ -155,6 +180,7 @@ def test_detect_bad_channels_parallel_unfiltered_spawn():
     )
 
     expected_bad_channel_ids, expected_channel_labels = detect_bad_channels(recording, **method_kwargs)
+    assert np.any(expected_channel_labels != "good"), "Injected dead channels were not detected; test is not meaningful"
 
     bad_channel_ids, channel_labels = detect_bad_channels(
         recording,

--- a/src/spikeinterface/preprocessing/tests/test_detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/tests/test_detect_bad_channels.py
@@ -101,6 +101,71 @@ def test_detect_bad_channels_std_mad():
     ), "wrong channels locations."
 
 
+@pytest.mark.parametrize("pool_engine", ["thread", "process"])
+def test_detect_bad_channels_parallel(pool_engine):
+    recording = generate_recording(num_channels=16, durations=[1, 1], seed=0)
+    recording.set_channel_gains(1)
+    recording.set_channel_offsets(0)
+    method_kwargs = dict(
+        method="coherence+psd",
+        num_random_chunks=4,
+        chunk_duration_s=0.05,
+        seed=0,
+    )
+
+    expected_bad_channel_ids, expected_channel_labels = detect_bad_channels(recording, **method_kwargs)
+    job_kwargs = dict(n_jobs=2, pool_engine=pool_engine, max_threads_per_worker=1)
+    if pool_engine == "process":
+        job_kwargs["mp_context"] = "spawn"
+
+    bad_channel_ids, channel_labels = detect_bad_channels(
+        recording,
+        **method_kwargs,
+        job_kwargs=job_kwargs,
+    )
+
+    np.testing.assert_array_equal(bad_channel_ids, expected_bad_channel_ids)
+    np.testing.assert_array_equal(channel_labels, expected_channel_labels)
+
+
+def test_detect_bad_channels_parallel_unfiltered_spawn():
+    """
+    generate_recording() marks its output as already filtered, so the parallel test above never
+    exercises the highpass_filter() wrapper that detect_bad_channels builds internally for an
+    unfiltered recording. Use a plain NumpyRecording (is_filtered() defaults to False) with a
+    spawned process pool, so that wrapper has to survive cross-process serialization.
+    """
+    num_channels = 16
+    sampling_frequency = 30000.0
+    rng = np.random.default_rng(0)
+    traces_list = [rng.standard_normal((int(sampling_frequency), num_channels)).astype("float32") for _ in range(2)]
+    recording = NumpyRecording(traces_list, sampling_frequency)
+    recording.set_channel_gains(1)
+    recording.set_channel_offsets(0)
+    probe = generate_linear_probe(num_elec=num_channels)
+    probe.set_device_channel_indices(np.arange(num_channels))
+    recording.set_probe(probe)
+    assert not recording.is_filtered()
+
+    method_kwargs = dict(
+        method="coherence+psd",
+        num_random_chunks=4,
+        chunk_duration_s=0.05,
+        seed=0,
+    )
+
+    expected_bad_channel_ids, expected_channel_labels = detect_bad_channels(recording, **method_kwargs)
+
+    bad_channel_ids, channel_labels = detect_bad_channels(
+        recording,
+        **method_kwargs,
+        job_kwargs=dict(n_jobs=2, pool_engine="process", mp_context="spawn", max_threads_per_worker=1),
+    )
+
+    np.testing.assert_array_equal(bad_channel_ids, expected_bad_channel_ids)
+    np.testing.assert_array_equal(channel_labels, expected_channel_labels)
+
+
 @pytest.mark.parametrize("outside_channels_location", ["bottom", "top", "both"])
 def test_detect_bad_channels_extremes(outside_channels_location):
     num_channels = 64


### PR DESCRIPTION
### Description

The default `coherence+psd` method first materialises 100 scaled chunks and then processes them in serial. On a 384-channel recording, profiling shows that the Welch and median computations dominate the call, while extracting the random traces takes a small part of the total time.

This change sends the same random slices through `TimeSeriesChunkExecutor`. The default stays at `n_jobs=1`, but the chunks are streamed instead of kept together in memory. A final `job_kwargs` parameter lets callers select a thread or process pool without changing positional arguments.

I measured the default 100 × 0.3 s chunk path on an Intel Core i9-13900HX, with numerical thread pools pinned to one thread. The generated row uses the 30 s / 384-channel shape reported in the issue. The second row uses real 384-channel SpikeGLX traces from the public Noise4Sam fixture; the public file is short, it was repeated in memory to cover the same chunk path.

| Workload | Before | After (`n_jobs=8`, processes) | Improvement |
|---|---:|---:|---:|
| Generated 30 s recording | 8.454 s (8.384–8.479) | 2.193 s (2.118–2.236) | 3.86x |
| Noise4Sam real traces | 12.836 s (12.749–12.964) | 2.984 s (2.973–3.014) | 4.30x |

The channel ids and labels matched exactly between both implementations in each run. On the serial real-trace path, three fresh-process peak RSS measurements gave a median of 1,688,604 KiB before (range 1,688,500-1,689,352) and 353,452 KiB after (range 352,984-354,896), around 79% less. This comes from processing one random slice at a time instead of retaining the scaled chunks.

Validation:

- `pytest -q src/spikeinterface/preprocessing/tests/test_detect_bad_channels.py`: 11 passed.
- The regression tests cover a thread pool, a spawned process pool, and a two-segment recording.
- A second spawned-process test uses a recording that is not pre-marked as filtered, so the
`highpass_filter` wrapper `detect_bad_channels` builds internally also gets exercised across a process boundary; it matches the serial result on the same data.
- Both new tests fail on the matching `main` revision and pass with this patch.
- `black` and the trailing-whitespace/end-of-file checks are clean.

Fixes #2869.
