### PR TITLE
Materialize templates array before amp scalings computation for lazy mode

### DIFF
--- a/src/spikeinterface/postprocessing/amplitude_scalings.py
+++ b/src/spikeinterface/postprocessing/amplitude_scalings.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from spikeinterface.core import ChannelSparsity
+from spikeinterface.core.core_tools import ms_to_samples
 from spikeinterface.core.template_tools import get_dense_templates_array, _get_nbefore
 from spikeinterface.core.sortinganalyzer import register_result_extension
 from spikeinterface.core.analyzer_extension_core import BaseSpikeVectorExtension
@@ -80,7 +81,7 @@ class ComputeAmplitudeScalings(BaseSpikeVectorExtension):
 
         return_in_uV = self.sorting_analyzer.return_in_uV
 
-        all_templates = get_dense_templates_array(self.sorting_analyzer, return_in_uV=return_in_uV)
+        all_templates = np.asarray(get_dense_templates_array(self.sorting_analyzer, return_in_uV=return_in_uV))
         nbefore = _get_nbefore(self.sorting_analyzer)
         nafter = all_templates.shape[1] - nbefore
         templates_ext = self.sorting_analyzer.get_extension("templates")


### PR DESCRIPTION
Noticed this bug when computing amp scalings on a lazy analyzer. The issue was that without materializing the template at init, the zarr array was accessed and decompressed at every spike!