### PR TITLE
Scale only the waveforms amplitude_scalings reads

### DIFF
--- a/src/spikeinterface/postprocessing/amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/amplitude_scalings.py
@@ -158,6 +158,33 @@ register_result_extension(ComputeAmplitudeScalings)
 compute_amplitude_scalings = ComputeAmplitudeScalings.function_factory()
 
 
+def _scale_local_waveform_to_uV(local_waveform, gains, offsets, sparse_indices):
+    """
+    Scale a cut-out local waveform to uV, using only the gain/offset of the channels
+    it was cut from.
+
+    Parameters
+    ----------
+    local_waveform : np.ndarray
+        The cut-out waveform, of shape (n_samples, len(sparse_indices)).
+    gains : np.ndarray
+        The gains of all channels in the recording.
+    offsets : np.ndarray
+        The offsets of all channels in the recording.
+    sparse_indices : np.ndarray
+        The channel indices `local_waveform` was cut from, used to index `gains`/`offsets`.
+
+    Returns
+    -------
+    np.ndarray
+        The waveform scaled to uV. `local_waveform` is cast to float32 first, but the
+        result follows numpy's promotion rules against `gains`/`offsets`, so it comes
+        out float64 whenever those are float64 (which is what `get_channel_gains()` /
+        `get_channel_offsets()` return for a gain/offset set from a Python float).
+    """
+    return local_waveform.astype("float32") * gains[sparse_indices] + offsets[sparse_indices]
+
+
 class AmplitudeScalingNode(PipelineNode):
     def __init__(
         self,
@@ -229,10 +256,8 @@ class AmplitudeScalingNode(PipelineNode):
     def compute(self, traces, peaks):
         from scipy.stats import linregress
 
-        # scale traces with margin to match scaling of templates
-        if self._gains is not None:
-            traces = traces.astype("float32") * self._gains + self._offsets
-
+        gains = self._gains
+        offsets = self._offsets
         all_templates = self._all_templates
         sparsity_mask = self._sparsity_mask
         nbefore = self._nbefore
@@ -289,6 +314,9 @@ class AmplitudeScalingNode(PipelineNode):
                 template = template[: -(sample_centered + cut_out_after - (traces.shape[0]))]
             else:
                 local_waveform = traces[cut_out_start:cut_out_end, sparse_indices]
+            # scale the waveform to match the scaling of the templates
+            if gains is not None:
+                local_waveform = _scale_local_waveform_to_uV(local_waveform, gains, offsets, sparse_indices)
             assert template.shape == local_waveform.shape
 
             # here we use linregress, which is equivalent to using sklearn LinearRegression with fit_intercept=True
@@ -318,6 +346,8 @@ class AmplitudeScalingNode(PipelineNode):
                     sparsity_mask,
                     cut_out_before,
                     cut_out_after,
+                    gains,
+                    offsets,
                 )
                 # the scaling for the current spike is at index 0
                 scalings[spike_index] = scaled_amps[0]
@@ -447,6 +477,8 @@ def fit_collision(
     sparsity_mask,
     cut_out_before,
     cut_out_after,
+    gains=None,
+    offsets=None,
 ):
     """
     Compute the best fit for a collision between a spike and its overlapping spikes.
@@ -485,6 +517,12 @@ def fit_collision(
         The number of samples to cut out before the spike.
     cut_out_after: int
         The number of samples to cut out after the spike.
+    gains : np.ndarray or None, default: None
+        The channel gains used to scale the local waveform to uV. If None, the
+        traces are used as they are.
+    offsets : np.ndarray or None, default: None
+        The channel offsets used to scale the local waveform to uV. If None, the
+        traces are used as they are.
 
     Returns
     -------
@@ -513,6 +551,9 @@ def fit_collision(
     local_waveform_start = max(0, sample_first_centered - cut_out_before)
     local_waveform_end = min(traces_with_margin.shape[0], sample_last_centered + cut_out_after)
     local_waveform = traces_with_margin[local_waveform_start:local_waveform_end, sparse_indices]
+    # scale the waveform to match the scaling of the templates
+    if gains is not None:
+        local_waveform = _scale_local_waveform_to_uV(local_waveform, gains, offsets, sparse_indices)
     num_samples_local_waveform = local_waveform.shape[0]
 
     y = local_waveform.T.flatten()

--- a/src/spikeinterface/postprocessing/amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/amplitude_scalings.py
@@ -158,33 +158,6 @@ register_result_extension(ComputeAmplitudeScalings)
 compute_amplitude_scalings = ComputeAmplitudeScalings.function_factory()
 
 
-def _scale_local_waveform_to_uV(local_waveform, gains, offsets, sparse_indices):
-    """
-    Scale a cut-out local waveform to uV, using only the gain/offset of the channels
-    it was cut from.
-
-    Parameters
-    ----------
-    local_waveform : np.ndarray
-        The cut-out waveform, of shape (n_samples, len(sparse_indices)).
-    gains : np.ndarray
-        The gains of all channels in the recording.
-    offsets : np.ndarray
-        The offsets of all channels in the recording.
-    sparse_indices : np.ndarray
-        The channel indices `local_waveform` was cut from, used to index `gains`/`offsets`.
-
-    Returns
-    -------
-    np.ndarray
-        The waveform scaled to uV. `local_waveform` is cast to float32 first, but the
-        result follows numpy's promotion rules against `gains`/`offsets`, so it comes
-        out float64 whenever those are float64 (which is what `get_channel_gains()` /
-        `get_channel_offsets()` return for a gain/offset set from a Python float).
-    """
-    return local_waveform.astype("float32") * gains[sparse_indices] + offsets[sparse_indices]
-
-
 class AmplitudeScalingNode(PipelineNode):
     def __init__(
         self,
@@ -316,7 +289,7 @@ class AmplitudeScalingNode(PipelineNode):
                 local_waveform = traces[cut_out_start:cut_out_end, sparse_indices]
             # scale the waveform to match the scaling of the templates
             if gains is not None:
-                local_waveform = _scale_local_waveform_to_uV(local_waveform, gains, offsets, sparse_indices)
+                local_waveform = local_waveform.astype("float32") * gains[sparse_indices] + offsets[sparse_indices]
             assert template.shape == local_waveform.shape
 
             # here we use linregress, which is equivalent to using sklearn LinearRegression with fit_intercept=True
@@ -553,7 +526,7 @@ def fit_collision(
     local_waveform = traces_with_margin[local_waveform_start:local_waveform_end, sparse_indices]
     # scale the waveform to match the scaling of the templates
     if gains is not None:
-        local_waveform = _scale_local_waveform_to_uV(local_waveform, gains, offsets, sparse_indices)
+        local_waveform = local_waveform.astype("float32") * gains[sparse_indices] + offsets[sparse_indices]
     num_samples_local_waveform = local_waveform.shape[0]
 
     y = local_waveform.T.flatten()

--- a/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
@@ -4,7 +4,6 @@ import pytest
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
 
 from spikeinterface.postprocessing import ComputeAmplitudeScalings
-from spikeinterface.postprocessing.amplitude_scalings import fit_collision, _scale_local_waveform_to_uV
 
 
 class TestAmplitudeScalingsExtension(AnalyzerExtensionCommonTestSuite):
@@ -36,66 +35,3 @@ class TestAmplitudeScalingsExtension(AnalyzerExtensionCommonTestSuite):
             scalings = ext.data["amplitude_scalings"][mask]
             median_scaling = np.median(scalings)
             np.testing.assert_array_equal(np.round(median_scaling), 1)
-
-
-@pytest.mark.parametrize(
-    "sparse_indices", [np.array([0, 1, 2]), np.array([2, 3, 4]), np.array([5, 6, 7]), np.array([0, 3, 7])]
-)
-def test_scale_local_waveform_to_uv_uses_its_own_channels_gain(sparse_indices):
-    """
-    `_scale_local_waveform_to_uV` is the scaling step shared by the two places that cut a
-    window out of the traces: the per-spike loop in `AmplitudeScalingNode.compute` and
-    `fit_collision`. It has to pick each channel's own gain/offset out of the chunk-wide
-    `gains`/`offsets` arrays, not some other subset. Scaling the cut-out window must equal
-    cutting the same window out of traces that were already scaled beforehand, for whichever
-    channel subset the caller cut out.
-    """
-    rng = np.random.default_rng(seed=2205)
-    num_channels, num_samples = 8, 50
-    gains = rng.uniform(0.5, 4.0, size=num_channels)
-    offsets = rng.uniform(-20.0, 20.0, size=num_channels)
-    raw_traces = rng.integers(-2000, 2000, size=(num_samples, num_channels)).astype("int16")
-
-    local_waveform = raw_traces[10:30, sparse_indices]
-    scaled_inside = _scale_local_waveform_to_uV(local_waveform, gains, offsets, sparse_indices)
-
-    scaled_beforehand = (raw_traces.astype("float32") * gains + offsets)[10:30, sparse_indices]
-
-    np.testing.assert_array_equal(scaled_inside, scaled_beforehand)
-
-
-def test_fit_collision_scales_each_channel_with_its_own_gain():
-    """
-    `fit_collision` scales the traces it cuts out to uV itself, so it has to apply
-    the gain of each channel to that channel. Scaling inside must give exactly what
-    passing already scaled traces gives. A gain taken from the wrong channel still
-    returns a well formed scaling, so the two paths are compared directly, with a
-    gain and an offset which are different on every channel.
-    """
-    rng = np.random.default_rng(seed=2205)
-    num_channels, num_units = 8, 3
-    nbefore, nafter, num_samples = 20, 30, 400
-
-    raw_traces = rng.integers(-2000, 2000, size=(num_samples, num_channels)).astype("int16")
-    all_templates = (rng.normal(size=(num_units, nbefore + nafter, num_channels)) * 50).astype("float32")
-    # unit 0 and unit 1 (the colliding pair below) are on non-contiguous, interleaved
-    # channels so their union isn't a single slice: sparse_indices must stay [0, 1, 3, 4, 6, 7].
-    sparsity_mask = np.zeros((num_units, num_channels), dtype=bool)
-    sparsity_mask[0, [0, 3, 6]] = True
-    sparsity_mask[1, [1, 4, 7]] = True
-    sparsity_mask[2, [2, 5]] = True
-
-    gains = rng.uniform(0.5, 4.0, size=num_channels)
-    offsets = rng.uniform(-20.0, 20.0, size=num_channels)
-
-    collision = np.zeros(2, dtype=[("sample_index", "int64"), ("unit_index", "int64")])
-    collision["sample_index"] = [180, 190]
-    collision["unit_index"] = [0, 1]
-
-    scaled_inside = fit_collision(
-        collision, raw_traces, nbefore, all_templates, sparsity_mask, nbefore, nafter, gains, offsets
-    )
-    scaled_traces = raw_traces.astype("float32") * gains + offsets
-    scaled_beforehand = fit_collision(collision, scaled_traces, nbefore, all_templates, sparsity_mask, nbefore, nafter)
-
-    np.testing.assert_array_equal(scaled_inside, scaled_beforehand)

--- a/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/tests/test_amplitude_scalings.py
@@ -4,6 +4,7 @@ import pytest
 from spikeinterface.postprocessing.tests.common_extension_tests import AnalyzerExtensionCommonTestSuite
 
 from spikeinterface.postprocessing import ComputeAmplitudeScalings
+from spikeinterface.postprocessing.amplitude_scalings import fit_collision, _scale_local_waveform_to_uV
 
 
 class TestAmplitudeScalingsExtension(AnalyzerExtensionCommonTestSuite):
@@ -35,3 +36,66 @@ class TestAmplitudeScalingsExtension(AnalyzerExtensionCommonTestSuite):
             scalings = ext.data["amplitude_scalings"][mask]
             median_scaling = np.median(scalings)
             np.testing.assert_array_equal(np.round(median_scaling), 1)
+
+
+@pytest.mark.parametrize(
+    "sparse_indices", [np.array([0, 1, 2]), np.array([2, 3, 4]), np.array([5, 6, 7]), np.array([0, 3, 7])]
+)
+def test_scale_local_waveform_to_uv_uses_its_own_channels_gain(sparse_indices):
+    """
+    `_scale_local_waveform_to_uV` is the scaling step shared by the two places that cut a
+    window out of the traces: the per-spike loop in `AmplitudeScalingNode.compute` and
+    `fit_collision`. It has to pick each channel's own gain/offset out of the chunk-wide
+    `gains`/`offsets` arrays, not some other subset. Scaling the cut-out window must equal
+    cutting the same window out of traces that were already scaled beforehand, for whichever
+    channel subset the caller cut out.
+    """
+    rng = np.random.default_rng(seed=2205)
+    num_channels, num_samples = 8, 50
+    gains = rng.uniform(0.5, 4.0, size=num_channels)
+    offsets = rng.uniform(-20.0, 20.0, size=num_channels)
+    raw_traces = rng.integers(-2000, 2000, size=(num_samples, num_channels)).astype("int16")
+
+    local_waveform = raw_traces[10:30, sparse_indices]
+    scaled_inside = _scale_local_waveform_to_uV(local_waveform, gains, offsets, sparse_indices)
+
+    scaled_beforehand = (raw_traces.astype("float32") * gains + offsets)[10:30, sparse_indices]
+
+    np.testing.assert_array_equal(scaled_inside, scaled_beforehand)
+
+
+def test_fit_collision_scales_each_channel_with_its_own_gain():
+    """
+    `fit_collision` scales the traces it cuts out to uV itself, so it has to apply
+    the gain of each channel to that channel. Scaling inside must give exactly what
+    passing already scaled traces gives. A gain taken from the wrong channel still
+    returns a well formed scaling, so the two paths are compared directly, with a
+    gain and an offset which are different on every channel.
+    """
+    rng = np.random.default_rng(seed=2205)
+    num_channels, num_units = 8, 3
+    nbefore, nafter, num_samples = 20, 30, 400
+
+    raw_traces = rng.integers(-2000, 2000, size=(num_samples, num_channels)).astype("int16")
+    all_templates = (rng.normal(size=(num_units, nbefore + nafter, num_channels)) * 50).astype("float32")
+    # unit 0 and unit 1 (the colliding pair below) are on non-contiguous, interleaved
+    # channels so their union isn't a single slice: sparse_indices must stay [0, 1, 3, 4, 6, 7].
+    sparsity_mask = np.zeros((num_units, num_channels), dtype=bool)
+    sparsity_mask[0, [0, 3, 6]] = True
+    sparsity_mask[1, [1, 4, 7]] = True
+    sparsity_mask[2, [2, 5]] = True
+
+    gains = rng.uniform(0.5, 4.0, size=num_channels)
+    offsets = rng.uniform(-20.0, 20.0, size=num_channels)
+
+    collision = np.zeros(2, dtype=[("sample_index", "int64"), ("unit_index", "int64")])
+    collision["sample_index"] = [180, 190]
+    collision["unit_index"] = [0, 1]
+
+    scaled_inside = fit_collision(
+        collision, raw_traces, nbefore, all_templates, sparsity_mask, nbefore, nafter, gains, offsets
+    )
+    scaled_traces = raw_traces.astype("float32") * gains + offsets
+    scaled_beforehand = fit_collision(collision, scaled_traces, nbefore, all_templates, sparsity_mask, nbefore, nafter)
+
+    np.testing.assert_array_equal(scaled_inside, scaled_beforehand)


### PR DESCRIPTION
### Description

`AmplitudeScalingNode.compute` scales every trace sample in a chunk before reading only the short, sparse windows around each spike. This PR moves the same scaling expression after each cut-out, including the collision path, so the temporary now scales with the samples and channels used by the regression instead of the whole chunk. The new `fit_collision` arguments are appended to keep existing positional calls compatible.

### Benchmarks

Binary-backed generated recordings, 384 channels at 30 kHz, GCP `c3-standard-22`, BLAS threads pinned to 1, fresh processes and interleaved arms. Times are median (range), with five runs per arm except the 11-extension pipeline, which uses three.

| pipeline | before | after | change | peak RSS |
|---|---:|---:|---:|---:|
| `valid_unit_periods`, 100 units | 13.946 s (13.916–13.985) | 12.476 s (12.413–12.550) | −10.5% | 522 → 389 MiB |
| `valid_unit_periods`, 200 units | 99.453 s (98.571–100.084) | 91.841 s (91.159–92.288) | −7.7% | 569 → 436 MiB |
| 11 postprocessing extensions, 200 units | 128.353 s (127.821–130.792) | 120.195 s (119.215–120.645) | −6.4% | 1,713 → 1,713 MiB |

The memory saving disappears in the wider pipeline because `waveforms` sets its high-water mark.

### Validation

The `amplitude_scalings` bytes have the same SHA-256 before and after in 128 comparisons covering float32/int16/float64/uint16 recordings, absent/uniform/per-channel gains, collisions on/off, `n_jobs=1/4`, two NumPy/SciPy combinations and a two-segment recording.

- `pytest src/spikeinterface/postprocessing/tests -q`: 97 passed, 40 skipped
- `bin/spikeinterface_lint.sh --check`: clean

Tested on Linux with generated data written to binary first; no real capture was used.
