### PR TITLE
Modify `define_function_handling_dict_from_class` to inject function to module directly

### DIFF
--- a/src/spikeinterface/core/core_tools.py
+++ b/src/spikeinterface/core/core_tools.py
@@ -56,7 +56,8 @@ def define_function_handling_dict_from_class(source_class, name):
     source_class_or_dict_of_sources_classes.__doc__ = source_class.__doc__
     source_class_or_dict_of_sources_classes.__name__ = name
 
-    return source_class_or_dict_of_sources_classes
+    # This is a trick to make the function available in the global namespace of the caller module
+    sys._getframe(1).f_globals[name] = source_class_or_dict_of_sources_classes
 
 
 # Generic typing needed to help propagate typing
@@ -67,7 +68,7 @@ T = TypeVar("T")
 
 
 def define_function_from_class(source_class: Callable[P, T], name: str) -> Callable[P, T]:
-    "Wrapper to change the name of a class"
+    "Wrapper to inject source_class into the caller's module namespace under name."
 
     return source_class
 

--- a/src/spikeinterface/core/segmentutils.py
+++ b/src/spikeinterface/core/segmentutils.py
@@ -83,7 +83,7 @@ class ProxyAppendRecordingSegment(BaseRecordingSegment):
         return self.parent_segment.get_traces(*args, **kwargs)
 
 
-append_recordings = define_function_from_class(source_class=AppendSegmentRecording, name="append_segment_recording")
+append_recordings = define_function_from_class(source_class=AppendSegmentRecording, name="append_recordings")
 
 
 class ConcatenateSegmentRecording(BaseRecording):

--- a/src/spikeinterface/extractors/neoextractors/mcsraw.py
+++ b/src/spikeinterface/extractors/neoextractors/mcsraw.py
@@ -60,4 +60,4 @@ class MCSRawRecordingExtractor(NeoBaseRecordingExtractor):
         return neo_kwargs
 
 
-read_mcsraw = define_function_from_class(source_class=MCSRawRecordingExtractor, name="read_maxwell_event")
+read_mcsraw = define_function_from_class(source_class=MCSRawRecordingExtractor, name="read_mcsraw")

--- a/src/spikeinterface/preprocessing/astype.py
+++ b/src/spikeinterface/preprocessing/astype.py
@@ -78,4 +78,4 @@ class AstypeRecordingSegment(BasePreprocessorSegment):
 
 
 # function for API
-astype = define_function_handling_dict_from_class(source_class=AstypeRecording, name="astype")
+define_function_handling_dict_from_class(source_class=AstypeRecording, name="astype")

--- a/src/spikeinterface/preprocessing/average_across_direction.py
+++ b/src/spikeinterface/preprocessing/average_across_direction.py
@@ -137,7 +137,7 @@ class AverageAcrossDirectionRecordingSegment(BasePreprocessorSegment):
 
 
 # function for API
-average_across_direction = define_function_handling_dict_from_class(
+define_function_handling_dict_from_class(
     source_class=AverageAcrossDirectionRecording,
     name="average_across_direction",
 )

--- a/src/spikeinterface/preprocessing/clip.py
+++ b/src/spikeinterface/preprocessing/clip.py
@@ -167,7 +167,5 @@ class ClipRecordingSegment(BasePreprocessorSegment):
         return traces
 
 
-clip = define_function_handling_dict_from_class(source_class=ClipRecording, name="clip")
-blank_saturation = define_function_handling_dict_from_class(
-    source_class=BlankSaturationRecording, name="blank_saturation"
-)
+define_function_handling_dict_from_class(source_class=ClipRecording, name="clip")
+define_function_handling_dict_from_class(source_class=BlankSaturationRecording, name="blank_saturation")

--- a/src/spikeinterface/preprocessing/common_reference.py
+++ b/src/spikeinterface/preprocessing/common_reference.py
@@ -325,6 +325,4 @@ class CommonReferenceRecordingSegment(BasePreprocessorSegment):
         return zip(group_indices, selected_channels, group_channels)
 
 
-common_reference = define_function_handling_dict_from_class(
-    source_class=CommonReferenceRecording, name="common_reference"
-)
+define_function_handling_dict_from_class(source_class=CommonReferenceRecording, name="common_reference")

--- a/src/spikeinterface/preprocessing/decimate.py
+++ b/src/spikeinterface/preprocessing/decimate.py
@@ -134,4 +134,4 @@ class DecimateRecordingSegment(BaseRecordingSegment):
         ].astype(self._dtype)
 
 
-decimate = define_function_handling_dict_from_class(source_class=DecimateRecording, name="decimate")
+define_function_handling_dict_from_class(source_class=DecimateRecording, name="decimate")

--- a/src/spikeinterface/preprocessing/deepinterpolation/deepinterpolation.py
+++ b/src/spikeinterface/preprocessing/deepinterpolation/deepinterpolation.py
@@ -191,6 +191,4 @@ class DeepInterpolatedRecordingSegment(BasePreprocessorSegment):
 
 
 # function for API
-deepinterpolate = define_function_handling_dict_from_class(
-    source_class=DeepInterpolatedRecording, name="deepinterpolate"
-)
+define_function_handling_dict_from_class(source_class=DeepInterpolatedRecording, name="deepinterpolate")

--- a/src/spikeinterface/preprocessing/depth_order.py
+++ b/src/spikeinterface/preprocessing/depth_order.py
@@ -41,4 +41,4 @@ class DepthOrderRecording(ChannelSliceRecording):
         )
 
 
-depth_order = define_function_handling_dict_from_class(source_class=DepthOrderRecording, name="depth_order")
+define_function_handling_dict_from_class(source_class=DepthOrderRecording, name="depth_order")

--- a/src/spikeinterface/preprocessing/detect_artifacts.py
+++ b/src/spikeinterface/preprocessing/detect_artifacts.py
@@ -785,7 +785,7 @@ class DetectAndRemoveArtifactsRecording(SilencedPeriodsRecording):
 
 
 # function for API
-detect_and_remove_artifacts = define_function_handling_dict_from_class(
+define_function_handling_dict_from_class(
     source_class=DetectAndRemoveArtifactsRecording, name="detect_and_remove_artifacts"
 )
 

--- a/src/spikeinterface/preprocessing/detect_bad_channels.py
+++ b/src/spikeinterface/preprocessing/detect_bad_channels.py
@@ -137,7 +137,7 @@ class DetectAndRemoveBadChannelsRecording(ChannelSliceRecording):
 DetectAndRemoveBadChannelsRecording.__doc__ = DetectAndRemoveBadChannelsRecording.__doc__.format(
     _bad_channel_detection_kwargs_doc
 )
-detect_and_remove_bad_channels = define_function_handling_dict_from_class(
+define_function_handling_dict_from_class(
     source_class=DetectAndRemoveBadChannelsRecording, name="detect_and_remove_bad_channels"
 )
 

--- a/src/spikeinterface/preprocessing/directional_derivative.py
+++ b/src/spikeinterface/preprocessing/directional_derivative.py
@@ -134,6 +134,4 @@ class DirectionalDerivativeRecordingSegment(BasePreprocessorSegment):
 
 
 # function for API
-directional_derivative = define_function_handling_dict_from_class(
-    source_class=DirectionalDerivativeRecording, name="directional_derivative"
-)
+define_function_handling_dict_from_class(source_class=DirectionalDerivativeRecording, name="directional_derivative")

--- a/src/spikeinterface/preprocessing/filter.py
+++ b/src/spikeinterface/preprocessing/filter.py
@@ -414,10 +414,10 @@ class NotchFilterRecording(FilterRecording):
 
 
 # functions for API
-filter = define_function_handling_dict_from_class(source_class=FilterRecording, name="filter")
-bandpass_filter = define_function_handling_dict_from_class(source_class=BandpassFilterRecording, name="bandpass_filter")
-notch_filter = define_function_handling_dict_from_class(source_class=NotchFilterRecording, name="notch_filter")
-highpass_filter = define_function_handling_dict_from_class(source_class=HighpassFilterRecording, name="highpass_filter")
+define_function_handling_dict_from_class(source_class=FilterRecording, name="filter")
+define_function_handling_dict_from_class(source_class=BandpassFilterRecording, name="bandpass_filter")
+define_function_handling_dict_from_class(source_class=NotchFilterRecording, name="notch_filter")
+define_function_handling_dict_from_class(source_class=HighpassFilterRecording, name="highpass_filter")
 
 
 def causal_filter(

--- a/src/spikeinterface/preprocessing/filter_gaussian.py
+++ b/src/spikeinterface/preprocessing/filter_gaussian.py
@@ -143,4 +143,4 @@ class GaussianFilterRecordingSegment(BasePreprocessorSegment):
         return gaussian
 
 
-gaussian_filter = define_function_handling_dict_from_class(source_class=GaussianFilterRecording, name="gaussian_filter")
+define_function_handling_dict_from_class(source_class=GaussianFilterRecording, name="gaussian_filter")

--- a/src/spikeinterface/preprocessing/highpass_spatial_filter.py
+++ b/src/spikeinterface/preprocessing/highpass_spatial_filter.py
@@ -272,9 +272,7 @@ class HighPassSpatialFilterSegment(BasePreprocessorSegment):
 
 
 # function for API
-highpass_spatial_filter = define_function_handling_dict_from_class(
-    source_class=HighpassSpatialFilterRecording, name="highpass_spatial_filter"
-)
+define_function_handling_dict_from_class(source_class=HighpassSpatialFilterRecording, name="highpass_spatial_filter")
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/spikeinterface/preprocessing/interpolate_bad_channels.py
+++ b/src/spikeinterface/preprocessing/interpolate_bad_channels.py
@@ -134,7 +134,7 @@ class DetectAndInterpolateBadChannelsRecording(InterpolateBadChannelsRecording):
 DetectAndInterpolateBadChannelsRecording.__doc__ = DetectAndInterpolateBadChannelsRecording.__doc__.format(
     _bad_channel_detection_kwargs_doc
 )
-detect_and_interpolate_bad_channels = define_function_handling_dict_from_class(
+define_function_handling_dict_from_class(
     source_class=DetectAndInterpolateBadChannelsRecording, name="detect_and_interpolate_bad_channels"
 )
 
@@ -170,6 +170,4 @@ def estimate_recommended_sigma_um(recording):
     return mode(np.diff(np.unique(y_sorted)), keepdims=False)[0]
 
 
-interpolate_bad_channels = define_function_handling_dict_from_class(
-    source_class=InterpolateBadChannelsRecording, name="interpolate_bad_channels"
-)
+define_function_handling_dict_from_class(source_class=InterpolateBadChannelsRecording, name="interpolate_bad_channels")

--- a/src/spikeinterface/preprocessing/normalize_scale.py
+++ b/src/spikeinterface/preprocessing/normalize_scale.py
@@ -323,9 +323,7 @@ class ZScoreRecording(BasePreprocessor):
 
 
 # functions for API
-normalize_by_quantile = define_function_handling_dict_from_class(
-    source_class=NormalizeByQuantileRecording, name="normalize_by_quantile"
-)
-scale = define_function_handling_dict_from_class(source_class=ScaleRecording, name="scale")
-center = define_function_handling_dict_from_class(source_class=CenterRecording, name="center")
-zscore = define_function_handling_dict_from_class(source_class=ZScoreRecording, name="zscore")
+define_function_handling_dict_from_class(source_class=NormalizeByQuantileRecording, name="normalize_by_quantile")
+define_function_handling_dict_from_class(source_class=ScaleRecording, name="scale")
+define_function_handling_dict_from_class(source_class=CenterRecording, name="center")
+define_function_handling_dict_from_class(source_class=ZScoreRecording, name="zscore")

--- a/src/spikeinterface/preprocessing/phase_shift.py
+++ b/src/spikeinterface/preprocessing/phase_shift.py
@@ -106,7 +106,7 @@ class PhaseShiftRecordingSegment(BasePreprocessorSegment):
 
 
 # function for API
-phase_shift = define_function_handling_dict_from_class(source_class=PhaseShiftRecording, name="phase_shift")
+define_function_handling_dict_from_class(source_class=PhaseShiftRecording, name="phase_shift")
 
 
 def apply_frequency_shift(signal, shift_samples, axis=0):

--- a/src/spikeinterface/preprocessing/rectify.py
+++ b/src/spikeinterface/preprocessing/rectify.py
@@ -25,4 +25,4 @@ class RectifyRecordingSegment(BasePreprocessorSegment):
 
 
 # function for API
-rectify = define_function_handling_dict_from_class(source_class=RectifyRecording, name="rectify")
+define_function_handling_dict_from_class(source_class=RectifyRecording, name="rectify")

--- a/src/spikeinterface/preprocessing/remove_artifacts.py
+++ b/src/spikeinterface/preprocessing/remove_artifacts.py
@@ -449,6 +449,4 @@ class RemoveArtifactsRecordingSegment(BasePreprocessorSegment):
 
 
 # function for API
-remove_artifacts = define_function_handling_dict_from_class(
-    source_class=RemoveArtifactsRecording, name="remove_artifacts"
-)
+define_function_handling_dict_from_class(source_class=RemoveArtifactsRecording, name="remove_artifacts")

--- a/src/spikeinterface/preprocessing/resample.py
+++ b/src/spikeinterface/preprocessing/resample.py
@@ -389,7 +389,7 @@ class ResampleRecordingSegment(BaseRecordingSegment):
         return result[:pos]
 
 
-resample = define_function_handling_dict_from_class(source_class=ResampleRecording, name="resample")
+define_function_handling_dict_from_class(source_class=ResampleRecording, name="resample")
 
 
 # Some helpers to do checks

--- a/src/spikeinterface/preprocessing/scale.py
+++ b/src/spikeinterface/preprocessing/scale.py
@@ -62,7 +62,7 @@ class ScaleToPhysicalUnits(ScaleRecording):
         self.set_channel_offsets(offsets=0.0)
 
 
-scale_to_physical_units = define_function_handling_dict_from_class(ScaleToPhysicalUnits, name="scale_to_physical_units")
+define_function_handling_dict_from_class(ScaleToPhysicalUnits, name="scale_to_physical_units")
 
 
 def scale_to_uV(recording: BasePreprocessor) -> BasePreprocessor:

--- a/src/spikeinterface/preprocessing/silence_periods.py
+++ b/src/spikeinterface/preprocessing/silence_periods.py
@@ -247,6 +247,4 @@ class SilencedPeriodsRecordingSegment(BasePreprocessorSegment):
 
 
 # function for API
-silence_periods = define_function_handling_dict_from_class(
-    source_class=SilencedPeriodsRecording, name="silence_periods"
-)
+define_function_handling_dict_from_class(source_class=SilencedPeriodsRecording, name="silence_periods")

--- a/src/spikeinterface/preprocessing/unsigned_to_signed.py
+++ b/src/spikeinterface/preprocessing/unsigned_to_signed.py
@@ -65,6 +65,4 @@ class UnsignedToSignedRecordingSegment(BasePreprocessorSegment):
 
 
 # function for API
-unsigned_to_signed = define_function_handling_dict_from_class(
-    source_class=UnsignedToSignedRecording, name="unsigned_to_signed"
-)
+define_function_handling_dict_from_class(source_class=UnsignedToSignedRecording, name="unsigned_to_signed")

--- a/src/spikeinterface/preprocessing/whiten.py
+++ b/src/spikeinterface/preprocessing/whiten.py
@@ -288,4 +288,4 @@ def compute_sklearn_covariance_matrix(data, regularize_kwargs):
 
 
 # function for API
-whiten = define_function_handling_dict_from_class(source_class=WhitenRecording, name="whiten")
+define_function_handling_dict_from_class(source_class=WhitenRecording, name="whiten")

--- a/src/spikeinterface/preprocessing/zero_channel_pad.py
+++ b/src/spikeinterface/preprocessing/zero_channel_pad.py
@@ -193,7 +193,5 @@ class ZeroChannelPaddedRecordingSegment(BasePreprocessorSegment):
 
 
 # function for API
-zero_channel_pad = define_function_handling_dict_from_class(
-    source_class=ZeroChannelPaddedRecording, name="zero_channel_pad"
-)
-pad_traces = define_function_handling_dict_from_class(source_class=TracePaddedRecording, name="pad_traces")
+define_function_handling_dict_from_class(source_class=ZeroChannelPaddedRecording, name="zero_channel_pad")
+define_function_handling_dict_from_class(source_class=TracePaddedRecording, name="pad_traces")

--- a/src/spikeinterface/sortingcomponents/motion/motion_interpolation.py
+++ b/src/spikeinterface/sortingcomponents/motion/motion_interpolation.py
@@ -523,6 +523,4 @@ class InterpolateMotionRecordingSegment(BasePreprocessorSegment):
         return traces
 
 
-interpolate_motion = define_function_handling_dict_from_class(
-    source_class=InterpolateMotionRecording, name="interpolate_motion"
-)
+define_function_handling_dict_from_class(source_class=InterpolateMotionRecording, name="interpolate_motion")


### PR DESCRIPTION
Having something like:
```
bandpass_filter = define_function_handling_dict_from_class(BandpassFilterRecording, name="bandpass_filter")
```
extends the function to work with individual recordings and dicts of. The function signature and __name__ are set to match the class and provided `name`. This could cause mismatches in the naming.

This PR uses a trick to add the new wrapped function directly to the caller module.

Related to #4319 : I suggest we do the same for `define_funtction_from_class` (already 2 mismatches found!!!) and use the `pyi` approach that Graham suggested to make IDEs happy.

@chrishalcrow @grahamfindlay thoughts?