### PR TITLE
Use a single dataset cache for all the runner OSes

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -12,6 +12,7 @@ on:
 env:
   KACHERY_API_KEY: ${{ secrets.KACHERY_API_KEY }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SPIKEINTERFACE_DATASET_FOLDER: ${{ github.workspace }}/spikeinterface_datasets
 
 concurrency:  # Cancel previous workflows on the same pull request
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -113,7 +114,7 @@ jobs:
         id: cache-datasets
         uses: actions/cache/restore@v5
         with:
-          path: ~/spikeinterface_datasets
+          path: spikeinterface_datasets
           key: datasets-${{ steps.repo_hash.outputs.dataset_hash }}
           restore-keys: datasets
           enableCrossOsArchive: true

--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -114,8 +114,9 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/spikeinterface_datasets
-          key: ${{ runner.os }}-datasets-${{ steps.repo_hash.outputs.dataset_hash }}
-          restore-keys: ${{ runner.os }}-datasets
+          key: datasets-${{ steps.repo_hash.outputs.dataset_hash }}
+          restore-keys: datasets
+          enableCrossOsArchive: true
 
       - name: Install git-annex
         shell: bash

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -11,11 +11,7 @@ on:
 jobs:
   create-gin-data-cache-if-missing:
     name: Caching data env
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v6
         with:
@@ -33,14 +29,20 @@ jobs:
       - name: Get current hash (SHA) of the ephy_testing_data repo
         id: repo_hash
         run: |
-          echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)"
-          echo "dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
+          dataset_hash=$(git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1)
+          if [ -z "$dataset_hash" ]; then
+            echo "::error::Could not resolve ephy_testing_data HEAD from gin.g-node.org"
+            exit 1
+          fi
+          echo "dataset_hash=$dataset_hash"
+          echo "dataset_hash=$dataset_hash" >> $GITHUB_OUTPUT
         shell: bash
       - uses: actions/cache@v5
         id: cache-datasets
         with:
           path: ~/spikeinterface_datasets
-          key: ${{ runner.os }}-datasets-${{ steps.repo_hash.outputs.dataset_hash }}
+          key: datasets-${{ steps.repo_hash.outputs.dataset_hash }}
+          enableCrossOsArchive: true # One cache for every runner OS, built here on Linux
           lookup-only: "true" # Avoids downloading the data, saving behavior is not affected.
       - name: Cache found?
         run: echo "Cache-hit == ${{steps.cache-datasets.outputs.cache-hit == 'true'}}"

--- a/.github/workflows/caches_cron_job.yml
+++ b/.github/workflows/caches_cron_job.yml
@@ -23,8 +23,8 @@ jobs:
           ignore-nothing-to-cache: true # some runs do not require building a cache (ie macOS) this says this is okay
       - name: Create the directory to store the data
         run: |
-          mkdir -p  ~/spikeinterface_datasets/ephy_testing_data/
-          ls -l ~/spikeinterface_datasets
+          mkdir -p  spikeinterface_datasets/ephy_testing_data/
+          ls -l spikeinterface_datasets
         shell: bash
       - name: Get current hash (SHA) of the ephy_testing_data repo
         id: repo_hash
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/cache@v5
         id: cache-datasets
         with:
-          path: ~/spikeinterface_datasets
+          path: spikeinterface_datasets
           key: datasets-${{ steps.repo_hash.outputs.dataset_hash }}
           enableCrossOsArchive: true # One cache for every runner OS, built here on Linux
           lookup-only: "true" # Avoids downloading the data, saving behavior is not affected.
@@ -71,11 +71,10 @@ jobs:
       - name: Move the downloaded data to the right directory
         if: steps.cache-datasets.outputs.cache-hit != 'true'
         run: |
-          mv ./ephy_testing_data ~/spikeinterface_datasets/
+          mv ./ephy_testing_data spikeinterface_datasets/
         shell: bash
       - name: Show size of the cache to assert data is downloaded
         run: |
-          cd ~
           pwd
           du -hs spikeinterface_datasets  # Should show the size of ephy_testing_data
           cd spikeinterface_datasets

--- a/.github/workflows/full-test-with-codecov.yml
+++ b/.github/workflows/full-test-with-codecov.yml
@@ -8,6 +8,7 @@ on:
 env:
   KACHERY_API_KEY: ${{ secrets.KACHERY_API_KEY }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SPIKEINTERFACE_DATASET_FOLDER: ${{ github.workspace }}/spikeinterface_datasets
 
 jobs:
   full-tests-with-codecov:
@@ -48,7 +49,7 @@ jobs:
           # the key depends on the last comit repo https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git
           HASH_EPHY_DATASET: git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1
         with:
-          path: ~/spikeinterface_datasets
+          path: spikeinterface_datasets
           key: datasets-${{ steps.vars.outputs.HASH_EPHY_DATASET }}
           restore-keys: datasets
           enableCrossOsArchive: true

--- a/.github/workflows/full-test-with-codecov.yml
+++ b/.github/workflows/full-test-with-codecov.yml
@@ -49,8 +49,9 @@ jobs:
           HASH_EPHY_DATASET: git ls-remote https://gin.g-node.org/NeuralEnsemble/ephy_testing_data.git HEAD | cut -f1
         with:
           path: ~/spikeinterface_datasets
-          key: ${{ runner.os }}-datasets-${{ steps.vars.outputs.HASH_EPHY_DATASET }}
-          restore-keys: ${{ runner.os }}-datasets
+          key: datasets-${{ steps.vars.outputs.HASH_EPHY_DATASET }}
+          restore-keys: datasets
+          enableCrossOsArchive: true
       - name: Install packages
         uses: ./.github/actions/build-test-environment
       - name: Pip list

--- a/src/spikeinterface/core/globals.py
+++ b/src/spikeinterface/core/globals.py
@@ -4,6 +4,7 @@
 It is useful when we do extractor.save(name="name").
 """
 
+import os
 import tempfile
 from pathlib import Path
 from copy import deepcopy
@@ -69,9 +70,14 @@ dataset_folder_set = False
 def get_global_dataset_folder():
     """
     Get the global dataset folder.
+
+    Unless it has been set manually with `set_global_dataset_folder`, it is read from the
+    `SPIKEINTERFACE_DATASET_FOLDER` environment variable and falls back to `~/spikeinterface_datasets`.
     """
     global dataset_folder
     global dataset_folder_set
+    if not dataset_folder_set:
+        dataset_folder = Path(os.environ.get("SPIKEINTERFACE_DATASET_FOLDER", Path.home() / "spikeinterface_datasets"))
     dataset_folder.mkdir(exist_ok=True, parents=True)
     return dataset_folder
 


### PR DESCRIPTION
I am still trying to figure out what exactly is failing on the caching cron job. It looks like multiple fetch requests are being denied on gin. While I think about a better solution that makes less fetch requests, one big thing we can do is reduce our cache footprint by using the same cache for all the OSes which will in turn reduce or requests. To do this we can use the new CI feature called `enableCrossOsArchive` which was released in `actions/cache` v3.2.3 in January 2023:
https://github.com/actions/cache/releases/tag/v3.2.3

I have been using it on neuroconv successfully for over a year now:
https://github.com/catalystneuro/neuroconv/pull/1385

So this PR builds the cache once on Linux and shares it with macOS and Windows. I also made the hash step exit when `git ls-remote` comes back empty. Right now it silently produces the key `datasets-`, guarantees a miss and forces the full download that gin just refused. 


I will be watching the first run to check for annex symlink behavior. 
