### PR TITLE
Prepare 0.104.9 release with sortingview fixes

### DIFF
--- a/doc/releases/0.104.9.rst
+++ b/doc/releases/0.104.9.rst
@@ -1,0 +1,16 @@
+.. _release0.104.9:
+
+SpikeInterface 0.104.9 release notes
+------------------------------------
+
+Sept 10th 2026
+
+Minor release with bug fixes for sortingview backend
+extractors:
+
+* Sortingview/Figpack: transpose templates (for sortingview) and cast to float32 to avoid serialization issues (#4774)
+#4774
+
+Contributors:
+
+* @alejoe91

--- a/doc/whatisnew.rst
+++ b/doc/whatisnew.rst
@@ -8,6 +8,7 @@ Release notes
 .. toctree::
   :maxdepth: 1
 
+  releases/0.104.9.rst
   releases/0.104.8.rst
   releases/0.104.7.rst
   releases/0.104.6.rst
@@ -60,7 +61,7 @@ Release notes
   releases/0.9.9.rst
   releases/0.9.1.rst
 
-Versions 0.104.1/8
+Versions 0.104.1/9
 ==================
 
 * Minor releases with bug fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spikeinterface"
-version = "0.104.8"
+version = "0.104.9"
 authors = [
   { name="Alessio Buccino", email="alessiop.buccino@gmail.com" },
   { name="Samuel Garcia", email="sam.garcia.die@gmail.com" },

--- a/src/spikeinterface/widgets/unit_templates.py
+++ b/src/spikeinterface/widgets/unit_templates.py
@@ -1,4 +1,5 @@
 from spikeinterface.core import SortingAnalyzer
+
 from .unit_waveforms import UnitWaveformsWidget
 from .base import to_attr
 
@@ -40,12 +41,17 @@ class UnitTemplatesWidget(UnitWaveformsWidget):
         templates_dict = {}
         for u_i, unit in enumerate(unit_ids):
             templates_dict[unit] = {}
-            template_data = dp.templates[u_i]
-            templates_dict[unit]["mean"] = template_data[:, unit_id_to_channel_indices[unit]]
+            template_data = dp.templates[u_i][:, unit_id_to_channel_indices[unit]].astype("float32")
+            if use_sortingview:
+                template_data = template_data.T
+            templates_dict[unit]["mean"] = template_data
             if dp.do_shading:
                 templates_dict[unit]["shading"] = []
                 for shading_data in dp.templates_shading:
-                    templates_dict[unit]["shading"].append(shading_data[u_i][:, unit_id_to_channel_indices[unit]])
+                    shading_data_unit = shading_data[u_i][:, unit_id_to_channel_indices[unit]].astype("float32")
+                    if use_sortingview:
+                        shading_data_unit = shading_data_unit.T
+                    templates_dict[unit]["shading"].append(shading_data_unit)
             else:
                 templates_dict[unit]["shading"] = None
 
@@ -59,7 +65,9 @@ class UnitTemplatesWidget(UnitWaveformsWidget):
             for u, t in templates_dict.items()
         ]
 
-        channel_locations = {str(ch): dp.channel_locations[i_ch].astype(float) for i_ch, ch in enumerate(channel_ids)}
+        channel_locations = {
+            str(ch): dp.channel_locations[i_ch].astype("float32") for i_ch, ch in enumerate(channel_ids)
+        }
         v_average_waveforms = vv_views.AverageWaveforms(average_waveforms=aw_items, channel_locations=channel_locations)
 
         if not dp.hide_unit_selector:


### PR DESCRIPTION
Includes:

- Sortingview/Figpack: transpose templates (for `sortingview`) and cast to `float32` to avoid serialization issues
#4774