### PR TITLE
Remove unused full-chunk scaling in spike_amplitudes

### DIFF
--- a/src/spikeinterface/postprocessing/spike_amplitudes.py
+++ b/src/spikeinterface/postprocessing/spike_amplitudes.py
@@ -102,7 +102,6 @@ class SpikeAmplitudeNode(PipelineNode):
 
         # and scale
         if self._gains is not None:
-            traces = traces.astype("float32") * self._gains + self._offsets
             amplitudes = amplitudes.astype("float32", copy=True)
             amplitudes *= self._gains[chan_inds]
             amplitudes += self._offsets[chan_inds]


### PR DESCRIPTION
### Description

`SpikeAmplitudeNode.compute` builds a fully scaled copy of the traces chunk and then never reads it. The amplitudes are gathered from the raw chunk on the line above, and they get their own scaling right after, so the chunk-wide conversion is dead work:

```python
amplitudes = traces[sample_indices, chan_inds]

# and scale
if self._gains is not None:
    traces = traces.astype("float32") * self._gains + self._offsets   # never read again
    amplitudes = amplitudes.astype("float32", copy=True)
    amplitudes *= self._gains[chan_inds]
    amplitudes += self._offsets[chan_inds]

return amplitudes
```

`traces` is a local name, so rebinding it cannot reach the caller or the other nodes of the pipeline, and `astype`, `*` and `+` each allocate a new array, so nothing is touched in place. Removing the line cannot change the result.

The cost is that the extension scales with the size of the recording instead of the number of spikes. On one 1 s chunk of 384 channels at 30 kHz that is 11.5 M elements converted, multiplied and added, then dropped, and it happens on every chunk that has at least one spike (the pipeline skips loading traces at all for a chunk with none, `core/node_pipeline.py:679-688`).

Where it comes from, since it is not obvious from the current code: before the node pipeline this extension asked the extractor for scaled traces (`recording.get_traces(..., return_scaled=return_scaled)`), so the amplitudes were picked out of an already scaled chunk. When it moved to the pipeline in d3ac13f1b the node started getting raw traces, so the conversion had to happen inside `compute`, and both ways of doing it ended up in the same block: scaling the whole chunk like the extractor used to, and scaling only the gathered values. The second one is what the function returns, so the first has been dead since that commit. The same line in `AmplitudeScalingNode.compute` is a real one, there the scaled `traces` is used to cut the waveforms out.

### Numbers

Generated ground truth recording written out to a binary file first, so the traces come from disk and not from the on-the-fly noise generator: 384 channels, 30 kHz, 120 s, 200 units, 120321 spikes. BLAS threads pinned to 1, on a GCP `c3-standard-22` (Xeon Platinum 8481C). Interleaved runs, a fresh process for each one, median and range. Five runs per arm, except the two slowest pipeline rows (the curation list and the real-data export list), which are three.

`n_jobs=1`:

| | before | after | |
|---|---:|---:|---:|
| `compute("spike_amplitudes")` | 7.807 s (7.748–7.856) | 0.191 s (0.190–0.212) | 40.8x |
| the `export_to_ibl_gui` list from `doc/modules/exporters.rst:107` | 22.83 s (22.54–23.36) | 15.24 s (15.14–15.49) | −33.3% |
| the list from the automated curation tutorial | 97.42 s (97.30–97.52) | 89.20 s (88.75–89.55) | −8.4% |

`n_jobs=8`, since that is closer to how people actually run it:

| | before | after | |
|---|---:|---:|---:|
| `compute("spike_amplitudes")` | 1.301 s (1.293–1.311) | 0.081 s (0.080–0.088) | 16.0x |
| the `export_to_ibl_gui` list | 6.031 s (6.029–6.047) | 4.840 s (4.795–4.842) | −19.8% |

Same thing on real traces, to make sure the shape of the data is not doing the work. The public `spikeglx/Noise4Sam_g0` fixture is int16 with real gains and a real probe but only 38.5 ms long, so its trace block was tiled in time to 120 s; the dtype, gains, offsets, channel count and values are the real ones:

| real SpikeGLX traces, `n_jobs=1` | before | after | |
|---|---:|---:|---:|
| `compute("spike_amplitudes")` | 7.695 s (7.676–7.770) | 0.291 s (0.288–0.310) | 26.5x |
| the `export_to_ibl_gui` list | 20.65 s (20.53–20.67) | 12.98 s (12.91–13.06) | −37.2% |

The two arms do not overlap in any row. The pipeline rows are the amortised numbers, on the extension lists the docs and the tutorials tell users to compute, not on the exporter functions themselves (`export_to_ibl_gui` also writes several `.npy` files and, when given an LFP recording as in the doc example, runs its own RMS/PSD pass, `exporters/to_ibl.py`). How much you get back depends on what else you compute alongside it: about a third of that extension list serially, still a fifth of it with 8 jobs, and 8% of the curation list where `principal_components` dominates.

`export_to_phy` also computes this extension on its own by default (`compute_amplitudes=True`, `exporters/to_phy.py:216-218`), which is the main way a user reaches this path without asking for it. Once computed, `spike_amplitudes` is also read by the sorting summary and unit summary widgets when the extension is already present, the `knn` step of `auto_merge`'s `feature_neighbors` preset, and the `amplitude_cutoff` quality metric.

### Correctness

The amplitudes come out bit-identical: same SHA-256 over the array bytes, and `view(uint32)` equal element by element.

One note if you want to reproduce that. `random_spikes` defaults to `seed=None` and caps at `max_spikes_per_unit=500`, so on a recording with more spikes than that per unit every run draws a different subset, which moves the templates and then the integer peak shifts. Without a seed, `main` compared against itself already shows those differences with no patch applied at all, so the comparison has to be seeded to mean anything.

Validation:

- `pytest src/spikeinterface/postprocessing/tests src/spikeinterface/exporters/tests`: 108 passed, 40 skipped. The common extension suite runs this extension over both sparsities and the three formats (`memory`, `binary_folder`, `zarr`); it exercises `select_units`/`merge_units` and checks the resulting unit ids and count, and separately compares the amplitude data itself across the `binary_folder`/`zarr` save-load round trip.
- `pytest src/spikeinterface/metrics`: 47 passed.
- No new test. The change is bit-identical, so a test asserting amplitude values would pass identically before and after it and would not discriminate; the common extension suite (`test_spike_amplitudes.py`) already exercises `spike_amplitudes` across sparsity, format, and the save-load round trip, and runs it through `select_units`/`merge_units` without asserting amplitude values there.
- `black` clean.
- Tested on Linux only.
